### PR TITLE
Fix replica crash on initial manifest resolution

### DIFF
--- a/src/rabbitmq_stream_s3_machine.erl
+++ b/src/rabbitmq_stream_s3_machine.erl
@@ -358,7 +358,7 @@ apply(
                     ),
                     Effect = #manifest_requested{stream = StreamId, requester = self()},
                     Replica = Replica0#{manifest := {pending, []}},
-                    {Replica, [Effect]}
+                    {State0#?MODULE{streams = Streams0#{StreamId := Replica}}, [Effect]}
             end;
         _ ->
             {State0, []}


### PR DESCRIPTION
Closes #83.

## Summary

Fix two bugs in `rabbitmq_stream_s3_machine` that cause crashes when a replica resolves its manifest after a node restart.

## Problem 1: `assertNotEqual` crash on initial manifest resolution (97c826b)

When a replica node starts up with an existing stream, the machine triggers a `#resolve_manifest` effect that reads the manifest directly from S3. The resulting `#manifest_resolved` event has `seq = undefined` because the S3 resolution task does not know the writer's current sequence number.

The `manifest_resolved` handler asserted `?assertNotEqual(undefined, Seq0)` for non-writer streams, which crashed the server:

```
** Reason for termination ==
** {{assertNotEqual,[{module,rabbitmq_stream_s3_machine},
                     {line,556},
                     {expression,"Seq0"},
                     {value,undefined}]},
```

The assertion assumed replicas only receive `manifest_resolved` events from the writer (via `#manifest_requested`), which always includes the seq. The initial S3 resolution path was not accounted for.

### Fix

Replace the assertion with `resolve_replica_seq/2`, which falls back to the stream's current seq when `Seq0` is `undefined`. After initial resolution, the next `#manifest_edited` from the writer will be detected as out-of-sequence, triggering a re-request from the writer that includes the correct seq.

## Problem 2: Machine state corruption on out-of-sequence edit (1b6f607)

The out-of-sequence `manifest_edited` handler returned `{Replica, [Effect]}` where `Replica` is the stream map, not the full `#?MODULE{}` machine state. This replaced the entire machine state with a single stream map, causing the next `apply/3` call to crash on pattern match.

This path becomes reachable after the first fix: replicas that resolve their manifest from S3 start with `seq => 0` and will receive an out-of-sequence edit when the writer's seq has advanced.

### Fix

Return `{State0#?MODULE{streams = Streams0#{StreamId := Replica}}, [Effect]}`, matching the successful branch.

## Testing

- Deployed to a 3-node cluster (`m7g.large`, `us-west-2`) with three existing streams
- Ran two high-throughput test runs (100k+ msg/s, 1 minute each)
- Restarted a replica node twice during active publishing (different runs)
- Zero `[error]` level log messages across all nodes after both restart cycles
- Previously produced 561 errors on a single restart
