### PR TITLE
Fix remote reader mailbox flood from cancelled S3 requests

### DIFF
--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -30,7 +30,7 @@ file-system operations. Use that in non-unit tests.
     delete/2,
     delete_prefix/1,
     delete_prefix/2,
-    match_async/2,
+    match_async/3,
     handle_async/3,
     cancel_async/2,
     request_duration_prometheus_format/0
@@ -79,13 +79,20 @@ examples.
 """.
 -callback delete(key() | [key()], request_opts()) -> ok | {error, any()}.
 -callback delete_prefix(key(), request_opts()) -> {ok, map()} | {error, any()}.
--callback match_async(Msg :: term(), #{async_req() := async_state()}) ->
+-callback match_async(
+    Msg :: term(),
+    Reqs :: #{async_req() := async_state()},
+    CancelledReqs :: #{async_req() => _}
+) ->
     {ok, async_req()}
+    | {cancelled, async_req(), final | more}
     | error.
 -callback handle_async(Msg :: term(), async_req(), async_state()) ->
     {continue, async_state()}
     | {data, binary(), async_state() | done}
-    | {done, ok | {error, any()}}.
+    | {done, ok | {error, any()}}
+    | {done_cancel, {error, any()}}
+    | ignore.
 -callback cancel_async(async_req(), async_state()) -> ok.
 
 -define(C_GET, 1).
@@ -240,15 +247,21 @@ delete_prefix(Prefix, Opts) when is_binary(Prefix) andalso is_map(Opts) ->
     counters:add(counter(), ?C_LIST, 1),
     observe(write, fun() -> (backend()):delete_prefix(Prefix, Opts) end).
 
--spec match_async(Msg :: term(), #{async_req() := async_state()}) ->
-    {ok, async_req()} | error.
-match_async(Msg, Reqs) ->
-    (backend()):match_async(Msg, Reqs).
+-spec match_async(
+    Msg :: term(),
+    Reqs :: #{async_req() := async_state()},
+    CancelledReqs :: #{async_req() => _}
+) ->
+    {ok, async_req()} | {cancelled, async_req(), final | more} | error.
+match_async(Msg, Reqs, CancelledReqs) ->
+    (backend()):match_async(Msg, Reqs, CancelledReqs).
 
 -spec handle_async(Msg :: term(), async_req(), AsyncState :: term()) ->
     {continue, AsyncState :: term()}
     | {data, binary(), async_state()}
-    | {done, ok | {error, any()}}.
+    | {done, ok | {error, any()}}
+    | {done_cancel, {error, any()}}
+    | ignore.
 handle_async(Msg, Req, {StartTs, BackendState0}) ->
     case (backend()):handle_async(Msg, Req, BackendState0) of
         {continue, BackendState} ->
@@ -262,7 +275,12 @@ handle_async(Msg, Req, {StartTs, BackendState0}) ->
             {data, Data, {StartTs, BackendState}};
         {done, _} = Done ->
             ok = finish_async(StartTs),
-            Done
+            Done;
+        {done_cancel, _} = DoneCancel ->
+            ok = finish_async(StartTs),
+            DoneCancel;
+        ignore ->
+            ignore
     end.
 
 -spec cancel_async(async_req(), async_state()) -> ok.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -26,7 +26,7 @@ A wrapper around the AWS S3 HTTP API.
     delete/2,
     delete_prefix/2,
     list/3,
-    match_async/2,
+    match_async/3,
     handle_async/3,
     cancel_async/2
 ]).
@@ -474,9 +474,16 @@ log_unexpected_status(Function, Status) ->
 log_unexpected_status(Function, Status, Key) ->
     ?LOG_DEBUG("~ts unexpected HTTP status ~b for key ~ts", [Function, Status, Key]).
 
--spec match_async(Msg :: term(), #{async_req() := async_state()}) ->
-    {ok, async_req()} | error.
-match_async({gun_error, Conn, _Reason}, Reqs) ->
+-spec match_async(
+    Msg :: term(),
+    Reqs :: #{async_req() := async_state()},
+    CancelledReqs :: #{async_req() => _}
+) ->
+    {ok, async_req()} | {cancelled, async_req(), final | more} | error.
+match_async({gun_error, Conn, _Reason}, Reqs, _CancelledReqs) ->
+    %% Connection-level error: match any active request on this connection.
+    %% We intentionally ignore cancelled requests - a dying connection only
+    %% needs to notify live requests.
     maps:fold(
         fun
             (Req, #{conn := C}, error) when C =:= Conn -> {ok, Req};
@@ -485,18 +492,25 @@ match_async({gun_error, Conn, _Reason}, Reqs) ->
         error,
         Reqs
     );
-match_async(Msg, Reqs) ->
-    Req =
+match_async(Msg, Reqs, CancelledReqs) ->
+    {Req, Final} =
         case Msg of
-            {gun_error, _, StreamRef, _} -> StreamRef;
-            {gun_response, _, StreamRef, _, _, _} -> StreamRef;
-            {gun_data, _, StreamRef, _, _} -> StreamRef;
-            {request_timeout, StreamRef} -> StreamRef;
-            _ -> undefined
+            {gun_error, _, StreamRef, _} -> {StreamRef, final};
+            {gun_response, _, StreamRef, fin, _, _} -> {StreamRef, final};
+            {gun_response, _, StreamRef, nofin, _, _} -> {StreamRef, more};
+            {gun_data, _, StreamRef, fin, _} -> {StreamRef, final};
+            {gun_data, _, StreamRef, nofin, _} -> {StreamRef, more};
+            {request_timeout, StreamRef} -> {StreamRef, final};
+            _ -> {undefined, final}
         end,
     case Reqs of
-        #{Req := _} -> {ok, Req};
-        _ -> error
+        #{Req := _} ->
+            {ok, Req};
+        _ ->
+            case CancelledReqs of
+                #{Req := _} -> {cancelled, Req, Final};
+                _ -> error
+            end
     end.
 
 -spec handle_async(Msg :: term(), async_req(), async_state()) ->
@@ -552,19 +566,35 @@ handle_async(
         206 ->
             State = State0#{data => [], pending_bytes => 0},
             {continue, State};
-        404 ->
-            finish_async(State0),
-            {done, {error, not_found}};
-        500 ->
-            finish_async(State0),
-            {done, {error, internal_error}};
-        503 ->
-            finish_async(State0),
-            {done, {error, slow_down}};
         _ ->
-            finish_async(State0),
-            {done, {error, #{status => Status, headers => Headers}}}
+            %% Non-success response with a body. Cancel the request timer
+            %% and drain the body before reporting the error so that the
+            %% remaining gun_data frames do not orphan in the caller's
+            %% mailbox.
+            Reason =
+                case Status of
+                    404 -> not_found;
+                    500 -> internal_error;
+                    503 -> slow_down;
+                    _ -> #{status => Status, headers => Headers}
+                end,
+            State = cancel_request_timer(State0),
+            {continue, State#{draining => Reason}}
     end;
+handle_async(
+    {gun_data, Conn, StreamRef, nofin, _Data},
+    StreamRef,
+    #{conn := Conn, stream_ref := StreamRef, draining := _}
+) ->
+    %% Discard body data from a non-success response being drained.
+    ignore;
+handle_async(
+    {gun_data, Conn, StreamRef, fin, _Data},
+    StreamRef,
+    #{conn := Conn, stream_ref := StreamRef, draining := Reason} = State
+) ->
+    finish_async(State),
+    {done, {error, Reason}};
 handle_async(
     {gun_data, Conn, StreamRef, nofin, Data},
     StreamRef,
@@ -604,12 +634,32 @@ handle_async(
     counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
     gun:cancel(Conn, StreamRef),
     finish_async(State),
-    {done, {error, timeout}}.
+    {done_cancel, {error, timeout}}.
 
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
     gun:cancel(Conn, StreamRef),
     ok = finish_async(State).
+
+%% Cancel the request timer without checking in the connection or
+%% decrementing the active-request counter. Used when the response
+%% body still needs to be drained before the request is complete.
+cancel_request_timer(State) ->
+    case State of
+        #{timer_ref := TimerRef, stream_ref := StreamRef} ->
+            case erlang:cancel_timer(TimerRef) of
+                false ->
+                    receive
+                        {request_timeout, StreamRef} -> ok
+                    after 0 -> ok
+                    end;
+                _ ->
+                    ok
+            end,
+            maps:remove(timer_ref, State);
+        _ ->
+            State
+    end.
 
 finish_async(#{conn := Conn, pool := Pool} = State) ->
     case State of
@@ -1558,6 +1608,94 @@ sign_test() ->
         Authorization3
     ),
 
+    ok.
+
+match_async_active_request_test() ->
+    Ref = make_ref(),
+    Conn = self(),
+    Reqs = #{Ref => #{conn => Conn, stream_ref => Ref}},
+    ?assertEqual(
+        {ok, Ref},
+        match_async({gun_data, Conn, Ref, nofin, <<"data">>}, Reqs, #{})
+    ),
+    ?assertEqual(
+        {ok, Ref},
+        match_async({gun_response, Conn, Ref, nofin, 200, []}, Reqs, #{})
+    ),
+    ?assertEqual(
+        {ok, Ref},
+        match_async({gun_error, Conn, Ref, some_reason}, Reqs, #{})
+    ),
+    ?assertEqual(
+        {ok, Ref},
+        match_async({request_timeout, Ref}, Reqs, #{})
+    ),
+    ok.
+
+match_async_cancelled_request_test() ->
+    Ref = make_ref(),
+    Conn = self(),
+    CancelledReqs = #{Ref => ok},
+    %% Terminal frames: fin data, fin response, stream-level gun_error,
+    %% request_timeout.
+    ?assertEqual(
+        {cancelled, Ref, final},
+        match_async({gun_data, Conn, Ref, fin, <<"stale">>}, #{}, CancelledReqs)
+    ),
+    ?assertEqual(
+        {cancelled, Ref, final},
+        match_async({gun_response, Conn, Ref, fin, 200, []}, #{}, CancelledReqs)
+    ),
+    ?assertEqual(
+        {cancelled, Ref, final},
+        match_async({gun_error, Conn, Ref, some_reason}, #{}, CancelledReqs)
+    ),
+    ?assertEqual(
+        {cancelled, Ref, final},
+        match_async({request_timeout, Ref}, #{}, CancelledReqs)
+    ),
+    %% Non-terminal frames: nofin data, nofin response.
+    ?assertEqual(
+        {cancelled, Ref, more},
+        match_async({gun_data, Conn, Ref, nofin, <<"stale">>}, #{}, CancelledReqs)
+    ),
+    ?assertEqual(
+        {cancelled, Ref, more},
+        match_async({gun_response, Conn, Ref, nofin, 200, []}, #{}, CancelledReqs)
+    ),
+    ok.
+
+match_async_unknown_request_test() ->
+    Ref = make_ref(),
+    Conn = self(),
+    ?assertEqual(
+        error,
+        match_async({gun_data, Conn, Ref, nofin, <<"x">>}, #{}, #{})
+    ),
+    ?assertEqual(
+        error,
+        match_async(some_other_message, #{}, #{})
+    ),
+    ok.
+
+match_async_connection_error_ignores_cancelled_test() ->
+    %% A connection-level gun_error (3-tuple) should match an active request
+    %% on that connection, not a cancelled one - even if the only request on
+    %% the connection is cancelled, we return `error` (the connection dying
+    %% has no active request to notify).
+    Conn = self(),
+    Ref = make_ref(),
+    ?assertEqual(
+        error,
+        match_async({gun_error, Conn, some_reason}, #{}, #{Ref => ok})
+    ),
+    %% With an active request on the connection, match_async returns it.
+    ActiveRef = make_ref(),
+    Reqs = #{ActiveRef => #{conn => Conn, stream_ref => ActiveRef}},
+    ?assertEqual(
+        {ok, ActiveRef},
+        match_async({gun_error, Conn, some_reason}, Reqs, #{Ref => ok})
+    ),
     ok.
 
 -endif.

--- a/src/rabbitmq_stream_s3_api_fs.erl
+++ b/src/rabbitmq_stream_s3_api_fs.erl
@@ -23,7 +23,7 @@ associated file in that folder.
     stream_finish/2,
     delete/2,
     delete_prefix/2,
-    match_async/2,
+    match_async/3,
     handle_async/3,
     cancel_async/2
 ]).
@@ -203,11 +203,17 @@ delete_prefix(Prefix, Opts) when is_binary(Prefix) andalso is_map(Opts) ->
         end
     end).
 
--spec match_async(Msg :: term(), #{async_req() := async_state()}) ->
-    {ok, async_req()} | error.
-match_async({'$async', Req, _Msg}, Reqs) when is_map_key(Req, Reqs) ->
+-spec match_async(
+    Msg :: term(),
+    Reqs :: #{async_req() := async_state()},
+    CancelledReqs :: #{async_req() => _}
+) ->
+    {ok, async_req()} | {cancelled, async_req(), final | more} | error.
+match_async({'$async', Req, _Msg}, Reqs, _CancelledReqs) when is_map_key(Req, Reqs) ->
     {ok, Req};
-match_async(_Msg, _Reqs) ->
+match_async({'$async', Req, _Msg}, _Reqs, CancelledReqs) when is_map_key(Req, CancelledReqs) ->
+    {cancelled, Req, final};
+match_async(_Msg, _Reqs, _CancelledReqs) ->
     error.
 
 -spec handle_async(Msg :: term(), async_req(), async_state()) ->
@@ -330,3 +336,16 @@ range_spec_to_location_number(FileSize, {StartByte, EndByte}) ->
             _ -> EndByte - StartByte + 1
         end,
     {StartByte, Number}.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+match_async_test() ->
+    Ref = make_ref(),
+    ?assertEqual({ok, Ref}, match_async({'$async', Ref, data}, #{Ref => state}, #{})),
+    ?assertEqual({cancelled, Ref, final}, match_async({'$async', Ref, data}, #{}, #{Ref => ok})),
+    ?assertEqual(error, match_async({'$async', Ref, data}, #{}, #{})),
+    ?assertEqual(error, match_async(other_message, #{}, #{})),
+    ok.
+
+-endif.

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -113,6 +113,12 @@ multiplicative decrease ([AIMD]) algorithm.
     %% All in-flight requests, keyed by async_req().
     requests = #{} :: #{rabbitmq_stream_s3_api:async_req() => #request{}},
 
+    %% Refs of requests cancelled via cancel_requests/1. Gun may still deliver
+    %% already-buffered frames for these refs after the cancel; tracking them
+    %% here lets match_async/3 drop those messages silently without flooding
+    %% the mailbox through the `error` branch.
+    cancelled_requests = #{} :: #{rabbitmq_stream_s3_api:async_req() => ok},
+
     %% Pending read from the log reader process.
     pending_read :: #pending_read{} | undefined,
     current_not_found = false :: boolean()
@@ -254,12 +260,21 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #?MODULE{reader_ref = MRef} 
 handle_info(retry_requests, State0) ->
     State = maybe_start_request(State0),
     maybe_reply_pending(State);
-handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = State0) ->
+handle_info(
+    Msg,
+    #?MODULE{
+        requests = Requests0,
+        cancelled_requests = CancelledRequests0,
+        retry_delay = RetryDelay0
+    } = State0
+) ->
     AsyncStates = #{Req => R#request.state || Req := R <- Requests0},
-    case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates) of
+    case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates, CancelledRequests0) of
         {ok, RequestId} ->
             #request{state = ReqState0} = Req0 = maps:get(RequestId, Requests0),
             case rabbitmq_stream_s3_api:handle_async(Msg, RequestId, ReqState0) of
+                ignore ->
+                    {noreply, State0};
                 {continue, ReqState} ->
                     Requests = Requests0#{RequestId := Req0#request{state = ReqState}},
                     {noreply, State0#?MODULE{requests = Requests}};
@@ -291,35 +306,27 @@ handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = Sta
                     counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
                     Requests = maps:remove(RequestId, Requests0),
                     State1 = State0#?MODULE{requests = Requests},
-                    case {Reason, Req0#request.fragment =:= State1#?MODULE.fragment} of
-                        {not_found, true} ->
-                            maybe_reply_pending(State1#?MODULE{
-                                current_not_found = true,
-                                retry_delay = ?MIN_RETRY_DELAY_MS
-                            });
-                        {not_found, false} ->
-                            maybe_reply_pending(State1#?MODULE{
-                                next = not_found,
-                                retry_delay = ?MIN_RETRY_DELAY_MS
-                            });
-                        {Transient, _} when
-                            Transient =:= slow_down;
-                            Transient =:= internal_error
-                        ->
-                            erlang:send_after(RetryDelay0, self(), retry_requests),
-                            RetryDelay = min(RetryDelay0 * 2, ?MAX_RETRY_DELAY_MS),
-                            State2 = State1#?MODULE{retry_delay = RetryDelay},
-                            maybe_reply_pending(State2);
-                        {Transient, _} when
-                            Transient =:= stream_error;
-                            Transient =:= connection_error;
-                            Transient =:= timeout
-                        ->
-                            maybe_reply_pending(State1);
-                        _ ->
-                            {stop, {shutdown, Reason}, State1}
-                    end
+                    handle_request_error(Reason, Req0, RetryDelay0, State1);
+                {done_cancel, {error, Reason}} ->
+                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+                    Requests = maps:remove(RequestId, Requests0),
+                    CancelledRequests = CancelledRequests0#{RequestId => ok},
+                    State1 = State0#?MODULE{
+                        requests = Requests,
+                        cancelled_requests = CancelledRequests
+                    },
+                    handle_request_error(Reason, Req0, RetryDelay0, State1)
             end;
+        {cancelled, Ref, Final} ->
+            %% Stale message for a request that called gun:cancel (e.g.
+            %% after a timeout). Drop silently and remove the ref once
+            %% its terminal frame arrives.
+            CancelledRequests =
+                case Final of
+                    final -> maps:remove(Ref, CancelledRequests0);
+                    more -> CancelledRequests0
+                end,
+            {noreply, State0#?MODULE{cancelled_requests = CancelledRequests}};
         error ->
             ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
             {noreply, State0}
@@ -327,6 +334,36 @@ handle_info(Msg, #?MODULE{requests = Requests0, retry_delay = RetryDelay0} = Sta
 handle_info(Msg, State) ->
     ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
     {noreply, State}.
+
+handle_request_error(Reason, Req0, RetryDelay0, State) ->
+    case {Reason, Req0#request.fragment =:= State#?MODULE.fragment} of
+        {not_found, true} ->
+            maybe_reply_pending(State#?MODULE{
+                current_not_found = true,
+                retry_delay = ?MIN_RETRY_DELAY_MS
+            });
+        {not_found, false} ->
+            maybe_reply_pending(State#?MODULE{
+                next = not_found,
+                retry_delay = ?MIN_RETRY_DELAY_MS
+            });
+        {Transient, _} when
+            Transient =:= slow_down;
+            Transient =:= internal_error
+        ->
+            erlang:send_after(RetryDelay0, self(), retry_requests),
+            RetryDelay = min(RetryDelay0 * 2, ?MAX_RETRY_DELAY_MS),
+            State1 = State#?MODULE{retry_delay = RetryDelay},
+            maybe_reply_pending(State1);
+        {Transient, _} when
+            Transient =:= stream_error;
+            Transient =:= connection_error;
+            Transient =:= timeout
+        ->
+            maybe_reply_pending(State);
+        _ ->
+            {stop, {shutdown, Reason}, State}
+    end.
 
 terminate(_Reason, #?MODULE{requests = Requests}) ->
     cancel_requests(Requests),
@@ -675,14 +712,13 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
         #?MODULE{requests = Requests} when map_size(Requests) =/= 0 ->
             %% The current fragment's info is being requested. Wait for its arrival.
             {await, State};
-        #?MODULE{current_not_found = true, stream = StreamId, requests = Requests} ->
+        #?MODULE{current_not_found = true, stream = StreamId} ->
             %% The current fragment was deleted by retention while being read.
-            %% Cancel all in-flight requests for the deleted fragment, then jump
-            %% to the oldest fragment still available in the remote tier.
-            cancel_requests(Requests),
+            %% Requests is empty here (the first case branch catches non-empty).
+            %% Jump to the oldest fragment still available in the remote tier.
             case rabbitmq_stream_s3_server:get_range(StreamId) of
                 empty ->
-                    {end_of_stream, State#?MODULE{requests = #{}}};
+                    {end_of_stream, State};
                 {FirstOffset, _} ->
                     Key = rabbitmq_stream_s3:fragment_key(StreamId, FirstOffset),
                     ?LOG_WARNING(
@@ -699,7 +735,6 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
                         current_pos = ?FRAGMENT_HEADER_B,
                         end_pos = ?FRAGMENT_HEADER_B,
                         next = undefined,
-                        requests = #{},
                         current_not_found = false
                     },
                     {next_fragment, NewState, FirstOffset}


### PR DESCRIPTION
Fixes #122.

## Problem

When retention deletes the fragment being read, or an S3 request exceeds the 30-second timeout, the remote reader receives `gun_data` frames for streams that gun has already cancelled, or whose error response body is still in flight. The reader has no matching request in its `requests` map, so `match_async/2` returns `error` and each stale frame is logged one at a time at debug level.

Under high load this produces thousands of stale messages. Processing them serially delays the re-issued request past the 60-second `gen_server:call` timeout that `rabbit_stream_reader` uses, which crashes the consumer connection.

## Root causes

Two `handle_async` paths return `{done, ...}` while gun still has frames to deliver for the same stream:

1. A `nofin` non-success response (404, 500, 503, other). The response headers arrive with `nofin`, the handler returns `{done, {error, ...}}`, and gun delivers the XML error body as `gun_data` frames against the now-removed ref.
2. `request_timeout`, which calls `gun:cancel` and returns `{done, {error, timeout}}`. Frames already buffered on the TCP connection arrive after the ref is removed from `requests`.

## Solution

**Drain error response bodies.** On a `nofin` non-success response, `handle_async` cancels the request timer, marks the state with `draining => Reason`, and returns `{continue, State}`. New clauses discard `gun_data nofin` frames during the drain and, on the terminal `gun_data fin`, call `finish_async` and return `{done, {error, Reason}}`. The request stays in `requests` throughout the drain, so no frame is orphaned.

**Track refs cancelled by `gun:cancel`.** A new `cancelled_requests` field is added to the reader state and the callback changes from `match_async/2` to `match_async/3` so callers pass the cancelled set alongside the active requests. `request_timeout` now returns `{done_cancel, {error, timeout}}`; the reader adds the ref to `cancelled_requests` on this return. Stale frames are matched as `{cancelled, Ref, final | more}` and dropped silently. The ref is removed from `cancelled_requests` on its terminal frame.

Extract `cancel_request_timer/1` from `finish_async/1` for use by the drain path.

## Testing

EUnit coverage:

- `rabbitmq_stream_s3_api_aws`: `match_async_active_request_test`, `match_async_cancelled_request_test`, `match_async_unknown_request_test`, `match_async_connection_error_ignores_cancelled_test`
- `rabbitmq_stream_s3_api_fs`: `match_async_test`

`gmake` and `gmake dialyze` pass cleanly.

`high-throughput-test.sh` on a test deployment, 45-minute run with 6 streams, 12 producers, and 12 consumers: 895 retention jumps across three nodes produced zero "received unexpected message" log entries. Prior runs on unfixed code produced over 16,000.
