### PR TITLE
Implement `osiris_log_reader:resolve_offset_spec/2`

### DIFF
--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -62,6 +62,8 @@ efficiently using the `rabbitmq_stream_s3_array` module.
     max_age := milliseconds()
 }.
 
+-type range() :: empty | {From :: osiris:offset(), To :: osiris:offset()}.
+
 -export_type([
     uid/0,
     key/0,
@@ -69,7 +71,8 @@ efficiently using the `rabbitmq_stream_s3_array` module.
     entries/0,
     kind/0,
     milliseconds/0,
-    retention_spec/0
+    retention_spec/0,
+    range/0
 ]).
 
 -export([

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -43,6 +43,7 @@
 %% API
 -export([
     get_manifest/1,
+    get_range/1,
     init_acceptor/2,
     init_writer/3,
     fragment_available/2,
@@ -90,6 +91,19 @@ start() ->
 -spec get_manifest(stream_id()) -> #manifest{} | undefined.
 get_manifest(StreamId) ->
     gen_server:call(?SERVER, #get_manifest{stream = StreamId}, infinity).
+
+-doc "Gets the range of offsets in the remote tier".
+-spec get_range(stream_id()) -> rabbitmq_stream_s3:range().
+get_range(StreamId) ->
+    try ets:lookup(?RANGE_TABLE, StreamId) of
+        [{StreamId, FirstOffset, NextOffset}] ->
+            {FirstOffset, NextOffset - 1};
+        [] ->
+            empty
+    catch
+        error:badarg ->
+            empty
+    end.
 
 -spec init_writer(stream_id(), osiris_log:config(), [#fragment{}]) -> ok.
 init_writer(StreamId, Config, AvailableFragments) ->


### PR DESCRIPTION
This is a new callback from a new `osiris_log` function in Osiris v1.12 which will be used for a new streams protocol command. See https://redirect.github.com/rabbitmq/osiris/pull/207 and https://redirect.github.com/rabbitmq/rabbitmq-server/pull/15381.

Like the `osiris_log` implementation, we move the core logic of finding the location for an offset spec into a helper function which is shared between this callback and `init_offset_reader/2`. This function then only uses the chunk ID from that helper.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
