### PR TITLE
Switch from IAM User to IAM Role for integration test

### DIFF
--- a/.github/workflows/s3-integration.yaml
+++ b/.github/workflows/s3-integration.yaml
@@ -1,6 +1,4 @@
 name: S3 Integration
-permissions:
-  contents: read
 
 # This workflow tests `test/rabbitmq_stream_s3_api_aws_SUITE.erl` specifically.
 # See the moduledoc in that file for more information about running manually.
@@ -8,11 +6,13 @@ permissions:
 # In addition to the steps there, these steps set up the secrets for use in
 # environment variables in this repository:
 #
-# 1. Go to `https://github.com/amazon-mq/rabbitmq-stream-s3/settings/secrets/actions` > New repository secret
-# 2. Create a secret `AWS_ACCESS_KEY_ID` with the Access key as the Secret.
-# 3. Create a secret `AWS_SECRET_ACCESS_KEY` with the Secret access key as the Secret.
-# 3. Create a secret `AWS_S3_BUCKET` with the bucket name.
-# 3. Create a secret `AWS_REGION` with the region of where the bucket exists.
+# 1. Follow <https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/>
+#    to set up an OIDC Identity provider for GitHub Actions and attach a role with the same policy documented
+#    in the SUITE.
+# 2. Go to <https://github.com/amazon-mq/rabbitmq-stream-s3/settings/secrets/actions> > New repository secret
+# 3. Create a secret `AWS_ROLE_ARN` with the ARN from IAM > Roles > Role you created.
+# 4. Create a secret `AWS_S3_BUCKET` with the bucket name.
+# 5. Create a secret `AWS_REGION` with the region of where the bucket exists.
 
 on:
   workflow_dispatch:
@@ -20,6 +20,11 @@ on:
     paths:
       - 'src/rabbitmq_stream_s3_api_aws.erl'
       - 'test/rabbitmq_stream_s3_api_aws_SUITE.erl'
+      - '.github/workflows/s3-integration.yaml'
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   s3-integration:
@@ -50,12 +55,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: rabbitmq-server/deps/rabbitmq_stream_s3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: make
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3
       - name: Integration tests
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 ct-rabbitmq_stream_s3_api_aws
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -71,7 +71,7 @@ init() ->
                 credentials,
                 AccessKey,
                 SecretKey,
-                undefined,
+                application:get_env(rabbitmq_stream_s3, aws_security_token, undefined),
                 undefined
             }),
             ok

--- a/test/rabbitmq_stream_s3_api_aws_SUITE.erl
+++ b/test/rabbitmq_stream_s3_api_aws_SUITE.erl
@@ -73,22 +73,30 @@ init_per_suite(Config) ->
     Cfg = {
         os:getenv("AWS_ACCESS_KEY_ID"),
         os:getenv("AWS_SECRET_ACCESS_KEY"),
+        os:getenv("AWS_SESSION_TOKEN"),
         os:getenv("AWS_REGION"),
         os:getenv("AWS_S3_BUCKET")
     },
     case Cfg of
-        {false, _, _, _} ->
+        {false, _, _, _, _} ->
             Skip;
-        {_, false, _, _} ->
+        {_, false, _, _, _} ->
             Skip;
-        {_, _, false, _} ->
+        {_, _, false, _, _} ->
             Skip;
-        {_, _, _, false} ->
+        {_, _, _, false, _} ->
             Skip;
-        {AccessKey, SecretKey, Region, Bucket} ->
+        {_, _, _, _, false} ->
+            Skip;
+        {AccessKey, SecretKey, SecurityToken, Region, Bucket} ->
             application:ensure_all_started(gun),
             ok = application:set_env(rabbitmq_stream_s3, aws_access_key, list_to_binary(AccessKey)),
             ok = application:set_env(rabbitmq_stream_s3, aws_secret_key, list_to_binary(SecretKey)),
+            ok = application:set_env(
+                rabbitmq_stream_s3,
+                aws_security_token,
+                list_to_binary(SecurityToken)
+            ),
             ok = application:set_env(rabbitmq_stream_s3, aws_region, list_to_binary(Region)),
             ok = application:set_env(rabbitmq_stream_s3, bucket, list_to_binary(Bucket)),
             Config


### PR DESCRIPTION
*Description of changes:*

IAM Users plus long lived access keys are a security anti-pattern. The better alternative is an IAM Role and we can follow the docs in https://github.com/aws-actions/configure-aws-credentials to have an action print us some temporary credentials following the existing IAM Policy we are already using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
