### PR TITLE
Cache first groups downloaded for retention

### DIFF
--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -650,7 +650,8 @@ convert_remote_to_local(#?MODULE{
 ) ->
     {ok, ChunkId :: osiris:offset(), byte_offset(), Fragment :: osiris:offset()}.
 find_position(Spec, Entries, StreamId) ->
-    Fragment = find_fragment(Entries, Spec, rabbitmq_stream_s3_server:get_group_fun(StreamId)),
+    GetGroupFun = rabbitmq_stream_s3_server:get_group_fun(StreamId, resolve_offset_spec),
+    Fragment = find_fragment(Entries, Spec, GetGroupFun),
     find_position0(Spec, Fragment, StreamId).
 
 -doc """

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -8,7 +8,12 @@
 -include("include/rabbitmq_stream_s3.hrl").
 
 -define(SERVER, ?MODULE).
--define(RANGE_TABLE, rabbitmq_stream_s3_log_manifest_range).
+%% Protected set of {stream_id(), FirstOffset, NextOffset} used to quickly
+%% look up remote tier ranges for the sake of local retention.
+-define(RANGE_TABLE, rabbitmq_stream_s3_server_range).
+%% Public set of {stream_id(), {#group_ref{}, rabbitmq_stream_s3:entries()}}
+%% used to avoid unnecessarily re-downloading the first group in a stream.
+-define(FIRST_GROUPS, rabbitmq_stream_s3_server_first_groups).
 
 -behaviour(gen_server).
 
@@ -55,8 +60,8 @@
 -export([
     get_fragment_trailer/1,
     get_fragment_trailer/2,
-    get_group_fun/1,
-    get_group/2
+    get_group_fun/2,
+    get_group/3
 ]).
 
 %% gen_server
@@ -88,6 +93,9 @@ start() ->
 
     ok = rabbitmq_stream_s3_counters:init(),
     ok = rabbitmq_stream_s3_db:setup(),
+
+    _ = ets:new(?FIRST_GROUPS, [named_table, public]),
+
     rabbit_sup:start_child(?MODULE).
 
 -spec get_manifest(stream_id()) -> #manifest{} | undefined.
@@ -739,7 +747,7 @@ execute_task(#evaluate_retention{
         Manifest,
         Now,
         RetentionSpec,
-        get_group_fun(StreamId)
+        get_group_fun(StreamId, retention)
     ),
     case Deletions of
         [] ->
@@ -843,12 +851,41 @@ set_tick_timer() ->
     _ = erlang:send_after(Timeout, self(), tick_timeout),
     ok.
 
-get_group_fun(StreamId) ->
+get_group_fun(StreamId, Reason) ->
     fun(#group_ref{} = Group) ->
-        get_group(StreamId, Group)
+        get_group(StreamId, Group, Reason)
     end.
 
-get_group(StreamId, #group_ref{offset = Offset} = GroupRef) ->
+-spec get_group(stream_id(), #group_ref{}, retention | resolve_offset_spec) ->
+    {ok, rabbitmq_stream_s3:entries()} | {error, any()}.
+get_group(StreamId, #group_ref{kind = ?MANIFEST_KIND_GROUP} = GroupRef, retention) ->
+    case get_group_cached(StreamId, GroupRef) of
+        undefined ->
+            case get_group0(StreamId, GroupRef) of
+                {ok, Entries} = Ok ->
+                    _ = ets:insert(?FIRST_GROUPS, {StreamId, {GroupRef, Entries}}),
+                    Ok;
+                {error, _} = Err ->
+                    Err
+            end;
+        Entries ->
+            {ok, Entries}
+    end;
+get_group(StreamId, #group_ref{} = GroupRef, _Reason) ->
+    get_group0(StreamId, GroupRef).
+
+get_group_cached(StreamId, #group_ref{kind = ?MANIFEST_KIND_GROUP} = GroupRef) ->
+    try ets:lookup(?FIRST_GROUPS, StreamId) of
+        [{StreamId, {GroupRef, Entries}}] ->
+            Entries;
+        _ ->
+            undefined
+    catch
+        error:badarg ->
+            undefined
+    end.
+
+get_group0(StreamId, #group_ref{offset = Offset} = GroupRef) ->
     {ok, Conn} = rabbitmq_stream_s3_api:open(),
     Key = rabbitmq_stream_s3:group_key(StreamId, GroupRef),
     ?LOG_DEBUG("Looking up key ~ts (~ts)", [Key, ?FUNCTION_NAME]),


### PR DESCRIPTION
*Issue #, if available:* fixes #59

*Description of changes:*

Retention needs to download the first group (covering the head of the stream) because it always deletes stream data from the head. Re-downloading it over and over is pointless since it never changes. The entries array of a group object is (at current numbers) 30KiB which fits into memory per-stream very comfortably.

I've been running this on a stream with 3 days of retention and it successfully avoids downloading the first group of a stream for the purposes of retention. Over the next few days I'll see this stream shrink from 10 TiB to a single fragment. Before this patch we would've downloaded the first group in the stream every 5 seconds. Now we only download the group once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.