### PR TITLE
Fix recovery of fragments from the current segment

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -216,7 +216,6 @@
     seq_no = 0 :: non_neg_integer(),
     %% NOTE: header size is not included.
     size = 0 :: non_neg_integer(),
-    %% TODO: do checksum during upload if undefined.
     checksum = ?SEGMENT_HEADER_HASH :: checksum() | undefined
 }).
 


### PR DESCRIPTION
When rebooting and a writer has stream data locally, we scan through the latest segment to recover metadata about fragments like offsets and positions in the file. We were not computing the size or next-offset for the latest fragment, however, because this info is not immediately available in the index file.

The index file does not track chunk size or the number of offsets in a chunk. This info can be derived from the index file when you have two adjacent entries: the later entry's chunk ID minus the earlier entry's gives the number of records, and similarly the file positions give the chunk's size. The final record in the index can't be used to determine this info as it has no adjacent entry, so we need to read this data from the chunk header instead.

So this commit fills in the `size` and `next_offset` on the current `#fragment{}` in recovery. The size in particular is important since, without it, the recovered fragment size defaults to zero and we end up with a potentially larger chunk than intended. The checksum is not computed for recovered fragments, so the checksum would then mismatch for any fragments uploaded after a recovered fragment until the next segment rolled over. Further checksumming improvements should be made to verify the chunk CRC32s of any fragments where we were not able to compute the outer CRC32 by checksumming the entire chunk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
