### PR TITLE
Implement retention for manifests containing groups

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -308,11 +308,21 @@
     first_offset :: osiris:offset(),
     first_timestamp :: osiris:timestamp(),
     first_last_timestamp :: osiris:timestamp(),
-    next_offset :: osiris:offset(),
-    total_size :: non_neg_integer(),
+    next_offset :: osiris:offset() | undefined,
+    %% The difference in total segment size. Adds or removes from
+    %% #manifest.total_size depending on the operation.
+    size = 0 :: integer(),
     entries = <<>> :: rabbitmq_stream_s3:entries(),
     pos = 0 :: non_neg_integer(),
     len = 0 :: non_neg_integer()
+}).
+
+%% A pointer to a group object. Together with the stream ID this has all of
+%% the necessary info to create the group's object key.
+-record(group_ref, {
+    offset :: osiris:offset(),
+    kind :: rabbitmq_stream_s3:kind(),
+    uid :: rabbitmq_stream_s3:uid()
 }).
 
 %% Events.
@@ -371,7 +381,7 @@
 %% This is somewhat similar to the append-entries RPC in raft.
 -record(manifest_edited, {
     stream :: stream_id(),
-    edits :: [#edit{}, ...],
+    edits :: nonempty_list(#edit{}),
     seq :: non_neg_integer(),
     %% Suggest that the replica triggers local retention. This is set to true
     %% when the writer finishes uploading a fragment which was taken because
@@ -388,6 +398,10 @@
     conflict :: rabbitmq_stream_s3_db:entry()
 }).
 -record(stream_deleted, {stream :: stream_id()}).
+-record(retention_executed, {
+    stream :: stream_id(),
+    edit :: #edit{}
+}).
 
 -type event() ::
     #acceptor_spawned{}
@@ -400,6 +414,7 @@
     | #manifest_resolved{}
     | #manifest_upload_rejected{}
     | #manifest_uploaded{}
+    | #retention_executed{}
     | #retention_updated{}
     | #stream_deleted{}
     | #tick{}
@@ -448,11 +463,9 @@
     %% See `erlang:send/3`.
     options = [] :: [nosuspend | noconnect | priority]
 }).
-%% TODO: include the fragment kind to make this generic for group objects
-%% as well?
--record(delete_fragments, {
+-record(delete_objects, {
     stream :: stream_id(),
-    offsets :: [osiris:offset()]
+    objects :: nonempty_list(osiris:offset() | #group_ref{})
 }).
 %% Read through the local stream data and find available fragments.
 %% This is done for the active segment when a writer spawns. This effect is
@@ -486,7 +499,7 @@
 }).
 
 -type effect() ::
-    #delete_fragments{}
+    #delete_objects{}
     | #delete_stream{}
     | #evaluate_retention{}
     | #find_fragments{}

--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -80,7 +80,7 @@ efficiently using the `rabbitmq_stream_s3_array` module.
     format_uid/1,
     offset_filename/2,
     manifest_key/2,
-    group_key/4,
+    group_key/2,
     group_name/1,
     next_group/1,
     fragment_key/2,
@@ -125,8 +125,8 @@ manifest_key(StreamId, Prefix, Uid, Suffix) when
         (format_uid(Uid))/binary, $., Suffix/binary>>.
 
 -doc "Creates the key for the given group".
--spec group_key(stream_id(), uid(), kind(), osiris:offset()) -> key().
-group_key(StreamId, Uid, Kind, Offset) ->
+-spec group_key(stream_id(), #group_ref{}) -> key().
+group_key(StreamId, #group_ref{uid = Uid, kind = Kind, offset = Offset}) ->
     manifest_key(StreamId, pad_zeroes(Offset), Uid, group_name(Kind)).
 
 %% TODO: this should be private.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -178,6 +178,9 @@ put(Conn, Key, Data, Opts) when is_pid(Conn) andalso is_binary(Key) andalso is_m
 delete(Conn, Keys, Opts) when is_pid(Conn) andalso is_list(Keys) andalso is_map(Opts) ->
     %% <https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html>
     ?assert(length(Keys) =< 1000),
+    %% Though not documented, S3 will reject the request if the list of keys
+    %% is empty.
+    ?assertNotEqual([], Keys),
     Data = delete_many_body(Keys),
     Headers = #{
         %% A checksum header seems to be required on this endpoint...

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -650,7 +650,7 @@ convert_remote_to_local(#?MODULE{
 ) ->
     {ok, ChunkId :: osiris:offset(), byte_offset(), Fragment :: osiris:offset()}.
 find_position(Spec, Entries, StreamId) ->
-    Fragment = find_fragment(Entries, Spec, get_group_fun(StreamId)),
+    Fragment = find_fragment(Entries, Spec, rabbitmq_stream_s3_server:get_group_fun(StreamId)),
     find_position0(Spec, Fragment, StreamId).
 
 -doc """
@@ -664,10 +664,7 @@ and then searched recursively.
 -spec find_fragment(
     rabbitmq_stream_s3:entries(),
     {offset, osiris:offset()} | {timestamp, osiris:timestamp()},
-    fun(
-        (rabbitmq_stream_s3:uid(), rabbitmq_stream_s3:kind(), osiris:offset()) ->
-            rabbitmq_stream_s3:entries()
-    )
+    fun((#group_ref{}) -> {ok, rabbitmq_stream_s3:entries()} | {error, any()})
 ) -> Fragment :: osiris:offset().
 find_fragment(Entries, Spec, GetGroup) ->
     PartitionPredicate =
@@ -691,7 +688,8 @@ find_fragment(Entries, Spec, GetGroup) ->
             ?LOG_DEBUG("Entry is not a fragment. Searching within group ~b kind ~b", [
                 GroupOffset, Kind
             ]),
-            GroupEntries = GetGroup(Uid, Kind, GroupOffset),
+            GroupRef = #group_ref{uid = Uid, kind = Kind, offset = GroupOffset},
+            {ok, GroupEntries} = GetGroup(GroupRef),
             find_fragment(GroupEntries, Spec, GetGroup)
     end.
 
@@ -758,31 +756,6 @@ index_data(StreamId, FragmentOffset, StartPos) ->
         ok = rabbitmq_stream_s3_api:close(Conn)
     end.
 
-get_group_fun(StreamId) ->
-    fun(Uid, Kind, Offset) ->
-        get_group(StreamId, Uid, Kind, Offset)
-    end.
-
-get_group(StreamId, Uid, Kind, GroupOffset) ->
-    {ok, Conn} = rabbitmq_stream_s3_api:open(),
-    Key = rabbitmq_stream_s3:group_key(StreamId, Uid, Kind, GroupOffset),
-    ?LOG_DEBUG("Looking up key ~ts (~ts)", [Key, ?FUNCTION_NAME]),
-    try
-        {ok, Data} = rabbitmq_stream_s3_api:get(Conn, Key, #{timeout => ?READ_TIMEOUT}),
-        <<
-            _Magic:4/binary,
-            _Vsn:32/unsigned,
-            GroupOffset:64/unsigned,
-            _FirstTimestamp:64/unsigned,
-            0:2/unsigned,
-            _TotalSize:70/unsigned,
-            GroupEntries/binary
-        >> = Data,
-        GroupEntries
-    after
-        ok = rabbitmq_stream_s3_api:close(Conn)
-    end.
-
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -838,11 +811,11 @@ find_fragment_test() ->
         GroupUid,
         NextFragmentEntries
     ),
-    GetGroup = fun(Uid, Kind, Offset) ->
+    GetGroup = fun(#group_ref{uid = Uid, kind = Kind, offset = Offset}) ->
         ?assertEqual(GroupUid, Uid),
         ?assertEqual(?MANIFEST_KIND_GROUP, Kind),
         ?assertEqual(0, Offset),
-        FragmentEntries
+        {ok, FragmentEntries}
     end,
     FindFragment2 = fun(Spec) ->
         find_fragment(Entries, Spec, GetGroup)

--- a/src/rabbitmq_stream_s3_machine.erl
+++ b/src/rabbitmq_stream_s3_machine.erl
@@ -99,6 +99,8 @@ for the log manifest server to execute.
 
 -export([new/0, new/1, get_manifest/2, apply/3, format/1]).
 
+-export([execute_retention/4]).
+
 %% Used by tests:
 -export([apply_infos/2, new_edit/1]).
 
@@ -420,14 +422,7 @@ apply(
     #?MODULE{streams = Streams0} = State0
 ) ->
     case Streams0 of
-        #{
-            StreamId := #{
-                kind := writer,
-                epoch := Epoch,
-                reference := Reference,
-                manifest := #manifest{revision = Revision0} = Manifest0
-            } = Writer0
-        } ->
+        #{StreamId := #{kind := writer, manifest := #manifest{} = Manifest0} = Writer0} ->
             %% NOTE: the entries array may have been modified in the meantime,
             %% but only from new fragments being uploaded and applied.
             %% (Retention and rebalancing are done exclusively of each other.)
@@ -435,17 +430,10 @@ apply(
             %% `Pos` and `Len` point to the same section of entries regardless
             %% of changes to the manifest since the group upload started.
             Edit = (new_edit(Manifest0))#edit{entries = Entry, pos = Pos, len = Len},
-            Manifest1 = apply_edit(Edit, Manifest0),
-            UploadManifest = #upload_manifest{
-                stream = StreamId,
-                epoch = Epoch,
-                reference = Reference,
-                manifest = Manifest1
-            },
-            Manifest = Manifest1#manifest{revision = Revision0 + 1},
+            Manifest = apply_edit(Edit, Manifest0),
             Writer1 = Writer0#{manifest := Manifest},
-            Effects0 = [UploadManifest],
-            {Writer, Effects} = notify_edits([Edit], false, StreamId, Writer1, Effects0),
+            {Writer2, Effects0} = upload(StreamId, Writer1, []),
+            {Writer, Effects} = notify_edits([Edit], false, StreamId, Writer2, Effects0),
             State = State0#?MODULE{streams = Streams0#{StreamId := Writer}},
             {State, Effects};
         _ ->
@@ -630,9 +618,9 @@ apply(
 ) ->
     Retention = #{K => V || {K, V} <- Retention0, K =:= max_age orelse K =:= max_bytes},
     case Streams0 of
-        #{StreamId := #{kind := writer, manifest := Manifest0} = Writer0} ->
+        #{StreamId := #{kind := writer, manifest := Manifest} = Writer0} ->
             Writer1 = Writer0#{retention := Retention},
-            case Manifest0 of
+            case Manifest of
                 #manifest{} ->
                     {Writer2, Edits, Effects0} = evaluate_retention(
                         Meta,
@@ -649,6 +637,22 @@ apply(
                     State = State0#?MODULE{streams = Streams0#{StreamId := Writer1}},
                     {State, []}
             end;
+        _ ->
+            {State0, []}
+    end;
+apply(
+    _Meta,
+    #retention_executed{stream = StreamId, edit = Edit},
+    #?MODULE{streams = Streams0} = State0
+) ->
+    case Streams0 of
+        #{StreamId := #{kind := writer, manifest := #manifest{} = Manifest0} = Writer0} ->
+            Manifest = apply_edit(Edit, Manifest0),
+            Writer1 = Writer0#{manifest := Manifest},
+            {Writer2, Effects0} = upload(StreamId, Writer1, []),
+            {Writer, Effects} = notify_edits([Edit], false, StreamId, Writer2, Effects0),
+            State = State0#?MODULE{streams = Streams0#{StreamId := Writer}},
+            {State, Effects};
         _ ->
             {State0, []}
     end;
@@ -711,15 +715,13 @@ new_edit(#manifest{
     first_offset = FirstOffset,
     first_timestamp = FirstTs,
     first_last_timestamp = FirstLastTs,
-    next_offset = NextOffset,
-    total_size = TotalSize
+    next_offset = NextOffset
 }) ->
     #edit{
         first_offset = FirstOffset,
         first_timestamp = FirstTs,
         first_last_timestamp = FirstLastTs,
-        next_offset = NextOffset,
-        total_size = TotalSize
+        next_offset = NextOffset
     }.
 
 -doc """
@@ -750,7 +752,7 @@ apply_infos0(
     ],
     #edit{
         next_offset = Offset,
-        total_size = TotalSize0,
+        size = Size0,
         entries = Entries0
     } = Edit0
 ) ->
@@ -773,7 +775,7 @@ apply_infos0(
         end,
     Edit = Edit1#edit{
         next_offset = NextOffset,
-        total_size = TotalSize0 + Size,
+        size = Size0 + Size,
         entries = <<Entries0/binary, ?FRAGMENT(Offset, FirstTs, LastTs, IsSeqZero, Size)/binary>>
     },
     apply_infos0(Rest, Edit);
@@ -790,13 +792,17 @@ apply_edit(
         first_offset = FirstOffset,
         first_timestamp = FirstTs,
         first_last_timestamp = FirstLastTs,
-        next_offset = NextOffset,
-        total_size = TotalSize,
+        next_offset = EditNextOffset,
+        size = Size,
         entries = EditEntries,
         pos = Pos,
         len = Len
     },
-    #manifest{entries = Entries0} = Manifest0
+    #manifest{
+        next_offset = ManifestNextOffset,
+        total_size = TotalSize0,
+        entries = Entries0
+    } = Manifest0
 ) ->
     Entries =
         if
@@ -819,12 +825,19 @@ apply_edit(
                     (binary:part(Entries0, Pos + Len, byte_size(Entries0) - Pos - Len))/binary
                 >>
         end,
+    NextOffset =
+        case EditNextOffset of
+            undefined ->
+                ManifestNextOffset;
+            _ when is_integer(EditNextOffset) ->
+                EditNextOffset
+        end,
     Manifest0#manifest{
         first_offset = FirstOffset,
         first_timestamp = FirstTs,
         first_last_timestamp = FirstLastTs,
         next_offset = NextOffset,
-        total_size = TotalSize,
+        total_size = TotalSize0 + Size,
         entries = Entries
     }.
 
@@ -841,7 +854,12 @@ notify_edits(
         shared := Shared,
         counter := Counter,
         replica_nodes := ReplicaNodes,
-        seq := Seq0
+        seq := Seq0,
+        manifest := #manifest{
+            first_offset = FirstOffset,
+            first_timestamp = FirstTs,
+            next_offset = NextOffset
+        }
     } = Writer0,
     Effects0
 ) ->
@@ -881,9 +899,6 @@ notify_edits(
             false ->
                 Effects1
         end,
-    %% The latest edit has the most up-to-date information on it.
-    [#edit{first_offset = FirstOffset, first_timestamp = FirstTs, next_offset = NextOffset} | _] =
-        Edits0,
     SetRange = #set_range{
         stream = StreamId,
         counter = Counter,
@@ -973,13 +988,10 @@ evaluate_retention(
     StreamId,
     #{
         pending_change := none,
-        epoch := Epoch,
-        reference := Reference,
         retention := RetentionSpec,
         manifest := #manifest{
             total_size = TotalSize0,
-            first_timestamp = FirstTs,
-            revision = Revision0,
+            first_last_timestamp = FirstLastTs,
             entries = Entries0
         } = Manifest0
     } = Writer0,
@@ -988,13 +1000,13 @@ evaluate_retention(
 ) ->
     ExceedsRetention =
         case RetentionSpec of
-            #{max_bytes := MaxBytes} when TotalSize0 > MaxBytes ->
-                true;
-            #{max_age := MaxAge} when FirstTs < Now - MaxAge ->
-                true;
-            _ when Entries0 =:= <<>> ->
+            _ when byte_size(Entries0) =< ?ENTRY_B ->
                 %% Nothing to reclaim!
                 false;
+            #{max_bytes := MaxBytes} when TotalSize0 > MaxBytes ->
+                true;
+            #{max_age := MaxAge} when Now - FirstLastTs > MaxAge ->
+                true;
             _ ->
                 false
         end,
@@ -1002,30 +1014,27 @@ evaluate_retention(
         true ->
             case Entries0 of
                 ?FRAGMENT(_O, _FTs, _LTs, _Sq, _Sz, _) ->
-                    %% In the common case a stream will not be so long that it
-                    %% needs groups. Luckily, this means we can determine
-                    %% which fragments can be deleted very efficiently by
-                    %% looking just at manifest's entries array.
-                    Edit0 = new_edit(Manifest0),
-                    {Edit, Offsets} = evaluate_retention1(
-                        Entries0,
-                        Edit0,
-                        Now,
-                        RetentionSpec
-                    ),
-                    Manifest1 = apply_edit(Edit, Manifest0),
-                    UploadManifest = #upload_manifest{
-                        stream = StreamId,
-                        epoch = Epoch,
-                        reference = Reference,
-                        manifest = Manifest1
-                    },
-                    Manifest = Manifest1#manifest{revision = Revision0 + 1},
-                    Writer = Writer0#{manifest := Manifest, pending_change := retention},
-                    DeleteFragments = #delete_fragments{stream = StreamId, offsets = Offsets},
-                    Edits = [Edit | Edits0],
-                    Effects = [UploadManifest, DeleteFragments | Effects0],
-                    {Writer, Edits, Effects};
+                    %% Groups are created at the array's beginning. If the
+                    %% first entry is a fragment then this entries array
+                    %% contains no groups.
+                    GetGroupFun = fun unreachable/1,
+                    case execute_retention(Manifest0, Now, RetentionSpec, GetGroupFun) of
+                        {_NoEdit, []} ->
+                            %% This shouldn't happen. If retention rules are
+                            %% out-of-order then we should be able to reclaim
+                            %% at least one fragment.
+                            ?LOG_WARNING(
+                                "Retention did not reclaim any fragments even though retention is required. Stream '~ts'",
+                                [StreamId]
+                            ),
+                            {Writer0, Edits0, Effects0};
+                        {Edit, Offsets} ->
+                            Manifest = apply_edit(Edit, Manifest0),
+                            Writer1 = Writer0#{manifest := Manifest},
+                            {Writer, Effects1} = upload(StreamId, Writer1, Effects0),
+                            DeleteFragments = #delete_objects{stream = StreamId, objects = Offsets},
+                            {Writer, [Edit | Edits0], [DeleteFragments | Effects1]}
+                    end;
                 _ ->
                     EvaluateRetention = #evaluate_retention{
                         stream = StreamId,
@@ -1043,49 +1052,173 @@ evaluate_retention(
 evaluate_retention(_Meta, _StreamId, Writer, Edits, Effects) ->
     {Writer, Edits, Effects}.
 
-evaluate_retention1(Entries, Edit, Now, RetentionSpec) ->
-    evaluate_retention1(Entries, Edit, Now, RetentionSpec, []).
+-spec unreachable(any()) -> no_return().
+unreachable(_) -> erlang:error(unreachable).
+
+-spec execute_retention(
+    #manifest{},
+    osiris:timestamp(),
+    rabbitmq_stream_s3:retention_spec(),
+    fun((#group_ref{}) -> rabbitmq_stream_s3:entries())
+) -> {#edit{}, [osiris:offset() | #group_ref{}]}.
+execute_retention(
+    #manifest{entries = Entries, total_size = TotalSize0} = Manifest,
+    Now,
+    RetentionSpec,
+    GetGroupFun
+) ->
+    Edit0 = new_edit(Manifest),
+    %% Retention does not affect the tail of the entries array. Clear
+    %% the next_offset to avoid clobbering edits made to the manifest
+    %% tail during asynchronous retention evaluation.
+    Edit1 = Edit0#edit{next_offset = undefined},
+    {false, Edit, _TotalSize, Deletions} = execute_retention(
+        Entries,
+        Edit1,
+        TotalSize0,
+        Now,
+        RetentionSpec,
+        GetGroupFun,
+        true,
+        []
+    ),
+    {Edit, lists:reverse(Deletions)}.
 
 %% NOTE: keep at least one entry so that we can set the `first_offset` and
-%% `first_timestamp`.
-evaluate_retention1(
+%% `first_timestamp` (`Rest /= <<>>`).
+execute_retention(
+    ?ENTRY(_, _, _, _, Rest) = Entries,
+    #edit{first_offset = FirstOffset} = Edit,
+    TotalSize,
+    Now,
+    Spec,
+    GetGroupFun,
+    IsRoot,
+    Deletions
+) ->
+    case Rest of
+        ?ENTRY(RightOffset, _, _, _, _) when RightOffset < FirstOffset ->
+            execute_retention(Rest, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions);
+        _ ->
+            execute_retention1(Entries, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions)
+    end;
+execute_retention(Entries, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions) ->
+    execute_retention1(Entries, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions).
+
+execute_retention1(
+    ?FRAGMENT(Offset, _FTs, _LTs, _Sq, _Sz, Rest),
+    #edit{first_offset = FirstOffset} = Edit,
+    TotalSize,
+    Now,
+    Spec,
+    GetGroupFun,
+    IsRoot,
+    Deletions
+) when Offset < FirstOffset ->
+    execute_retention1(Rest, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions);
+execute_retention1(
     ?FRAGMENT(Offset, _FTs, _LTs, _Sq, Size, Rest),
-    #edit{total_size = TotalSize0, len = Len0} = Edit0,
+    #edit{size = Size0, len = Len0} = Edit0,
+    TotalSize0,
     Now,
     #{max_bytes := MaxBytes} = Spec,
-    Offsets0
-) when TotalSize0 > MaxBytes andalso Rest /= <<>> ->
-    Edit = Edit0#edit{
-        total_size = TotalSize0 - Size,
-        len = Len0 + ?ENTRY_B
-    },
-    evaluate_retention1(Rest, Edit, Now, Spec, [Offset | Offsets0]);
-evaluate_retention1(
+    GetGroupFun,
+    IsRoot,
+    Deletions
+) when TotalSize0 > MaxBytes andalso (Rest /= <<>> orelse not IsRoot) ->
+    TotalSize = TotalSize0 - Size,
+    Edit1 = Edit0#edit{size = Size0 - Size},
+    Edit =
+        case IsRoot of
+            true ->
+                Edit1#edit{len = Len0 + ?ENTRY_B};
+            false ->
+                Edit1
+        end,
+    execute_retention1(Rest, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, [Offset | Deletions]);
+execute_retention1(
     ?FRAGMENT(Offset, _FTs, LastTs, _Sq, Size, Rest),
-    #edit{total_size = TotalSize0, len = Len0} = Edit0,
+    #edit{size = Size0, len = Len0} = Edit0,
+    TotalSize0,
     Now,
     #{max_age := MaxAge} = Spec,
-    Offsets0
-) when Now - LastTs > MaxAge andalso Rest /= <<>> ->
-    Edit = Edit0#edit{
-        total_size = TotalSize0 - Size,
-        len = Len0 + ?ENTRY_B
-    },
-    evaluate_retention1(Rest, Edit, Now, Spec, [Offset | Offsets0]);
-evaluate_retention1(
+    GetGroupFun,
+    IsRoot,
+    Deletions
+) when Now - LastTs > MaxAge andalso (Rest /= <<>> orelse not IsRoot) ->
+    TotalSize = TotalSize0 - Size,
+    Edit1 = Edit0#edit{size = Size0 - Size},
+    Edit =
+        case IsRoot of
+            true ->
+                Edit1#edit{len = Len0 + ?ENTRY_B};
+            false ->
+                Edit1
+        end,
+    execute_retention1(Rest, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, [Offset | Deletions]);
+execute_retention1(
     ?FRAGMENT(Offset, FTs, LTs, _Sq, _Sz, _Rest),
     Edit0,
+    TotalSize,
     _Now,
     _Spec,
-    Offsets
+    _GetGroupFun,
+    _IsRoot,
+    Deletions
 ) ->
     Edit = Edit0#edit{
         first_offset = Offset,
         first_timestamp = FTs,
         first_last_timestamp = LTs
     },
-    %% No real point to this lists:reverse/1. It just makes it appear nicer.
-    {Edit, lists:reverse(Offsets)}.
+    {false, Edit, TotalSize, Deletions};
+execute_retention1(
+    ?GROUP(Offset, _FTs, _LTs, Kind, Uid, Rest),
+    #edit{len = Len0} = Edit0,
+    TotalSize0,
+    Now,
+    Spec,
+    GetGroupFun,
+    IsRoot,
+    Deletions0
+) ->
+    %% Rebalancing always keeps one fragment at the end of the root.
+    ?assert(Rest =/= <<>> orelse not IsRoot),
+    GroupRef = #group_ref{uid = Uid, kind = Kind, offset = Offset},
+    case GetGroupFun(GroupRef) of
+        {ok, ChildEntries} ->
+            {Continue, Edit1, TotalSize, Deletions1} = execute_retention(
+                ChildEntries,
+                Edit0,
+                TotalSize0,
+                Now,
+                Spec,
+                GetGroupFun,
+                false,
+                Deletions0
+            ),
+            case Continue of
+                true ->
+                    Edit =
+                        case IsRoot of
+                            true ->
+                                Edit1#edit{len = Len0 + ?ENTRY_B};
+                            false ->
+                                Edit1
+                        end,
+                    Deletions = [GroupRef | Deletions1],
+                    execute_retention1(
+                        Rest, Edit, TotalSize, Now, Spec, GetGroupFun, IsRoot, Deletions
+                    );
+                false ->
+                    {false, Edit1, TotalSize, Deletions1}
+            end;
+        {error, not_found} ->
+            execute_retention1(Rest, Edit0, TotalSize0, Now, Spec, GetGroupFun, IsRoot, Deletions0)
+    end;
+execute_retention1(<<>>, Edit, TotalSize, _Now, _Spec, _GetGroupFun, IsRoot, Deletions) ->
+    ?assertNot(IsRoot),
+    {true, Edit, TotalSize, Deletions}.
 
 -doc """
 Evaluate whether the array `#manifest.entries` is too large and a group should
@@ -1183,14 +1316,11 @@ evaluate_upload(
     StreamId,
     #{
         kind := writer,
-        manifest := #manifest{revision = Revision0} = Manifest0,
-        epoch := Epoch,
-        reference := Reference,
         modifications := Mods,
         last_uploaded := LastUploadTs,
         pending_change := none
-    } = Writer0,
-    Effects0
+    } = Writer,
+    Effects
 ) ->
     ExceedsDebounce =
         case Cfg of
@@ -1203,22 +1333,35 @@ evaluate_upload(
         end,
     case ExceedsDebounce of
         true ->
-            UploadManifest = #upload_manifest{
-                stream = StreamId,
-                epoch = Epoch,
-                reference = Reference,
-                manifest = Manifest0
-            },
-            Writer = Writer0#{
-                pending_change := upload,
-                manifest := Manifest0#manifest{revision = Revision0 + 1}
-            },
-            {Writer, [UploadManifest | Effects0]};
+            upload(StreamId, Writer, Effects);
         false ->
-            {Writer0, Effects0}
+            {Writer, Effects}
     end;
 evaluate_upload(_Cfg, _Meta, _StreamId, Writer, Effects) ->
     {Writer, Effects}.
+
+-spec upload(stream_id(), writer(), [effect()]) -> {writer(), [effect()]}.
+upload(
+    StreamId,
+    #{
+        kind := writer,
+        manifest := #manifest{revision = Revision0} = Manifest0,
+        epoch := Epoch,
+        reference := Reference
+    } = Writer0,
+    Effects0
+) ->
+    UploadManifest = #upload_manifest{
+        stream = StreamId,
+        epoch = Epoch,
+        reference = Reference,
+        manifest = Manifest0
+    },
+    Writer = Writer0#{
+        pending_change := upload,
+        manifest := Manifest0#manifest{revision = Revision0 + 1}
+    },
+    {Writer, [UploadManifest | Effects0]}.
 
 -spec maybe_find_fragments(stream_id(), writer(), [effect()]) -> [effect()].
 maybe_find_fragments(_StreamId, #{available_fragments := []}, Effects) ->
@@ -1446,7 +1589,10 @@ apply_infos_test() ->
     ),
     ok.
 
-evaluate_retention1_test() ->
+root_retention_test() ->
+    %% When a manifest root only points to fragments, we can figure out which
+    %% fragments to delete in-place without kicking off a task involving
+    %% downloading group objects.
     Ts = erlang:system_time(millisecond),
     Entries = <<
         ?FRAGMENT((N * 20), (Ts - 100 + (N - 1) * 20), (Ts - 100 + N * 20), 0, 200)
@@ -1460,49 +1606,209 @@ evaluate_retention1_test() ->
         total_size = 1000,
         entries = Entries
     },
-    Edit = new_edit(Manifest),
+    ExecuteRetention = fun(Spec) ->
+        execute_retention(Manifest, Ts, Spec, fun unreachable/1)
+    end,
     %% No retention spec, nothing to do.
     ?assertMatch(
-        {Edit, []},
-        evaluate_retention1(Entries, Edit, Ts, #{})
+        {#edit{size = 0}, []},
+        ExecuteRetention(#{})
     ),
 
     %% == MAX BYTES ==
     ?assertMatch(
-        {Edit, []},
-        evaluate_retention1(Entries, Edit, Ts, #{max_bytes => 1000})
+        {#edit{first_offset = 0, size = 0}, []},
+        ExecuteRetention(#{max_bytes => 1000})
     ),
     ?assertMatch(
-        {#edit{first_offset = 20, total_size = 800}, [0]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_bytes => 900})
+        {#edit{first_offset = 20, size = -200}, [0]},
+        ExecuteRetention(#{max_bytes => 900})
     ),
     ?assertMatch(
-        {#edit{first_offset = 60, total_size = 400}, [0, 20, 40]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_bytes => 500})
+        {#edit{first_offset = 60, size = -600}, [0, 20, 40]},
+        ExecuteRetention(#{max_bytes => 500})
     ),
     %% Make sure we keep at least one entry.
     ?assertMatch(
-        {#edit{first_offset = 80, total_size = 200}, [0, 20, 40, 60]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_bytes => 100})
+        {#edit{first_offset = 80, size = -800}, [0, 20, 40, 60]},
+        ExecuteRetention(#{max_bytes => 100})
     ),
 
     %% == MAX AGE ==
     ?assertMatch(
-        {Edit, []},
-        evaluate_retention1(Entries, Edit, Ts, #{max_age => 100_000})
+        {#edit{first_offset = 0, size = 0}, []},
+        ExecuteRetention(#{max_age => 100_000})
     ),
     ?assertMatch(
-        {#edit{first_offset = 20, total_size = 800}, [0]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_age => 99})
+        {#edit{first_offset = 20, size = -200}, [0]},
+        ExecuteRetention(#{max_age => 99})
     ),
     ?assertMatch(
-        {#edit{first_offset = 60, total_size = 400}, [0, 20, 40]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_age => 59})
+        {#edit{first_offset = 60, size = -600}, [0, 20, 40]},
+        ExecuteRetention(#{max_age => 59})
     ),
     ?assertMatch(
-        {#edit{first_offset = 80, total_size = 200}, [0, 20, 40, 60]},
-        evaluate_retention1(Entries, Edit, Ts, #{max_age => 1})
+        {#edit{first_offset = 80, size = -800}, [0, 20, 40, 60]},
+        ExecuteRetention(#{max_age => 1})
     ),
+
+    ok.
+
+recursive_retention_test() ->
+    %% When a manifest contains groups we need to evaluate retention in a task,
+    %% since we need to download groups. We might need to download groups
+    %% recursively if the manifest has a kilo or mega group.
+    %%
+    %%     root
+    %%     ├── KG0
+    %%     │   ├── G0
+    %%     │   │   ├── F0 (0)
+    %%     │   │   └── F1 (20)
+    %%     │   └── G1
+    %%     │       ├── F2 (40)
+    %%     │       └── F3 (60)
+    %%     ├── G2
+    %%     │   ├── F4 (80)
+    %%     │   └── F5 (100)
+    %%     └── F6 (120)
+    Ts = erlang:system_time(millisecond),
+    %% Rebalancing factor is 2 for simplicity.
+    FragmentSize = 200,
+    [F0, F1, F2, F3, F4, F5, F6] = [
+        ?FRAGMENT(
+            (N * 20),
+            (Ts - 1000 + (N - 1) * 20),
+            (Ts - 1000 + N * 20 - 1),
+            0,
+            FragmentSize
+        )
+     || N <- lists:seq(0, 6)
+    ],
+    %% Group 0 covers fragments 0 and 1, group 2 covers fragments 2 and 3, etc..
+    [G0, G1, G2] = [
+        ?GROUP(
+            (N * 40),
+            (Ts - 1000 + ((N * 2) - 1) * 20),
+            (Ts - 1000 + (N * 2) * 20 - 1),
+            ?MANIFEST_KIND_GROUP,
+            (rabbitmq_stream_s3:uid())
+        )
+     || N <- lists:seq(0, 2)
+    ],
+    %% Kilo-group 0 covers groups 0 and 1 (i.e. fragments 1-3).
+    KG0 = ?GROUP(
+        0,
+        (Ts - 1000 + -20),
+        (Ts - 1000 + 39),
+        ?MANIFEST_KIND_KILO_GROUP,
+        (rabbitmq_stream_s3:uid())
+    ),
+    Entries = <<KG0/binary, G2/binary, F6/binary>>,
+    Manifest = #manifest{
+        first_offset = 0,
+        first_timestamp = Ts - 1000 - 20,
+        first_last_timestamp = Ts - 1000 - 1,
+        next_offset = 7 * 20,
+        total_size = 7 * 200,
+        entries = Entries
+    },
+    GetGroupFun = fun
+        (#group_ref{kind = ?MANIFEST_KIND_KILO_GROUP, offset = 0}) ->
+            %% KG0
+            {ok, <<G0/binary, G1/binary>>};
+        (#group_ref{kind = ?MANIFEST_KIND_GROUP, offset = 0}) ->
+            %% G0
+            {ok, <<F0/binary, F1/binary>>};
+        (#group_ref{kind = ?MANIFEST_KIND_GROUP, offset = 40}) ->
+            %% G1
+            {ok, <<F2/binary, F3/binary>>};
+        (#group_ref{kind = ?MANIFEST_KIND_GROUP, offset = 80}) ->
+            %% G2
+            {ok, <<F4/binary, F5/binary>>}
+    end,
+    ExecuteRetention = fun(Spec) ->
+        execute_retention(Manifest, Ts, Spec, GetGroupFun)
+    end,
+
+    %% No retention spec, no-op.
+    ?assertMatch(
+        {#edit{first_offset = 0, size = 0}, []},
+        ExecuteRetention(#{})
+    ),
+
+    %% Recursively reclaim everything but the last fragment.
+    ?assertMatch(
+        {#edit{first_offset = 120, size = -1200}, [
+            %% F0
+            0,
+            %% F1
+            20,
+            %% G0
+            #group_ref{offset = 0, kind = ?MANIFEST_KIND_GROUP},
+            %% F2
+            40,
+            %% F3
+            60,
+            %% G1
+            #group_ref{offset = 40, kind = ?MANIFEST_KIND_GROUP},
+            %% KG0
+            #group_ref{offset = 0, kind = ?MANIFEST_KIND_KILO_GROUP},
+            %% F4
+            80,
+            %% F5
+            100,
+            %% G2
+            #group_ref{offset = 80, kind = ?MANIFEST_KIND_GROUP}
+        ]},
+        ExecuteRetention(#{max_bytes => FragmentSize})
+    ),
+
+    %% Reclaim just the kilo group.
+    ?assertMatch(
+        {#edit{first_offset = 80, len = ?ENTRY_B}, [
+            %% F0
+            0,
+            %% F1
+            20,
+            %% G0
+            #group_ref{offset = 0, kind = ?MANIFEST_KIND_GROUP},
+            %% F2
+            40,
+            %% F3
+            60,
+            %% G1
+            #group_ref{offset = 40, kind = ?MANIFEST_KIND_GROUP},
+            %% KG0
+            #group_ref{offset = 0, kind = ?MANIFEST_KIND_KILO_GROUP}
+        ]},
+        ExecuteRetention(#{max_bytes => 3 * FragmentSize})
+    ),
+
+    %% Reclaim G0. Then G1 (and KG0).
+    {#edit{first_offset = 40, len = 0} = Edit1, [
+        %% F0
+        0,
+        %% F1
+        20,
+        %% G0
+        #group_ref{offset = 0, kind = ?MANIFEST_KIND_GROUP}
+    ]} = ExecuteRetention(#{max_bytes => 5 * FragmentSize}),
+    Manifest1 = apply_edit(Edit1, Manifest),
+    ?assertEqual(5 * FragmentSize, Manifest1#manifest.total_size),
+    {#edit{first_offset = 80, size = -400, len = ?ENTRY_B} = Edit3, [
+        %% G0. Returned because looking it up was successful.
+        #group_ref{offset = 0, kind = ?MANIFEST_KIND_GROUP},
+        %% F2
+        40,
+        %% F3
+        60,
+        %% G1
+        #group_ref{offset = 40, kind = ?MANIFEST_KIND_GROUP},
+        %% KG0
+        #group_ref{offset = 0, kind = ?MANIFEST_KIND_KILO_GROUP}
+    ]} = execute_retention(Manifest1, Ts, #{max_bytes => 3 * FragmentSize}, GetGroupFun),
+    Manifest2 = apply_edit(Edit3, Manifest1),
+    ?assertEqual(3 * FragmentSize, Manifest2#manifest.total_size),
 
     ok.
 

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -54,7 +54,9 @@
 %% Useful for other modules
 -export([
     get_fragment_trailer/1,
-    get_fragment_trailer/2
+    get_fragment_trailer/2,
+    get_group_fun/1,
+    get_group/2
 ]).
 
 %% gen_server
@@ -73,7 +75,7 @@
 -export([format_state/1]).
 
 %% Need to be exported for `erlang:apply/3`.
--export([start/0, format_osiris_event/1, execute_task/2]).
+-export([start/0, format_osiris_event/1, execute_task/1, execute_task/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -232,8 +234,8 @@ handle_info(tick_timeout, State0) ->
 handle_info({'DOWN', _MRef, process, Pid, Reason}, #?MODULE{tasks = Tasks0} = State0) ->
     case maps:take(Pid, Tasks0) of
         {Effect, Tasks} ->
-            ?LOG_INFO("Task ~0p (~p) down with reason ~0p. Tasks: ~0P", [
-                Effect, Pid, Reason, Tasks0, 10
+            ?LOG_INFO("Task ~0P (~p) down with reason ~0P. Tasks: ~0P", [
+                Effect, 5, Pid, Reason, 5, Tasks0, 10
             ]),
             %% TODO: retry. We have the effect and can attempt it again.
             {noreply, State0#?MODULE{tasks = Tasks}};
@@ -338,7 +340,7 @@ apply_effect(#find_fragments{} = Effect, State) ->
     spawn_task(Effect, State);
 apply_effect(#evaluate_retention{} = Effect, State) ->
     spawn_task(Effect, State);
-apply_effect(#delete_fragments{} = Effect, State) ->
+apply_effect(#delete_objects{} = Effect, State) ->
     spawn_task(Effect, State);
 apply_effect(#delete_stream{} = Effect, State) ->
     spawn_task(Effect, State).
@@ -469,7 +471,8 @@ execute_task(#upload_group{
     ?ENTRY(_, _, GroupLTs, _, _) = rabbitmq_stream_s3_array:last(?ENTRY_B, GroupEntries),
     Uid = rabbitmq_stream_s3:uid(),
     Ext = rabbitmq_stream_s3:group_name(GroupKind),
-    Key = rabbitmq_stream_s3:group_key(StreamId, Uid, GroupKind, GroupOffset),
+    GroupRef = #group_ref{uid = Uid, kind = GroupKind, offset = GroupOffset},
+    Key = rabbitmq_stream_s3:group_key(StreamId, GroupRef),
     Data = <<
         (group_header(GroupKind))/binary,
         GroupOffset:64/unsigned,
@@ -648,12 +651,18 @@ execute_task(#resolve_manifest{stream = StreamId}) ->
         stream = StreamId,
         manifest = resolve_manifest_tail(StreamId, Manifest0)
     };
-execute_task(#delete_fragments{stream = StreamId, offsets = Offsets}) ->
-    NumFragments = length(Offsets),
-    ?LOG_DEBUG("Deleting ~b fragments for stream '~ts' with offsets ~0p", [
-        NumFragments, StreamId, Offsets
+execute_task(#delete_objects{stream = StreamId, objects = Objects}) ->
+    NumObjects = length(Objects),
+    ?LOG_DEBUG("Deleting ~b objects for stream '~ts' ~0p", [
+        NumObjects, StreamId, Objects
     ]),
-    Keys = [rabbitmq_stream_s3:fragment_key(StreamId, Offset) || Offset <- Offsets],
+    Keys = lists:map(
+        fun
+            (#group_ref{} = Ref) -> rabbitmq_stream_s3:group_key(StreamId, Ref);
+            (Offset) -> rabbitmq_stream_s3:fragment_key(StreamId, Offset)
+        end,
+        Objects
+    ),
     {ok, Conn} = rabbitmq_stream_s3_api:open(),
     try
         {DeleteMsec, ok} = timer:tc(
@@ -663,7 +672,7 @@ execute_task(#delete_fragments{stream = StreamId, offsets = Offsets}) ->
             millisecond
         ),
         ?LOG_DEBUG("Deleted ~b fragments from stream '~ts' in ~b msec", [
-            NumFragments, StreamId, DeleteMsec
+            NumObjects, StreamId, DeleteMsec
         ]),
         ok
     after
@@ -694,10 +703,30 @@ execute_task(#delete_stream{stream = StreamId}) ->
     %% LIST all keys with the prefix of this stream ID and delete 1000 objects
     %% at a time.
     ok;
-execute_task(#evaluate_retention{stream = StreamId}) ->
+execute_task(#evaluate_retention{
+    stream = StreamId,
+    manifest = #manifest{} = Manifest,
+    retention_spec = RetentionSpec,
+    now = Now
+}) ->
     ?LOG_DEBUG("Evaluating retention for stream '~ts'", [StreamId]),
-    %% TODO
-    ok.
+    {Edit, Deletions} = rabbitmq_stream_s3_machine:execute_retention(
+        Manifest,
+        Now,
+        RetentionSpec,
+        get_group_fun(StreamId)
+    ),
+    case Deletions of
+        [] ->
+            ok;
+        _ ->
+            %% Don't await deletion in this task. Object deletion can be done
+            %% in the background.
+            ExecuteDelete = #delete_objects{stream = StreamId, objects = Deletions},
+            _ = spawn(?MODULE, execute_task, [ExecuteDelete]),
+            ok
+    end,
+    #retention_executed{stream = StreamId, edit = Edit}.
 
 resolve_manifest_tail(
     StreamId,
@@ -788,6 +817,35 @@ set_tick_timer() ->
     Timeout = application:get_env(rabbitmq_stream_s3, tick_timeout_milliseconds, 5000),
     _ = erlang:send_after(Timeout, self(), tick_timeout),
     ok.
+
+get_group_fun(StreamId) ->
+    fun(#group_ref{} = Group) ->
+        get_group(StreamId, Group)
+    end.
+
+get_group(StreamId, #group_ref{offset = Offset} = GroupRef) ->
+    {ok, Conn} = rabbitmq_stream_s3_api:open(),
+    Key = rabbitmq_stream_s3:group_key(StreamId, GroupRef),
+    ?LOG_DEBUG("Looking up key ~ts (~ts)", [Key, ?FUNCTION_NAME]),
+    try
+        case rabbitmq_stream_s3_api:get(Conn, Key) of
+            {ok, Data} ->
+                <<
+                    _Magic:4/binary,
+                    _Vsn:32/unsigned,
+                    Offset:64/unsigned,
+                    _FirstTimestamp:64/unsigned,
+                    0:2/unsigned,
+                    _TotalSize:70/unsigned,
+                    GroupEntries/binary
+                >> = Data,
+                {ok, GroupEntries};
+            {error, _} = Err ->
+                Err
+        end
+    after
+        ok = rabbitmq_stream_s3_api:close(Conn)
+    end.
 
 -spec metadata() -> rabbitmq_stream_s3_machine:metadata().
 metadata() ->

--- a/test/rabbitmq_stream_s3_machine_SUITE.erl
+++ b/test/rabbitmq_stream_s3_machine_SUITE.erl
@@ -417,7 +417,8 @@ retention(Config) ->
         first_offset = 40,
         first_timestamp = Ts - 100 + 20,
         first_last_timestamp = Ts - 100 + 40,
-        total_size = 600,
+        next_offset = undefined,
+        size = -400,
         %% Deletion from retention always starts at zero and goes for the
         %% number of entries being deleted. Two fragments in this edit.
         pos = 0,
@@ -434,8 +435,8 @@ retention(Config) ->
         [
             #set_range{first_offset = 40, next_offset = 120},
             #send{to = {_, ReplicaNode}, message = ManifestEdited1},
-            #upload_manifest{manifest = #manifest{first_offset = 40, total_size = 600}},
-            #delete_fragments{offsets = [0, 20]}
+            #delete_objects{objects = [0, 20]},
+            #upload_manifest{manifest = #manifest{first_offset = 40, total_size = 600}}
         ],
         Effects3
     ),
@@ -452,7 +453,7 @@ retention(Config) ->
         first_offset = 60,
         first_timestamp = Ts - 100 + 40,
         first_last_timestamp = Ts - 100 + 60,
-        total_size = 400,
+        size = -200,
         %% Only one fragment this time.
         len = ?ENTRY_B
     },
@@ -466,8 +467,8 @@ retention(Config) ->
         [
             #set_range{first_offset = 60, next_offset = 120},
             #send{to = {_, ReplicaNode}, message = ManifestEdited2},
-            #upload_manifest{manifest = #manifest{first_offset = 60, total_size = 400}},
-            #delete_fragments{offsets = [40]}
+            #delete_objects{objects = [40]},
+            #upload_manifest{manifest = #manifest{first_offset = 60, total_size = 400}}
         ],
         Effects5
     ),
@@ -508,7 +509,8 @@ retention(Config) ->
         first_offset = 80,
         first_timestamp = Ts - 100 + 60,
         first_last_timestamp = Ts - 100 + 80,
-        total_size = 400,
+        next_offset = undefined,
+        size = -200,
         entries = <<>>,
         pos = 0,
         len = ?ENTRY_B
@@ -524,10 +526,10 @@ retention(Config) ->
             #set_range{first_offset = 80, next_offset = 140},
             #trigger_retention{},
             #send{to = {_, ReplicaNode}, message = ManifestEdited3},
+            #delete_objects{objects = [60]},
             #upload_manifest{
                 manifest = #manifest{first_offset = 80, next_offset = 140, total_size = 400}
-            },
-            #delete_fragments{offsets = [60]}
+            }
         ],
         Effects8
     ),
@@ -688,10 +690,10 @@ manifest_upload_conflict(Config) ->
         [
             #set_range{first_offset = 40, next_offset = 80},
             #trigger_retention{},
+            #delete_objects{objects = [0, 20]},
             #upload_manifest{
                 manifest = #manifest{first_offset = 40, next_offset = 80, total_size = 400}
-            },
-            #delete_fragments{offsets = [0, 20]}
+            }
         ],
         NewEffects4
     ),
@@ -708,10 +710,10 @@ manifest_upload_conflict(Config) ->
         [
             %% Note that it does not know about F4.
             #set_range{first_offset = 20, next_offset = 60},
+            #delete_objects{objects = [0]},
             #upload_manifest{
                 manifest = #manifest{first_offset = 20, next_offset = 60, total_size = 400}
-            },
-            #delete_fragments{offsets = [0]}
+            }
         ],
         OldEffects4
     ),
@@ -828,6 +830,36 @@ rebalance_group(Config) ->
     ?assertEqual(Entries, (?MAC:get_manifest(StreamId, Replica4))#manifest.entries),
     %% Two entries in the array now, the group and fragment 6.
     ?assertEqual(2, byte_size(Entries) div ?ENTRY_B),
+
+    ManifestUploaded = #manifest_uploaded{stream = StreamId, entry = #{revision => 1}},
+    {Writer5, WEffects5} = ?MAC:apply(?META(), ManifestUploaded, Writer4),
+    ?assertMatch([], WEffects5),
+
+    %% Now evaluate retention with a spec so low that we reclaim the entire
+    %% group. The group entry should be deleted from the root of the writer
+    %% and replicas.
+    RetentionUpdated = #retention_updated{stream = StreamId, retention = [{max_bytes, 100}]},
+    {Writer6, WEffects6} = ?MAC:apply(?META(), RetentionUpdated, Writer5),
+    ?assertMatch([#evaluate_retention{}], WEffects6),
+    Edit0 = ?MAC:new_edit(?MAC:get_manifest(StreamId, Writer6)),
+    Edit = Edit0#edit{
+        %% Retention would delete everything except F6.
+        first_offset = F6#fragment.first_offset,
+        first_timestamp = F6#fragment.first_timestamp,
+        first_last_timestamp = F6#fragment.last_timestamp,
+        size = 200,
+        len = ?ENTRY_B
+    },
+    RetentionExecuted = #retention_executed{stream = StreamId, edit = Edit},
+    {_Writer7, WEffects7} = ?MAC:apply(?META(), RetentionExecuted, Writer6),
+    [
+        #set_range{first_offset = 60},
+        #send{to = {_, ReplicaNode}, message = #manifest_edited{} = ManifestEdited4},
+        #upload_manifest{}
+    ] = WEffects7,
+    {_Replica5, REffects5} = ?MAC:apply(?META(), ManifestEdited4, Replica4),
+    ?assertMatch([#set_range{}], REffects5),
+
     ok.
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
With the recent changes to reimplement rebalancing (see the "rebalancing" section of the overview document), manifests may contain pointers to groups of fragments rather than direct pointers to fragments. This creates a tree-like hierarchy which scales favorably up to absurd stream data sizes.

To make retention calculations cheap, we already track the last timestamp of the first fragment in the stream and the stream's total size. When we know that retention should be performed and when we see that a manifest is not tracking only fragments (i.e. the small stream / common case), we kick off a task to download necessary groups (potentially recursively) to find fragments which we can delete to satisfy the retention spec.

Instead of editing group objects, we just move the total size and first-last timestamp forward. So group objects remain immutable. This prevents unnecessary requests to the remote tier and more complicated chains of updates. If we updated group objects then each group object changed by retention would need to be updated, and retention would cause O(height) updates. Instead we can track the necessary info at the root level and use the first offset tracked there to eliminate objects which have already been reclaimed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Continues #55