### PR TITLE
Set writer local retention to reclaim fully uploaded segments

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -238,11 +238,13 @@
 %% last fragment to see if fragments have been uploaded but not yet applied.
 -record(resolve_manifest, {dir :: file:filename_all()}).
 -record(reply, {to :: gen_server:from(), response :: term()}).
+-record(set_last_tiered_offset, {dir :: file:filename_all(), offset :: osiris:offset()}).
 
 -type effect() ::
     #rebalance_manifest{}
     | #register_offset_listener{}
     | #reply{}
     | #resolve_manifest{}
+    | #set_last_tiered_offset{}
     | #upload_fragment{}
     | #upload_manifest{}.

--- a/src/rabbitmq_stream_s3_log_manifest_machine.erl
+++ b/src/rabbitmq_stream_s3_log_manifest_machine.erl
@@ -164,13 +164,20 @@ apply(
                 #manifest{} -> ok;
                 undefined -> ok
             end,
-            {Manifest, UploadStatus, Effects} = apply_infos_to_manifest(
+            {Manifest, UploadStatus, Effects0} = apply_infos_to_manifest(
                 Finished, Manifest0, UploadStatus0, Dir
             ),
             Writer = Writer0#writer{
                 uploaded_fragments = Pending,
                 next_tiered_offset = NTO
             },
+            Effects =
+                case NTO of
+                    NTO0 ->
+                        Effects0;
+                    _ ->
+                        [#set_last_tiered_offset{dir = Dir, offset = NTO - 1} | Effects0]
+                end,
             State = State0#?MODULE{
                 writers = Writers0#{WriterRef := Writer},
                 manifests = Manifests0#{Dir := {Manifest, UploadStatus}}

--- a/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
+++ b/test/rabbitmq_stream_s3_log_manifest_machine_SUITE.erl
@@ -118,7 +118,13 @@ out_of_order_fragment_uploads(Config) ->
     %% Once the first fragment has finished uploading then the manifest is
     %% updated for all fragments.
     {_Mac4, Effects4} = ?MAC:apply(?META(), Up1, Mac3),
-    ?assertMatch([#upload_manifest{manifest = #manifest{first_offset = 0}}], Effects4),
+    ?assertMatch(
+        [
+            #set_last_tiered_offset{offset = 59},
+            #upload_manifest{manifest = #manifest{first_offset = 0}}
+        ],
+        Effects4
+    ),
     ok.
 
 recover_uploaded_fragments(Config) ->
@@ -148,7 +154,10 @@ recover_uploaded_fragments(Config) ->
     %% only sees 1 complete its upload.
     {_Mac3, Effects3} = ?MAC:apply(?META(), Up1, Mac2),
     ?assertMatch(
-        [#upload_manifest{manifest = #manifest{first_offset = 0, total_size = 1}}],
+        [
+            #set_last_tiered_offset{offset = 19},
+            #upload_manifest{manifest = #manifest{first_offset = 0, total_size = 1}}
+        ],
         Effects3
     ),
 


### PR DESCRIPTION
We can override the writer's retention to use the retention function spec `{'fun', fun()}` and pass in a function which checks local segment offsets against the offset that was last fully uploaded to the remote tier (including being applied to the manifest).

This only applies to the writer so far, so replicas don't currently apply the same retention rules. That will be covered in child commit(s).

Connects #12 and adds a TODO for #18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
