### PR TITLE
Fix consumer crash when reading from S3 after retention

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -156,7 +156,11 @@ get(Conn, Key, Opts) when is_pid(Conn) andalso is_binary(Key) andalso is_map(Opt
             {ok, Data};
         {ok, #{status := 404}} ->
             {error, not_found};
-        {ok, Other} ->
+        {ok, #{status := Status} = Other} ->
+            ?LOG_DEBUG(
+                "rabbitmq_stream_s3_api_aws:get/3 unexpected status ~b for key ~ts",
+                [Status, Key]
+            ),
             {error, Other};
         {error, _} = Err ->
             Err
@@ -180,7 +184,11 @@ get_range(Conn, Key, Range, Opts) when is_pid(Conn) andalso is_binary(Key) andal
             {ok, Data};
         {ok, #{status := 404}} ->
             {error, not_found};
-        {ok, Other} ->
+        {ok, #{status := Status} = Other} ->
+            ?LOG_DEBUG(
+                "rabbitmq_stream_s3_api_aws:get_range/4 unexpected status ~b for key ~ts",
+                [Status, Key]
+            ),
             {error, Other};
         {error, _} = Err ->
             Err
@@ -199,7 +207,11 @@ put(Conn, Key, Data, Opts) when is_pid(Conn) andalso is_binary(Key) andalso is_m
     case request(Conn, <<"PUT">>, key_to_path(Key), Headers, Data, Opts) of
         {ok, #{status := 200}} ->
             ok;
-        {ok, Other} ->
+        {ok, #{status := Status} = Other} ->
+            ?LOG_DEBUG(
+                "rabbitmq_stream_s3_api_aws:put/4 unexpected status ~b for key ~ts",
+                [Status, Key]
+            ),
             {error, Other};
         {error, _} = Err ->
             Err
@@ -222,7 +234,11 @@ delete(Conn, Keys, Opts) when is_pid(Conn) andalso is_list(Keys) andalso is_map(
     case request(Conn, <<"POST">>, <<"/?delete=">>, Headers, Data, Opts) of
         {ok, #{status := 200}} ->
             ok;
-        {ok, Other} ->
+        {ok, #{status := Status} = Other} ->
+            ?LOG_DEBUG(
+                "rabbitmq_stream_s3_api_aws:delete/3 (multi) unexpected status ~b",
+                [Status]
+            ),
             {error, Other};
         {error, _} = Err ->
             Err
@@ -232,7 +248,11 @@ delete(Conn, Key, Opts) when is_pid(Conn) andalso is_binary(Key) andalso is_map(
     case request(Conn, <<"DELETE">>, key_to_path(Key), #{}, <<>>, Opts) of
         {ok, #{status := 204}} ->
             ok;
-        {ok, Other} ->
+        {ok, #{status := Status} = Other} ->
+            ?LOG_DEBUG(
+                "rabbitmq_stream_s3_api_aws:delete/3 unexpected status ~b for key ~ts",
+                [Status, Key]
+            ),
             {error, Other};
         {error, _} = Err ->
             Err

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -571,36 +571,16 @@ advance_fragment(
                     read_header1(Remote);
                 {error, not_found} ->
                     %% The fragment at NextChId was deleted by retention.
-                    %% Use the manifest to find the correct fragment for
-                    %% NextChId, or jump to first_offset if it has been
-                    %% deleted.
+                    %% Jump to the oldest fragment still in S3. The guard
+                    %% ensures first_offset strictly increases on each
+                    %% recursion, so this terminates.
                     case rabbitmq_stream_s3_server:get_manifest(StreamId) of
-                        undefined ->
-                            {end_of_stream, Remote0};
-                        #manifest{first_offset = FirstOffset}
-                          when NextChId < FirstOffset ->
+                        #manifest{first_offset = FirstOffset} when
+                            FirstOffset > NextChId
+                        ->
                             advance_fragment(Remote0#remote{next_offset = FirstOffset});
-                        #manifest{next_offset = ManifestNext, entries = Entries}
-                          when NextChId < ManifestNext ->
-                            case find_position({offset, NextChId}, Entries, StreamId) of
-                                {ok, ChunkId, Position, Fragment} ->
-                                    FragKey = rabbitmq_stream_s3:fragment_key(StreamId, Fragment),
-                                    case rabbitmq_stream_s3_log_reader_sup:add_child(self(), FragKey) of
-                                        {ok, Pid} ->
-                                            ok = gen_server:cast(Pid0, close),
-                                            Remote = Remote0#remote{
-                                                pid = Pid,
-                                                fragment = Fragment,
-                                                next_offset = ChunkId,
-                                                position = Position
-                                            },
-                                            read_header1(Remote);
-                                        {error, not_found} ->
-                                            {end_of_stream, Remote0}
-                                    end;
-                                _ ->
-                                    {end_of_stream, Remote0}
-                            end
+                        _ ->
+                            {end_of_stream, Remote0}
                     end
             end
     end.
@@ -785,10 +765,6 @@ find_fragment(Entries, Spec, GetGroup) ->
 
 find_position0(Spec, Fragment, StreamId) ->
     %% TODO: pass in size now that we have it.
-    %% TODO: TOCTOU risk — the manifest may list Fragment as existing, but
-    %% remote retention could delete it between the manifest fetch and this
-    %% get_fragment_trailer call. The badmatch would crash the caller.
-    %% Fix: handle {error, _} here and propagate it instead of crashing.
     {ok, #fragment_info{index_start_pos = IdxStartPos}} = rabbitmq_stream_s3_server:get_fragment_trailer(
         StreamId,
         Fragment

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -764,8 +764,7 @@ find_fragment(Entries, Spec, GetGroup) ->
     end.
 
 find_position0(Spec, Fragment, StreamId) ->
-    %% TODO: pass in size now that we have it.
-    {ok, #fragment_info{index_start_pos = IdxStartPos}} = rabbitmq_stream_s3_server:get_fragment_trailer(
+    {ok, #fragment_info{index_start_pos = IdxStartPos}} = rabbitmq_stream_s3_server:get_fragment_info(
         StreamId,
         Fragment
     ),

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -559,8 +559,6 @@ advance_fragment(
         _ when NextChId > LastChId ->
             {end_of_stream, Remote0};
         _ ->
-            %% TODO: what if retention takes away fragments? We need to
-            %% jump ahead to the start of the log.
             Key = rabbitmq_stream_s3:fragment_key(StreamId, NextChId),
             case rabbitmq_stream_s3_log_reader_sup:add_child(self(), Key) of
                 {ok, Pid} ->
@@ -572,7 +570,17 @@ advance_fragment(
                     },
                     read_header1(Remote);
                 {error, not_found} ->
-                    {end_of_stream, Remote0}
+                    %% The fragment at NextChId was deleted by retention.
+                    %% Jump to the oldest fragment still in S3. The guard
+                    %% ensures first_offset strictly increases on each
+                    %% recursion, so this terminates.
+                    case rabbitmq_stream_s3_server:get_manifest(StreamId) of
+                        #manifest{first_offset = FirstOffset}
+                          when FirstOffset > NextChId ->
+                            advance_fragment(Remote0#remote{next_offset = FirstOffset});
+                        _ ->
+                            {end_of_stream, Remote0}
+                    end
             end
     end.
 

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -23,9 +23,6 @@ tier.
 -define(READAHEAD, "5MiB").
 -define(READ_TIMEOUT, 10000).
 -define(SLOW_READ_THRESHOLD_MS, 10_000).
-%% Byte position of the first chunk within a fragment object.
-%% Layout: [?FRAGMENT_HEADER_B fragment header][?SEGMENT_HEADER_B segment header][chunks...]
--define(FRAGMENT_FIRST_CHUNK_POS, (?FRAGMENT_HEADER_B + ?SEGMENT_HEADER_B)).
 
 %% TODO: add counters
 
@@ -123,9 +120,9 @@ resolve_remote_location(first, #{name := StreamId, shared := Shared}) ->
         #manifest{first_offset = RemoteFirstOffset} when RemoteFirstOffset < LocalFirstOffset ->
             ?LOG_DEBUG(
                 "Attaching remote reader at first offset ~b pos ~b for spec 'first'",
-                [RemoteFirstOffset, ?FRAGMENT_FIRST_CHUNK_POS]
+                [RemoteFirstOffset, ?FRAGMENT_HEADER_B]
             ),
-            {ok, RemoteFirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, RemoteFirstOffset};
+            {ok, RemoteFirstOffset, ?FRAGMENT_HEADER_B, RemoteFirstOffset};
         _ ->
             {local, first}
     end;
@@ -156,7 +153,7 @@ resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
                 #manifest{first_offset = FirstOffset} when Offset < FirstOffset ->
                     %% Emulate osiris_log's behavior: attach at the beginning
                     %% of the stream.
-                    {ok, FirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, FirstOffset};
+                    {ok, FirstOffset, ?FRAGMENT_HEADER_B, FirstOffset};
                 #manifest{entries = Entries} ->
                     {ok, ChunkId, Position, Fragment} = find_position(
                         {offset, Offset},
@@ -174,7 +171,7 @@ resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
     %% Instead try the remote tier first.
     case rabbitmq_stream_s3_server:get_manifest(StreamId) of
         #manifest{first_offset = FirstOffset, first_timestamp = FirstTs} when Ts < FirstTs ->
-            {ok, FirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, FirstOffset};
+            {ok, FirstOffset, ?FRAGMENT_HEADER_B, FirstOffset};
         #manifest{entries = Entries} ->
             case rabbitmq_stream_s3_array:last(?ENTRY_B, Entries) of
                 ?ENTRY(_O, _FTs, LTs, _, _) when LTs >= Ts ->
@@ -574,7 +571,7 @@ advance_fragment(
                     Remote = Remote0#remote{
                         pid = Pid,
                         fragment = NextChId,
-                        position = ?FRAGMENT_FIRST_CHUNK_POS
+                        position = ?FRAGMENT_HEADER_B
                     },
                     read_header1(Remote);
                 {error, _} ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -23,6 +23,9 @@ tier.
 -define(READAHEAD, "5MiB").
 -define(READ_TIMEOUT, 10000).
 -define(SLOW_READ_THRESHOLD_MS, 10_000).
+%% Byte position of the first chunk within a fragment object.
+%% Layout: [?FRAGMENT_HEADER_B fragment header][?SEGMENT_HEADER_B segment header][chunks...]
+-define(FRAGMENT_FIRST_CHUNK_POS, (?FRAGMENT_HEADER_B + ?SEGMENT_HEADER_B)).
 
 %% TODO: add counters
 
@@ -120,9 +123,9 @@ resolve_remote_location(first, #{name := StreamId, shared := Shared}) ->
         #manifest{first_offset = RemoteFirstOffset} when RemoteFirstOffset < LocalFirstOffset ->
             ?LOG_DEBUG(
                 "Attaching remote reader at first offset ~b pos ~b for spec 'first'",
-                [RemoteFirstOffset, ?FRAGMENT_HEADER_B]
+                [RemoteFirstOffset, ?FRAGMENT_FIRST_CHUNK_POS]
             ),
-            {ok, RemoteFirstOffset, ?FRAGMENT_HEADER_B, RemoteFirstOffset};
+            {ok, RemoteFirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, RemoteFirstOffset};
         _ ->
             {local, first}
     end;
@@ -153,7 +156,7 @@ resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
                 #manifest{first_offset = FirstOffset} when Offset < FirstOffset ->
                     %% Emulate osiris_log's behavior: attach at the beginning
                     %% of the stream.
-                    {ok, FirstOffset, ?FRAGMENT_HEADER_B, FirstOffset};
+                    {ok, FirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, FirstOffset};
                 #manifest{entries = Entries} ->
                     {ok, ChunkId, Position, Fragment} = find_position(
                         {offset, Offset},
@@ -171,7 +174,7 @@ resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
     %% Instead try the remote tier first.
     case rabbitmq_stream_s3_server:get_manifest(StreamId) of
         #manifest{first_offset = FirstOffset, first_timestamp = FirstTs} when Ts < FirstTs ->
-            {ok, FirstOffset, ?FRAGMENT_HEADER_B, FirstOffset};
+            {ok, FirstOffset, ?FRAGMENT_FIRST_CHUNK_POS, FirstOffset};
         #manifest{entries = Entries} ->
             case rabbitmq_stream_s3_array:last(?ENTRY_B, Entries) of
                 ?ENTRY(_O, _FTs, LTs, _, _) when LTs >= Ts ->
@@ -566,7 +569,7 @@ advance_fragment(
                     Remote = Remote0#remote{
                         pid = Pid,
                         fragment = NextChId,
-                        position = ?SEGMENT_HEADER_B
+                        position = ?FRAGMENT_FIRST_CHUNK_POS
                     },
                     read_header1(Remote);
                 {error, _} ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -571,16 +571,36 @@ advance_fragment(
                     read_header1(Remote);
                 {error, not_found} ->
                     %% The fragment at NextChId was deleted by retention.
-                    %% Jump to the oldest fragment still in S3. The guard
-                    %% ensures first_offset strictly increases on each
-                    %% recursion, so this terminates.
+                    %% Use the manifest to find the correct fragment for
+                    %% NextChId, or jump to first_offset if it has been
+                    %% deleted.
                     case rabbitmq_stream_s3_server:get_manifest(StreamId) of
-                        #manifest{first_offset = FirstOffset} when
-                            FirstOffset > NextChId
-                        ->
+                        undefined ->
+                            {end_of_stream, Remote0};
+                        #manifest{first_offset = FirstOffset}
+                          when NextChId < FirstOffset ->
                             advance_fragment(Remote0#remote{next_offset = FirstOffset});
-                        _ ->
-                            {end_of_stream, Remote0}
+                        #manifest{next_offset = ManifestNext, entries = Entries}
+                          when NextChId < ManifestNext ->
+                            case find_position({offset, NextChId}, Entries, StreamId) of
+                                {ok, ChunkId, Position, Fragment} ->
+                                    FragKey = rabbitmq_stream_s3:fragment_key(StreamId, Fragment),
+                                    case rabbitmq_stream_s3_log_reader_sup:add_child(self(), FragKey) of
+                                        {ok, Pid} ->
+                                            ok = gen_server:cast(Pid0, close),
+                                            Remote = Remote0#remote{
+                                                pid = Pid,
+                                                fragment = Fragment,
+                                                next_offset = ChunkId,
+                                                position = Position
+                                            },
+                                            read_header1(Remote);
+                                        {error, not_found} ->
+                                            {end_of_stream, Remote0}
+                                    end;
+                                _ ->
+                                    {end_of_stream, Remote0}
+                            end
                     end
             end
     end.
@@ -764,7 +784,12 @@ find_fragment(Entries, Spec, GetGroup) ->
     end.
 
 find_position0(Spec, Fragment, StreamId) ->
-    {ok, #fragment_info{index_start_pos = IdxStartPos}} = rabbitmq_stream_s3_server:get_fragment_info(
+    %% TODO: pass in size now that we have it.
+    %% TODO: TOCTOU risk — the manifest may list Fragment as existing, but
+    %% remote retention could delete it between the manifest fetch and this
+    %% get_fragment_trailer call. The badmatch would crash the caller.
+    %% Fix: handle {error, _} here and propagate it instead of crashing.
+    {ok, #fragment_info{index_start_pos = IdxStartPos}} = rabbitmq_stream_s3_server:get_fragment_trailer(
         StreamId,
         Fragment
     ),

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -569,7 +569,7 @@ advance_fragment(
                         position = ?SEGMENT_HEADER_B
                     },
                     read_header1(Remote);
-                {error, not_found} ->
+                {error, _} ->
                     %% The fragment at NextChId was deleted by retention.
                     %% Jump to the oldest fragment still in S3. The guard
                     %% ensures first_offset strictly increases on each

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -575,8 +575,9 @@ advance_fragment(
                     %% ensures first_offset strictly increases on each
                     %% recursion, so this terminates.
                     case rabbitmq_stream_s3_server:get_manifest(StreamId) of
-                        #manifest{first_offset = FirstOffset}
-                          when FirstOffset > NextChId ->
+                        #manifest{first_offset = FirstOffset} when
+                            FirstOffset > NextChId
+                        ->
                             advance_fragment(Remote0#remote{next_offset = FirstOffset});
                         _ ->
                             {end_of_stream, Remote0}

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -537,6 +537,11 @@ read_header1(
         millisecond
     ),
     validate_read_timing(ReadMsec),
+    ?LOG_DEBUG(
+        "read_header1 position ~b next_offset ~b result ~w",
+        [Position, Remote0#remote.next_offset,
+         case ReadResult of {ok, B} -> {ok, binary:part(B, 0, min(16, byte_size(B)))}; _ -> ReadResult end]
+    ),
     case ReadResult of
         {ok, Header} ->
             read_header2(Remote0, Header);
@@ -598,7 +603,19 @@ read_header2(
     HeaderBin
 ) ->
     <<HeaderBin1:?CHUNK_HEADER_B/binary, _/binary>> = HeaderBin,
-    {ok, Header} = osiris_log:parse_header(HeaderBin1, Position0),
+    Header =
+        case osiris_log:parse_header(HeaderBin1, Position0) of
+            {error, invalid_chunk_header} ->
+                ?LOG_ERROR(
+                    "invalid_chunk_header at position ~b next_offset ~b fragment ~w "
+                    "first_bytes ~w",
+                    [Position0, NextChId0, Remote0#remote.fragment,
+                     binary:part(HeaderBin1, 0, min(16, byte_size(HeaderBin1)))]
+                ),
+                error({badmatch, {error, invalid_chunk_header}});
+            {ok, H} ->
+                H
+        end,
     #{
         type := ChunkType,
         chunk_id := NextChId0,
@@ -773,6 +790,10 @@ find_position0(Spec, Fragment, StreamId) ->
     ),
     IndexData = index_data(StreamId, Fragment, IdxStartPos),
     {ChunkId, _, Pos} = find_index_position(IndexData, Spec),
+    ?LOG_DEBUG(
+        "find_position0 spec ~w fragment ~b -> chunk_id ~b pos ~b",
+        [Spec, Fragment, ChunkId, Pos]
+    ),
     {ok, ChunkId, Pos, Fragment}.
 
 find_index_position(IndexData, Spec) ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -257,22 +257,29 @@ send_file(Socket, #?MODULE{mode = #remote{} = Remote0} = State0, Callback) ->
             {ToSkip, ToSend} = select_amount_to_send(ChunkSelector, Header),
             DataPos = Position + ?CHUNK_HEADER_B + ToSkip,
             PrefixData = Callback(Header, ToSend + byte_size(HeaderData)),
-            {ReadMsec, {ok, Data}} = timer:tc(
+            {ReadMsec, ReadResult} = timer:tc(
                 gen_server,
                 call,
                 [Pid, {read, DataPos, ToSend, within_chunk}, ?GEN_SERVER_CALL_TIMEOUT],
                 millisecond
             ),
             validate_read_timing(ReadMsec, ToSend, DataPos),
-            case send(Transport, Socket, [PrefixData, HeaderData, Data]) of
-                ok ->
-                    Remote = Remote1#remote{
-                        next_offset = ChId + NumRecords,
-                        position = NextPosition
-                    },
-                    {ok, State0#?MODULE{mode = Remote}};
-                {error, _} = Err ->
-                    Err
+            case ReadResult of
+                {ok, Data} ->
+                    case send(Transport, Socket, [PrefixData, HeaderData, Data]) of
+                        ok ->
+                            Remote = Remote1#remote{
+                                next_offset = ChId + NumRecords,
+                                position = NextPosition
+                            },
+                            {ok, State0#?MODULE{mode = Remote}};
+                        {error, _} = Err ->
+                            Err
+                    end;
+                {error, _} ->
+                    %% The fragment was deleted by retention while being read,
+                    %% or another S3 error occurred.
+                    {end_of_stream, State0#?MODULE{mode = Remote1}}
             end;
         {local, Remote} ->
             case convert_remote_to_local(State0#?MODULE{mode = Remote}) of
@@ -400,6 +407,8 @@ handle_call({read, Offset, Bytes, Hint}, _From, State0) ->
         {State, ?IDX_HEADER(_)} when Hint =:= chunk_boundary ->
             %% The reader has reached the section of the
             {reply, eof, State};
+        {error, _} = Err ->
+            {reply, Err, State0};
         {State, Data} ->
             {reply, {ok, Data}, State};
         eof ->
@@ -456,24 +465,30 @@ do_read(
     Bytes
 ) ->
     End = Offset + Bytes - 1,
-    case (Offset >= BufStart) and (End =< BufEnd) of
+    case (Offset >= BufStart) andalso (End =< BufEnd) of
         % Data is in buffer
         true ->
             OffsetInBuf = Offset - BufStart,
             {State0, binary:part(Buffer, OffsetInBuf, Bytes)};
         false ->
             ToRead = max(ReadSize, Bytes),
-            {ok, NewBuffer} = rabbitmq_stream_s3_api:get_range(
-                Connection,
-                Object,
-                {Offset, Offset + ToRead - 1}
-            ),
-            State = State0#state{
-                buffer = NewBuffer,
-                offset_start = Offset,
-                offset_end = Offset + ToRead - 1
-            },
-            {State, binary:part(NewBuffer, 0, Bytes)}
+            case
+                rabbitmq_stream_s3_api:get_range(
+                    Connection,
+                    Object,
+                    {Offset, Offset + ToRead - 1}
+                )
+            of
+                {ok, NewBuffer} ->
+                    State = State0#state{
+                        buffer = NewBuffer,
+                        offset_start = Offset,
+                        offset_end = Offset + ToRead - 1
+                    },
+                    {State, binary:part(NewBuffer, 0, Bytes)};
+                {error, _} = Err ->
+                    Err
+            end
     end.
 
 %% This helper is mostly the same as osiris_log:read_header0/1. There are some
@@ -500,10 +515,7 @@ read_header(#remote{shared = Shared, next_offset = NextOffset} = Remote) ->
 read_header1(
     #remote{
         pid = Pid0,
-        stream = StreamId,
-        position = Position,
-        next_offset = NextChId,
-        shared = Shared
+        position = Position
     } = Remote0
 ) ->
     %% Over-read the chunk header so that the filter (if it exists) is always
@@ -526,29 +538,41 @@ read_header1(
         {ok, Header} ->
             read_header2(Remote0, Header);
         eof ->
-            FirstChId = osiris_log_shared:first_chunk_id(Shared),
-            LastChId = osiris_log_shared:last_chunk_id(Shared),
-            case NextChId of
-                FirstChId ->
-                    {local, Remote0};
-                _ when NextChId > LastChId ->
-                    {end_of_stream, Remote0};
-                _ ->
-                    %% TODO: what if retention takes away fragments? We need to
-                    %% jump ahead to the start of the log.
-                    Key = rabbitmq_stream_s3:fragment_key(StreamId, NextChId),
-                    case rabbitmq_stream_s3_log_reader_sup:add_child(self(), Key) of
-                        {ok, Pid} ->
-                            ok = gen_server:cast(Pid0, close),
-                            Remote = Remote0#remote{
-                                pid = Pid,
-                                fragment = NextChId,
-                                position = ?FRAGMENT_HEADER_B
-                            },
-                            read_header1(Remote);
-                        {error, _} ->
-                            {end_of_stream, Remote0}
-                    end
+            advance_fragment(Remote0);
+        {error, _} ->
+            advance_fragment(Remote0)
+    end.
+
+advance_fragment(
+    #remote{
+        pid = Pid0,
+        stream = StreamId,
+        next_offset = NextChId,
+        shared = Shared
+    } = Remote0
+) ->
+    FirstChId = osiris_log_shared:first_chunk_id(Shared),
+    LastChId = osiris_log_shared:last_chunk_id(Shared),
+    case NextChId of
+        FirstChId ->
+            {local, Remote0};
+        _ when NextChId > LastChId ->
+            {end_of_stream, Remote0};
+        _ ->
+            %% TODO: what if retention takes away fragments? We need to
+            %% jump ahead to the start of the log.
+            Key = rabbitmq_stream_s3:fragment_key(StreamId, NextChId),
+            case rabbitmq_stream_s3_log_reader_sup:add_child(self(), Key) of
+                {ok, Pid} ->
+                    ok = gen_server:cast(Pid0, close),
+                    Remote = Remote0#remote{
+                        pid = Pid,
+                        fragment = NextChId,
+                        position = ?SEGMENT_HEADER_B
+                    },
+                    read_header1(Remote);
+                {error, not_found} ->
+                    {end_of_stream, Remote0}
             end
     end.
 


### PR DESCRIPTION
Fixes #105. Related: #33.

## What this fixes

When consumers fall back to reading from S3 after local segments are deleted by retention, `rabbit_stream_reader` crashes with `{badmatch, {error, invalid_chunk_header}}` and the supervisor hits `reached_max_restart_intensity`. This is reproducible on `main` within ~3 minutes of a high-throughput test with `--max-length-bytes 10gb`.

See #105 for the full root cause analysis.

## Changes

**Fix `advance_fragment` using wrong starting position in new fragment** (8ca3e45)

`advance_fragment` set `position = ?SEGMENT_HEADER_B` (8) when attaching to a new fragment. Fragment objects have the layout `[58-byte fragment header][chunk data][index]` — chunk data starts at byte 58 (`?FRAGMENT_HEADER_B`), not byte 8. Diagnostic logging confirmed the crash was occurring at position 66 (an earlier overcorrection) and then at position 8 on `main`.

**Add diagnostic logging around invalid_chunk_header crash** (629669a)

Logs position, fragment, next_offset, and first bytes of the header binary when `parse_header` fails. Also logs the position and result in `read_header1` and the position returned by `find_position0`. These logs identified the root cause.

**Fix undefined `get_fragment_trailer/2` call in `find_position0`** (388c2dd)

A prior partial revert left a call to the non-existent `rabbitmq_stream_s3_server:get_fragment_trailer/2` in `find_position0`. Renamed back to `get_fragment_info/2`.

**Handle `{error, normal}` from `add_child` in `advance_fragment`** (addcd23)

Broadened the error match in `advance_fragment` from `{error, not_found}` to `{error, _}` to handle `{error, normal}` returned when `init/1` stops normally (e.g. fragment deleted by retention).

**Jump to oldest S3 fragment when `advance_fragment` hits a deleted one** (d93589e)

When `advance_fragment` cannot attach to the next fragment because it has been deleted by retention, jump to `first_offset` from the manifest rather than returning `end_of_stream`.

**Handle S3 errors in `rabbitmq_stream_s3_log_reader` gracefully** (7bbf6c7)

Return `{error, not_found}` from `init/1` when the fragment key does not exist in S3, rather than crashing.

**Log unexpected HTTP status codes from S3 API calls at debug level** (56280e0)
