### PR TITLE
reader: Add committed_chunk_id/1 callback implementation

### DIFF
--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -50,6 +50,7 @@
 -export([
     init_offset_reader/2,
     next_offset/1,
+    committed_chunk_id/1,
     committed_offset/1,
     close/1,
     send_file/3,
@@ -127,8 +128,13 @@ next_offset(#?MODULE{mode = #remote{next_offset = NextOffset}}) ->
 next_offset(#?MODULE{mode = Local}) ->
     osiris_log:next_offset(Local).
 
-committed_offset(#?MODULE{mode = #remote{shared = Shared}}) ->
+committed_chunk_id(#?MODULE{mode = #remote{shared = Shared}}) ->
     osiris_log_shared:committed_chunk_id(Shared);
+committed_chunk_id(#?MODULE{mode = Local}) ->
+    osiris_log:committed_chunk_id(Local).
+
+committed_offset(#?MODULE{mode = #remote{shared = Shared}}) ->
+    osiris_log_shared:committed_offset(Shared);
 committed_offset(#?MODULE{mode = Local}) ->
     osiris_log:committed_offset(Local).
 


### PR DESCRIPTION
This adds an implementation for `osiris_log_reader:committed_chunk_id/1` which was added upstream recently in https://github.com/rabbitmq/osiris/pull/203. The committed chunk ID is now a different concept than the committed offset. The committed chunk Id is the first offset in the chunk which is committed by a quorum. The committed offset is the last offset in that chunk.

Here we do the same as `osiris_log`: read the values which are being maintained in the `osiris_log_shared` atomic.

I have rebased the branches in Osiris and the server to add this new callback.

Also see https://github.com/rabbitmq/rabbitmq-server/pull/15225

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
