### PR TITLE
Fix `unimplemented` crash on retention race in `try_read/3`

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 27
-          rebar3-version: 3.22
+          otp-version: '27'
+          rebar3-version: '3.27'
       - run: |
           git clone --branch v1.7.0 https://github.com/WhatsApp/erlfmt.git ${{ github.workspace }}/erlfmt
           cd ${{ github.workspace }}/erlfmt && rebar3 as release escriptize

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -681,9 +681,40 @@ try_read(
     ),
     case RemoteRange of
         {RemoteStartOffset, _EndOffset} when RemoteStartOffset >= NextFragment ->
-            %% re-set the state at this offset. Also take the min between this
-            %% and the first local offset.
-            erlang:error(unimplemented);
+            %% Retention has evicted the next fragment and advanced past it.
+            %% Jump to the oldest fragment still available. Cancel any
+            %% in-flight requests and track their refs as cancelled so that
+            %% late frames are dropped silently.
+            #?MODULE{
+                fragment = CurrentFragment,
+                requests = Requests,
+                cancelled_requests = Cancelled0
+            } = State0,
+            cancel_requests(Requests),
+            Cancelled = maps:merge(
+                Cancelled0,
+                #{Req => ok || Req := _ <- Requests}
+            ),
+            Key = rabbitmq_stream_s3:fragment_key(StreamId, RemoteStartOffset),
+            ?LOG_WARNING(
+                "Fragment ~20..0B finished but next fragment ~20..0B was evicted. "
+                "Jumping to oldest available fragment ~20..0B",
+                [CurrentFragment, NextFragment, RemoteStartOffset]
+            ),
+            State = State0#?MODULE{
+                fragment = RemoteStartOffset,
+                key = Key,
+                info = undefined,
+                buffer = <<>>,
+                start_pos = ?FRAGMENT_HEADER_B,
+                current_pos = ?FRAGMENT_HEADER_B,
+                end_pos = ?FRAGMENT_HEADER_B,
+                next = undefined,
+                current_not_found = false,
+                requests = #{},
+                cancelled_requests = Cancelled
+            },
+            {next_fragment, State, RemoteStartOffset};
         {_StartOffset, EndOffset} when EndOffset < NextFragment ->
             State = goto_next_fragment(State0),
             {become_local, State};


### PR DESCRIPTION
Fixes #131.

## Problem

`rabbitmq_stream_s3_remote_reader:try_read/3` crashes with `erlang:error(unimplemented)` when a 404 on the next-fragment request is followed by the remote tier's start offset advancing past `NextFragment`. This happens when retention evicts the next fragment and keeps going, so by the time the reader re-queries the remote range, the oldest available offset is at or beyond the fragment the reader was about to request.

The crash takes down the remote reader. Every `rabbit_stream_reader` consumer connection with an in-flight `gen_server:call` to that reader then terminates with a `timeout` exit, disconnecting the client.

## Solution

Mirror the existing retention-jump logic used in the `current_not_found = true` branch of the `EndPos` clause of `try_read/3`:

1. Read the remote range
2. Jump to the oldest available fragment offset
3. Reset the reader state (fragment, key, buffer, positions, info, next, current_not_found)
4. Return `{next_fragment, State, RemoteStartOffset}`

Unlike the `current_not_found = true` branch, `requests` can be non-empty here. A trailing current-fragment request may still be in flight when the next-fragment probe receives its 404. Cancel those requests and merge their refs into `cancelled_requests` so that late frames are dropped silently by the `match_async/3` mechanism added in #130.

## Testing

The 45-minute `high-throughput-test.sh` on the test deployment against this branch produced:

- 0 `unimplemented` crashes across all three nodes (baseline on `main`: 2 crashes in the same workload)
- 2 occurrences of the new `"Fragment ... finished but next fragment ... was evicted"` warning, confirming the new code path was exercised
- 2,485 total retention-jump events handled cleanly
- 0 `received unexpected message` log entries, confirming PR #130's mailbox-flood fix still holds under the new code path

`gmake`, `gmake dialyze`, and `gmake eunit` (54 tests) all pass on this branch.

