### PR TITLE
Optimize rabbitmq_stream_s3:pad_zeroes/1

### DIFF
--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -128,8 +128,18 @@ The offset is padded with leading zeroes to a width of 20.
 offset_filename(Offset, Suffix) when is_integer(Offset) andalso is_binary(Suffix) ->
     <<(pad_zeroes(Offset))/binary, $., Suffix/binary>>.
 
+-spec pad_zeroes(osiris:offset()) -> <<_:20 * 8>>.
 pad_zeroes(Offset) ->
-    iolist_to_binary(io_lib:format("~20..0B", [Offset])).
+    %% Same as `io_lib:format("~20..0B", [Offset])` but much more efficient.
+    %% NOTE: 2^64 is 20 digits.
+    Num = integer_to_binary(Offset),
+    Pad = 20 - byte_size(Num),
+    case Pad > 0 of
+        true ->
+            <<(binary:copy(<<$0>>, Pad))/binary, Num/binary>>;
+        false ->
+            Num
+    end.
 
 -doc "Creates the key for the given stream and UID".
 -spec manifest_key(stream_id(), uid()) -> key().


### PR DESCRIPTION
This function is used fairly often to create remote tier object keys and local filenames. This change is based on a similar optimization made recently in Ra. `io_lib:format/2` is very wasteful in terms of garbage production. Calculating the necessary padding and using `binary:copy/2` to create the zeroes is much more efficient.

```erlang
tprof:profile(rabbitmq_stream_s3, pad_zeroes, [531684743],
              #{type => call_memory}).
```

Before.

    ****** Process <0.723.0>  --  100.00% of total ***
    FUNCTION                         CALLS  WORDS  PER CALL  [    %]
    io_lib_format:collect/2              2      2      1.00  [ 0.61]
    io_lib_format:adjust/3               1      2      2.00  [ 0.61]
    rabbitmq_stream_s3:pad_zeroes/1      1      2      2.00  [ 0.61]
    io_lib_format:modifiers/3            1      4      4.00  [ 1.21]
    io_lib_format:field_value/2          2      4      2.00  [ 1.21]
    io_lib_format:field_value/3          3      4      1.33  [ 1.21]
    io_lib_format:pad_char/2             1      4      4.00  [ 1.21]
    erlang:iolist_to_binary/1            1      5      5.00  [ 1.52]
    io_lib_format:field_width/3          1      5      5.00  [ 1.52]
    io_lib_format:collect_cc/2           1      7      7.00  [ 2.12]
    io_lib_format:chars/2                3     12      4.00  [ 3.64]
    erlang:integer_to_list/2             1     18     18.00  [ 5.45]
    io_lib_format:collect_cseq/2         1     36     36.00  [10.91]
    erlang:'++'/2                        1     40     40.00  [12.12]
    lists:do_flatten/2                  29     40      1.38  [12.12]
    io_lib_format:count_small/2         21    145      6.90  [43.94]
                                              330            [100.0]

After.

    ****** Process <0.740.0>  --  100.00% of total ***
    FUNCTION                         CALLS  WORDS  PER CALL  [    %]
    erlang:integer_to_binary/1           1      4      4.00  [25.00]
    binary:copy/2                        1      4      4.00  [25.00]
    rabbitmq_stream_s3:pad_zeroes/1      1      8      8.00  [50.00]
                                               16            [100.0]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
