### PR TITLE
Extract `reload_config/0` from `init/1` in `rabbitmq_stream_s3_api_aws`

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -13,6 +13,7 @@ A wrapper around the AWS S3 HTTP API.
 %% API:
 -export([
     init/0,
+    reload_config/0,
     open/0,
     close/1,
     get/3,
@@ -101,8 +102,11 @@ Called "HTTP Verb" in S3 docs.
 init() ->
     Cnt = seshat:new(rabbitmq_stream_s3, ?MODULE, ?COUNTERS),
     persistent_term:put(?COUNTER_KEY, Cnt),
-
     _ = ets:new(?TABLE, [public, named_table]),
+    reload_config().
+
+-spec reload_config() -> ok.
+reload_config() ->
     AccessKey0 = application:get_env(rabbitmq_stream_s3, aws_access_key),
     SecretKey0 = application:get_env(rabbitmq_stream_s3, aws_secret_key),
     case {AccessKey0, SecretKey0} of


### PR DESCRIPTION
The credential and region loading logic in `init/0` is extracted into a new exported function `reload_config/0`. This allows callers to update the application environment at runtime (via `application:set_env/3`) and then call `reload_config/0` to apply the new values without restarting the node. `init/0` now delegates to `reload_config/0` after setting up the ETS table and counter.