### PR TITLE
Store first and last timestamp in metadata

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -120,7 +120,7 @@ When a fragment is uploaded, a metadata record for it is appended to the array o
 
 ![M-way tree manifest](./ManifestMWay.svg)
 
-The branching factor will be tuned in testing but a relatively high value like `M=1024` provides a theoretically good balance. With 35 bytes of metadata per fragment, group files would take around 35 KiB to represent - small enough to be comfortably downloaded and searched in-memory. A high branching factor keeps the height of the tree low. With `M=1024` and fragments even as small as 1 MB, a lookup within the tree for one of the oldest fragments would take at-most four round-trips to S3: the root (cached), a kilo-group, a group, and the leaf (fragment). Within tree nodes, fragment metadata is naturally stored in ascending order of offset. This mitigates the high branching factor: binary search can be used on the record arrays to quickly find specific fragments or groups within each tree node.
+The branching factor will be tuned in testing but a relatively high value like `M=1024` provides a theoretically good balance. With 30 bytes of metadata per fragment, group files would take around 30 KiB to represent - small enough to be comfortably downloaded and searched in-memory. A high branching factor keeps the height of the tree low. With `M=1024` and fragments even as small as 1 MB, a lookup within the tree for one of the oldest fragments would take at-most four round-trips to S3: the root (cached), a kilo-group, a group, and the leaf (fragment). Within tree nodes, fragment metadata is naturally stored in ascending order of offset. This mitigates the high branching factor: binary search can be used on the record arrays to quickly find specific fragments or groups within each tree node.
 
 ```
 rabbitmq/

--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -154,7 +154,7 @@ put(
     Epoch,
     ExpectedRevision,
     Uid
-) when is_binary(StreamId) andalso is_integer(ExpectedRevision) andalso is_binary(Uid) ->
+) when is_binary(StreamId) andalso is_integer(ExpectedRevision) andalso is_integer(Uid) ->
     Path = ?PATH(StreamId),
     Conditions =
         case ExpectedRevision of


### PR DESCRIPTION
Continuation of #55. This mainly fixes max-age retention.

We continue to use the first timestamp in a fragment to resolve timestamp offsets and set the first-timestamp counter. The last timestamp is used for retention - as Osiris uses it. To make retention calculations very cheap we store this data in the metadata arrays rather than rely on its presence in fragment trailers (which would cost a remote tier lookup).

This change also splits the representations of fragment and group entries so that they are more compact. Fragments do not need to hold UIDs and groups do not need to hold sizes, so the binary representations diverge now. This reduces the size of each entry from 35 bytes down to 30 bytes despite tracking another 8 bytes for the last timestamp.

Cutting down on the size of each `#manifest.entries` entry is high value since that is the only memory cost that scales with stream length. (Note that that memory cost scales logarithmically with stream length because of the rebalancing reintroduced in the parent commits.)

This change also reduces the number of bits of entropy we use for the optimistic lock from 8 bytes down to 46 bits (i.e. 6 bytes minus two bits). According to my math this is still enough entropy for our needs. See the approximate calculations in the docs of the `rabbitmq_stream_s3:uid()` type. And we reduce the number of bits we use to store fragment size. This was previously 70 bits which is enough to store an impossibly long stream total size (2^70 is 1024^7 - one ZiB). With 45 bits we can describe a fragment 32 TiB in size. Fragments should be several orders of magnitude smaller so this leaves plenty of breathing room.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
