### PR TITLE
Prefer binaries for file/directory names

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -1,6 +1,11 @@
 %% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 %% SPDX-License-Identifier: Apache-2.0
 
+%% Prefer binaries for filenames. This is a subtype of file:filename_all().
+%% Binaries represent ASCII in a much more compact fashion than lists.
+-type filename() :: binary().
+-type directory() :: binary().
+
 %% Segment and fragment file header size. 4 bytes for the magic and 4 bytes for
 %% the version.
 -define(SEGMENT_HEADER_B, 8).
@@ -199,14 +204,14 @@
 %% The writer notified the manifest that the commit offset has moved forward.
 -record(commit_offset_increased, {writer_ref :: writer_ref(), offset :: osiris:offset()}).
 -record(fragment_uploaded, {writer_ref :: writer_ref(), info :: #fragment_info{}}).
--record(manifest_uploaded, {dir :: file:filename_all()}).
--record(manifest_rebalanced, {dir :: file:filename_all(), manifest :: #manifest{}}).
--record(manifest_requested, {requester :: gen_server:from(), dir :: file:filename_all()}).
--record(manifest_resolved, {dir :: file:filename_all(), manifest :: #manifest{} | undefined}).
+-record(manifest_uploaded, {dir :: directory()}).
+-record(manifest_rebalanced, {dir :: directory(), manifest :: #manifest{}}).
+-record(manifest_requested, {requester :: gen_server:from(), dir :: directory()}).
+-record(manifest_resolved, {dir :: directory(), manifest :: #manifest{} | undefined}).
 -record(writer_spawned, {
     pid :: pid(),
     writer_ref :: writer_ref(),
-    dir :: file:filename_all()
+    dir :: directory()
 }).
 
 -type event() ::
@@ -222,12 +227,12 @@
 %% Effects.
 
 -record(upload_fragment, {
-    writer_ref :: writer_ref(), dir :: file:filename_all(), fragment :: #fragment{}
+    writer_ref :: writer_ref(), dir :: directory(), fragment :: #fragment{}
 }).
 -record(register_offset_listener, {writer_pid :: pid(), offset :: osiris:offset() | -1}).
--record(upload_manifest, {dir :: file:filename_all(), manifest :: #manifest{}}).
+-record(upload_manifest, {dir :: directory(), manifest :: #manifest{}}).
 -record(rebalance_manifest, {
-    dir :: file:filename_all(),
+    dir :: directory(),
     kind :: rabbitmq_stream_s3_log_manifest_entry:kind(),
     size :: pos_integer(),
     new_group :: rabbitmq_stream_s3_log_manifest_entry:entries(),
@@ -236,9 +241,9 @@
 }).
 %% Download the manifest from the remote tier and also check the tail of the
 %% last fragment to see if fragments have been uploaded but not yet applied.
--record(resolve_manifest, {dir :: file:filename_all()}).
+-record(resolve_manifest, {dir :: directory()}).
 -record(reply, {to :: gen_server:from(), response :: term()}).
--record(set_last_tiered_offset, {dir :: file:filename_all(), offset :: osiris:offset()}).
+-record(set_last_tiered_offset, {dir :: directory(), offset :: osiris:offset()}).
 
 -type effect() ::
     #rebalance_manifest{}

--- a/src/rabbitmq_stream_s3_log_manifest_machine.erl
+++ b/src/rabbitmq_stream_s3_log_manifest_machine.erl
@@ -22,7 +22,7 @@ for the log manifest server to execute.
     %% Pid of the osiris_writer process. Used to attach offset listeners.
     pid :: pid(),
     %% Local dir of the log.
-    dir :: file:filename_all(),
+    dir :: directory(),
     %% Current commit offset (updated by offset listener notifications) known
     %% to the manifest - this can lag behind the actual commit offset.
     commit_offset = -1 :: osiris:offset() | -1,
@@ -47,7 +47,7 @@ for the log manifest server to execute.
 -record(?MODULE, {
     writers = #{} :: #{writer_ref() => #writer{}},
     manifests = #{} :: #{
-        file:filename_all() =>
+        directory() =>
             {#manifest{} | undefined, upload_status()}
             | {pending, [gen_server:from()]}
     }
@@ -70,7 +70,7 @@ Create a default, empty machine state.
 -spec new() -> state().
 new() -> #?MODULE{}.
 
--spec get_manifest(Dir :: file:filename_all(), state()) -> #manifest{} | undefined.
+-spec get_manifest(Dir :: directory(), state()) -> #manifest{} | undefined.
 get_manifest(Dir, #?MODULE{manifests = Manifests}) ->
     maps:get(Dir, Manifests, undefined).
 
@@ -380,7 +380,7 @@ This function also evaluates whether the manifest should be rebalanced and/or
 uploaded to the remote tier.
 """.
 -spec apply_infos_to_manifest(
-    [#fragment_info{}], #manifest{} | undefined, upload_status(), file:filename_all()
+    [#fragment_info{}], #manifest{} | undefined, upload_status(), directory()
 ) ->
     {#manifest{}, upload_status(), [effect()]}.
 apply_infos_to_manifest(Infos, Manifest, UploadStatus, Dir) ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -15,7 +15,7 @@
 
 -record(remote, {
     pid :: pid(),
-    dir :: file:filename_all(),
+    dir :: directory(),
     transport :: tcp | ssl,
     next_offset :: osiris:offset(),
     shared :: atomics:atomics_ref(),
@@ -561,7 +561,7 @@ convert_remote_to_local(#?MODULE{
 -spec find_fragment_for_offset(
     osiris:offset(),
     #manifest{} | rabbitmq_stream_s3_binary_array:array(),
-    file:filename_all()
+    directory()
 ) ->
     {ok, ChunkId :: osiris:offset(), byte_offset(), Fragment :: osiris:offset()}.
 find_fragment_for_offset(Offset, #manifest{entries = Entries}, Dir) ->


### PR DESCRIPTION
Binaries are much more compressed memory-wise than lists for all text, especially ASCII. Additionally, directory names may be longer than the 64-byte small binary size, so directory names may be stored in the binary section of the VM and shared more efficiently between processes than list directory names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
