### PR TITLE
Add workflows for checking fmt, build rabbitmq, and build tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * *' # Runs daily at 16:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rmq-version: ['streams-tiered-storage']
+        include:
+          - rmq-version: 'streams-tiered-storage'
+            otp-version: 27
+            elixir-version: 1.18
+    steps:
+      - id: restore-rabbitmq-server-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/rabbitmq-server
+          key: rmq-${{ matrix.rmq-version }}-otp-${{ matrix.otp-version }}-elixir-${{ matrix.elixir-version }}
+      - id: maybe-fail-rabbitmq-server-miss
+        if: steps.restore-rabbitmq-server-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.setFailed('could not restore cached rabbitmq-server build');
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp-version }}
+          elixir-version: ${{ matrix.elixir-version }}
+      - uses: actions/checkout@v5
+        with:
+          path: rabbitmq-server/deps/rabbitmq_stream_s3
+      - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3
+      - run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 tests

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -1,0 +1,26 @@
+name: erlfmt
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 27
+          rebar3-version: 3.22
+      - run: |
+          git clone --branch v1.7.0 https://github.com/WhatsApp/erlfmt.git ${{ github.workspace }}/erlfmt
+          cd ${{ github.workspace }}/erlfmt && rebar3 as release escriptize
+      - name: Run erlfmt check
+        run: ${{ github.workspace }}/erlfmt/_build/release/bin/erlfmt -c

--- a/src/rabbitmq_stream_s3_counters.erl
+++ b/src/rabbitmq_stream_s3_counters.erl
@@ -23,21 +23,17 @@
 -define(INDEX_BYTES_WRITTEN, 8).
 
 -define(LOG_MANIFEST_COUNTERS, [
-    {manifests_read, ?MANIFESTS_READ, counter,
-        "Number of (non-empty) manifests read"},
+    {manifests_read, ?MANIFESTS_READ, counter, "Number of (non-empty) manifests read"},
     {manifest_bytes_read, ?MANIFEST_BYTES_READ, counter,
         "Number of manifest file bytes read from S3"},
-    {manifests_written, ?MANIFESTS_WRITTEN, counter,
-        "Number of manifests written to S3"},
+    {manifests_written, ?MANIFESTS_WRITTEN, counter, "Number of manifests written to S3"},
     {manifest_bytes_written, ?MANIFEST_BYTES_WRITTEN, counter,
         "Number of bytes of manifest files written to S3"},
     %% TODO will rename to "fragment" (maybe keep the segment ones too though).
-    {uploaded_segments, ?SEGMENTS_WRITTEN, counter,
-        "Number of segment files uploaded to S3"},
+    {uploaded_segments, ?SEGMENTS_WRITTEN, counter, "Number of segment files uploaded to S3"},
     {uploaded_segment_bytes, ?SEGMENT_BYTES_WRITTEN, counter,
         "Number of bytes of segment files written to S3"},
-    {uploaded_indexes, ?INDEXES_WRITTEN, counter,
-        "Number of index files uploaded to S3"},
+    {uploaded_indexes, ?INDEXES_WRITTEN, counter, "Number of index files uploaded to S3"},
     {uploaded_index_bytes, ?INDEX_BYTES_WRITTEN, counter,
         "Number of bytes of index files written to S3"}
 ]).

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -451,7 +451,7 @@ read_header2(
     } = Remote0,
     HeaderBin
 ) ->
-    <<HeaderBin1:?CHUNK_HEADER_B/binary, _/binary>> = HeaderBin, 
+    <<HeaderBin1:?CHUNK_HEADER_B/binary, _/binary>> = HeaderBin,
     {ok, Header} = osiris_log:parse_header(HeaderBin1, Position0),
     #{
         type := ChunkType,
@@ -552,7 +552,9 @@ init_remote_reader(
             Err
     end.
 
-convert_remote_to_local(#?MODULE{config = Config, mode = #remote{pid = Pid, next_offset = NextOffset}}) ->
+convert_remote_to_local(#?MODULE{
+    config = Config, mode = #remote{pid = Pid, next_offset = NextOffset}
+}) ->
     ?LOG_DEBUG("Converting to local reader at offset ~b", [NextOffset]),
     ok = gen_server:cast(Pid, close),
     init_local_reader(first, Config).


### PR DESCRIPTION
*Description of changes:*

3 workflows:

- format-check: Runs erlfmt on each PR
- build-rabbitmq-server: Builds and cache rabbitmq builds
- build-test: builds and tests this plugin (Currently does not run dialyzes)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
