### PR TITLE
Stream fragment uploads with aws-chunked content encoding

### DIFF
--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -23,6 +23,9 @@ file-system operations. Use that in non-unit tests.
     get_range_async/3,
     put/2,
     put/3,
+    stream_put/3,
+    stream_data/2,
+    stream_finish/2,
     delete/1,
     delete/2,
     delete_prefix/1,
@@ -61,6 +64,10 @@ file-system operations. Use that in non-unit tests.
 -callback get_range_async(key(), range_spec(), request_opts()) ->
     {ok, async_req(), async_state()} | {error, any()}.
 -callback put(key(), iodata(), request_opts()) -> ok | {error, any()}.
+-callback stream_put(key(), pos_integer(), request_opts()) ->
+    {ok, async_state()} | {error, any()}.
+-callback stream_data(async_state(), iodata()) -> async_state().
+-callback stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
 -doc """
 Delete the given key or all of the listed keys from the remote tier.
 
@@ -174,6 +181,31 @@ put(Key, Data, Opts) when is_binary(Key) andalso is_map(Opts) ->
     counters:add(counter(), ?C_PUT, 1),
     counters:add(counter(), ?C_BYTES_SENT, iolist_size(Data)),
     observe(write, fun() -> (backend()):put(Key, Data, Opts) end).
+
+-spec stream_put(key(), pos_integer(), request_opts()) -> {ok, async_state()} | {error, any()}.
+stream_put(Key, ContentLength, Opts) when
+    is_binary(Key) andalso is_integer(ContentLength) andalso is_map(Opts)
+->
+    counters:add(counter(), ?C_PUT, 1),
+    StartTs = erlang:monotonic_time(),
+    case (backend()):stream_put(Key, ContentLength, Opts) of
+        {ok, BackendState} ->
+            {ok, {StartTs, BackendState}};
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec stream_data(async_state(), iodata()) -> async_state().
+stream_data({StartTs, BackendState}, Data) ->
+    counters:add(counter(), ?C_BYTES_SENT, iolist_size(Data)),
+    {StartTs, (backend()):stream_data(BackendState, Data)}.
+
+-spec stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
+stream_finish({StartTs, BackendState}, Crc32) ->
+    Result = (backend()):stream_finish(BackendState, Crc32),
+    Ms = erlang:convert_time_unit(erlang:monotonic_time() - StartTs, native, millisecond),
+    rabbitmq_stream_s3_request_metrics:observe(write, Ms),
+    Result.
 
 -doc #{equiv => delete(Keys, #{})}.
 -spec delete(key() | [key()]) -> ok | {error, any()}.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -10,6 +10,8 @@ A wrapper around the AWS S3 HTTP API.
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
+-define(MiB, 1048576).
+
 %% API:
 -export([
     init/0,
@@ -18,6 +20,9 @@ A wrapper around the AWS S3 HTTP API.
     get_range/3,
     get_range_async/3,
     put/3,
+    stream_put/3,
+    stream_data/2,
+    stream_finish/2,
     delete/2,
     delete_prefix/2,
     list/3,
@@ -91,6 +96,7 @@ Called "HTTP Verb" in S3 docs. "GET", "PUT", "HEAD", "POST", "DELETE", etc..
     pages := non_neg_integer()
 }.
 -type async_state() :: #{
+    pool := ?GENERAL_POOL | ?UPLOAD_POOL,
     conn := pid(),
     stream_ref := gun:stream_ref(),
     %% PERF: The remote tier sends relatively small binaries when reading with
@@ -103,7 +109,8 @@ Called "HTTP Verb" in S3 docs. "GET", "PUT", "HEAD", "POST", "DELETE", etc..
     %% to this list and reverse and concatenate the binaries into one large
     %% binary when a fairly large amount of data has been collected.
     data => [binary()],
-    pending_bytes => non_neg_integer()
+    pending_bytes => non_neg_integer(),
+    timeout => timeout()
 }.
 %% Re-use the gun stream ref since it's already a reference.
 -type async_req() :: gun:stream_ref().
@@ -207,6 +214,110 @@ put(Key, Data, Opts) when is_binary(Key) andalso is_map(Opts) ->
         {error, _} = Err ->
             Err
     end.
+
+-spec stream_put(key(), pos_integer(), request_opts()) -> {ok, async_state()} | {error, any()}.
+stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) ->
+    Method = <<"PUT">>,
+    Path = key_to_path(Key),
+    EncodedLength = aws_chunked_encoded_length(ContentLength),
+    Headers0 = #{
+        <<"content-length">> => integer_to_binary(EncodedLength),
+        <<"content-encoding">> => <<"aws-chunked">>,
+        <<"x-amz-decoded-content-length">> => integer_to_binary(ContentLength),
+        <<"x-amz-trailer">> => <<"x-amz-checksum-crc32">>
+    },
+    case get_credentials() of
+        {ok, AccessKey, SecretKey, SecurityToken} ->
+            Headers = sign_headers(
+                Headers0,
+                AccessKey,
+                SecretKey,
+                SecurityToken,
+                Method,
+                Path,
+                no_body,
+                Opts0#{stream_payload => true}
+            ),
+            Cnt = counter(),
+            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
+            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+            Pool = ?UPLOAD_POOL,
+            Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
+            StreamRef = gun:headers(Conn, Method, Path, Headers),
+            State = #{
+                pool => Pool,
+                conn => Conn,
+                stream_ref => StreamRef,
+                data => [],
+                pending_bytes => 0,
+                timeout => maps:get(timeout, Opts0, 60_000)
+            },
+            {ok, State};
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec stream_data(async_state(), iodata()) -> async_state().
+stream_data(#{data := PendingData0, pending_bytes := PendingBytes0} = State0, Data) ->
+    PendingData = [PendingData0, Data],
+    PendingBytes = PendingBytes0 + iolist_size(Data),
+    State = State0#{data := PendingData, pending_bytes := PendingBytes},
+    flush_chunks(State).
+
+flush_chunks(
+    #{
+        conn := Conn,
+        stream_ref := StreamRef,
+        data := PendingData,
+        pending_bytes := PendingBytes
+    } = State0
+) when PendingBytes >= ?MiB ->
+    Flat = iolist_to_binary(PendingData),
+    <<Chunk:?MiB/binary, Rest/binary>> = Flat,
+    send_chunk(Conn, StreamRef, Chunk),
+    flush_chunks(State0#{data := [Rest], pending_bytes := byte_size(Rest)});
+flush_chunks(State) ->
+    State.
+
+-spec stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
+stream_finish(
+    #{
+        conn := Conn,
+        stream_ref := StreamRef,
+        data := PendingData,
+        pending_bytes := PendingBytes,
+        timeout := Timeout
+    } = State,
+    Crc32
+) ->
+    %% Flush remaining buffer as the last data chunk (may be smaller than ?MiB).
+    case PendingBytes of
+        0 -> ok;
+        _ -> send_chunk(Conn, StreamRef, iolist_to_binary(PendingData))
+    end,
+    Checksum = base64:encode(<<Crc32:32/unsigned>>),
+    %% Final aws-chunked terminator + trailer + CRLF, sent as the last body chunk.
+    ok = gun:data(
+        Conn,
+        StreamRef,
+        fin,
+        <<"0\r\nx-amz-checksum-crc32:", Checksum/binary, "\r\n\r\n">>
+    ),
+    try await_response(Conn, StreamRef, Timeout) of
+        {ok, #{status := 200}} ->
+            ok;
+        {ok, #{status := Status} = Other} ->
+            log_unexpected_status(?FUNCTION_NAME, Status),
+            {error, Other};
+        {error, _} = Err ->
+            Err
+    after
+        finish_async(State)
+    end.
+
+send_chunk(Conn, StreamRef, Chunk) when is_binary(Chunk) ->
+    Size = byte_size(Chunk),
+    gun:data(Conn, StreamRef, nofin, [integer_to_binary(Size, 16), <<"\r\n">>, Chunk, <<"\r\n">>]).
 
 -doc "Deletes the given key or list of keys".
 -spec delete(key() | [key()], request_opts()) ->
@@ -484,9 +595,9 @@ cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
     gun:cancel(Conn, StreamRef),
     ok = finish_async(State).
 
-finish_async(#{conn := Conn}) ->
+finish_async(#{conn := Conn, pool := Pool}) ->
     counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
-    ok = rabbitmq_stream_s3_api_aws_pool:checkin(?GENERAL_POOL, Conn).
+    ok = rabbitmq_stream_s3_api_aws_pool:checkin(Pool, Conn).
 
 -spec request(http_method(), key(), req_headers(), iodata(), request_opts()) ->
     {ok, http_response()}
@@ -546,28 +657,32 @@ request1(Method, Path, Headers, Body, Opts) ->
     T1 = start_timeout_window(Timeout),
     rabbitmq_stream_s3_api_aws_pool:with(Pool, Timeout, fun(Conn) ->
         StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-        case gun:await(Conn, StreamRef, end_timeout_window(Timeout, T1)) of
-            {response, fin, Status, RespHeaders} ->
-                Response = #{status => Status, headers => RespHeaders},
-                postprocess_response(Response),
-                {ok, Response};
-            {response, nofin, Status, RespHeaders} ->
-                case gun:await_body(Conn, StreamRef, end_timeout_window(Timeout, T1)) of
-                    {ok, RespBody} ->
-                        Response = #{
-                            status => Status,
-                            headers => RespHeaders,
-                            body => RespBody
-                        },
-                        postprocess_response(Response),
-                        {ok, Response};
-                    {error, _} = Err ->
-                        Err
-                end;
-            {error, _} = Err ->
-                Err
-        end
+        await_response(Conn, StreamRef, end_timeout_window(Timeout, T1))
     end).
+
+await_response(Conn, StreamRef, Timeout) ->
+    T1 = start_timeout_window(Timeout),
+    case gun:await(Conn, StreamRef, Timeout) of
+        {response, fin, Status, RespHeaders} ->
+            Response = #{status => Status, headers => RespHeaders},
+            postprocess_response(Response),
+            {ok, Response};
+        {response, nofin, Status, RespHeaders} ->
+            case gun:await_body(Conn, StreamRef, end_timeout_window(Timeout, T1)) of
+                {ok, RespBody} ->
+                    Response = #{
+                        status => Status,
+                        headers => RespHeaders,
+                        body => RespBody
+                    },
+                    postprocess_response(Response),
+                    {ok, Response};
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
 
 postprocess_response(#{status := 503}) ->
     counters:add(counter(), ?C_RESPONSE_503, 1);
@@ -592,11 +707,12 @@ request_async(Method, Path, Headers0, Body, Opts) ->
             Cnt = counter(),
             counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
             counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
-            Conn = rabbitmq_stream_s3_api_aws_pool:checkout(?GENERAL_POOL, 10_000),
+            Pool = ?GENERAL_POOL,
+            Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
             %% NOTE: no need to wrap this in try/catch and checkin the conn
             %% since gun:request/5 cannot exit/error/throw.
             StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-            {ok, StreamRef, #{conn => Conn, stream_ref => StreamRef}};
+            {ok, StreamRef, #{pool => Pool, conn => Conn, stream_ref => StreamRef}};
         {error, _} = Err ->
             Err
     end.
@@ -1013,22 +1129,31 @@ sign_headers(
         case Opts of
             #{unsigned_payload := true} ->
                 <<"UNSIGNED-PAYLOAD">>;
+            #{stream_payload := true} ->
+                <<"STREAMING-UNSIGNED-PAYLOAD-TRAILER">>;
             _ ->
                 hex(sha256hash(Body))
         end,
     DefaultHeaders0 = #{
-        %% TODO: support chunked transfer.
-        <<"content-length">> => integer_to_binary(iolist_size(Body)),
         <<"host">> => Host,
         <<"x-amz-date">> => RequestTimestamp,
         <<"x-amz-content-sha256">> => PayloadHash
     },
+    DefaultHeaders1 =
+        case Opts of
+            #{stream_payload := true} ->
+                %% content-length (encoded size) is provided in Headers0 and will be
+                %% merged in below. Do not add it here from iolist_size(Body).
+                DefaultHeaders0;
+            _ ->
+                DefaultHeaders0#{<<"content-length">> => integer_to_binary(iolist_size(Body))}
+        end,
     DefaultHeaders =
         case SecurityToken of
             undefined ->
-                DefaultHeaders0;
+                DefaultHeaders1;
             _ ->
-                DefaultHeaders0#{<<"x-amz-security-token">> => SecurityToken}
+                DefaultHeaders1#{<<"x-amz-security-token">> => SecurityToken}
         end,
     Headers1 = maps:merge(DefaultHeaders, Headers0),
     URIMap = uri_string:parse(Path),
@@ -1134,6 +1259,7 @@ hmac_sha256(Key, Message) ->
 %%   be added...
 %% We also include `range` and `date` since the AWS documentation does too.
 is_canonical_header(<<"host">>) -> true;
+is_canonical_header(<<"content-encoding">>) -> true;
 is_canonical_header(<<"Content-MD5">>) -> true;
 is_canonical_header(<<"x-amz-", _/binary>>) -> true;
 is_canonical_header(<<"range">>) -> true;
@@ -1184,11 +1310,63 @@ delete_many_body(Keys) when is_list(Keys) ->
 key_to_path(Key) ->
     <<$/, (uri_string:quote(Key, "/"))/binary>>.
 
+%% Computes the aws-chunked framing overhead for a single chunk of DataSize bytes.
+%% Each chunk is framed as: <hex-size>\r\n<data>\r\n
+-spec aws_chunked_chunk_length(non_neg_integer()) -> non_neg_integer().
+aws_chunked_chunk_length(DataSize) ->
+    hex_digits(DataSize) + 2 + DataSize + 2.
+
+-spec hex_digits(non_neg_integer()) -> pos_integer().
+hex_digits(0) -> 1;
+hex_digits(N) -> hex_digits(N, 0).
+
+hex_digits(0, Acc) -> Acc;
+hex_digits(N, Acc) -> hex_digits(N bsr 4, Acc + 1).
+
+-doc """
+Computes the total encoded content-length for an aws-chunked body with a CRC32 trailer,
+given the decoded content length. All chunks except the last are exactly `?MiB` bytes.
+
+The final terminator + trailer is:
+
+    0\\r\\nx-amz-checksum-crc32:<8-char-base64>\\r\\n\\r\\n
+""".
+-spec aws_chunked_encoded_length(non_neg_integer()) -> non_neg_integer().
+aws_chunked_encoded_length(ContentLength) ->
+    FullChunks = ContentLength div ?MiB,
+    Remainder = ContentLength rem ?MiB,
+    %% "0\r\n" (3) + "x-amz-checksum-crc32:" (21) + base64(4 bytes)=8 + "\r\n" (2) + "\r\n" (2)
+    TrailerLength = 3 + 21 + 8 + 2 + 2,
+    FullChunks * aws_chunked_chunk_length(?MiB) +
+        case Remainder of
+            0 -> 0;
+            _ -> aws_chunked_chunk_length(Remainder)
+        end +
+        TrailerLength.
+
 counter() ->
     persistent_term:get(?COUNTER_KEY).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+hex_digits_test() ->
+    ?assertEqual(1, hex_digits(0)),
+    ?assertEqual(1, hex_digits(1)),
+    ?assertEqual(1, hex_digits(15)),
+    ?assertEqual(2, hex_digits(16)),
+    ?assertEqual(2, hex_digits(255)),
+    ?assertEqual(3, hex_digits(256)),
+    %% 1 MiB = 0x100000 = 6 hex digits
+    ?assertEqual(6, hex_digits(1048576)),
+    ok.
+
+aws_chunked_chunk_length_test() ->
+    %% "3a\r\n<58 bytes>\r\n" = 2+2+58+2 = 64
+    ?assertEqual(64, aws_chunked_chunk_length(58)),
+    %% "100000\r\n<1048576 bytes>\r\n" = 6+2+1048576+2 = 1048586
+    ?assertEqual(1048586, aws_chunked_chunk_length(1048576)),
+    ok.
 
 parse_iso8601_test() ->
     ?assertEqual(

--- a/src/rabbitmq_stream_s3_api_fs.erl
+++ b/src/rabbitmq_stream_s3_api_fs.erl
@@ -18,6 +18,9 @@ associated file in that folder.
     get_range/3,
     get_range_async/3,
     put/3,
+    stream_put/3,
+    stream_data/2,
+    stream_finish/2,
     delete/2,
     delete_prefix/2,
     match_async/2,
@@ -33,7 +36,7 @@ associated file in that folder.
 ]).
 
 -type async_req() :: reference().
--type async_state() :: undefined.
+-type async_state() :: term().
 
 -ifdef(TEST).
 -export([range_spec_to_location_number/2]).
@@ -217,6 +220,31 @@ handle_async({'$async', Req, Msg}, Req, undefined) ->
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(_Req, _State) ->
     ok.
+
+-spec stream_put(key(), pos_integer(), rabbitmq_stream_s3_api:request_opts()) ->
+    {ok, async_state()} | {error, any()}.
+stream_put(Key, _ContentLength, _Opts) ->
+    case key_to_path(Key) of
+        {error, _} = Err ->
+            Err;
+        FilePath ->
+            ok = filelib:ensure_path(filename:dirname(FilePath)),
+            {ok, Fd} = file:open(FilePath, [write, raw, binary]),
+            {ok, {Fd, 0}}
+    end.
+
+-spec stream_data(async_state(), iodata()) -> async_state().
+stream_data({Fd, Crc0}, Data) ->
+    ok = file:write(Fd, Data),
+    {Fd, erlang:crc32(Crc0, Data)}.
+
+-spec stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
+stream_finish({Fd, Crc}, Crc32) ->
+    ok = file:close(Fd),
+    case Crc of
+        Crc32 -> ok;
+        _ -> {error, {checksum_mismatch, #{expected => Crc32, actual => Crc}}}
+    end.
 
 -spec get_stream_data(StreamName) ->
     {ok, Manifest, [FragmentFile]} | {error, not_found | path_not_set}

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -4,6 +4,7 @@
 -module(rabbitmq_stream_s3_server).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("include/rabbitmq_stream_s3.hrl").
@@ -15,6 +16,7 @@
 %% Public set of {stream_id(), {#group_ref{}, rabbitmq_stream_s3:entries()}}
 %% used to avoid unnecessarily re-downloading the first group in a stream.
 -define(FIRST_GROUPS, rabbitmq_stream_s3_server_first_groups).
+-define(MiB, 1048576).
 
 -behaviour(gen_server).
 
@@ -527,104 +529,8 @@ execute_task(Effect, ManifestServer) ->
         counters:sub(Cnt, ?C_ACTIVE_TASKS, 1)
     end.
 
-execute_task(#upload_fragment{
-    stream = StreamId,
-    dir = Dir,
-    fragment =
-        #fragment{
-            segment_offset = SegmentOffset,
-            segment_pos = SegmentPos,
-            first_offset = FragmentOffset,
-            first_timestamp = FirstTs,
-            last_timestamp = LastTs,
-            next_offset = NextOffset,
-            checksum = SegmentDataCrc,
-            num_chunks = {IdxStart, IdxLen},
-            seq_no = SeqNo,
-            size = Size,
-            roll_reason = RollReason
-        } = Fragment
-}) ->
-    Timeout = application:get_env(rabbitmq_stream_s3, segment_upload_timeout, 45_000),
-    FragmentFilename = rabbitmq_stream_s3:offset_filename(FragmentOffset, <<"fragment">>),
-    SegmentFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"segment">>),
-    IndexFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"index">>),
-    Key = rabbitmq_stream_s3:fragment_key(StreamId, FragmentOffset),
-    ?LOG_DEBUG(
-        "Starting upload of ~ts (~b of ~ts, next offset ~b of ~ts): ~w", [
-            FragmentFilename, SeqNo, SegmentFilename, NextOffset, StreamId, Fragment
-        ]
-    ),
-
-    {UploadMSec, {UploadSize, FragmentInfo0}} = timer:tc(
-        fun() ->
-            {ok, SegFd} = file:open(filename:join(Dir, SegmentFilename), [read, raw, binary]),
-            {ok, IdxFd} = file:open(filename:join(Dir, IndexFilename), [read, raw, binary]),
-
-            {ok, SegData} = file:pread(SegFd, SegmentPos, Size),
-            {ok, IdxData0} = file:pread(
-                IdxFd,
-                ?IDX_HEADER_B + (IdxStart * ?INDEX_RECORD_SIZE_B),
-                IdxLen * ?INDEX_RECORD_SIZE_B
-            ),
-            %% Convert from osiris index style to fragment index. We can
-            %% drop epoch since it's not necessary after commit. TODO: right?
-            %% TODO: this is pretty messy. Use the INDEX_RECORD macro.
-            IdxData = <<
-                <<
-                    IdxChId:64/unsigned,
-                    IdxTs:64/signed,
-                    (SegmentFilePos - SegmentPos + ?FRAGMENT_HEADER_B):32/unsigned
-                >>
-             || <<
-                    IdxChId:64/unsigned,
-                    IdxTs:64/signed,
-                    _Epoch:64/unsigned,
-                    SegmentFilePos:32/unsigned,
-                    _ChType:8/unsigned
-                >> <= IdxData0
-            >>,
-            Header = ?FRAGMENT_HEADER(
-                FragmentOffset,
-                NextOffset,
-                FirstTs,
-                LastTs,
-                SeqNo,
-                SegmentOffset,
-                SegmentPos,
-                (?FRAGMENT_HEADER_B + Size),
-                <<>>
-            ),
-            Data = [Header, SegData, ?IDX_HEADER, IdxData],
-            Crc =
-                case SegmentDataCrc of
-                    undefined ->
-                        %% TODO: If there is no CRC32 cached then we need
-                        %% to validate chunks data during the upload and
-                        %% rebuild the index from the segment data.
-                        erlang:crc32(Data);
-                    _ ->
-                        Crc0 = erlang:crc32_combine(erlang:crc32(Header), SegmentDataCrc, Size),
-                        erlang:crc32(Crc0, [?IDX_HEADER, IdxData])
-                end,
-            %% TODO: should be able to upload this in chunks. Gun should
-            %% support that.
-            ReqOpts = #{unsigned_payload => true, crc32 => Crc, timeout => Timeout},
-            case rabbitmq_stream_s3_api:put(Key, Data, ReqOpts) of
-                ok ->
-                    ok;
-                {error, _} = Err ->
-                    exit(Err)
-            end,
-            {iolist_size(Data), fragment_header_to_info(Header)}
-        end,
-        millisecond
-    ),
-    ?LOG_DEBUG("Uploaded ~ts of ~ts in ~b msec (~b bytes)", [
-        FragmentFilename, SegmentFilename, UploadMSec, UploadSize
-    ]),
-    counters:add(counter(), ?C_FRAGMENTS_CREATED, 1),
-    FragmentInfo = FragmentInfo0#fragment_info{roll_reason = RollReason},
+execute_task(#upload_fragment{stream = StreamId, dir = Dir, fragment = Fragment}) ->
+    FragmentInfo = upload_fragment(StreamId, Dir, Fragment),
     #fragment_uploaded{stream = StreamId, info = FragmentInfo};
 execute_task(#upload_group{
     stream = StreamId,
@@ -937,6 +843,157 @@ execute_task(#evaluate_retention{
             ok
     end,
     #retention_executed{stream = StreamId, edit = Edit}.
+
+upload_fragment(
+    StreamId,
+    Dir,
+    #fragment{
+        segment_offset = SegmentOffset,
+        first_offset = FragmentOffset,
+        next_offset = NextOffset,
+        seq_no = SeqNo,
+        size = Size,
+        roll_reason = RollReason
+    } = Fragment
+) ->
+    ?LOG_DEBUG(
+        "Starting upload of ~20..0B.fragment (~b of ~20..0B.segment, next offset ~b of ~ts, size ~b)",
+        [
+            FragmentOffset, SeqNo, SegmentOffset, NextOffset, StreamId, Size
+        ]
+    ),
+    {UploadMSec, {UploadSize, FragmentInfo0}} = timer:tc(
+        fun() -> upload_fragment0(StreamId, Dir, Fragment) end,
+        millisecond
+    ),
+    ?LOG_DEBUG("Uploaded ~20..0B (seg ~20..0B) in ~b msec (~b bytes)", [
+        FragmentOffset, SegmentOffset, UploadMSec, UploadSize
+    ]),
+    counters:add(counter(), ?C_FRAGMENTS_CREATED, 1),
+    FragmentInfo0#fragment_info{roll_reason = RollReason}.
+
+upload_fragment0(
+    StreamId,
+    Dir,
+    #fragment{
+        segment_offset = SegmentOffset,
+        segment_pos = SegmentPos,
+        first_offset = FragmentOffset,
+        first_timestamp = FirstTs,
+        last_timestamp = LastTs,
+        next_offset = NextOffset,
+        checksum = SegmentDataCrc,
+        num_chunks = {IdxStart, IdxLen},
+        seq_no = SeqNo,
+        size = Size
+    }
+) ->
+    Timeout = application:get_env(rabbitmq_stream_s3, segment_upload_timeout, 45_000),
+    SegmentFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"segment">>),
+    IndexFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"index">>),
+
+    Key = rabbitmq_stream_s3:fragment_key(StreamId, FragmentOffset),
+
+    ContentLength = ?FRAGMENT_HEADER_B + Size + ?IDX_HEADER_B + (IdxLen * ?INDEX_RECORD_B),
+    {ok, Stream0} = rabbitmq_stream_s3_api:stream_put(Key, ContentLength, #{timeout => Timeout}),
+    Header = ?FRAGMENT_HEADER(
+        FragmentOffset,
+        NextOffset,
+        FirstTs,
+        LastTs,
+        SeqNo,
+        SegmentOffset,
+        SegmentPos,
+        (?FRAGMENT_HEADER_B + Size),
+        <<>>
+    ),
+    Stream1 = rabbitmq_stream_s3_api:stream_data(Stream0, Header),
+    Crc0 = erlang:crc32(Header),
+
+    {ok, SegFd} = file:open(filename:join(Dir, SegmentFilename), [read, raw, binary]),
+    {Stream2, Crc1} =
+        try
+            stream_segment_data(Stream1, SegFd, Crc0, SegmentPos, Size)
+        after
+            file:close(SegFd)
+        end,
+    case SegmentDataCrc of
+        undefined ->
+            ok;
+        _ ->
+            ?assertEqual(Crc1, erlang:crc32_combine(Crc0, SegmentDataCrc, Size))
+    end,
+
+    %% TODO: do we even need the index header anymore? It doesn't have
+    %% structural significance now that we know the index start in the remote
+    %% reader.
+    Stream3 = rabbitmq_stream_s3_api:stream_data(Stream2, ?IDX_HEADER),
+    Crc2 = erlang:crc32(Crc1, ?IDX_HEADER),
+    {ok, IdxFd} = file:open(filename:join(Dir, IndexFilename), [read, raw, binary]),
+    {Stream4, Crc} =
+        try
+            stream_index_data(
+                Stream3,
+                IdxFd,
+                Crc2,
+                ?IDX_HEADER_B + (IdxStart * ?INDEX_RECORD_SIZE_B),
+                IdxLen,
+                SegmentPos
+            )
+        after
+            file:close(IdxFd)
+        end,
+
+    case rabbitmq_stream_s3_api:stream_finish(Stream4, Crc) of
+        ok ->
+            ok;
+        {error, _} = Err ->
+            exit(Err)
+    end,
+    {ContentLength, fragment_header_to_info(Header)}.
+
+stream_segment_data(Stream, _Fd, Crc, _Pos, 0) ->
+    {Stream, Crc};
+stream_segment_data(Stream0, Fd, Crc0, Pos, Size) ->
+    Bytes = min(Size, ?MiB),
+    {ok, Data} = file:pread(Fd, Pos, Bytes),
+    Crc = erlang:crc32(Crc0, Data),
+    Stream = rabbitmq_stream_s3_api:stream_data(Stream0, Data),
+    stream_segment_data(Stream, Fd, Crc, Pos + Bytes, Size - Bytes).
+
+stream_index_data(Stream, Fd, Crc0, StartPos, IdxLen, SegmentPos) ->
+    stream_index_data(Stream, Fd, Crc0, StartPos, IdxLen, SegmentPos, 0).
+
+stream_index_data(Stream, _Fd, Crc, _Pos, Total, _SegmentPos, Total) ->
+    {Stream, Crc};
+stream_index_data(Stream0, Fd, Crc0, Pos, Total, SegmentPos, Done) ->
+    ChunkRecords = min(Total - Done, ?MiB div ?INDEX_RECORD_SIZE_B),
+    {ok, RawData} = file:pread(Fd, Pos, ChunkRecords * ?INDEX_RECORD_SIZE_B),
+    Transformed = <<
+        <<
+            IdxChId:64/unsigned,
+            IdxTs:64/signed,
+            (SegFilePos - SegmentPos + ?FRAGMENT_HEADER_B):32/unsigned
+        >>
+     || <<
+            IdxChId:64/unsigned,
+            IdxTs:64/signed,
+            _Epoch:64/unsigned,
+            SegFilePos:32/unsigned,
+            _ChType:8/unsigned
+        >> <= RawData
+    >>,
+    Crc = erlang:crc32(Crc0, Transformed),
+    Stream = rabbitmq_stream_s3_api:stream_data(Stream0, Transformed),
+    stream_index_data(
+        Stream,
+        Fd,
+        Crc,
+        Pos + ChunkRecords * ?INDEX_RECORD_SIZE_B,
+        Total,
+        SegmentPos,
+        Done + ChunkRecords
+    ).
 
 resolve_manifest_tail(
     StreamId,

--- a/test/rabbitmq_stream_s3_api_aws_SUITE.erl
+++ b/test/rabbitmq_stream_s3_api_aws_SUITE.erl
@@ -159,6 +159,21 @@ kick_the_tires(_Config) ->
         ok = rabbitmq_stream_s3_api_aws:put(K2, <<"Object 2">>, #{}),
         ok = rabbitmq_stream_s3_api_aws:put(K3, <<"Object 3">>, #{}),
 
+        %% Streaming upload: send data in two chunks and verify the result.
+        StreamKey = <<(atom_to_binary(?FUNCTION_NAME))/binary, "-stream-", (nonce())/binary>>,
+        Chunk1 = <<"Hello, ">>,
+        Chunk2 = <<"streaming S3!">>,
+        StreamData = <<Chunk1/binary, Chunk2/binary>>,
+        Crc = erlang:crc32([Chunk1, Chunk2]),
+        {ok, Stream0} = rabbitmq_stream_s3_api_aws:stream_put(
+            StreamKey, byte_size(StreamData), #{}
+        ),
+        Stream1 = rabbitmq_stream_s3_api_aws:stream_data(Stream0, Chunk1),
+        Stream2 = rabbitmq_stream_s3_api_aws:stream_data(Stream1, Chunk2),
+        ok = rabbitmq_stream_s3_api_aws:stream_finish(Stream2, Crc),
+        {ok, StreamData} = rabbitmq_stream_s3_api_aws:get(StreamKey, #{}),
+        ok = rabbitmq_stream_s3_api_aws:delete(StreamKey, #{}),
+
         ok = rabbitmq_stream_s3_api_aws:delete(K1, #{}),
         {error, not_found} = rabbitmq_stream_s3_api_aws:get(K1, #{}),
 


### PR DESCRIPTION
This change aims to reduce peak memory during fragment uploads. Previously uploading was very naive. We read all segment and index data into memory and then sent all of that data in one call to Gun. With this approach we stream data on the request with `gun:data/4`.

S3 does not accept regular HTTP/1 chunked transfer (**edit**: if you want to provider trailers, specifically). Instead it has a special `content-encoding: aws-chunked` mode. The framing is identical (unless you choose to sign chunks). Really the only difference is that we need to set the `content-length` header. With HTTP/1.1 chunked transfer you shouldn't set `content-length`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
