### PR TITLE
Add continuous membership reconciliation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 Add the following to `rabbitmq.conf` to route stream reads and writes through the plugin:
 
-```
+```ini
 streams.log_reader = rabbitmq_stream_s3_log_reader
 streams.log_manifest = rabbitmq_stream_s3_log_manifest
 ```
@@ -15,7 +15,7 @@ streams.log_manifest = rabbitmq_stream_s3_log_manifest
 
 The S3 bucket to use for remote tier storage. Required.
 
-```
+```ini
 s3.bucket = my-rabbitmq-streams-bucket
 ```
 
@@ -23,7 +23,7 @@ s3.bucket = my-rabbitmq-streams-bucket
 
 The AWS region of the S3 bucket. If not set, the plugin attempts to determine the region automatically via the EC2 instance metadata service.
 
-```
+```ini
 s3.region = us-east-1
 ```
 
@@ -31,7 +31,7 @@ s3.region = us-east-1
 
 Overrides the endpoint hostname for a given region. Useful for S3-compatible storage or VPC endpoints.
 
-```
+```ini
 s3.region_endpoints.us-east-1 = s3.us-east-1.amazonaws.com
 ```
 
@@ -47,7 +47,32 @@ The plugin resolves AWS credentials in the following order:
 
 Static AWS credentials. Not recommended for production; prefer IAM roles.
 
-```
+```ini
 s3.access_key_id = AKIAIOSFODNN7EXAMPLE
 s3.secret_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+## Continuous Membership Reconciliation (CMR)
+
+This plugin provides the same functionality as [Quorum Queue CMR](https://www.rabbitmq.com/docs/quorum-queues#member-reconciliation) for streams, if enabled in configuration.
+
+```ini
+# Whether membership should be periodically evaluated.
+# Type: boolean. Default: false.
+stream.continuous_membership_reconciliation.enabled = true
+# The desired size to which stream clusters should grow.
+# Type: positive integer. Default: none.
+stream.continuous_membership_reconciliation.target_group_size = 3
+# Whether to remove 'dangling' members which are no longer
+# part of the RabbitMQ cluster.
+# Type: boolean. Default: false.
+stream.continuous_membership_reconciliation.auto_remove = true
+# Interval at which membership is evaluated, in milliseconds.
+# Type: positive integer. Default: 360000 (60 minutes).
+stream.continuous_membership_reconciliation.interval = 360000
+# Delay in milliseconds after which membership is evaluated
+# following any trigger event, for example when a node joins the
+# RabbitMQ cluster.
+# Type: positive integer. Default: 10000 (10 seconds).
+stream.continuous_membership_reconciliation.trigger_interval = 10000
 ```

--- a/priv/schema/rabbit_s3.schema
+++ b/priv/schema/rabbit_s3.schema
@@ -120,3 +120,25 @@ end}.
 {mapping, "streams.log_manifest", "osiris.log_manifest", [
     {datatype, {enum, [osiris_log, rabbitmq_stream_s3_log_manifest]}}
 ]}.
+
+%%
+%% Stream membership reconciliation
+%%
+
+{mapping, "stream.continuous_membership_reconciliation.enabled", "rabbitmq_stream_s3.membership_reconciliation_enabled", [
+    {datatype, {enum, [true, false]}}]}.
+
+{mapping, "stream.continuous_membership_reconciliation.auto_remove", "rabbitmq_stream_s3.membership_reconciliation_auto_remove", [
+    {datatype, {enum, [true, false]}}]}.
+
+{mapping, "stream.continuous_membership_reconciliation.interval", "rabbitmq_stream_s3.membership_reconciliation_interval", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
+
+{mapping, "stream.continuous_membership_reconciliation.trigger_interval", "rabbitmq_stream_s3.membership_reconciliation_trigger_interval", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
+
+{mapping, "stream.continuous_membership_reconciliation.target_group_size", "rabbitmq_stream_s3.membership_reconciliation_target_group_size", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.

--- a/src/rabbitmq_stream_s3_log_manifest.erl
+++ b/src/rabbitmq_stream_s3_log_manifest.erl
@@ -85,6 +85,7 @@ init_manifest(#{name := StreamId0, dir := Dir0} = Config0, writer) ->
                 recover_fragments(LastIdxFile)
         end,
     ok = rabbitmq_stream_s3_server:init_writer(StreamId, Config1, Available),
+    ok = rabbitmq_stream_s3_membership_reconciliation:writer_started(),
     Manifest = #log_writer{
         type = writer,
         stream = StreamId,

--- a/src/rabbitmq_stream_s3_membership_reconciliation.erl
+++ b/src/rabbitmq_stream_s3_membership_reconciliation.erl
@@ -1,0 +1,235 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_membership_reconciliation).
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+
+-record(?MODULE, {timer :: reference()}).
+
+-define(SERVER, ?MODULE).
+-define(EVAL, evaluate_membership).
+
+-export([
+    is_enabled/0,
+    schedule/0,
+    writer_started/0,
+    evaluate_membership/0
+]).
+
+-export([
+    start_link/0,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%%----------------------------------------------------------------------------
+
+is_enabled() ->
+    application:get_env(
+        rabbitmq_stream_s3,
+        membership_reconciliation_enabled,
+        false
+    ).
+
+schedule() ->
+    gen_server:cast(?SERVER, {schedule, manual}).
+
+writer_started() ->
+    gen_server:cast(?SERVER, {schedule, writer_started}).
+
+-doc """
+Evaluates all streams with writers on this node immediately, even if automatic
+evaluation is not enabled.
+""".
+evaluate_membership() ->
+    ?LOG_DEBUG(?MODULE_STRING ": evaluating membership"),
+    Qs = [
+        Q
+     || Q <- rabbit_amqqueue:list_by_type(rabbit_stream_queue),
+        amqqueue:get_leader_node(Q) =:= node()
+    ],
+    AllNodes = rabbit_nodes:list_members(),
+    Running = rabbit_nodes:filter_running(AllNodes),
+    evaluate_membership(Qs, AllNodes, Running, target_group_size(), auto_remove(), #{}).
+
+%%----------------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    case is_enabled() of
+        true ->
+            ?LOG_INFO(?MODULE_STRING " is enabled. Scheduling membership evaluation."),
+            rabbitmq_stream_s3_membership_reconciliation_events:register(self()),
+            {ok, #?MODULE{timer = erlang:send_after(trigger_interval(), self(), ?EVAL)}};
+        false ->
+            ?LOG_INFO(?MODULE_STRING " is not enabled. Exiting."),
+            ignore
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(
+    {schedule, Reason},
+    #?MODULE{timer = Timer} = State0
+) ->
+    ?LOG_DEBUG("Delayed exchange membership reconciliation scheduled because of ~0p", [Reason]),
+    _ = erlang:cancel_timer(Timer),
+    {noreply, State0#?MODULE{timer = erlang:send_after(trigger_interval(), self(), ?EVAL)}};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(?EVAL, #?MODULE{} = State0) ->
+    Changes = evaluate_membership(),
+    Timeout =
+        case map_size(Changes) of
+            0 ->
+                interval();
+            _ ->
+                ?LOG_INFO(?MODULE_STRING ": evaluated memberships and made changes ~0p", [Changes]),
+                trigger_interval()
+        end,
+    {noreply, State0#?MODULE{timer = erlang:send_after(Timeout, self(), ?EVAL)}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, #?MODULE{}) ->
+    rabbitmq_stream_s3_membership_reconciliation_events:unregister(self()),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%----------------------------------------------------------------------------
+
+interval() ->
+    application:get_env(
+        rabbitmq_stream_s3,
+        membership_reconciliation_interval,
+        60_000 * 60
+    ).
+trigger_interval() ->
+    application:get_env(
+        rabbitmq_stream_s3,
+        membership_reconciliation_trigger_interval,
+        10_000
+    ).
+target_group_size() ->
+    application:get_env(
+        rabbitmq_stream_s3,
+        membership_reconciliation_target_group_size,
+        undefined
+    ).
+auto_remove() ->
+    application:get_env(
+        rabbitmq_stream_s3,
+        membership_reconciliation_auto_remove,
+        false
+    ).
+
+evaluate_membership(_Qs, [], _Running, _TargetSize, _AutoRemove, Changes) ->
+    %% If there was an error attempting to list members, skip this round of evaluation.
+    Changes;
+evaluate_membership([], _AllNodes, _Running, _TargetSize, _AutoRemove, Changes) ->
+    Changes;
+evaluate_membership([Q | Qs], AllNodes, Running, TargetSize, AutoRemove, Changes0) ->
+    maybe
+        #{nodes := MemberNodes, leader_node := LeaderNode} = amqqueue:get_type_state(Q),
+        LeaderNode ?= node(),
+        false ?= rabbit_maintenance:is_being_drained_local_read(node()),
+        DanglingNodes = MemberNodes -- AllNodes,
+        Changes =
+            case DanglingNodes of
+                [_ | _] when AutoRemove ->
+                    remove_members(Q, DanglingNodes, Changes0);
+                _ ->
+                    maybe_add_member(Q, Running, MemberNodes, TargetSize, Changes0)
+            end,
+        evaluate_membership(Qs, AllNodes, Running, TargetSize, AutoRemove, Changes)
+    else
+        {timeout, _Leader} ->
+            increment_key(timeout, Changes0);
+        _ ->
+            Changes0
+    end.
+
+increment_key(Key, Map) ->
+    maps:update_with(Key, fun(V) -> V + 1 end, 1, Map).
+
+remove_members(_Q, [], Changes) ->
+    Changes;
+remove_members(Q, [Node | Rest], Changes0) ->
+    QName = amqqueue:get_name(Q),
+    ?LOG_DEBUG(?MODULE_STRING ": removing member of ~ts on node ~tw", [
+        rabbit_misc:rs(QName), Node
+    ]),
+    Changes =
+        case delete_replica(Q, Node) of
+            ok ->
+                increment_key(delete_ok, Changes0);
+            {error, Reason} ->
+                ?LOG_INFO(
+                    ?MODULE_STRING ": failed to remove member of ~ts on node ~tw, error: ~0p",
+                    [rabbit_misc:rs(QName), Node, Reason]
+                ),
+                increment_key(delete_error, Changes0)
+        end,
+    remove_members(Q, Rest, Changes).
+
+delete_replica(Q, Node) ->
+    #{name := StreamId} = amqqueue:get_type_state(Q),
+    case rabbit_stream_coordinator:delete_replica(StreamId, Node) of
+        {ok, Result, _} ->
+            Result;
+        {error, _} = Err ->
+            Err
+    end.
+
+maybe_add_member(Q, Running, MemberNodes, TargetSize, Changes0) ->
+    QName = amqqueue:get_name(Q),
+    New = rabbit_maintenance:filter_out_drained_nodes_local_read(Running -- MemberNodes),
+    case should_add_node(MemberNodes, New, TargetSize) of
+        true ->
+            Node = select_node(New),
+            ?LOG_DEBUG(?MODULE_STRING ": adding member of ~ts on node ~tw", [
+                rabbit_misc:rs(QName), Node
+            ]),
+            case rabbit_stream_coordinator:add_replica(Q, Node) of
+                ok ->
+                    increment_key(add_ok, Changes0);
+                {error, Reason} ->
+                    QName = amqqueue:get_name(Q),
+                    ?LOG_INFO(
+                        ?MODULE_STRING ": failed to add member of ~ts on node ~tw, error: ~0p",
+                        [rabbit_misc:rs(QName), Node, Reason]
+                    ),
+                    increment_key(add_error, Changes0)
+            end;
+        false ->
+            Changes0
+    end.
+
+should_add_node(MemberNodes, New, TargetSize) ->
+    CurrentSize = length(MemberNodes),
+    NumberOfNewNodes = length(New),
+    maybe
+        true ?= NumberOfNewNodes > 0,
+        true ?= CurrentSize < TargetSize,
+        true ?= rabbit_misc:is_even(CurrentSize) orelse NumberOfNewNodes > 1,
+        true ?= rabbit_nodes:is_running(lists:delete(node(), MemberNodes))
+    end.
+
+select_node([Node]) ->
+    Node;
+select_node(Nodes) ->
+    %% This could be improved to sort the nodes by viability.
+    lists:nth(rand:uniform(length(Nodes)), Nodes).

--- a/src/rabbitmq_stream_s3_membership_reconciliation_events.erl
+++ b/src/rabbitmq_stream_s3_membership_reconciliation_events.erl
@@ -1,0 +1,65 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_membership_reconciliation_events).
+-moduledoc """
+A gen_event implementation which notifies the membership reconciliation server
+that membership should be evaluated.
+
+This gen_event subscribes to:
+
+* `rabbit_alarm` for node up/down notifications
+* `rabbit_event` for queue creation and policy change notifications
+
+The `rabbit_event` subscription is not really necessary at the moment since
+the plugin does not subscribe check for policies and
+`rabbitmq_stream_s3_log_manifest` triggers an evaluation upon writer spawn,
+but it is left here to match membership reconciliation for quorum queues.
+""".
+
+-behaviour(gen_event).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([register/1, unregister/1]).
+
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2]).
+
+%%----------------------------------------------------------------------------
+
+register(Server) ->
+    gen_event:add_handler(rabbit_alarm, ?MODULE, Server).
+
+unregister(Server) ->
+    gen_event:delete_handler(rabbit_alarm, ?MODULE, Server),
+    ok.
+
+%%----------------------------------------------------------------------------
+
+init(Server) ->
+    {ok, Server}.
+
+handle_event({node_up, Node}, Server) ->
+    gen_server:cast(Server, {schedule, {node_up, Node}}),
+    {ok, Server};
+handle_event({node_down, Node}, Server) ->
+    gen_server:cast(Server, {schedule, {node_down, Node}}),
+    {ok, Server};
+handle_event(#event{type = queue_created}, Server) ->
+    gen_server:cast(Server, {schedule, queue_created}),
+    {ok, Server};
+handle_event(#event{type = policy_set}, Server) ->
+    gen_server:cast(Server, {schedule, policy_set}),
+    {ok, Server};
+handle_event(#event{type = operator_policy_set}, Server) ->
+    gen_server:cast(Server, {schedule, policy_set}),
+    {ok, Server};
+handle_event(_Event, Server) ->
+    {ok, Server}.
+
+handle_call(_Msg, State) ->
+    {ok, ok, State}.
+handle_info(_Msg, State) ->
+    {ok, State}.
+terminate(_Reason, _State) ->
+    ok.

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -11,13 +11,16 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    %% TODO we don't really need this outer supervisor anymore now that
-    %% the manifest worker is started by a boot step.
     SupFlags = #{strategy => one_for_one, intensity => 1, period => 5},
     LogReaderSup = #{
         id => rabbitmq_stream_s3_log_reader_sup,
         type => supervisor,
         start => {rabbitmq_stream_s3_log_reader_sup, start_link, []}
     },
-    Procs = [LogReaderSup],
+    MembershipReconciliation = #{
+        id => rabbitmq_stream_s3_membership_reconciliation,
+        type => worker,
+        start => {rabbitmq_stream_s3_membership_reconciliation, start_link, []}
+    },
+    Procs = [LogReaderSup, MembershipReconciliation],
     {ok, {SupFlags, Procs}}.

--- a/test/membership_reconciliation_SUITE.erl
+++ b/test/membership_reconciliation_SUITE.erl
@@ -1,0 +1,150 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(membership_reconciliation_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+-compile([nowarn_export_all, export_all]).
+
+all() ->
+    [add_remove].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config, []).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config0) ->
+    rabbit_ct_helpers:testcase_started(Config0, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config0, [
+        {rmq_nodes_count, 3},
+        {rmq_nodes_clustered, false},
+        {rmq_nodename_suffix, Testcase},
+        {testcase_name, <<?MODULE_STRING "-", (atom_to_binary(Testcase))/binary>>}
+    ]),
+    %% Lower the tick interval so that newly joined cluster members are added
+    %% to the coordinator's membership faster.
+    Config2 = rabbit_ct_helpers:merge_app_env(
+        Config1,
+        {rabbit, [{stream_tick_interval, 50}]}
+    ),
+    Config = rabbit_ct_helpers:merge_app_env(
+        Config2,
+        {rabbitmq_stream_s3, [
+            {membership_reconciliation_auto_remove, true}
+        ]}
+    ),
+    rabbit_ct_helpers:run_steps(
+        Config,
+        rabbit_ct_broker_helpers:setup_steps() ++
+            rabbit_ct_client_helpers:setup_steps()
+    ).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(
+        Config,
+        rabbit_ct_client_helpers:teardown_steps() ++
+            rabbit_ct_broker_helpers:teardown_steps()
+    ),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+
+add_remove(Config) ->
+    [N0, N1, N2] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, N0),
+    QName = <<(?config(testcase_name, Config))/binary, "-q">>,
+    QRef = rabbit_misc:r(<<"/">>, queue, QName),
+    ?assertMatch(
+        #'queue.declare_ok'{},
+        amqp_channel:call(Ch, #'queue.declare'{
+            queue = QName,
+            durable = true,
+            auto_delete = false,
+            arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]
+        })
+    ),
+    rabbit_ct_client_helpers:close_connection_and_channel(Conn, Ch),
+
+    ?assertMatch(Members when map_size(Members) =:= 1, members(Config, N0, QRef)),
+    join_cluster(N1, N0),
+    ?awaitMatch([_, _], stream_coordinator_members(Config, N0), 1_000),
+    %% We won't grow to an even number of nodes since it would threaten
+    %% availability.
+    evaluate_membership(Config, N0),
+    ?assertMatch(Members when map_size(Members) =:= 1, members(Config, N0, QRef)),
+
+    join_cluster(N2, N0),
+    ?awaitMatch([_, _, _], stream_coordinator_members(Config, N0), 1_000),
+    %% Once there are an odd number of candidates though, we grow to the
+    %% default target size.
+    evaluate_membership(Config, N0),
+    ?awaitMatch(#{nodes := [_, _]}, get_type_state(Config, N0, QRef), 1_000),
+    ?assertMatch(Members when map_size(Members) =:= 2, members(Config, N0, QRef)),
+    %% We only grow once per evaluation so we need to evaluate twice to reach
+    %% the target size. The writer also might've changed since the replica was
+    %% added, so we need to find the writer node first.
+    #{leader_node := Leader1} = get_type_state(Config, N0, QRef),
+    evaluate_membership(Config, Leader1),
+    ?awaitMatch(#{nodes := [_, _, _]}, get_type_state(Config, N0, QRef), 1_000),
+    #{leader_node := Leader2, replica_nodes := Replicas1} = get_type_state(Config, N0, QRef),
+    ?assertMatch(Members when map_size(Members) =:= 3, members(Config, Leader2, QRef)),
+
+    StopNode = hd(Replicas1),
+    ok = rabbit_ct_broker_helpers:rpc(Config, StopNode, rabbit, stop_and_halt, []),
+    ?awaitMatch([_], rabbit_ct_broker_helpers:rpc(Config, Leader2, erlang, nodes, []), 5_000),
+    ok = rabbit_ct_broker_helpers:rpc(Config, Leader2, rabbit_db_cluster, forget_member, [
+        StopNode,
+        false
+    ]),
+    ?awaitMatch([_, _], stream_coordinator_members(Config, Leader2), 1_000),
+    evaluate_membership(Config, Leader2),
+    ?awaitMatch(#{nodes := [_, _]}, get_type_state(Config, Leader2, QRef), 1_000),
+    ?awaitMatch(Members when map_size(Members) =:= 2, members(Config, Leader2, QRef), 5_000),
+
+    ok.
+
+%% -------------------------------------------------------------------
+
+members(Config, Node, QRef) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ?MODULE, members_rpc, [QRef]).
+
+members_rpc(QRef) ->
+    {ok, Q} = rabbit_amqqueue:lookup(QRef),
+    #{name := StreamId} = amqqueue:get_type_state(Q),
+    {ok, Members} = rabbit_stream_coordinator:members(StreamId),
+    Members.
+
+stream_coordinator_members(Config, Node) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ra_leaderboard, lookup_members, [
+        rabbit_stream_coordinator
+    ]).
+
+get_type_state(Config, Node, QRef) ->
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_amqqueue, lookup, [QRef]),
+    amqqueue:get_type_state(Q).
+
+evaluate_membership(Config, Node) ->
+    Changes = rabbit_ct_broker_helpers:rpc(
+        Config,
+        Node,
+        rabbitmq_stream_s3_membership_reconciliation,
+        evaluate_membership,
+        []
+    ),
+    ct:pal("Evaluated membership on node ~tw and made the following changes: ~tw", [Node, Changes]),
+    ok.
+
+join_cluster(Server, Leader) ->
+    %% NOTE: When using Khepri, `stop_app` is no longer necessary before
+    %% using the `join_cluster` command.
+    rabbit_control_helper:command(join_cluster, Server, [atom_to_list(Leader)], []).


### PR DESCRIPTION
This is the same as the continuous membership reconciliation (CMR) feature for quorum queue membership, but for streams. The options are identical but are under the 'stream' key rather than 'quorum_queues'. The design of the server and gen_event is mostly the same but has been refactored to make manual runs easier to trigger.

Automating stream membership makes more sense in this plugin than in the server since membership changes are much cheaper when only a small amount of data is stored locally. We can also trigger evaluation when a writer starts from the log manifest implementation, reducing the time between leadership changes and evaluations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
