### PR TITLE
Fix consumer crash when reading from S3 after retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,15 +31,20 @@ Read the relevant doc before modifying any module.
 | `rabbitmq_stream_s3.erl` | Utility functions: key construction, index file helpers |
 | `rabbitmq_stream_s3_api.erl` | Storage backend behaviour (callbacks for get, put, delete) |
 | `rabbitmq_stream_s3_api_aws.erl` | AWS S3 backend implementation (production) |
+| `rabbitmq_stream_s3_api_aws_pool.erl` | Connection pool for S3 HTTP connections; separate pools for reads and writes avoid reader starvation |
 | `rabbitmq_stream_s3_api_fs.erl` | Filesystem backend implementation (tests) |
 | `rabbitmq_stream_s3_app.erl` | OTP application module |
 | `rabbitmq_stream_s3_array.erl` | Binary array operations (at, slice, partition_point, etc.) |
 | `rabbitmq_stream_s3_db.erl` | Khepri interactions: stream ID storage, triggers, keep-while conditions |
 | `rabbitmq_stream_s3_log_manifest.erl` | `osiris_log_manifest` behaviour: local tier interface, fragment recovery on boot |
 | `rabbitmq_stream_s3_log_reader.erl` | `osiris_log_reader` behaviour: reads from local or remote tier |
+| `rabbitmq_stream_s3_machine.erl` | Manifest state machine: fragment tracking, retention, groups |
+| `rabbitmq_stream_s3_membership_reconciliation.erl` | `gen_server` implementing Continuous Membership Reconciliation (CMR) for streams |
+| `rabbitmq_stream_s3_membership_reconciliation_events.erl` | `gen_event` handler that notifies the CMR server when membership should be evaluated |
+| `rabbitmq_stream_s3_prometheus_collector.erl` | Prometheus metrics collector; implements the `prometheus_collector` behaviour |
 | `rabbitmq_stream_s3_remote_reader.erl` | `gen_server` that pre-fetches and buffers data from the remote tier for a single consumer |
 | `rabbitmq_stream_s3_remote_reader_sup.erl` | Supervisor for remote reader `gen_server` processes |
-| `rabbitmq_stream_s3_machine.erl` | Manifest state machine: fragment tracking, retention, groups |
+| `rabbitmq_stream_s3_request_metrics.erl` | Tracks S3 request duration as a histogram (set of per-bucket counters) |
 | `rabbitmq_stream_s3_server.erl` | `gen_server` coordinating uploads, deletions, manifest updates |
 | `rabbitmq_stream_s3_sup.erl` | Top-level supervisor |
 
@@ -60,6 +65,8 @@ constants (`?INDEX_RECORD_SIZE_B`, `?CHUNK_HEADER_B`, `?MAX_FRAGMENT_SIZE_B`).
 
 | Suite | What it tests |
 |-------|---------------|
+| `config_schema_SUITE.erl` | Configuration schema snippets from `docs/configuration.md` |
+| `membership_reconciliation_SUITE.erl` | Continuous Membership Reconciliation behaviour |
 | `unit_SUITE.erl` | Property-based tests for `_array`, `find_fragment`, `find_index_position` |
 | `s3_streams_SUITE.erl` | Integration tests: publish, read from remote tier by offset and timestamp |
 | `rabbitmq_stream_s3_machine_SUITE.erl` | State machine transitions |
@@ -125,5 +132,11 @@ The backend is configured via application environment, not `rabbitmq.conf`.
   `init_local_reader` which returns `{ok, Reader}`
 - The `rabbitmq_stream_s3_server` public API (`get_manifest/1`, `get_range/1`)
   uses the stream ID, not the user-visible queue name
+- `maybe_start_request/1` in `rabbitmq_stream_s3_remote_reader` has a guard
+  `when EndPos - CurrentPos > ReadSize` that skips `maybe_start_current_request`
+  and calls only `maybe_start_next_request`. After the initial fetch this guard
+  is always true, so calling `maybe_start_request` when the buffer is exhausted
+  leaves the reader in `await` indefinitely. Call `maybe_start_current_request`
+  directly in that case
 - Index records are 29 bytes (`?INDEX_RECORD_SIZE_B`):
   `<<ChunkId:64, Timestamp:64, Epoch:64, FilePos:32, ChunkType:8>>`

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -305,11 +305,7 @@ handle_info(Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, #?MODULE{requests = Requests}) ->
-    _ = [
-        rabbitmq_stream_s3_api:cancel_async(RequestId, ReqState)
-     || RequestId := #request{state = ReqState} <- Requests
-    ],
-    counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0),
+    cancel_requests(Requests),
     ok.
 
 format_status(#{state := #?MODULE{} = State} = Status0) ->
@@ -638,19 +634,39 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
         #?MODULE{requests = Requests} when map_size(Requests) =/= 0 ->
             %% The current fragment's info is being requested. Wait for its arrival.
             {await, State};
-        #?MODULE{current_not_found = true} ->
-            %% TODO: fragment deletion. Skip ahead to the next fragment if the
-            %% stream still exists, or convert to a local reader if that has
-            %% older data than the remote tier. (Possible if retention
-            %% reclaims fragments but not the current segment.)
-            erlang:error(unimplemented);
+        #?MODULE{current_not_found = true, stream = StreamId, requests = Requests} ->
+            %% The current fragment was deleted by retention while being read.
+            %% Cancel all in-flight requests for the deleted fragment, then jump
+            %% to the oldest fragment still available in the remote tier.
+            cancel_requests(Requests),
+            {FirstOffset, _} = rabbitmq_stream_s3_server:get_range(StreamId),
+            Key = rabbitmq_stream_s3:fragment_key(StreamId, FirstOffset),
+            ?LOG_WARNING(
+                "Fragment ~20..0B was deleted by retention while being read. "
+                "Jumping to oldest available fragment ~20..0B",
+                [State#?MODULE.fragment, FirstOffset]
+            ),
+            NewState = State#?MODULE{
+                fragment = FirstOffset,
+                key = Key,
+                info = undefined,
+                buffer = <<>>,
+                start_pos = ?FRAGMENT_HEADER_B,
+                current_pos = ?FRAGMENT_HEADER_B,
+                end_pos = ?FRAGMENT_HEADER_B,
+                next = undefined,
+                requests = #{},
+                current_not_found = false
+            },
+            {next_fragment, NewState, FirstOffset};
         #?MODULE{read_size = ReadSize0} ->
             %% The chunk is larger than the read-ahead. Bump read_size to
-            %% cover the needed bytes so maybe_start_request issues a
-            %% sufficiently large request.
+            %% cover the needed bytes and call maybe_start_current_request
+            %% directly - bypassing the maybe_start_request guard that skips
+            %% current requests when the buffer already exceeds read_size.
             Needed = Offset + Bytes - EndPos,
             ReadSize = max(ReadSize0, Needed),
-            {await, State#?MODULE{read_size = ReadSize}}
+            {await, maybe_start_current_request(State#?MODULE{read_size = ReadSize})}
     end;
 try_read(
     #?MODULE{
@@ -703,6 +719,15 @@ goto_next_fragment(
         info = Info,
         next = undefined
     }.
+
+cancel_requests(Requests) ->
+    maps:foreach(
+        fun(RequestId, #request{state = ReqState}) ->
+            rabbitmq_stream_s3_api:cancel_async(RequestId, ReqState)
+        end,
+        Requests
+    ),
+    counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0).
 
 format_state(#?MODULE{
     stream = StreamId,

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -639,26 +639,30 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
             %% Cancel all in-flight requests for the deleted fragment, then jump
             %% to the oldest fragment still available in the remote tier.
             cancel_requests(Requests),
-            {FirstOffset, _} = rabbitmq_stream_s3_server:get_range(StreamId),
-            Key = rabbitmq_stream_s3:fragment_key(StreamId, FirstOffset),
-            ?LOG_WARNING(
-                "Fragment ~20..0B was deleted by retention while being read. "
-                "Jumping to oldest available fragment ~20..0B",
-                [State#?MODULE.fragment, FirstOffset]
-            ),
-            NewState = State#?MODULE{
-                fragment = FirstOffset,
-                key = Key,
-                info = undefined,
-                buffer = <<>>,
-                start_pos = ?FRAGMENT_HEADER_B,
-                current_pos = ?FRAGMENT_HEADER_B,
-                end_pos = ?FRAGMENT_HEADER_B,
-                next = undefined,
-                requests = #{},
-                current_not_found = false
-            },
-            {next_fragment, NewState, FirstOffset};
+            case rabbitmq_stream_s3_server:get_range(StreamId) of
+                empty ->
+                    {end_of_stream, State#?MODULE{requests = #{}}};
+                {FirstOffset, _} ->
+                    Key = rabbitmq_stream_s3:fragment_key(StreamId, FirstOffset),
+                    ?LOG_WARNING(
+                        "Fragment ~20..0B was deleted by retention while being read. "
+                        "Jumping to oldest available fragment ~20..0B",
+                        [State#?MODULE.fragment, FirstOffset]
+                    ),
+                    NewState = State#?MODULE{
+                        fragment = FirstOffset,
+                        key = Key,
+                        info = undefined,
+                        buffer = <<>>,
+                        start_pos = ?FRAGMENT_HEADER_B,
+                        current_pos = ?FRAGMENT_HEADER_B,
+                        end_pos = ?FRAGMENT_HEADER_B,
+                        next = undefined,
+                        requests = #{},
+                        current_not_found = false
+                    },
+                    {next_fragment, NewState, FirstOffset}
+            end;
         #?MODULE{read_size = ReadSize0} ->
             %% The chunk is larger than the read-ahead. Bump read_size to
             %% cover the needed bytes and call maybe_start_current_request


### PR DESCRIPTION
Fixes #105.

## What this fixes

Consumers crash with `reached_max_restart_intensity` when reading from the remote (S3) tier after local segments are deleted by retention. The root cause is two unimplemented code paths in `rabbitmq_stream_s3_remote_reader:try_read/3`.

## Changes

**Handle deleted fragment by jumping to oldest available**

When a fragment is deleted by retention while a consumer is actively reading it, S3 returns 404, setting `current_not_found = true`. `try_read/3` previously crashed with `erlang:error(unimplemented)`.

Cancel all in-flight requests for the deleted fragment and call `get_range/1` to find the oldest fragment still in the remote tier. If the remote tier is empty (stream fully deleted), return `end_of_stream`. Otherwise reset the reader state to start from the oldest available fragment, setting `info = undefined` so `maybe_start_current_request` issues a new GET from byte 0 of the new fragment. Return `{next_fragment, FirstOffset}` so the log reader updates its `next_offset` accordingly.

Extract `cancel_requests/1` to replace the inline list comprehension in `terminate/2` and use it in both call sites.

**Handle exhausted buffer with no in-flight requests**

When the buffer has insufficient data and there are no in-flight requests, `try_read/3` previously crashed with `erlang:error(unimplemented)`. This occurs when a chunk is larger than the current read-ahead window (AIMD may reduce `read_size` to 1 MiB minimum).

Bump `read_size` to cover the needed bytes and call `maybe_start_current_request` directly. Calling `maybe_start_request` instead would skip the current fragment fetch: its first clause guards on `EndPos - CurrentPos > ReadSize`, which is always true after the initial fetch due to AIMD halving, causing the remote_reader to sit in `await` indefinitely until the 60-second `gen_server:call` timeout.

## Testing

Verified with a 30-minute high-throughput test (6 streams, 12 producers, 12 consumers, `--max-length-bytes 10gb`). The previous `main` crashed within ~3 minutes when retention first fired. With this fix, the full 30-minute test ran without crashes, consumers read from S3 throughout (including the `current_not_found` path being exercised repeatedly in logs), and full replay from `first` across all 6 streams completed successfully (57,813,558 / 57,838,579 messages).
