### PR TITLE
Exit cleanly on S3 API errors instead of crashing with badmatch

### DIFF
--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -914,17 +914,22 @@ execute_task(#delete_stream{stream = StreamId}) ->
     Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
     {ok, Conn} = rabbitmq_stream_s3_api:open(),
     try
-        {DeleteMsec, {ok, Details}} = timer:tc(
+        {DeleteMsec, Result} = timer:tc(
             rabbitmq_stream_s3_api,
             delete_prefix,
             [Conn, Prefix],
             millisecond
         ),
-        ?LOG_INFO("Deleted remote tier data for deleted stream '~ts' in ~b msec ~0p", [
-            StreamId, DeleteMsec, Details
-        ]),
-        counters:add(counter(), ?C_STREAMS_DELETED, 1),
-        ok
+        case Result of
+            {ok, Details} ->
+                ?LOG_INFO("Deleted remote tier data for deleted stream '~ts' in ~b msec ~0p", [
+                    StreamId, DeleteMsec, Details
+                ]),
+                counters:add(counter(), ?C_STREAMS_DELETED, 1),
+                ok;
+            {error, _} = Err ->
+                exit(Err)
+        end
     after
         rabbitmq_stream_s3_api:close(Conn)
     end;


### PR DESCRIPTION
Several call sites match directly on `{ok, _}` or `ok` when calling `rabbitmq_stream_s3_api` functions. When the API returns an error tuple (e.g. `{error, #{status => 503, ...}}` from S3 throttling), the `badmatch` crash produces noisy SASL crash reports at `[error]` level.

Replace bare pattern matches with explicit `case` expressions that call `exit(Err)` on `{error, _}` responses. This avoids crash reports while preserving the existing error handling:

- **Task processes** (`rabbitmq_stream_s3_server`): `upload_fragment`, `upload_group`, `upload_manifest`, `delete_objects` — the server's `DOWN` handler still receives the error reason and retries with exponential backoff
- **Stream deletion** (`rabbitmq_stream_s3_server`): `delete_stream` — `delete_prefix` result inside `timer:tc`, same retry mechanism

Log reader error handling is left for #42.

Closes #84
