### PR TITLE
Add `rabbitmq_stream_s3_config` module

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: make
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3
       - name: tests
-        run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 tests
+        run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 EUNIT_OPTS=verbose tests
       - name: maybe upload CT logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -111,7 +111,7 @@ examples.
 -define(REQUEST_DURATION_BUCKETS, [10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, infinity]).
 
 backend() ->
-    application:get_env(rabbitmq_stream_s3, ?MODULE, rabbitmq_stream_s3_api_aws).
+    rabbitmq_stream_s3_config:api_backend().
 
 counter() ->
     persistent_term:get(?COUNTER_KEY).

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -129,27 +129,27 @@ init() ->
 
 -spec reload_config() -> ok.
 reload_config() ->
-    AccessKey0 = application:get_env(rabbitmq_stream_s3, aws_access_key),
-    SecretKey0 = application:get_env(rabbitmq_stream_s3, aws_secret_key),
+    AccessKey0 = rabbitmq_stream_s3_config:aws_access_key(),
+    SecretKey0 = rabbitmq_stream_s3_config:aws_secret_key(),
     case {AccessKey0, SecretKey0} of
         {undefined, undefined} ->
             ok;
-        {{ok, AccessKey}, {ok, SecretKey}} ->
+        {AccessKey, SecretKey} when is_binary(AccessKey) andalso is_binary(SecretKey) ->
             _ = ets:insert(?TABLE, {
                 credentials,
                 AccessKey,
                 SecretKey,
-                application:get_env(rabbitmq_stream_s3, aws_security_token, undefined),
+                rabbitmq_stream_s3_config:aws_security_token(),
                 undefined
             }),
             ok
         %% TODO: helpful error message when only one of these keys is set...
     end,
-    case application:get_env(rabbitmq_stream_s3, aws_region) of
-        {ok, Region} ->
-            persistent_term:put(?REGION_KEY, Region),
-            ok;
+    case rabbitmq_stream_s3_config:aws_region() of
         undefined ->
+            ok;
+        Region ->
+            persistent_term:put(?REGION_KEY, Region),
             ok
     end,
     ok.
@@ -777,7 +777,7 @@ hostname(Region) ->
 
 -spec region() -> binary().
 region() ->
-    Attempts = application:get_env(rabbitmq_stream_s3, get_region_attempts, 10),
+    Attempts = rabbitmq_stream_s3_config:get_region_attempts(),
     region(Attempts).
 
 region(Retries) ->
@@ -835,7 +835,7 @@ tld(Region) ->
             <<"us-isof-south-1">> => <<"csp.hci.ic.gov">>,
             <<"eusc-de-east-1">> => <<"amazonaws.eu">>
         },
-        application:get_env(rabbitmq_stream_s3, region_endpoints, #{})
+        rabbitmq_stream_s3_config:aws_region_endpoints()
     ),
     maps:get(Region, Mapping, <<"amazonaws.com">>).
 
@@ -853,7 +853,7 @@ fetch_credentials(false) ->
         ?MODULE_STRING
         ": no AWS credentials available, requesting from EC2 instance metadata"
     ),
-    Attempts = application:get_env(rabbitmq_stream_s3, get_credentials_attempts, 10),
+    Attempts = rabbitmq_stream_s3_config:get_credentials_attempts(),
     {Msec, Result} = timer:tc(?MODULE, get_credentials, [Attempts, imds], millisecond),
     log_credentials_result(Result, Msec, "EC2 instance metadata service"),
     Result;
@@ -862,7 +862,7 @@ fetch_credentials(URI) ->
         ?MODULE_STRING
         ": no AWS credentials available, requesting from container credentials endpoint"
     ),
-    Attempts = application:get_env(rabbitmq_stream_s3, get_credentials_attempts, 10),
+    Attempts = rabbitmq_stream_s3_config:get_credentials_attempts(),
     {Msec, Result} = timer:tc(?MODULE, get_credentials, [Attempts, {container, URI}], millisecond),
     log_credentials_result(Result, Msec, "container credentials endpoint"),
     Result.
@@ -1133,7 +1133,7 @@ with_instance_metadata_conn(Fun) when is_function(Fun, 1) ->
     end.
 
 sign_headers(Headers, AccessKey, SecretKey, SecurityToken, Method, Path, Body, Opts) ->
-    {ok, Bucket} = application:get_env(rabbitmq_stream_s3, bucket),
+    Bucket = rabbitmq_stream_s3_config:bucket(),
     Region = region(),
     Host = <<Bucket/binary, $., (hostname(Region))/binary>>,
     sign_headers(

--- a/src/rabbitmq_stream_s3_api_fs.erl
+++ b/src/rabbitmq_stream_s3_api_fs.erl
@@ -294,7 +294,7 @@ set_data_dir(DataDir) ->
 
 -spec data_dir() -> binary() | undefined.
 data_dir() ->
-    application:get_env(rabbitmq_stream_s3, api_fs_data_dir, undefined).
+    rabbitmq_stream_s3_config:api_fs_data_dir().
 
 -spec key_to_path(rabbitmq_stream_s3_api:key()) -> binary() | {error, path_not_set}.
 key_to_path(Key) ->

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -1,0 +1,214 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_config).
+-moduledoc """
+Accessors for the `rabbitmq_stream_s3` application environment.
+
+Every application:get_env/2,3 call for the `rabbitmq_stream_s3` application
+lives here. Callers use these functions instead of calling
+`application:get_env/2,3` directly.
+""".
+
+-export([
+    api_backend/0,
+    aws_access_key/0,
+    aws_secret_key/0,
+    aws_security_token/0,
+    aws_region/0,
+    aws_region_endpoints/0,
+    get_region_attempts/0,
+    get_credentials_attempts/0,
+    bucket/0,
+    api_fs_data_dir/0,
+    upload_pool_min_size/0,
+    upload_pool_max_size/0,
+    general_pool_min_size/0,
+    general_pool_max_size/0,
+    manifest_rebalance_factor/0,
+    manifest_debounce_modifications/0,
+    manifest_debounce_milliseconds/0,
+    membership_reconciliation_enabled/0,
+    membership_reconciliation_interval/0,
+    membership_reconciliation_trigger_interval/0,
+    membership_reconciliation_target_group_size/0,
+    membership_reconciliation_auto_remove/0,
+    task_retry_delay_max_ms/0,
+    task_retry_delay_constant/0,
+    task_retry_delay_exponent/0,
+    verbose_logging/0,
+    segment_upload_timeout/0,
+    tick_timeout_milliseconds/0
+]).
+
+-define(APP, rabbitmq_stream_s3).
+
+%% The API backend module. Defaults to the AWS implementation.
+-spec api_backend() -> module().
+api_backend() ->
+    application:get_env(?APP, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws).
+
+%% AWS credentials. Return `undefined` when not configured (instance role is used).
+-spec aws_access_key() -> binary() | undefined.
+aws_access_key() ->
+    case application:get_env(?APP, aws_access_key) of
+        {ok, V} -> V;
+        undefined -> undefined
+    end.
+
+-spec aws_secret_key() -> binary() | undefined.
+aws_secret_key() ->
+    case application:get_env(?APP, aws_secret_key) of
+        {ok, V} -> V;
+        undefined -> undefined
+    end.
+
+-spec aws_security_token() -> binary() | undefined.
+aws_security_token() ->
+    application:get_env(?APP, aws_security_token, undefined).
+
+-spec aws_region() -> binary() | undefined.
+aws_region() ->
+    case application:get_env(?APP, aws_region) of
+        {ok, V} -> V;
+        undefined -> undefined
+    end.
+
+%% Overrides for the default region-to-TLD mapping.
+-spec aws_region_endpoints() -> #{binary() => binary()}.
+aws_region_endpoints() ->
+    application:get_env(?APP, aws_region_endpoints, #{}).
+
+-spec get_region_attempts() -> pos_integer().
+get_region_attempts() ->
+    application:get_env(?APP, get_region_attempts, 10).
+
+-spec get_credentials_attempts() -> pos_integer().
+get_credentials_attempts() ->
+    application:get_env(?APP, get_credentials_attempts, 10).
+
+%% Required. Crashes with badmatch if not configured.
+-spec bucket() -> binary().
+bucket() ->
+    {ok, Bucket} = application:get_env(?APP, bucket),
+    Bucket.
+
+-spec api_fs_data_dir() -> file:filename_all() | undefined.
+api_fs_data_dir() ->
+    application:get_env(?APP, api_fs_data_dir, undefined).
+
+-spec upload_pool_min_size() -> non_neg_integer().
+upload_pool_min_size() ->
+    application:get_env(?APP, upload_pool_min_size, 0).
+
+-spec upload_pool_max_size() -> pos_integer().
+upload_pool_max_size() ->
+    application:get_env(?APP, upload_pool_max_size, 20).
+
+-spec general_pool_min_size() -> non_neg_integer().
+general_pool_min_size() ->
+    application:get_env(?APP, general_pool_min_size, 0).
+
+-spec general_pool_max_size() -> pos_integer().
+general_pool_max_size() ->
+    application:get_env(?APP, general_pool_max_size, 50).
+
+-spec manifest_rebalance_factor() -> pos_integer().
+manifest_rebalance_factor() ->
+    application:get_env(?APP, manifest_rebalance_factor, 1024).
+
+-spec manifest_debounce_modifications() -> non_neg_integer().
+manifest_debounce_modifications() ->
+    application:get_env(?APP, manifest_debounce_modifications, 10).
+
+-spec manifest_debounce_milliseconds() -> non_neg_integer().
+manifest_debounce_milliseconds() ->
+    application:get_env(?APP, manifest_debounce_milliseconds, 5000).
+
+-spec membership_reconciliation_enabled() -> boolean().
+membership_reconciliation_enabled() ->
+    application:get_env(?APP, membership_reconciliation_enabled, false).
+
+-spec membership_reconciliation_interval() -> non_neg_integer().
+membership_reconciliation_interval() ->
+    application:get_env(?APP, membership_reconciliation_interval, 60_000 * 60).
+
+-spec membership_reconciliation_trigger_interval() -> non_neg_integer().
+membership_reconciliation_trigger_interval() ->
+    application:get_env(?APP, membership_reconciliation_trigger_interval, 10_000).
+
+-spec membership_reconciliation_target_group_size() -> pos_integer() | undefined.
+membership_reconciliation_target_group_size() ->
+    application:get_env(?APP, membership_reconciliation_target_group_size, undefined).
+
+-spec membership_reconciliation_auto_remove() -> boolean().
+membership_reconciliation_auto_remove() ->
+    application:get_env(?APP, membership_reconciliation_auto_remove, false).
+
+-spec task_retry_delay_max_ms() -> non_neg_integer().
+task_retry_delay_max_ms() ->
+    application:get_env(?APP, task_retry_delay_max_ms, 5_000).
+
+-spec task_retry_delay_constant() -> non_neg_integer().
+task_retry_delay_constant() ->
+    application:get_env(?APP, task_retry_delay_constant, 10).
+
+-spec task_retry_delay_exponent() -> non_neg_integer().
+task_retry_delay_exponent() ->
+    application:get_env(?APP, task_retry_delay_exponent, 2).
+
+-spec verbose_logging() -> boolean().
+verbose_logging() ->
+    application:get_env(?APP, verbose_logging, false).
+
+-spec segment_upload_timeout() -> non_neg_integer().
+segment_upload_timeout() ->
+    application:get_env(?APP, segment_upload_timeout, 45_000).
+
+-spec tick_timeout_milliseconds() -> non_neg_integer().
+tick_timeout_milliseconds() ->
+    application:get_env(?APP, tick_timeout_milliseconds, 5000).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+defaults_test_() ->
+    [
+        ?_assertEqual(rabbitmq_stream_s3_api_aws, api_backend()),
+        ?_assertEqual(undefined, aws_access_key()),
+        ?_assertEqual(undefined, aws_secret_key()),
+        ?_assertEqual(undefined, aws_security_token()),
+        ?_assertEqual(undefined, aws_region()),
+        ?_assertEqual(#{}, aws_region_endpoints()),
+        ?_assertEqual(10, get_region_attempts()),
+        ?_assertEqual(10, get_credentials_attempts()),
+        ?_assertEqual(undefined, api_fs_data_dir()),
+        ?_assertEqual(0, upload_pool_min_size()),
+        ?_assertEqual(20, upload_pool_max_size()),
+        ?_assertEqual(0, general_pool_min_size()),
+        ?_assertEqual(50, general_pool_max_size()),
+        ?_assertEqual(1024, manifest_rebalance_factor()),
+        ?_assertEqual(10, manifest_debounce_modifications()),
+        ?_assertEqual(5000, manifest_debounce_milliseconds()),
+        ?_assertEqual(false, membership_reconciliation_enabled()),
+        ?_assertEqual(3_600_000, membership_reconciliation_interval()),
+        ?_assertEqual(10_000, membership_reconciliation_trigger_interval()),
+        ?_assertEqual(undefined, membership_reconciliation_target_group_size()),
+        ?_assertEqual(false, membership_reconciliation_auto_remove()),
+        ?_assertEqual(5_000, task_retry_delay_max_ms()),
+        ?_assertEqual(10, task_retry_delay_constant()),
+        ?_assertEqual(2, task_retry_delay_exponent()),
+        ?_assertEqual(false, verbose_logging()),
+        ?_assertEqual(45_000, segment_upload_timeout()),
+        ?_assertEqual(5000, tick_timeout_milliseconds())
+    ].
+
+configured_test_() ->
+    {foreach, fun() -> ok end, fun(_) -> application:unset_env(rabbitmq_stream_s3, bucket) end, [
+        fun(_) ->
+            application:set_env(rabbitmq_stream_s3, bucket, <<"my-bucket">>),
+            ?_assertEqual(<<"my-bucket">>, bucket())
+        end
+    ]}.
+
+-endif.

--- a/src/rabbitmq_stream_s3_machine.erl
+++ b/src/rabbitmq_stream_s3_machine.erl
@@ -184,15 +184,9 @@ Create a default, empty machine state.
 -spec new() -> state().
 new() ->
     new(#{
-        rebalance_factor => application:get_env(
-            rabbitmq_stream_s3, manifest_rebalance_factor, 1024
-        ),
-        debounce_modifications => application:get_env(
-            rabbitmq_stream_s3, manifest_debounce_modifications, 10
-        ),
-        debounce_milliseconds => application:get_env(
-            rabbitmq_stream_s3, manifest_debounce_milliseconds, 5000
-        )
+        rebalance_factor => rabbitmq_stream_s3_config:manifest_rebalance_factor(),
+        debounce_modifications => rabbitmq_stream_s3_config:manifest_debounce_modifications(),
+        debounce_milliseconds => rabbitmq_stream_s3_config:manifest_debounce_milliseconds()
     }).
 
 -spec new(cfg()) -> state().

--- a/src/rabbitmq_stream_s3_membership_reconciliation.erl
+++ b/src/rabbitmq_stream_s3_membership_reconciliation.erl
@@ -32,11 +32,7 @@
 %%----------------------------------------------------------------------------
 
 is_enabled() ->
-    application:get_env(
-        rabbitmq_stream_s3,
-        membership_reconciliation_enabled,
-        false
-    ).
+    rabbitmq_stream_s3_config:membership_reconciliation_enabled().
 
 schedule() ->
     gen_server:cast(?SERVER, {schedule, manual}).
@@ -111,29 +107,13 @@ code_change(_OldVsn, State, _Extra) ->
 %%----------------------------------------------------------------------------
 
 interval() ->
-    application:get_env(
-        rabbitmq_stream_s3,
-        membership_reconciliation_interval,
-        60_000 * 60
-    ).
+    rabbitmq_stream_s3_config:membership_reconciliation_interval().
 trigger_interval() ->
-    application:get_env(
-        rabbitmq_stream_s3,
-        membership_reconciliation_trigger_interval,
-        10_000
-    ).
+    rabbitmq_stream_s3_config:membership_reconciliation_trigger_interval().
 target_group_size() ->
-    application:get_env(
-        rabbitmq_stream_s3,
-        membership_reconciliation_target_group_size,
-        undefined
-    ).
+    rabbitmq_stream_s3_config:membership_reconciliation_target_group_size().
 auto_remove() ->
-    application:get_env(
-        rabbitmq_stream_s3,
-        membership_reconciliation_auto_remove,
-        false
-    ).
+    rabbitmq_stream_s3_config:membership_reconciliation_auto_remove().
 
 evaluate_membership(_Qs, [], _Running, _TargetSize, _AutoRemove, Changes) ->
     %% If there was an error attempting to list members, skip this round of evaluation.

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -339,15 +339,14 @@ handle_info(
             Task = Task0#task{failures = Failures},
             %% With default settings, retry after 100, 400, 900, 1600, 2500, 3600,
             %% 4900, 5000, 5000, 5000, ... ms
-            Max = application:get_env(rabbitmq_stream_s3, task_retry_delay_max_ms, 5_000),
-            Constant = application:get_env(rabbitmq_stream_s3, task_retry_delay_constant, 10),
-            Exponent = application:get_env(rabbitmq_stream_s3, task_retry_delay_exponent, 2),
+            Max = rabbitmq_stream_s3_config:task_retry_delay_max_ms(),
+            Constant = rabbitmq_stream_s3_config:task_retry_delay_constant(),
+            Exponent = rabbitmq_stream_s3_config:task_retry_delay_exponent(),
             DelayMs = min(trunc(math:pow(Constant * Failures, Exponent)), Max),
             TaskRef = erlang:make_ref(),
             erlang:send_after(DelayMs, self(), #retry_task{task = TaskRef}),
             DelayedTasks = DelayedTasks0#{TaskRef => Task},
-            %% TODO: move all application:get_env calls to rabbitmq_stream_s3_config.
-            case application:get_env(rabbitmq_stream_s3, verbose_logging, false) of
+            case rabbitmq_stream_s3_config:verbose_logging() of
                 true ->
                     ?LOG_INFO(
                         "Task ~p (~p) down (~b other outstanding), retrying in ~bms. Reason: ~p", [
@@ -905,7 +904,7 @@ upload_fragment0(
         size = Size
     }
 ) ->
-    Timeout = application:get_env(rabbitmq_stream_s3, segment_upload_timeout, 45_000),
+    Timeout = rabbitmq_stream_s3_config:segment_upload_timeout(),
     SegmentFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"segment">>),
     IndexFilename = rabbitmq_stream_s3:offset_filename(SegmentOffset, <<"index">>),
 
@@ -1099,7 +1098,7 @@ fragment_header_to_info(Data) ->
     Info.
 
 set_tick_timer() ->
-    Timeout = application:get_env(rabbitmq_stream_s3, tick_timeout_milliseconds, 5000),
+    Timeout = rabbitmq_stream_s3_config:tick_timeout_milliseconds(),
     _ = erlang:send_after(Timeout, self(), tick_timeout),
     ok.
 

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -25,8 +25,8 @@ start_pools() ->
         UploadPoolId,
         #{
             name => UploadPoolId,
-            min_size => application:get_env(rabbitmq_stream_s3, upload_pool_min_size, 0),
-            max_size => application:get_env(rabbitmq_stream_s3, upload_pool_max_size, 20)
+            min_size => rabbitmq_stream_s3_config:upload_pool_min_size(),
+            max_size => rabbitmq_stream_s3_config:upload_pool_max_size()
         }
     ]),
     GeneralPoolId = rabbitmq_stream_s3_general_pool,
@@ -34,8 +34,8 @@ start_pools() ->
         GeneralPoolId,
         #{
             name => GeneralPoolId,
-            min_size => application:get_env(rabbitmq_stream_s3, general_pool_min_size, 0),
-            max_size => application:get_env(rabbitmq_stream_s3, general_pool_max_size, 50)
+            min_size => rabbitmq_stream_s3_config:general_pool_min_size(),
+            max_size => rabbitmq_stream_s3_config:general_pool_max_size()
         }
     ]).
 


### PR DESCRIPTION
Requires #127.

## Summary

Add a `rabbitmq_stream_s3_config` module that centralises all `application:get_env/2,3` calls for the `rabbitmq_stream_s3` application. All call sites updated to use it. The module includes EUnit tests for all default values and a configured value.

## Additional fixes

- Fix the `-type config()` spec in `rabbitmq_stream_s3_api_aws_pool` to include the required `name` field, and fix the corresponding test.
- Fix a pre-existing key name discrepancy: the cuttlefish schema writes region endpoint overrides to `aws_region_endpoints` but the code was reading `region_endpoints`. The code now reads `aws_region_endpoints` to match the schema.
- Update `start_pools/0` in `rabbitmq_stream_s3_sup` to use `rabbitmq_stream_s3_config` for pool size configuration.
