### PR TITLE
Fix #reply{} return when requesting an existing manifest

### DIFF
--- a/src/rabbitmq_stream_s3_log_manifest_machine.erl
+++ b/src/rabbitmq_stream_s3_log_manifest_machine.erl
@@ -222,7 +222,7 @@ apply(
 ) ->
     case Manifests0 of
         #{Dir := {#manifest{} = Manifest, _UploadStatus}} ->
-            {State0, #reply{to = Requester, response = Manifest}};
+            {State0, [#reply{to = Requester, response = Manifest}]};
         #{Dir := {pending, Requesters}} ->
             Manifests = Manifests0#{Dir := {pending, [Requester | Requesters]}},
             {State0#?MODULE{manifests = Manifests}, []};


### PR DESCRIPTION
The manifest machine `apply/3` function should always return a list of effects. This fixes `rabbitmq_stream_s3_log_manifest:get_manifest/1` when the manifest is already downloaded / cached in memory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
