### PR TITLE
Gracefully stand down deposed writers

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -257,7 +257,7 @@
 }).
 -record(manifest_uploaded, {
     stream :: stream_id(),
-    revision :: rabbitmq_stream_s3_db:revision()
+    entry :: rabbitmq_stream_s3_db:entry()
 }).
 -record(manifest_rebalanced, {
     stream :: stream_id(),
@@ -303,9 +303,9 @@
 }).
 -record(manifest_upload_rejected, {
     stream :: stream_id(),
-    expected :: rabbitmq_stream_s3_db:revision(),
-    actual :: rabbitmq_stream_s3_db:revision()
+    conflict :: rabbitmq_stream_s3_db:entry()
 }).
+-record(stream_deleted, {stream :: stream_id()}).
 
 -type event() ::
     #acceptor_spawned{}
@@ -319,6 +319,7 @@
     | #manifest_upload_rejected{}
     | #manifest_uploaded{}
     | #retention_updated{}
+    | #stream_deleted{}
     | #tick{}
     | #writer_spawned{}.
 

--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -108,7 +108,8 @@ modifications which would inconvenience the successor writer.
     rabbitmq_stream_s3:uid()
 ) ->
     {ok, Old :: {rabbitmq_stream_s3:uid(), osiris:epoch()} | undefined, New :: revision()}
-    | {error, {conflict, Expected :: revision(), Actual :: revision()}}
+    | {error, {conflict, entry()}}
+    | {error, not_found}
     | {error, any()}.
 put(
     StreamId,
@@ -153,9 +154,20 @@ put(
         {ok, #{Path := #{payload_version := NewRevision}}} ->
             {ok, undefined, NewRevision};
         {error,
-            ?khepri_error(mismatching_node, #{node_props := #{payload_version := ActualRevision}})} ->
-            %% This branch covers a mismatch of any condition.
-            {error, {conflict, ExpectedRevision, ActualRevision}};
+            ?khepri_error(mismatching_node, #{
+                node_props := #{
+                    payload_version := ActualRevision,
+                    data := {ActualUid, ActualEpoch}
+                }
+            })} ->
+            %% This branch covers a failed expectation if the node actually
+            %% exists, so `data` must be defined here.
+            Entry = #{revision => ActualRevision, uid => ActualUid, epoch => ActualEpoch},
+            {error, {conflict, Entry}};
+        {error, ?khepri_error(node_not_found, _Props)} ->
+            %% The metadata store entry might've been deleted since the last
+            %% update.
+            {error, not_found};
         {error, _} = Err ->
             Err
     end.


### PR DESCRIPTION
*Issue #, if available:* continues work on https://github.com/amazon-mq/rabbitmq-stream-s3/discussions/32

*Description of changes:*

This also introduces an effect for deleted streams that can be emitted later when stream deletion is handled. A deposed writer should be fenced off to prevent it from causing a conflict with a new writer. With this change, when a deposed writer recognizes that the most recent data in the metadata store points to a newer writer, it gracefully steps down and deletes its knowledge of the stream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
