### PR TITLE
AWS API: Use xmerl to form multi-key deletion request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PROJECT_MOD = rabbitmq_stream_s3_app
 
 DEPS = rabbit_common rabbit osiris khepri gun
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+LOCAL_DEPS = xmerl
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
This resolves a TODO to properly sanitize the key names so they don't violate the XML spec. `rabbitmq_aws` is also using `xmerl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
