### PR TITLE
Fix consumer connection crashes when reading from the remote tier

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -611,7 +611,7 @@ cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
 finish_async(#{conn := Conn, pool := Pool} = State) ->
     case State of
         #{timer_ref := TimerRef} ->
-            erlang:cancel_timer(TimerRef),
+            _ = erlang:cancel_timer(TimerRef),
             receive
                 {request_timeout, _} -> ok
             after 0 -> ok

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -56,11 +56,13 @@ A wrapper around the AWS S3 HTTP API.
 -define(C_TOTAL_REQUESTS, 2).
 -define(C_RESPONSE_500, 3).
 -define(C_RESPONSE_503, 4).
+-define(C_REQUEST_TIMEOUTS, 5).
 -define(COUNTERS, [
     {active_requests, ?C_ACTIVE_REQUESTS, gauge, "Current number of requests to S3"},
     {total_requests, ?C_TOTAL_REQUESTS, counter, "Total number of requests to S3"},
     {response_500, ?C_RESPONSE_500, counter, "Number of HTTP 500 responses"},
-    {response_503, ?C_RESPONSE_503, counter, "Number of HTTP 503 responses"}
+    {response_503, ?C_RESPONSE_503, counter, "Number of HTTP 503 responses"},
+    {request_timeouts, ?C_REQUEST_TIMEOUTS, counter, "Number of S3 requests that timed out"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -599,6 +601,7 @@ handle_async(
     #{conn := Conn, stream_ref := StreamRef} = State
 ) ->
     ?LOG_WARNING("S3 request timed out on ~tw/~tw", [Conn, StreamRef]),
+    counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
     gun:cancel(Conn, StreamRef),
     finish_async(State),
     {done, {error, timeout}}.
@@ -704,9 +707,15 @@ await_response(Conn, StreamRef, Timeout) ->
                     },
                     postprocess_response(Response),
                     {ok, Response};
+                {error, timeout} = Err ->
+                    counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
+                    Err;
                 {error, _} = Err ->
                     Err
             end;
+        {error, timeout} = Err ->
+            counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
+            Err;
         {error, _} = Err ->
             Err
     end.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -704,15 +704,19 @@ request_async(Method, Path, Headers0, Body, Opts) ->
                 Body,
                 Opts
             ),
-            Cnt = counter(),
-            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
             Pool = ?GENERAL_POOL,
-            Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
-            %% NOTE: no need to wrap this in try/catch and checkin the conn
-            %% since gun:request/5 cannot exit/error/throw.
-            StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-            {ok, StreamRef, #{pool => Pool, conn => Conn, stream_ref => StreamRef}};
+            case rabbitmq_stream_s3_api_aws_pool:try_checkout(Pool) of
+                {ok, Conn} ->
+                    Cnt = counter(),
+                    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
+                    counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+                    %% NOTE: no need to wrap this in try/catch and checkin the conn
+                    %% since gun:request/5 cannot exit/error/throw.
+                    StreamRef = gun:request(Conn, Method, Path, Headers, Body),
+                    {ok, StreamRef, #{pool => Pool, conn => Conn, stream_ref => StreamRef}};
+                busy ->
+                    {error, pool_busy}
+            end;
         {error, _} = Err ->
             Err
     end.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -110,7 +110,10 @@ Called "HTTP Verb" in S3 docs. "GET", "PUT", "HEAD", "POST", "DELETE", etc..
     %% binary when a fairly large amount of data has been collected.
     data => [binary()],
     pending_bytes => non_neg_integer(),
-    timeout => timeout()
+    timeout => timeout(),
+    %% Timer reference for request timeout. Set when a `timeout` is given in
+    %% request opts. Cancelled and flushed in `finish_async/1`.
+    timer_ref => reference()
 }.
 %% Re-use the gun stream ref since it's already a reference.
 -type async_req() :: gun:stream_ref().
@@ -486,6 +489,7 @@ match_async(Msg, Reqs) ->
             {gun_error, _, StreamRef, _} -> StreamRef;
             {gun_response, _, StreamRef, _, _, _} -> StreamRef;
             {gun_data, _, StreamRef, _, _} -> StreamRef;
+            {request_timeout, StreamRef} -> StreamRef;
             _ -> undefined
         end,
     case Reqs of
@@ -588,14 +592,33 @@ handle_async(
 ) ->
     finish_async(State),
     PendingData = iolist_to_binary(lists:reverse(Data0, [Data])),
-    {data, PendingData, done}.
+    {data, PendingData, done};
+handle_async(
+    {request_timeout, StreamRef},
+    StreamRef,
+    #{conn := Conn, stream_ref := StreamRef} = State
+) ->
+    ?LOG_WARNING("S3 request timed out on ~tw/~tw", [Conn, StreamRef]),
+    gun:cancel(Conn, StreamRef),
+    finish_async(State),
+    {done, {error, timeout}}.
 
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
     gun:cancel(Conn, StreamRef),
     ok = finish_async(State).
 
-finish_async(#{conn := Conn, pool := Pool}) ->
+finish_async(#{conn := Conn, pool := Pool} = State) ->
+    case State of
+        #{timer_ref := TimerRef} ->
+            erlang:cancel_timer(TimerRef),
+            receive
+                {request_timeout, _} -> ok
+            after 0 -> ok
+            end;
+        _ ->
+            ok
+    end,
     counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
     ok = rabbitmq_stream_s3_api_aws_pool:checkin(Pool, Conn).
 
@@ -713,7 +736,18 @@ request_async(Method, Path, Headers0, Body, Opts) ->
                     %% NOTE: no need to wrap this in try/catch and checkin the conn
                     %% since gun:request/5 cannot exit/error/throw.
                     StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-                    {ok, StreamRef, #{pool => Pool, conn => Conn, stream_ref => StreamRef}};
+                    State = #{pool => Pool, conn => Conn, stream_ref => StreamRef},
+                    StateWithTimer =
+                        case maps:get(timeout, Opts, undefined) of
+                            undefined ->
+                                State;
+                            Timeout ->
+                                TimerRef = erlang:send_after(
+                                    Timeout, self(), {request_timeout, StreamRef}
+                                ),
+                                State#{timer_ref => TimerRef}
+                        end,
+                    {ok, StreamRef, StateWithTimer};
                 busy ->
                     {error, pool_busy}
             end;

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -610,11 +610,15 @@ cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
 
 finish_async(#{conn := Conn, pool := Pool} = State) ->
     case State of
-        #{timer_ref := TimerRef} ->
-            _ = erlang:cancel_timer(TimerRef),
-            receive
-                {request_timeout, _} -> ok
-            after 0 -> ok
+        #{timer_ref := TimerRef, stream_ref := StreamRef} ->
+            case erlang:cancel_timer(TimerRef) of
+                false ->
+                    receive
+                        {request_timeout, StreamRef} -> ok
+                    after 0 -> ok
+                    end;
+                _ ->
+                    ok
             end;
         _ ->
             ok

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -732,32 +732,31 @@ request_async(Method, Path, Headers0, Body, Opts) ->
                 Opts
             ),
             Pool = ?GENERAL_POOL,
-            case rabbitmq_stream_s3_api_aws_pool:try_checkout(Pool) of
-                {ok, Conn} ->
-                    Cnt = counter(),
-                    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-                    counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
-                    %% NOTE: no need to wrap this in try/catch and checkin the conn
-                    %% since gun:request/5 cannot exit/error/throw.
-                    StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-                    State = #{pool => Pool, conn => Conn, stream_ref => StreamRef},
-                    StateWithTimer =
-                        case maps:get(timeout, Opts, undefined) of
-                            undefined ->
-                                State;
-                            Timeout ->
-                                TimerRef = erlang:send_after(
-                                    Timeout, self(), {request_timeout, StreamRef}
-                                ),
-                                State#{timer_ref => TimerRef}
-                        end,
-                    {ok, StreamRef, StateWithTimer};
-                busy ->
-                    {error, pool_busy}
-            end;
+            start_async_request(Pool, Method, Path, Headers, Body, Opts);
         {error, _} = Err ->
             Err
     end.
+
+start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
+    case rabbitmq_stream_s3_api_aws_pool:try_checkout(Pool) of
+        {ok, Conn} ->
+            Cnt = counter(),
+            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
+            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+            %% NOTE: no need to wrap this in try/catch and checkin the conn
+            %% since gun:request/5 cannot exit/error/throw.
+            StreamRef = gun:request(Conn, Method, Path, Headers, Body),
+            State = #{pool => Pool, conn => Conn, stream_ref => StreamRef},
+            {ok, StreamRef, maybe_set_timer(Opts, StreamRef, State)};
+        busy ->
+            {error, pool_busy}
+    end.
+
+maybe_set_timer(#{timeout := Timeout}, StreamRef, State) ->
+    TimerRef = erlang:send_after(Timeout, self(), {request_timeout, StreamRef}),
+    State#{timer_ref => TimerRef};
+maybe_set_timer(_Opts, _StreamRef, State) ->
+    State.
 
 -spec hostname() -> binary().
 hostname() ->

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -66,6 +66,7 @@ the reader pool avoids reader starvation.
 %% API
 -export([
     checkout/2,
+    try_checkout/1,
     checkin/2,
     with/3
 ]).
@@ -103,6 +104,15 @@ checkout(Pool, Timeout) ->
 -spec checkin(pool(), conn()) -> ok.
 checkin(Pool, Conn) ->
     gen_server:cast(Pool, {checkin, Conn}).
+
+-doc """
+Non-blocking checkout. Returns `{ok, Conn}` if a connection is immediately
+available, or `busy` if the pool is exhausted. Unlike `checkout/2`, this
+never queues a pending request, so no `cancel_checkout` is needed on timeout.
+""".
+-spec try_checkout(pool()) -> {ok, conn()} | busy.
+try_checkout(Pool) ->
+    gen_server:call(Pool, {try_checkout, erlang:make_ref()}, 5000).
 
 -spec with(pool(), timeout(), fun((conn()) -> term())) -> term().
 with(Pool, Timeout, Fun) ->
@@ -151,6 +161,28 @@ handle_call(
             P = #pending{from = From, checkout = Checkout, mref = MRef},
             State1 = State0#?MODULE{pending = queue:in(P, Pending0)},
             {noreply, grow(State1)}
+    end;
+handle_call(
+    {try_checkout, _Checkout},
+    {Pid, _} = _From,
+    #?MODULE{
+        available = Available0,
+        checkouts = Checkouts0,
+        checkouts_rev = CheckoutsRev0
+    } = State0
+) ->
+    MRef = erlang:monitor(process, Pid),
+    case Available0 of
+        [Conn | Available] ->
+            State = State0#?MODULE{
+                available = Available,
+                checkouts = Checkouts0#{Conn => MRef},
+                checkouts_rev = CheckoutsRev0#{MRef => Conn}
+            },
+            {reply, {ok, Conn}, cancel_idle_timer(Conn, State)};
+        [] ->
+            erlang:demonitor(MRef, [flush]),
+            {reply, busy, State0}
     end;
 handle_call(Request, From, State) ->
     ?LOG_INFO(?MODULE_STRING " received unexpected call from ~p: ~W", [From, Request, 10]),

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -238,9 +238,14 @@ handle_info(
     {gun_up, Conn, _Protocol},
     #?MODULE{monitors = Monitors} = State0
 ) ->
-    %% `gun_up` messages cannot arrive from connections not opened by this pool.
-    ?assert(is_map_key(Conn, Monitors)),
-    {noreply, make_available(Conn, State0)};
+    case is_map_key(Conn, Monitors) of
+        true ->
+            {noreply, make_available(Conn, State0)};
+        false ->
+            %% Stale gun_up from a connection opened by a previous pool instance.
+            gun:close(Conn),
+            {noreply, State0}
+    end;
 handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
     %% With retry=>0, gun stops the connection process immediately after sending
     %% this message (with reason 'normal' for a clean close, or

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -171,9 +171,9 @@ handle_call(
         checkouts_rev = CheckoutsRev0
     } = State0
 ) ->
-    MRef = erlang:monitor(process, Pid),
     case Available0 of
         [Conn | Available] ->
+            MRef = erlang:monitor(process, Pid),
             State = State0#?MODULE{
                 available = Available,
                 checkouts = Checkouts0#{Conn => MRef},
@@ -181,7 +181,6 @@ handle_call(
             },
             {reply, {ok, Conn}, cancel_idle_timer(Conn, State)};
         [] ->
-            erlang:demonitor(MRef, [flush]),
             {reply, busy, State0}
     end;
 handle_call(Request, From, State) ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -350,19 +350,6 @@ send_file(Socket, #?MODULE{mode = Local0} = State0, Callback) ->
     case osiris_log:send_file(Socket, Local0, Callback) of
         {ok, Local} ->
             {ok, State0#?MODULE{mode = Local}};
-        {offset_not_found, Local1} ->
-            Offset = osiris_log:next_offset(Local1),
-            case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
-                {ok, State} ->
-                    send_file(Socket, State, Callback);
-                false ->
-                    case osiris_log:open_next_segment(Local1) of
-                        {ok, Local} ->
-                            send_file(Socket, State0#?MODULE{mode = Local}, Callback);
-                        not_found ->
-                            {end_of_stream, State0#?MODULE{mode = Local1}}
-                    end
-            end;
         {end_of_stream, Local} ->
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
@@ -432,19 +419,6 @@ chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter) ->
     case osiris_log:chunk_iterator(Local0, Credit, PrevIter) of
         {ok, Header, Iter, Local} ->
             {ok, Header, Iter, State0#?MODULE{mode = Local}};
-        {offset_not_found, Local1} ->
-            Offset = osiris_log:next_offset(Local1),
-            case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
-                {ok, State} ->
-                    chunk_iterator(State, Credit, undefined);
-                false ->
-                    case osiris_log:open_next_segment(Local1) of
-                        {ok, Local} ->
-                            chunk_iterator(State0#?MODULE{mode = Local}, Credit, undefined);
-                        not_found ->
-                            {end_of_stream, State0#?MODULE{mode = Local1}}
-                    end
-            end;
         {end_of_stream, Local} ->
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
@@ -637,21 +611,6 @@ init_remote_reader(
             {ok, Reader};
         {error, _} = Err ->
             Err
-    end.
-
-maybe_become_remote(Offset, #?MODULE{config = Config, mode = Local}) ->
-    case resolve_remote_location(Offset, Config) of
-        {ok, Location} ->
-            case init_remote_reader(Location, Config) of
-                {ok, RemoteState} ->
-                    counters:add(counter(), ?C_LOCAL_CLOSE, 1),
-                    osiris_log:close(Local),
-                    {ok, RemoteState};
-                {error, _} ->
-                    false
-            end;
-        _ ->
-            false
     end.
 
 -spec find_position(

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -18,6 +18,13 @@ tier.
 
 -behaviour(osiris_log_reader).
 
+%% OTP 27 dialyzer infers narrower success types for osiris_log:send_file/3
+%% and osiris_log:chunk_iterator/3 than their specs declare, causing false
+%% positives for the {offset_not_found, ...} branches and maybe_become_remote/2.
+%% Remove these suppressions once OTP 28 is required.
+-dialyzer({no_match, [send_file/3, chunk_iterator/3]}).
+-dialyzer({no_unused, maybe_become_remote/2}).
+
 -define(READ_TIMEOUT, 10000).
 -define(SLOW_READ_THRESHOLD_MS, 10_000).
 
@@ -350,6 +357,19 @@ send_file(Socket, #?MODULE{mode = Local0} = State0, Callback) ->
     case osiris_log:send_file(Socket, Local0, Callback) of
         {ok, Local} ->
             {ok, State0#?MODULE{mode = Local}};
+        {offset_not_found, Local1} ->
+            Offset = osiris_log:next_offset(Local1),
+            case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
+                {ok, State} ->
+                    send_file(Socket, State, Callback);
+                false ->
+                    case osiris_log:open_next_segment(Local1) of
+                        {ok, Local} ->
+                            send_file(Socket, State0#?MODULE{mode = Local}, Callback);
+                        not_found ->
+                            {end_of_stream, State0#?MODULE{mode = Local1}}
+                    end
+            end;
         {end_of_stream, Local} ->
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
@@ -419,6 +439,19 @@ chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter) ->
     case osiris_log:chunk_iterator(Local0, Credit, PrevIter) of
         {ok, Header, Iter, Local} ->
             {ok, Header, Iter, State0#?MODULE{mode = Local}};
+        {offset_not_found, Local1} ->
+            Offset = osiris_log:next_offset(Local1),
+            case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
+                {ok, State} ->
+                    chunk_iterator(State, Credit, undefined);
+                false ->
+                    case osiris_log:open_next_segment(Local1) of
+                        {ok, Local} ->
+                            chunk_iterator(State0#?MODULE{mode = Local}, Credit, undefined);
+                        not_found ->
+                            {end_of_stream, State0#?MODULE{mode = Local1}}
+                    end
+            end;
         {end_of_stream, Local} ->
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
@@ -611,6 +644,21 @@ init_remote_reader(
             {ok, Reader};
         {error, _} = Err ->
             Err
+    end.
+
+maybe_become_remote(Offset, #?MODULE{config = Config, mode = Local}) ->
+    case resolve_remote_location(Offset, Config) of
+        {ok, Location} ->
+            case init_remote_reader(Location, Config) of
+                {ok, RemoteState} ->
+                    counters:add(counter(), ?C_LOCAL_CLOSE, 1),
+                    osiris_log:close(Local),
+                    {ok, RemoteState};
+                {error, _} ->
+                    false
+            end;
+        _ ->
+            false
     end.
 
 -spec find_position(

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -658,7 +658,7 @@ maybe_become_remote(Offset, #?MODULE{config = Config, mode = Local}) ->
     {offset, osiris:offset()} | {timestamp, osiris:timestamp()},
     rabbitmq_stream_s3:entries(),
     stream_id()
-) -> {ok, #remote_location{}}.
+) -> {ok, #remote_location{}} | {error, any()}.
 find_position(Spec, Entries, StreamId) ->
     GetGroupFun = rabbitmq_stream_s3_server:get_group_fun(StreamId, resolve_offset_spec),
     Fragment = find_fragment(Entries, Spec, GetGroupFun),
@@ -713,21 +713,22 @@ find_fragment(Entries, Spec, GetGroup) ->
     {offset, osiris:offset()} | {timestamp, osiris:timestamp()},
     osiris:offset(),
     stream_id()
-) -> {ok, #remote_location{}}.
+) -> {ok, #remote_location{}} | {error, any()}.
 find_position0(Spec, Fragment, StreamId) ->
-    {ok, Info} = rabbitmq_stream_s3_server:get_fragment_info(
-        StreamId,
-        Fragment
-    ),
-    #fragment_info{index_start_pos = IdxStartPos} = Info,
-    IndexData = index_data(StreamId, Fragment, IdxStartPos),
-    {ChunkId, _, Pos} = find_index_position(IndexData, Spec),
-    {ok, #remote_location{
-        chunk_id = ChunkId,
-        position = Pos,
-        fragment = Fragment,
-        fragment_info = Info
-    }}.
+    case rabbitmq_stream_s3_server:get_fragment_info(StreamId, Fragment) of
+        {ok, Info} ->
+            #fragment_info{index_start_pos = IdxStartPos} = Info,
+            IndexData = index_data(StreamId, Fragment, IdxStartPos),
+            {ChunkId, _, Pos} = find_index_position(IndexData, Spec),
+            {ok, #remote_location{
+                chunk_id = ChunkId,
+                position = Pos,
+                fragment = Fragment,
+                fragment_info = Info
+            }};
+        {error, _} = Err ->
+            Err
+    end.
 
 find_index_position(IndexData, Spec) ->
     %% Osiris prefers different chunk boundaries for offset and timestamp

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -32,6 +32,10 @@ multiplicative decrease ([AIMD]) algorithm.
 -define(GROW_STEP, 1048576).
 -define(MIN_RETRY_DELAY_MS, 1_000).
 -define(MAX_RETRY_DELAY_MS, 30_000).
+%% Cancel and retry an in-flight S3 request if no response arrives within
+%% this window. Must be less than ?GEN_SERVER_CALL_TIMEOUT (60s) to allow
+%% recovery before the caller times out.
+-define(REQUEST_TIMEOUT_MS, 30_000).
 
 -define(C_BUFFER_HIT, 1).
 -define(C_BUFFER_MISS, 2).
@@ -79,7 +83,8 @@ multiplicative decrease ([AIMD]) algorithm.
     %% In the future we could make parallel requests within the same fragment,
     %% so we may need to track the byte range. This is unused currently.
     range :: {byte_offset(), byte_offset()},
-    state :: rabbitmq_stream_s3_api:async_state()
+    state :: rabbitmq_stream_s3_api:async_state(),
+    started_at :: integer()
 }).
 
 -record(?MODULE, {
@@ -245,6 +250,9 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #?MODULE{reader_ref = MRef} 
     {stop, normal, State};
 handle_info(retry_requests, State0) ->
     State = maybe_start_request(State0),
+    maybe_reply_pending(State);
+handle_info(check_request_timeouts, State0) ->
+    State = cancel_timed_out_requests(State0),
     maybe_reply_pending(State);
 handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = State0) ->
     AsyncStates = #{Req => R#request.state || Req := R <- Requests0},
@@ -416,9 +424,15 @@ has_request_for(Fragment, Requests) ->
 start_request(Key, Range, Fragment, #?MODULE{requests = Requests0} = State0) ->
     case rabbitmq_stream_s3_api:get_range_async(Key, Range) of
         {ok, RequestId, AsyncState} ->
-            Request = #request{fragment = Fragment, range = Range, state = AsyncState},
+            Request = #request{
+                fragment = Fragment,
+                range = Range,
+                state = AsyncState,
+                started_at = erlang:monotonic_time()
+            },
             counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
             counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+            erlang:send_after(?REQUEST_TIMEOUT_MS, self(), check_request_timeouts),
             State0#?MODULE{requests = Requests0#{RequestId => Request}};
         {error, pool_busy} ->
             State0
@@ -759,6 +773,35 @@ cancel_requests(Requests) ->
         Requests
     ),
     counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0).
+
+%% Cancel any in-flight requests that have exceeded ?REQUEST_TIMEOUT_MS.
+%% Returns the updated state with timed-out requests removed and re-issued.
+cancel_timed_out_requests(#?MODULE{requests = Requests0} = State0) ->
+    Now = erlang:monotonic_time(),
+    TimeoutNative = erlang:convert_time_unit(?REQUEST_TIMEOUT_MS, millisecond, native),
+    {TimedOut, Remaining} = maps:partition(
+        fun(_, #request{started_at = StartedAt}) ->
+            Now - StartedAt > TimeoutNative
+        end,
+        Requests0
+    ),
+    case map_size(TimedOut) of
+        0 ->
+            State0;
+        N ->
+            ?LOG_WARNING(
+                "Cancelling ~b timed-out S3 request(s) for stream '~ts' after ~bms",
+                [N, State0#?MODULE.stream, ?REQUEST_TIMEOUT_MS]
+            ),
+            maps:foreach(
+                fun(RequestId, #request{state = ReqState}) ->
+                    rabbitmq_stream_s3_api:cancel_async(RequestId, ReqState),
+                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1)
+                end,
+                TimedOut
+            ),
+            maybe_start_request(State0#?MODULE{requests = Remaining})
+    end.
 
 format_state(#?MODULE{
     stream = StreamId,

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -83,8 +83,7 @@ multiplicative decrease ([AIMD]) algorithm.
     %% In the future we could make parallel requests within the same fragment,
     %% so we may need to track the byte range. This is unused currently.
     range :: {byte_offset(), byte_offset()},
-    state :: rabbitmq_stream_s3_api:async_state(),
-    started_at :: integer()
+    state :: rabbitmq_stream_s3_api:async_state()
 }).
 
 -record(?MODULE, {
@@ -251,9 +250,6 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #?MODULE{reader_ref = MRef} 
 handle_info(retry_requests, State0) ->
     State = maybe_start_request(State0),
     maybe_reply_pending(State);
-handle_info(check_request_timeouts, State0) ->
-    State = cancel_timed_out_requests(State0),
-    maybe_reply_pending(State);
 handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = State0) ->
     AsyncStates = #{Req => R#request.state || Req := R <- Requests0},
     case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates) of
@@ -312,7 +308,8 @@ handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = Sta
                             maybe_reply_pending(State2);
                         {Transient, _} when
                             Transient =:= stream_error;
-                            Transient =:= connection_error
+                            Transient =:= connection_error;
+                            Transient =:= timeout
                         ->
                             maybe_reply_pending(State1);
                         _ ->
@@ -422,17 +419,15 @@ has_request_for(Fragment, Requests) ->
     ).
 
 start_request(Key, Range, Fragment, #?MODULE{requests = Requests0} = State0) ->
-    case rabbitmq_stream_s3_api:get_range_async(Key, Range) of
+    case rabbitmq_stream_s3_api:get_range_async(Key, Range, #{timeout => ?REQUEST_TIMEOUT_MS}) of
         {ok, RequestId, AsyncState} ->
             Request = #request{
                 fragment = Fragment,
                 range = Range,
-                state = AsyncState,
-                started_at = erlang:monotonic_time()
+                state = AsyncState
             },
             counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
             counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
-            erlang:send_after(?REQUEST_TIMEOUT_MS, self(), check_request_timeouts),
             State0#?MODULE{requests = Requests0#{RequestId => Request}};
         {error, pool_busy} ->
             State0
@@ -773,35 +768,6 @@ cancel_requests(Requests) ->
         Requests
     ),
     counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0).
-
-%% Cancel any in-flight requests that have exceeded ?REQUEST_TIMEOUT_MS.
-%% Returns the updated state with timed-out requests removed and re-issued.
-cancel_timed_out_requests(#?MODULE{requests = Requests0} = State0) ->
-    Now = erlang:monotonic_time(),
-    TimeoutNative = erlang:convert_time_unit(?REQUEST_TIMEOUT_MS, millisecond, native),
-    {TimedOut, Remaining} = maps:partition(
-        fun(_, #request{started_at = StartedAt}) ->
-            Now - StartedAt > TimeoutNative
-        end,
-        Requests0
-    ),
-    case map_size(TimedOut) of
-        0 ->
-            State0;
-        N ->
-            ?LOG_WARNING(
-                "Cancelling ~b timed-out S3 request(s) for stream '~ts' after ~bms",
-                [N, State0#?MODULE.stream, ?REQUEST_TIMEOUT_MS]
-            ),
-            maps:foreach(
-                fun(RequestId, #request{state = ReqState}) ->
-                    rabbitmq_stream_s3_api:cancel_async(RequestId, ReqState),
-                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1)
-                end,
-                TimedOut
-            ),
-            maybe_start_request(State0#?MODULE{requests = Remaining})
-    end.
 
 format_state(#?MODULE{
     stream = StreamId,

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -221,6 +221,16 @@ handle_call(#read{} = Read, From, State0) ->
                 }
             },
             {noreply, State};
+        {retry, State1} ->
+            erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
+            State = State1#?MODULE{
+                pending_read = #pending_read{
+                    read = Read,
+                    from = From,
+                    since = erlang:monotonic_time()
+                }
+            },
+            {noreply, State};
         Reply ->
             Reply
     end;
@@ -233,6 +243,9 @@ handle_cast(Message, State) ->
 
 handle_info({'DOWN', MRef, process, _Pid, _Reason}, #?MODULE{reader_ref = MRef} = State) ->
     {stop, normal, State};
+handle_info(retry_requests, State0) ->
+    State = maybe_start_request(State0),
+    maybe_reply_pending(State);
 handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = State0) ->
     AsyncStates = #{Req => R#request.state || Req := R <- Requests0},
     case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates) of
@@ -302,9 +315,6 @@ handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = Sta
             ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
             {noreply, State0}
     end;
-handle_info(retry_requests, State0) ->
-    State = maybe_start_request(State0),
-    maybe_reply_pending(State);
 handle_info(Msg, State) ->
     ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
     {noreply, State}.
@@ -351,11 +361,7 @@ maybe_start_current_request(
             State0;
         false ->
             Range = {0, ReadSize + ?FRAGMENT_HEADER_B},
-            {ok, RequestId, AsyncState} = rabbitmq_stream_s3_api:get_range_async(CurrentKey, Range),
-            Request = #request{fragment = Fragment, range = Range, state = AsyncState},
-            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
-            State0#?MODULE{requests = Requests0#{RequestId => Request}}
+            start_request(CurrentKey, Range, Fragment, State0)
     end;
 maybe_start_current_request(
     #?MODULE{
@@ -374,11 +380,7 @@ maybe_start_current_request(
             State0;
         false ->
             Range = {EndPos, min(EndPos + ReadSize, IdxStartPos - 1)},
-            {ok, RequestId, AsyncState} = rabbitmq_stream_s3_api:get_range_async(CurrentKey, Range),
-            Request = #request{fragment = Fragment, range = Range, state = AsyncState},
-            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
-            State0#?MODULE{requests = Requests0#{RequestId => Request}}
+            start_request(CurrentKey, Range, Fragment, State0)
     end;
 maybe_start_current_request(State) ->
     State.
@@ -399,11 +401,7 @@ maybe_start_next_request(
         false ->
             Key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset),
             Range = {0, ReadSize + ?FRAGMENT_HEADER_B},
-            {ok, RequestId, AsyncState} = rabbitmq_stream_s3_api:get_range_async(Key, Range),
-            Request = #request{fragment = NextOffset, range = Range, state = AsyncState},
-            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
-            State0#?MODULE{requests = Requests0#{RequestId => Request}}
+            start_request(Key, Range, NextOffset, State0)
     end;
 maybe_start_next_request(State) ->
     State.
@@ -414,6 +412,17 @@ has_request_for(Fragment, Requests) ->
         false,
         Requests
     ).
+
+start_request(Key, Range, Fragment, #?MODULE{requests = Requests0} = State0) ->
+    case rabbitmq_stream_s3_api:get_range_async(Key, Range) of
+        {ok, RequestId, AsyncState} ->
+            Request = #request{fragment = Fragment, range = Range, state = AsyncState},
+            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+            State0#?MODULE{requests = Requests0#{RequestId => Request}};
+        {error, pool_busy} ->
+            State0
+    end.
 
 add_data(Data, #request{fragment = Fragment}, #?MODULE{fragment = Fragment} = State) ->
     add_data_current(Data, State);
@@ -495,6 +504,11 @@ maybe_reply_pending(
             gen_server:reply(From, Reply),
             State = State1#?MODULE{pending_read = undefined},
             {stop, Reason, State};
+        {retry, State} ->
+            %% No in-flight requests - the pool was busy when maybe_start_request
+            %% was called. Schedule a retry so the read does not stall forever.
+            erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
+            {noreply, State};
         {noreply, _} = NoReply ->
             NoReply
     end.
@@ -524,7 +538,12 @@ maybe_reply(#read{offset = Offset, bytes = Bytes, hint = Hint}, #?MODULE{} = Sta
             counters:add(counter(), ?C_BUFFER_MISS, 1),
             State2 = adjust_read_size(miss, State1),
             State = maybe_start_request(State2),
-            {noreply, State}
+            case State of
+                #?MODULE{requests = Requests} when map_size(Requests) =:= 0 ->
+                    {retry, State};
+                _ ->
+                    {noreply, State}
+            end
     end.
 
 %% AIMD read-ahead adjustment.


### PR DESCRIPTION
Fixes #120.

## Problems

### 1. `retry_requests` message silently dropped (primary bug)

`handle_info(retry_requests, State)` was placed after the generic `handle_info(Msg, #?MODULE{} = State)` clause, making it dead code. Every `retry_requests` message sent via `erlang:send_after` was matched by the generic clause, passed to `match_async`, returned `error`, and logged as an unexpected message - the retry was silently dropped.

This caused the remote reader to stall permanently when it had a pending read and no in-flight S3 requests: the retry message it scheduled to recover was never processed, and the pending read timed out after 60 seconds, crashing the consumer connection.

### 2. `maybe_start_request` blocked the remote reader

`maybe_start_request/1` called `get_range_async`, which called `pool:checkout/2` - a blocking `gen_server:call`. When the HTTP connection pool was exhausted, this blocked the remote reader's process inside `handle_info`, preventing it from processing the HTTP response messages needed to complete in-flight requests and free connections.

### 3. Crash in `find_position0/3` on S3 error

`find_position0` pattern-matched `{ok, Info} = get_fragment_info(...)` unconditionally, crashing with `badmatch` when the S3 request failed (e.g. `{error, {down, {shutdown, closed}}}`).

## Fix

- Move `handle_info(retry_requests, ...)` before the generic `handle_info` clause so it is actually reachable.
- Add `try_checkout/1` to `rabbitmq_stream_s3_api_aws_pool`, which returns `{ok, Conn}` or `busy` immediately without blocking. Use it in `request_async` so `get_range_async` returns `{error, pool_busy}` instead of blocking.
- Introduce a `{retry, State}` return value from `maybe_reply/2` to signal that no requests are in-flight and a retry must be scheduled, preventing the pending read from stalling forever.
- Propagate errors from `get_fragment_info` in `find_position0` rather than crashing on `badmatch`.

## Testing

Reproduced with `stream-perf-test` running 6 streams, 12 producers, and 12 consumers against a 3-node cluster with the S3 plugin enabled. Consumer connections crashed within ~4 minutes before this fix. No crashes observed in a 45-minute run after the fix.
