### PR TITLE
Improve HTTP pool

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -523,6 +523,20 @@ request(Method, Path, Headers0, Body, Opts) when
     end.
 
 request0(Method, Path, Headers, Body, Opts) ->
+    request0(Method, Path, Headers, Body, Opts, 2).
+
+request0(Method, Path, Headers, Body, Opts, 0) ->
+    request1(Method, Path, Headers, Body, Opts);
+request0(Method, Path, Headers, Body, Opts, Retries) ->
+    case request1(Method, Path, Headers, Body, Opts) of
+        {error, {down, normal}} ->
+            %% Retry if we get a connection that closes upon request.
+            request0(Method, Path, Headers, Body, Opts, Retries - 1);
+        Other ->
+            Other
+    end.
+
+request1(Method, Path, Headers, Body, Opts) ->
     Pool =
         case Method of
             <<"PUT">> -> ?UPLOAD_POOL;

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -30,7 +30,7 @@ A wrapper around the AWS S3 HTTP API.
 -export([get_credentials/0, get_credentials/2]).
 
 %% For the pool. Not to be called by anyone else.
--export([open/0]).
+-export([hostname/0]).
 
 -define(ALGORITHM, "AWS4-HMAC-SHA256").
 -define(ISOFORMAT_BASIC, "~4.10.0b~2.10.0b~2.10.0bT~2.10.0b~2.10.0b~2.10.0bZ").
@@ -141,19 +141,6 @@ reload_config() ->
             ok
     end,
     ok.
-
--doc """
-Opens a connection to S3 in the configured region.
-""".
--spec open() -> {ok, pid()} | {error, any()}.
-open() ->
-    %% NOTE: unfortunately, `inet:hostname()` is a string not a binary.
-    Host = binary_to_list(hostname()),
-    %% NOTE: AWS S3 only supports HTTP/1.1 but other providers like Google Cloud
-    %% support HTTP/2 (from what I heard). TODO: Evaluate HTTP/2 on other
-    %% providers. Maybe just pin to HTTP/1.1.
-    Opts = #{transport => tls, protocols => [http2, http]},
-    gun:open(Host, 443, Opts).
 
 -doc "Gets the body of an object at key `Key`".
 -spec get(key(), request_opts()) -> {ok, binary()} | {error, any()}.

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -210,8 +210,9 @@ handle_info(
     ?assert(is_map_key(Conn, Monitors)),
     {noreply, make_available(Conn, State0)};
 handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
-    %% With retry=>0, gun sends this message before stopping the connection
-    %% process. We'll do the necessary cleanup in the 'DOWN' handler instead.
+    %% With retry=>0, gun stops the connection process immediately after sending
+    %% this message (with reason 'normal' for a clean close, or
+    %% '{shutdown, Reason}' otherwise). The 'DOWN' handler does all cleanup.
     {noreply, State};
 handle_info(
     {'DOWN', MRef, process, Pid, _Reason},

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -27,13 +27,11 @@ the reader pool avoids reader starvation.
 -record(?MODULE, {
     min_size :: non_neg_integer(),
     max_size :: pos_integer(),
-    %% A queue of connections which are available to be checked out of the
-    %% pool. IDEA: consider LIFO ordering instead. More recently used connections
-    %% might be 'hotter'.
-    available = queue:new() :: queue:queue(conn()),
-    %% Number of conns in the `available` queue. This value is cached here
-    %% since `queue:len/1` takes linear time.
-    num_available = 0 :: non_neg_integer(),
+    %% A stack of connections which are available to be checked out of the
+    %% pool. This is a stack rather than a queue so that the most recently used
+    %% connection (which is most 'hot' and least likely to be closed because of
+    %% idleness) is prioritized for a checkout.
+    available = [] :: [conn()],
     %% Monitors on all connections whether they are available, checked out,
     %% or down.
     monitors = #{} :: #{conn() => MRef :: reference()},
@@ -133,22 +131,20 @@ handle_call(
     #?MODULE{
         pending = Pending0,
         available = Available0,
-        num_available = NumAvailable0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0
     } = State0
 ) ->
     MRef = erlang:monitor(process, Pid),
-    case queue:out(Available0) of
-        {{value, Conn}, Available} ->
+    case Available0 of
+        [Conn | Available] ->
             State = State0#?MODULE{
                 available = Available,
-                num_available = NumAvailable0 - 1,
                 checkouts = Checkouts0#{Conn => MRef},
                 checkouts_rev = CheckoutsRev0#{MRef => Conn}
             },
             {reply, Conn, State};
-        {empty, _Available0} ->
+        [] ->
             P = #pending{from = From, checkout = Checkout, mref = MRef},
             State1 = State0#?MODULE{pending = queue:in(P, Pending0)},
             {noreply, grow(State1)}
@@ -161,7 +157,6 @@ handle_cast(
     {checkin, Conn},
     #?MODULE{
         available = Available0,
-        num_available = NumAvailable0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
         down = Down
@@ -179,10 +174,7 @@ handle_cast(
                     %% Connection is reconnecting. Don't return to available.
                     {noreply, State1};
                 _ ->
-                    State2 = State1#?MODULE{
-                        available = queue:in(Conn, Available0),
-                        num_available = NumAvailable0 + 1
-                    },
+                    State2 = State1#?MODULE{available = [Conn | Available0]},
                     {noreply, checkout(State2)}
             end;
         _ ->
@@ -212,7 +204,6 @@ handle_info(
     {gun_up, Conn, _Protocol},
     #?MODULE{
         available = Available0,
-        num_available = NumAvailable0,
         monitors = Monitors,
         down = Down0
     } = State0
@@ -220,8 +211,7 @@ handle_info(
     %% `gun_up` messages cannot arrive from connections not opened by this pool.
     ?assert(is_map_key(Conn, Monitors)),
     State1 = State0#?MODULE{
-        available = queue:in(Conn, Available0),
-        num_available = NumAvailable0 + 1,
+        available = [Conn | Available0],
         down = maps:remove(Conn, Down0)
     },
     {noreply, checkout(State1)};
@@ -234,7 +224,6 @@ handle_info(
     {'DOWN', MRef, process, Pid, _Reason},
     #?MODULE{
         available = Available0,
-        num_available = NumAvailable0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
         monitors = Monitors0,
@@ -258,8 +247,7 @@ handle_info(
                     %% A caller process is down which has a conn checked out.
                     %% Return the conn.
                     State1 = State0#?MODULE{
-                        available = queue:in(Conn, Available0),
-                        num_available = NumAvailable0 + 1,
+                        available = [Conn | Available0],
                         checkouts = maps:remove(Conn, Checkouts0),
                         checkouts_rev = maps:remove(MRef, CheckoutsRev0)
                     },
@@ -297,14 +285,14 @@ grow(
     #?MODULE{
         min_size = MinSize,
         max_size = MaxSize,
-        num_available = NumAvailable,
+        available = Available,
         checkouts = Checkouts,
         pending = Pending,
         monitors = Monitors0
     } = State0
 ) ->
     Count = map_size(Monitors0),
-    InFlight = Count - NumAvailable - map_size(Checkouts),
+    InFlight = Count - length(Available) - map_size(Checkouts),
     Demand = queue:len(Pending) - InFlight,
     Target = max(MinSize - Count, max(Demand, 0)),
     N = min(Target, MaxSize - Count),
@@ -351,18 +339,16 @@ checkout(
     #?MODULE{
         pending = Pending0,
         available = Available0,
-        num_available = NumAvailable0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0
     } = State0
 ) ->
-    case {queue:out(Pending0), queue:out(Available0)} of
-        {{{value, #pending{from = From, mref = MRef}}, Pending}, {{value, Conn}, Available}} ->
+    case {queue:out(Pending0), Available0} of
+        {{{value, #pending{from = From, mref = MRef}}, Pending}, [Conn | Available]} ->
             gen_server:reply(From, Conn),
             State1 = State0#?MODULE{
                 pending = Pending,
                 available = Available,
-                num_available = NumAvailable0 - 1,
                 checkouts = Checkouts0#{Conn => MRef},
                 checkouts_rev = CheckoutsRev0#{MRef => Conn}
             },
@@ -375,7 +361,6 @@ cancel(
     Conn,
     #?MODULE{
         available = Available0,
-        num_available = NumAvailable0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0
     } = State0
@@ -388,12 +373,9 @@ cancel(
                 checkouts_rev = maps:remove(CallerMRef, CheckoutsRev0)
             };
         _ ->
-            case queue:member(Conn, Available0) of
+            case lists:member(Conn, Available0) of
                 true ->
-                    State0#?MODULE{
-                        available = queue:delete(Conn, Available0),
-                        num_available = NumAvailable0 - 1
-                    };
+                    State0#?MODULE{available = lists:delete(Conn, Available0)};
                 false ->
                     %% The conn could be spawned but never sent a
                     %% gun_up, so it might not be checked out or
@@ -405,7 +387,7 @@ cancel(
 format_state(#?MODULE{
     min_size = MinSize,
     max_size = MaxSize,
-    num_available = NumAvailable,
+    available = Available,
     monitors = Monitors,
     checkouts = Checkouts,
     pending = Pending
@@ -413,7 +395,7 @@ format_state(#?MODULE{
     #{
         min_size => MinSize,
         max_size => MaxSize,
-        available => NumAvailable,
+        available => length(Available),
         monitors => map_size(Monitors),
         checkouts => map_size(Checkouts),
         pending => queue:len(Pending)

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -42,9 +42,7 @@ the reader pool avoids reader starvation.
     %% Same as above but reversed.
     checkouts_rev = #{} :: #{MRef :: reference() => conn()},
     %% A queue of requests to check out a connection.
-    pending = queue:new() :: queue:queue(#pending{}),
-    %% Connections that received gun_down but not yet gun_up.
-    down = #{} :: #{conn() => true}
+    pending = queue:new() :: queue:queue(#pending{})
 }).
 
 %% Gun connection pid.
@@ -159,7 +157,7 @@ handle_cast(
         available = Available0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
-        down = Down
+        monitors = Monitors
     } = State0
 ) ->
     case Checkouts0 of
@@ -169,13 +167,13 @@ handle_cast(
                 checkouts = maps:remove(Conn, Checkouts0),
                 checkouts_rev = maps:remove(MRef, CheckoutsRev0)
             },
-            case Down of
+            case Monitors of
                 #{Conn := _} ->
-                    %% Connection is reconnecting. Don't return to available.
-                    {noreply, State1};
-                _ ->
+                    %% Connection is still alive and should be able to be reused.
                     State2 = State1#?MODULE{available = [Conn | Available0]},
-                    {noreply, checkout(State2)}
+                    {noreply, checkout(State2)};
+                _ ->
+                    {noreply, State1}
             end;
         _ ->
             {noreply, State0}
@@ -204,22 +202,17 @@ handle_info(
     {gun_up, Conn, _Protocol},
     #?MODULE{
         available = Available0,
-        monitors = Monitors,
-        down = Down0
+        monitors = Monitors
     } = State0
 ) ->
     %% `gun_up` messages cannot arrive from connections not opened by this pool.
     ?assert(is_map_key(Conn, Monitors)),
-    State1 = State0#?MODULE{
-        available = [Conn | Available0],
-        down = maps:remove(Conn, Down0)
-    },
+    State1 = State0#?MODULE{available = [Conn | Available0]},
     {noreply, checkout(State1)};
-handle_info({gun_down, Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{down = Down0} = State0) ->
-    %% The connection is down. Gun automatically attempts re-connection so
-    %% remove it from available or checkouts until it comes back up.
-    State1 = State0#?MODULE{down = Down0#{Conn => true}},
-    {noreply, cancel(Conn, State1)};
+handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
+    %% With retry=>0, gun sends this message before stopping the connection
+    %% process. We'll do the necessary cleanup in the 'DOWN' handler instead.
+    {noreply, State};
 handle_info(
     {'DOWN', MRef, process, Pid, _Reason},
     #?MODULE{
@@ -227,18 +220,14 @@ handle_info(
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
         monitors = Monitors0,
-        pending = Pending0,
-        down = Down0
+        pending = Pending0
     } = State0
 ) ->
     case Monitors0 of
         #{Pid := MRef} ->
-            %% A connection is down. Forget it and grow a new one.
+            %% A connection is down. Forget it and maybe grow a new one.
             Conn = Pid,
-            State1 = State0#?MODULE{
-                monitors = maps:remove(Conn, Monitors0),
-                down = maps:remove(Conn, Down0)
-            },
+            State1 = State0#?MODULE{monitors = maps:remove(Conn, Monitors0)},
             State2 = cancel(Pid, State1),
             {noreply, grow(State2)};
         _ ->
@@ -331,7 +320,12 @@ open() ->
             %% holding until the nth minor GC triggers a full sweep.
             {receiver_spawn_opts, [{fullsweep_after, 0}]},
             {sender_spawn_opts, [{fullsweep_after, 0}]}
-        ]
+        ],
+        %% Let connections which were closed from idleness (or errors) close
+        %% and be reopened lazily. With TLSv1.3 it only costs one round trip.
+        %% This pool optimizes for best resource use rather than consistently
+        %% low latency. (A fully idle broker should have a min-sized pool.)
+        retry => 0
     },
     gun:open(Host, 443, Opts).
 

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -18,6 +18,9 @@ the reader pool avoids reader starvation.
 
 -behaviour(gen_server).
 
+%% Reap proactively before S3 closes an idle connection from under us.
+-define(IDLE_TIMEOUT_MS, 10_000).
+
 -record(pending, {
     from :: gen_server:from(),
     checkout :: checkout(),
@@ -42,7 +45,9 @@ the reader pool avoids reader starvation.
     %% Same as above but reversed.
     checkouts_rev = #{} :: #{MRef :: reference() => conn()},
     %% A queue of requests to check out a connection.
-    pending = queue:new() :: queue:queue(#pending{})
+    pending = queue:new() :: queue:queue(#pending{}),
+    %% Idle timers for available connections.
+    idle_timers = #{} :: #{conn() => reference()}
 }).
 
 %% Gun connection pid.
@@ -141,7 +146,7 @@ handle_call(
                 checkouts = Checkouts0#{Conn => MRef},
                 checkouts_rev = CheckoutsRev0#{MRef => Conn}
             },
-            {reply, Conn, State};
+            {reply, Conn, cancel_idle_timer(Conn, State)};
         [] ->
             P = #pending{from = From, checkout = Checkout, mref = MRef},
             State1 = State0#?MODULE{pending = queue:in(P, Pending0)},
@@ -154,7 +159,6 @@ handle_call(Request, From, State) ->
 handle_cast(
     {checkin, Conn},
     #?MODULE{
-        available = Available0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
         monitors = Monitors
@@ -169,9 +173,9 @@ handle_cast(
             },
             case Monitors of
                 #{Conn := _} ->
-                    %% Connection is still alive and should be able to be reused.
-                    State2 = State1#?MODULE{available = [Conn | Available0]},
-                    {noreply, checkout(State2)};
+                    %% Connection is still alive as far as we know, and should
+                    %% be reused.
+                    {noreply, make_available(Conn, State1)};
                 _ ->
                     {noreply, State1}
             end;
@@ -200,15 +204,11 @@ handle_info(grow, State0) ->
     {noreply, grow(State0)};
 handle_info(
     {gun_up, Conn, _Protocol},
-    #?MODULE{
-        available = Available0,
-        monitors = Monitors
-    } = State0
+    #?MODULE{monitors = Monitors} = State0
 ) ->
     %% `gun_up` messages cannot arrive from connections not opened by this pool.
     ?assert(is_map_key(Conn, Monitors)),
-    State1 = State0#?MODULE{available = [Conn | Available0]},
-    {noreply, checkout(State1)};
+    {noreply, make_available(Conn, State0)};
 handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
     %% With retry=>0, gun sends this message before stopping the connection
     %% process. We'll do the necessary cleanup in the 'DOWN' handler instead.
@@ -216,7 +216,6 @@ handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = 
 handle_info(
     {'DOWN', MRef, process, Pid, _Reason},
     #?MODULE{
-        available = Available0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
         monitors = Monitors0,
@@ -236,11 +235,10 @@ handle_info(
                     %% A caller process is down which has a conn checked out.
                     %% Return the conn.
                     State1 = State0#?MODULE{
-                        available = [Conn | Available0],
                         checkouts = maps:remove(Conn, Checkouts0),
                         checkouts_rev = maps:remove(MRef, CheckoutsRev0)
                     },
-                    {noreply, checkout(State1)};
+                    {noreply, make_available(Conn, State1)};
                 _ ->
                     %% A pending caller process is down. Remove it from the
                     %% pending queue.
@@ -250,6 +248,25 @@ handle_info(
                     State = State0#?MODULE{pending = Pending},
                     {noreply, State}
             end
+    end;
+handle_info({idle_timeout, Conn}, #?MODULE{idle_timers = Timers, monitors = Monitors} = State0) ->
+    case Timers of
+        #{Conn := _} ->
+            %% Timer is still active (wasn't cancelled by a checkout), so the
+            %% connection has been idle too long. Close it.
+            State1 = State0#?MODULE{idle_timers = maps:remove(Conn, Timers)},
+            State2 = cancel(Conn, State1),
+            case Monitors of
+                #{Conn := ConnMRef} ->
+                    erlang:demonitor(ConnMRef, [flush]),
+                    gun:close(Conn),
+                    {noreply, State2#?MODULE{monitors = maps:remove(Conn, Monitors)}};
+                _ ->
+                    {noreply, State2}
+            end;
+        _ ->
+            %% Timer was already cancelled (stale message). Ignore.
+            {noreply, State0}
     end;
 handle_info(Message, State) ->
     ?LOG_DEBUG(
@@ -312,7 +329,6 @@ open() ->
         %% AWS S3 only supports HTTP/1.1.
         protocols => [http],
         tls_opts => [
-            {hibernate_after, 5000},
             %% Connections are mostly data pipes for large refc binaries.
             %% Full sweeps are nearly free since the process's heap doesn't
             %% contain much, and the immediate cleanup of dead refc binary
@@ -340,12 +356,12 @@ checkout(
     case {queue:out(Pending0), Available0} of
         {{{value, #pending{from = From, mref = MRef}}, Pending}, [Conn | Available]} ->
             gen_server:reply(From, Conn),
-            State1 = State0#?MODULE{
+            State1 = cancel_idle_timer(Conn, State0#?MODULE{
                 pending = Pending,
                 available = Available,
                 checkouts = Checkouts0#{Conn => MRef},
                 checkouts_rev = CheckoutsRev0#{MRef => Conn}
-            },
+            }),
             checkout(State1);
         _ ->
             State0
@@ -369,13 +385,27 @@ cancel(
         _ ->
             case lists:member(Conn, Available0) of
                 true ->
-                    State0#?MODULE{available = lists:delete(Conn, Available0)};
+                    State1 = State0#?MODULE{available = lists:delete(Conn, Available0)},
+                    cancel_idle_timer(Conn, State1);
                 false ->
-                    %% The conn could be spawned but never sent a
-                    %% gun_up, so it might not be checked out or
-                    %% available.
                     State0
             end
+    end.
+
+make_available(Conn, #?MODULE{available = Available, idle_timers = Timers} = State) ->
+    TRef = erlang:send_after(?IDLE_TIMEOUT_MS, self(), {idle_timeout, Conn}),
+    checkout(State#?MODULE{
+        available = [Conn | Available],
+        idle_timers = Timers#{Conn => TRef}
+    }).
+
+cancel_idle_timer(Conn, #?MODULE{idle_timers = Timers0} = State) ->
+    case Timers0 of
+        #{Conn := TRef} ->
+            ok = erlang:cancel_timer(TRef, [{async, true}, {info, false}]),
+            State#?MODULE{idle_timers = maps:remove(Conn, Timers0)};
+        _ ->
+            State
     end.
 
 format_state(#?MODULE{

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -313,7 +313,7 @@ grow(
 grow(0, State) ->
     State;
 grow(N, #?MODULE{monitors = Monitors0} = State0) ->
-    case rabbitmq_stream_s3_api_aws:open() of
+    case open() of
         {ok, Conn} ->
             State = State0#?MODULE{monitors = Monitors0#{Conn => erlang:monitor(process, Conn)}},
             grow(N - 1, State);
@@ -322,6 +322,30 @@ grow(N, #?MODULE{monitors = Monitors0} = State0) ->
             erlang:send_after(1_000, self(), grow),
             State0
     end.
+
+-doc """
+Opens a connection to S3 in the configured region.
+""".
+-spec open() -> {ok, pid()} | {error, any()}.
+open() ->
+    %% NOTE: unfortunately, `inet:hostname()` is a string not a binary.
+    Host = binary_to_list(rabbitmq_stream_s3_api_aws:hostname()),
+    Opts = #{
+        transport => tls,
+        %% AWS S3 only supports HTTP/1.1.
+        protocols => [http],
+        tls_opts => [
+            {hibernate_after, 5000},
+            %% Connections are mostly data pipes for large refc binaries.
+            %% Full sweeps are nearly free since the process's heap doesn't
+            %% contain much, and the immediate cleanup of dead refc binary
+            %% references lets the binary allocator free promptly rather than
+            %% holding until the nth minor GC triggers a full sweep.
+            {receiver_spawn_opts, [{fullsweep_after, 0}]},
+            {sender_spawn_opts, [{fullsweep_after, 0}]}
+        ]
+    },
+    gun:open(Host, 443, Opts).
 
 checkout(
     #?MODULE{

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -20,7 +20,7 @@ init([]) ->
             {rabbitmq_stream_s3_api_aws_pool, start_link, [
                 rabbitmq_stream_s3_upload_pool,
                 #{
-                    min_size => application:get_env(rabbitmq_stream_s3, upload_pool_min_size, 4),
+                    min_size => application:get_env(rabbitmq_stream_s3, upload_pool_min_size, 0),
                     max_size => application:get_env(rabbitmq_stream_s3, upload_pool_max_size, 20)
                 }
             ]}
@@ -32,7 +32,7 @@ init([]) ->
             {rabbitmq_stream_s3_api_aws_pool, start_link, [
                 rabbitmq_stream_s3_general_pool,
                 #{
-                    min_size => application:get_env(rabbitmq_stream_s3, general_pool_min_size, 8),
+                    min_size => application:get_env(rabbitmq_stream_s3, general_pool_min_size, 0),
                     max_size => application:get_env(rabbitmq_stream_s3, general_pool_max_size, 50)
                 }
             ]}


### PR DESCRIPTION
This is series of small improvements to the HTTP connection pool to S3 based on what some official SDKs do.

* Reap idle connections eagerly instead of waiting for S3 to close them.
* Along those lines, allow the pool to shrink to zero so that an idle broker doesn't waste resources reconnecting every few seconds/minutes. This also means turning off automatic reconnection (default in Gun).
* Switch from FIFO to LIFO checkouts (`queue:queue(conn())` -> `[conn()]` stack) to prioritize reusing hot connections.
* Tune process flags to garbage-collect binaries quicker and reduce memory pressure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
