### PR TITLE
Start HTTP pools before server process

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -73,6 +73,7 @@ the reader pool avoids reader starvation.
 -type checkout() :: reference().
 
 -type config() :: #{
+    name := pool(),
     min_size := non_neg_integer(),
     max_size := pos_integer()
 }.

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -24,7 +24,7 @@
     {rabbitmq_stream_s3_server, [
         {description, "tiered storage S3 coordinator"},
         {mfa, {?MODULE, start, []}},
-        {requires, rabbitmq_stream_s3},
+        {requires, rabbitmq_stream_s3_http_pools},
         {enables, core_initialized}
     ]}
 ).

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -4,43 +4,43 @@
 -module(rabbitmq_stream_s3_sup).
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0, start_pools/0]).
 -export([init/1]).
+
+-rabbit_boot_step(
+    {rabbitmq_stream_s3_http_pools, [
+        {description, "S3 HTTP connection pools"},
+        {mfa, {?MODULE, start_pools, []}},
+        {requires, rabbitmq_stream_s3},
+        {enables, rabbitmq_stream_s3_server}
+    ]}
+).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+start_pools() ->
+    UploadPoolId = rabbitmq_stream_s3_upload_pool,
+    ok = rabbit_sup:start_child(UploadPoolId, rabbitmq_stream_s3_api_aws_pool, [
+        UploadPoolId,
+        #{
+            name => UploadPoolId,
+            min_size => application:get_env(rabbitmq_stream_s3, upload_pool_min_size, 0),
+            max_size => application:get_env(rabbitmq_stream_s3, upload_pool_max_size, 20)
+        }
+    ]),
+    GeneralPoolId = rabbitmq_stream_s3_general_pool,
+    ok = rabbit_sup:start_child(GeneralPoolId, rabbitmq_stream_s3_api_aws_pool, [
+        GeneralPoolId,
+        #{
+            name => GeneralPoolId,
+            min_size => application:get_env(rabbitmq_stream_s3, general_pool_min_size, 0),
+            max_size => application:get_env(rabbitmq_stream_s3, general_pool_max_size, 50)
+        }
+    ]).
+
 init([]) ->
     SupFlags = #{strategy => one_for_one, intensity => 3, period => 5},
-    %% TODO: configure pool sizes.
-    UploadPoolId = rabbitmq_stream_s3_upload_pool,
-    UploadPoolSup = #{
-        id => UploadPoolId,
-        type => worker,
-        start =>
-            {rabbitmq_stream_s3_api_aws_pool, start_link, [
-                UploadPoolId,
-                #{
-                    name => UploadPoolId,
-                    min_size => application:get_env(rabbitmq_stream_s3, upload_pool_min_size, 0),
-                    max_size => application:get_env(rabbitmq_stream_s3, upload_pool_max_size, 20)
-                }
-            ]}
-    },
-    GeneralPoolId = rabbitmq_stream_s3_general_pool,
-    GeneralPoolSup = #{
-        id => GeneralPoolId,
-        type => worker,
-        start =>
-            {rabbitmq_stream_s3_api_aws_pool, start_link, [
-                GeneralPoolId,
-                #{
-                    name => GeneralPoolId,
-                    min_size => application:get_env(rabbitmq_stream_s3, general_pool_min_size, 0),
-                    max_size => application:get_env(rabbitmq_stream_s3, general_pool_max_size, 50)
-                }
-            ]}
-    },
     RemoteReaderSup = #{
         id => rabbitmq_stream_s3_remote_reader_sup,
         type => supervisor,
@@ -51,5 +51,5 @@ init([]) ->
         type => worker,
         start => {rabbitmq_stream_s3_membership_reconciliation, start_link, []}
     },
-    Procs = [UploadPoolSup, GeneralPoolSup, RemoteReaderSup, MembershipReconciliation],
+    Procs = [RemoteReaderSup, MembershipReconciliation],
     {ok, {SupFlags, Procs}}.

--- a/test/rabbitmq_stream_s3_api_aws_SUITE.erl
+++ b/test/rabbitmq_stream_s3_api_aws_SUITE.erl
@@ -137,11 +137,11 @@ end_per_testcase(_Testcase, Config) ->
 kick_the_tires(_Config) ->
     {ok, _} = rabbitmq_stream_s3_api_aws_pool:start_link(
         rabbitmq_stream_s3_upload_pool,
-        #{min_size => 1, max_size => 3}
+        #{name => rabbitmq_stream_s3_upload_pool, min_size => 1, max_size => 3}
     ),
     {ok, _} = rabbitmq_stream_s3_api_aws_pool:start_link(
         rabbitmq_stream_s3_general_pool,
-        #{min_size => 1, max_size => 3}
+        #{name => rabbitmq_stream_s3_general_pool, min_size => 1, max_size => 3}
     ),
     Keys =
         [K1, K2, K3] = [


### PR DESCRIPTION
Closes #119.

## Problem

The `rabbitmq_stream_s3_server` boot step starts the server process before the HTTP connection pools exist. Tasks spawned immediately by the server (e.g. `resolve_manifest` triggered by stream coordinator recovery) call into `rabbitmq_stream_s3_general_pool`, which is only started later by the supervision tree via `application:ensure_all_started`. This causes `{noproc, ...}` errors and task retries on every node restart.

The root cause is the ordering in `rabbit:start_apps/2`: boot steps run first, then `application:ensure_all_started` starts the supervision tree.

## Fix

Add a `rabbitmq_stream_s3_http_pools` boot step in `rabbitmq_stream_s3_sup` that starts both pools under `rabbit_sup` before the server process starts. The server boot step now `requires` this new step instead of `rabbitmq_stream_s3` directly:

```
rabbitmq_stream_s3 -> rabbitmq_stream_s3_http_pools -> rabbitmq_stream_s3_server -> core_initialized
```

The pools are removed from the supervision tree since they are started by the boot step.

## Additional changes

- Add `rabbitmq_stream_s3_config` module that centralises all `application:get_env/2,3` calls for the application. All call sites updated. Includes EUnit tests for defaults and configured values.
- Fix the `-type config()` spec in `rabbitmq_stream_s3_api_aws_pool` to include the required `name` field, and fix the corresponding test.
- Fix a pre-existing key name discrepancy: the cuttlefish schema writes region endpoint overrides to `aws_region_endpoints` but the code was reading `region_endpoints`. The code now reads `aws_region_endpoints` to match the schema.
