### PR TITLE
Cache next offset in manifest root

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -109,22 +109,26 @@
 -define(MANIFEST_KIND_MEGA_GROUP, 3).
 
 %% The root and all groups have the same header.
-%% magic (4) + version (4) + offset (8) + timestamp (8) + size (9) = 33
--define(MANIFEST_HEADER_SIZE, 33).
+%% * magic (4)
+%% * version (4)
+%% * first offset (8)
+%% * first timestamp (8)
+%% * next offset (8)
+%% * size (9)
+%% = 41 bytes
+-define(MANIFEST_HEADER_SIZE, 41).
 
--define(MANIFEST(FirstOffset, FirstTimestamp, TotalSize, Entries), <<
+-define(MANIFEST(FirstOffset, FirstTimestamp, NextOffset, TotalSize, Entries), <<
     ?MANIFEST_ROOT_MAGIC,
     ?MANIFEST_ROOT_VERSION:32/unsigned,
     FirstOffset:64/unsigned,
     FirstTimestamp:64/signed,
+    NextOffset:64/unsigned,
     0:2/unsigned,
     TotalSize:70/unsigned,
     %% Entries array:
     Entries/binary
 >>).
-%% THOUGHT: keep NextOffset in the entries array? 8 more bytes but it lets us
-%% avoid a trailer lookup when resolving the manifest.
-%% Maybe keeping just the next_offset on the overall manifest is enough.
 -define(ENTRY(Offset, Timestamp, Kind, Size, SeqNo, Rest), <<
     Offset:64/unsigned,
     Timestamp:64/signed,
@@ -138,6 +142,7 @@
 -record(manifest, {
     first_offset :: osiris:offset(),
     first_timestamp :: osiris:timestamp(),
+    next_offset :: osiris:offset(),
     total_size :: non_neg_integer(),
     entries :: binary()
 }).

--- a/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
+++ b/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
@@ -237,10 +237,18 @@ fragment_to_info(#fragment{
     }.
 
 fragments_to_manifest([
-    #fragment{first_offset = Offset, first_timestamp = Ts, size = Size, seq_no = SeqNo} | Rest
+    #fragment{
+        first_offset = Offset,
+        next_offset = NextOffset,
+        first_timestamp = Ts,
+        size = Size,
+        seq_no = SeqNo
+    }
+    | Rest
 ]) ->
     fragments_to_manifest(Rest, #manifest{
         first_offset = Offset,
+        next_offset = NextOffset,
         first_timestamp = Ts,
         total_size = Size,
         entries = ?ENTRY(Offset, Ts, ?MANIFEST_KIND_FRAGMENT, Size, SeqNo, <<>>)
@@ -249,10 +257,20 @@ fragments_to_manifest([
 fragments_to_manifest([], Manifest) ->
     Manifest;
 fragments_to_manifest(
-    [#fragment{first_offset = Offset, first_timestamp = Ts, size = Size, seq_no = SeqNo} | Rest],
+    [
+        #fragment{
+            first_offset = Offset,
+            next_offset = NextOffset,
+            first_timestamp = Ts,
+            size = Size,
+            seq_no = SeqNo
+        }
+        | Rest
+    ],
     #manifest{total_size = TotalSize0, entries = Entries0} = Manifest0
 ) ->
     Manifest = Manifest0#manifest{
+        next_offset = NextOffset,
         total_size = TotalSize0 + Size,
         entries =
             <<Entries0/binary,


### PR DESCRIPTION
The manifest can spend an extra 8 bytes to store the "next offset" (the offset of the next fragment which will be uploaded) in its header. Caching this value lets us skip a round-trip during manifest resolution since we don't need to look up the last known fragment's trailer to find this information.

This resolves a TODO/THOUGHT from the parent commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
