### PR TITLE
Clear cached first group when deleting the group object

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -467,6 +467,7 @@
 }).
 -record(delete_objects, {
     stream :: stream_id(),
+    %% Assumed to be sorted increasing by offset.
     objects :: nonempty_list(osiris:offset() | #group_ref{})
 }).
 %% Read through the local stream data and find available fragments.

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -804,6 +804,25 @@ execute_task(#delete_objects{stream = StreamId, objects = Objects}) ->
     ?LOG_DEBUG("Deleting ~b objects for stream '~ts' ~0p", [
         NumObjects, StreamId, Objects
     ]),
+    %% If one of the objects being deleted is a group, attempt to clear it from
+    %% the FIRST_GROUPS ETS cache. This ensures that a stream which only has
+    %% one group does not keep the group object cached indefinitely after it
+    %% is deleted by retention.
+    FirstGroup = lists:search(
+        fun
+            (#group_ref{kind = ?MANIFEST_KIND_GROUP}) -> true;
+            (_) -> false
+        end,
+        Objects
+    ),
+    case FirstGroup of
+        {value, GroupRef} ->
+            _ = catch ets:match_delete(?FIRST_GROUPS, {StreamId, {GroupRef, '_'}}),
+            ok;
+        false ->
+            ok
+    end,
+    %% Then delete all keys.
     Keys = lists:map(
         fun
             (#group_ref{} = Ref) -> rabbitmq_stream_s3:group_key(StreamId, Ref);
@@ -1009,7 +1028,7 @@ get_group(StreamId, #group_ref{kind = ?MANIFEST_KIND_GROUP} = GroupRef, retentio
         undefined ->
             case get_group0(StreamId, GroupRef) of
                 {ok, Entries} = Ok ->
-                    _ = ets:insert(?FIRST_GROUPS, {StreamId, {GroupRef, Entries}}),
+                    _ = catch ets:insert(?FIRST_GROUPS, {StreamId, {GroupRef, Entries}}),
                     Ok;
                 {error, _} = Err ->
                     Err


### PR DESCRIPTION
An ets table caches the first group object in a stream, if there is one. It's roughly a lookup like:

```erlang
#{stream_id() => {#group_ref{}, rabbitmq_stream_s3:entries()}}
```

This cache is updated when requesting a group object to evaluate remote tier retention on it. It was previously never cleared though. So it would update correctly when a group was deleted but once the last group of a stream was deleted by retention, the entry would sit in the cache forever.

In the task to `#delete_objects{}` we can find the first group object being deleted, if there is one, and clear the cache matching that stream and group ref.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
