### PR TITLE
Recover fragments idempotently on writer reboot

### DIFF
--- a/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
+++ b/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
@@ -19,7 +19,8 @@ all() ->
     [
         spawn_writer,
         simultaneous_manifest_requests,
-        out_of_order_fragment_uploads
+        out_of_order_fragment_uploads,
+        recover_uploaded_fragments
     ].
 
 %%----------------------------------------------------------------------------
@@ -28,22 +29,22 @@ spawn_writer(Config) ->
     Dir = get_config(Config, priv_dir),
     Mac0 = ?MAC:new(),
     Pid = self(),
-    Tag = erlang:make_ref(),
-    From = {Pid, Tag},
     Event1 = #writer_spawned{
         pid = Pid,
-        reply_tag = Tag,
         writer_ref = rabbit_misc:r(<<"/">>, queue, <<"sq">>),
         dir = Dir
     },
     {Mac1, Effects1} = ?MAC:apply(?META(), Event1, Mac0),
-    ?assertEqual(Effects1, [
-        #register_offset_listener{writer_pid = Pid, offset = -1},
-        #download_manifest{dir = Dir}
-    ]),
-    Event2 = #manifest_downloaded{dir = Dir, manifest = undefined},
+    ?assertEqual(
+        [
+            #register_offset_listener{writer_pid = Pid, offset = -1},
+            #resolve_manifest{dir = Dir}
+        ],
+        Effects1
+    ),
+    Event2 = #manifest_resolved{dir = Dir, manifest = undefined},
     {_Mac2, Effects2} = ?MAC:apply(?META(), Event2, Mac1),
-    ?assertEqual(Effects2, [#reply{to = From, response = undefined}]),
+    ?assertEqual([], Effects2),
     ok.
 
 simultaneous_manifest_requests(Config) ->
@@ -54,11 +55,8 @@ simultaneous_manifest_requests(Config) ->
 
     Dir = get_config(Config, priv_dir),
     WriterPid = self(),
-    Tag = erlang:make_ref(),
-    WriterFrom = {WriterPid, Tag},
     Event1 = #writer_spawned{
         pid = WriterPid,
-        reply_tag = Tag,
         writer_ref = rabbit_misc:r(<<"/">>, queue, <<"sq">>),
         dir = Dir
     },
@@ -73,18 +71,23 @@ simultaneous_manifest_requests(Config) ->
     Event3 = #manifest_requested{requester = From2, dir = Dir},
 
     {Mac1, Effects1} = handle_events(?META(), [Event1, Event2, Event3], ?MAC:new()),
-    ?assertEqual(Effects1, [
-        #register_offset_listener{writer_pid = WriterPid, offset = -1},
-        #download_manifest{dir = Dir}
-    ]),
+    ?assertEqual(
+        [
+            #register_offset_listener{writer_pid = WriterPid, offset = -1},
+            #resolve_manifest{dir = Dir}
+        ],
+        Effects1
+    ),
 
-    Event4 = #manifest_downloaded{dir = Dir, manifest = undefined},
+    Event4 = #manifest_resolved{dir = Dir, manifest = undefined},
     {_Mac2, Effects2} = ?MAC:apply(?META(), Event4, Mac1),
-    ?assertEqual(Effects2, [
-        #reply{to = WriterFrom, response = undefined},
-        #reply{to = From1, response = undefined},
-        #reply{to = From2, response = undefined}
-    ]),
+    ?assertEqual(
+        [
+            #reply{to = From1, response = undefined},
+            #reply{to = From2, response = undefined}
+        ],
+        Effects2
+    ),
     ok.
 
 out_of_order_fragment_uploads(Config) ->
@@ -92,7 +95,7 @@ out_of_order_fragment_uploads(Config) ->
     Fragments = [fragment(From, To) || {From, To} <- [{0, 19}, {20, 39}, {40, 59}]],
     FragmentsAvailable = [#fragment_available{writer_ref = Ref, fragment = F} || F <- Fragments],
     {Mac1, Effects1} = handle_events(?META(), FragmentsAvailable, Mac0),
-    ?assertEqual(Effects1, []),
+    ?assertEqual([], Effects1),
     Event1 = #commit_offset_increased{writer_ref = Ref, offset = 60},
     {Mac2, Effects2} = ?MAC:apply(?META(), Event1, Mac1),
     ?assertMatch(
@@ -111,11 +114,76 @@ out_of_order_fragment_uploads(Config) ->
     {Mac3, Effects3} = handle_events(?META(), [Up2, Up3], Mac2),
     %% The manifest won't be updated until a run of fragments have been uploaded:
     %% no holes are allowed in the manifest.
-    ?assertEqual(Effects3, []),
+    ?assertEqual([], Effects3),
     %% Once the first fragment has finished uploading then the manifest is
     %% updated for all fragments.
     {_Mac4, Effects4} = ?MAC:apply(?META(), Up1, Mac3),
     ?assertMatch([#upload_manifest{manifest = #manifest{first_offset = 0}}], Effects4),
+    ok.
+
+recover_uploaded_fragments(Config) ->
+    %% The writer uploads fragments but the updated manifest is not yet
+    %% uploaded. When restarting, the writer resolve the full manifest and
+    %% upload it.
+    {Mac0, Ref} = setup_writer(Config),
+    [F1, F2, _F3] = Fragments = [fragment(From, To) || {From, To} <- [{0, 19}, {20, 39}, {40, 59}]],
+    FragmentsAvailable = [#fragment_available{writer_ref = Ref, fragment = F} || F <- Fragments],
+    {Mac1, Effects1} = handle_events(?META(), FragmentsAvailable, Mac0),
+    ?assertEqual([], Effects1),
+    COI1 = #commit_offset_increased{writer_ref = Ref, offset = 40},
+    {Mac2, Effects2} = ?MAC:apply(?META(), COI1, Mac1),
+    ?assertMatch(
+        [
+            #upload_fragment{writer_ref = Ref, fragment = #fragment{first_offset = 0}},
+            #upload_fragment{writer_ref = Ref, fragment = #fragment{first_offset = 20}},
+            #register_offset_listener{}
+        ],
+        Effects2
+    ),
+    [Up1, _Up2, Up3] = [
+        #fragment_uploaded{writer_ref = Ref, info = fragment_to_info(F)}
+     || F <- Fragments
+    ],
+    %% Say that 1 and 2 are uploaded but before the reboot the manifest server
+    %% only sees 1 complete its upload.
+    {_Mac3, Effects3} = ?MAC:apply(?META(), Up1, Mac2),
+    ?assertMatch(
+        [#upload_manifest{manifest = #manifest{first_offset = 0, total_size = 1}}],
+        Effects3
+    ),
+
+    %% --- Say that the writer reboots now ---
+    %% During recovery it will notify the manifest server of the available
+    %% fragments in the current segment. The manifest server will resolve
+    %% what has been uploaded (fragments 1 and 2 now) and
+
+    Pid = self(),
+    Dir = get_config(Config, priv_dir),
+    WriterSpawned = #writer_spawned{
+        pid = Pid,
+        writer_ref = Ref,
+        dir = Dir
+    },
+    {Mac4, Effects4} = ?MAC:apply(?META(), WriterSpawned, ?MAC:new()),
+    ?assertMatch([#register_offset_listener{}, #resolve_manifest{dir = Dir}], Effects4),
+    %% The existing local fragments are sent to the manifest server as
+    %% available.
+    {Mac5, Effects5} = handle_events(?META(), FragmentsAvailable, Mac4),
+    ?assertEqual([], Effects5),
+    %% Before the manifest is resolved, the commit offset increases.
+    COI2 = #commit_offset_increased{writer_ref = Ref, offset = 60},
+    {Mac6, Effects6} = ?MAC:apply(?META(), COI2, Mac5),
+    ?assertMatch([#register_offset_listener{}], Effects6),
+    ManifestResolved = #manifest_resolved{dir = Dir, manifest = fragments_to_manifest([F1, F2])},
+    {Mac7, Effects7} = ?MAC:apply(?META(), ManifestResolved, Mac6),
+    %% The last fragment is now eligible for upload since the commit offset
+    %% increased.
+    ?assertMatch(
+        [#upload_fragment{writer_ref = Ref, fragment = #fragment{first_offset = 40}}],
+        Effects7
+    ),
+    {_Mac8, Effects8} = ?MAC:apply(?META(), Up3, Mac7),
+    ?assertEqual([], Effects8),
     ok.
 
 %%----------------------------------------------------------------------------
@@ -123,15 +191,13 @@ out_of_order_fragment_uploads(Config) ->
 setup_writer(Config) ->
     Dir = get_config(Config, priv_dir),
     Pid = self(),
-    Tag = erlang:make_ref(),
     WriterRef = rabbit_misc:r(<<"/">>, queue, <<"sq">>),
     Event1 = #writer_spawned{
         pid = Pid,
-        reply_tag = Tag,
         writer_ref = WriterRef,
         dir = Dir
     },
-    Event2 = #manifest_downloaded{dir = Dir, manifest = undefined},
+    Event2 = #manifest_resolved{dir = Dir, manifest = undefined},
     {Mac, _} = handle_events(?META(), [Event1, Event2], ?MAC:new()),
     {Mac, WriterRef}.
 
@@ -151,7 +217,8 @@ fragment(Offset, LastOffset) ->
         first_offset = Offset,
         first_timestamp = erlang:system_time(millisecond),
         last_offset = LastOffset,
-        next_offset = LastOffset + 1
+        next_offset = LastOffset + 1,
+        size = 1
     }.
 
 fragment_to_info(#fragment{
@@ -168,3 +235,27 @@ fragment_to_info(#fragment{
         seq_no = Seq,
         size = Size
     }.
+
+fragments_to_manifest([
+    #fragment{first_offset = Offset, first_timestamp = Ts, size = Size, seq_no = SeqNo} | Rest
+]) ->
+    fragments_to_manifest(Rest, #manifest{
+        first_offset = Offset,
+        first_timestamp = Ts,
+        total_size = Size,
+        entries = ?ENTRY(Offset, Ts, ?MANIFEST_KIND_FRAGMENT, Size, SeqNo, <<>>)
+    }).
+
+fragments_to_manifest([], Manifest) ->
+    Manifest;
+fragments_to_manifest(
+    [#fragment{first_offset = Offset, first_timestamp = Ts, size = Size, seq_no = SeqNo} | Rest],
+    #manifest{total_size = TotalSize0, entries = Entries0} = Manifest0
+) ->
+    Manifest = Manifest0#manifest{
+        total_size = TotalSize0 + Size,
+        entries =
+            <<Entries0/binary,
+                (?ENTRY(Offset, Ts, ?MANIFEST_KIND_FRAGMENT, Size, SeqNo, <<>>))/binary>>
+    },
+    fragments_to_manifest(Rest, Manifest).


### PR DESCRIPTION
When rebooting a writer, for example by rebooting a single-instance Rabbit, we need to recover the information about the current fragment (its size, where in the segment file it starts, number of chunks, etc.). We can read through the latest index file to determine all of this info. While reading through the index file we also find the other fragment(s) in the current segment and we can forward those to the manifest server so that it can attempt to upload them if uploading failed before the reboot.

This change also makes the manifest server "resolve" the manifest when it is downloading it from the remote tier. The manifest could be out of date: a fragment could've just been uploaded to the remote tier and the manifest server may have applied it to the in-memory copy of the manifest, but it may not have successfully uploaded the updated manifest to the remote tier before reboot. We can follow the "tail pointers" (the `next_offset` which is in the fragment trailer) to discover fragments which have been successfully uploaded but weren't applied to the manifest as it is in the remote tier.

Fixes https://github.com/amazon-mq/rabbitmq-stream-s3/issues/20
Fixes https://github.com/amazon-mq/rabbitmq-stream-s3/issues/22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
