### PR TITLE
Add a stub for deleting a stream from the remote tier

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -382,9 +382,11 @@
     %% to be sent to the manifest server.
     to :: osiris:offset()
 }).
+-record(delete_stream, {stream :: stream_id()}).
 
 -type effect() ::
     #delete_fragments{}
+    | #delete_stream{}
     | #find_fragments{}
     | #rebalance_manifest{}
     | #register_offset_listener{}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-mq/rabbitmq-stream-s3/issues/17

*Description of changes:*

Currently this is just a stub. We log that a stream should be deleted but do nothing. The actual deletion can be done in future changes.
    
The way it works is that we set keep-while conditions in the entries for each stream ID so that the entry is deleted when the stream queue is deleted (from `rabbit_db_queue`). That kicks off a cast to the local manifest server which kicks off a task that can perform deletion.

These changes were originally part of #43.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
