### PR TITLE
Add a test suite for the log reader

### DIFF
--- a/src/rabbitmq_stream_s3_api_fs.erl
+++ b/src/rabbitmq_stream_s3_api_fs.erl
@@ -31,6 +31,7 @@ associated file in that folder.
 % Auxiliary function for testing
 -export([
     get_stream_data/1,
+    list_fragments/1,
     clear/0,
     set_data_dir/1
 ]).
@@ -256,9 +257,8 @@ stream_finish({Fd, Crc}, Crc32) ->
     {ok, Manifest, [FragmentFile]} | {error, not_found | path_not_set}
 when
     StreamName :: binary(),
-    Manifest :: Path | undefined,
-    FragmentFile :: Path,
-    Path :: binary().
+    Manifest :: file:filename() | undefined,
+    FragmentFile :: file:filename().
 get_stream_data(StreamName0) ->
     case data_dir() of
         undefined ->
@@ -290,6 +290,16 @@ get_stream_data(StreamName0) ->
             end
     end.
 
+-doc "Returns the sorted first offsets of fragment files stored for the given stream.".
+-spec list_fragments(StreamName :: binary()) -> [osiris:offset()].
+list_fragments(StreamName) ->
+    case get_stream_data(StreamName) of
+        {ok, _Manifest, Fragments} ->
+            lists:sort([binary_to_integer(filename:basename(F, <<".fragment">>)) || F <- Fragments]);
+        _ ->
+            []
+    end.
+
 -spec clear() -> ok | {error, any()}.
 clear() ->
     file:del_dir_r(data_dir()).
@@ -298,7 +308,7 @@ clear() ->
 set_data_dir(DataDir) ->
     application:set_env(rabbitmq_stream_s3, api_fs_data_dir, DataDir).
 
--spec data_dir() -> binary() | undefined.
+-spec data_dir() -> file:filename_all() | undefined.
 data_dir() ->
     rabbitmq_stream_s3_config:api_fs_data_dir().
 

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -12,6 +12,7 @@ lives here. Callers use these functions instead of calling
 
 -export([
     api_backend/0,
+    manifest_server_backend/0,
     aws_access_key/0,
     aws_secret_key/0,
     aws_security_token/0,
@@ -47,6 +48,10 @@ lives here. Callers use these functions instead of calling
 -spec api_backend() -> module().
 api_backend() ->
     application:get_env(?APP, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws).
+
+-spec manifest_server_backend() -> module().
+manifest_server_backend() ->
+    application:get_env(?APP, rabbitmq_stream_s3_server, rabbitmq_stream_s3_server).
 
 %% AWS credentials. Return `undefined` when not configured (instance role is used).
 -spec aws_access_key() -> binary() | undefined.

--- a/src/rabbitmq_stream_s3_log_manifest.erl
+++ b/src/rabbitmq_stream_s3_log_manifest.erl
@@ -36,6 +36,7 @@ and the server handles background uploads.
 ]).
 
 -export([
+    recover_fragments/1,
     recover_fragments/2,
     find_fragments_in_range/3
 ]).

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -103,6 +103,9 @@ tier.
     iterator_next/1
 ]).
 
+%% Debugging, testing.
+-export([mode/1]).
+
 -ifdef(TEST).
 -export([find_fragment/3, find_index_position/2]).
 -endif.
@@ -477,6 +480,10 @@ iterator_next(Local) ->
 
 %%---------------------------------------------------------------------------
 %% Helpers
+
+-spec mode(#?MODULE{}) -> local | remote.
+mode(#?MODULE{mode = #remote{}}) -> remote;
+mode(#?MODULE{}) -> local.
 
 send(tcp, Socket, Data) ->
     gen_tcp:send(Socket, Data);

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -172,7 +172,7 @@ resolve_remote_location(Spec, _Config) when Spec =:= last orelse Spec =:= next -
     {local, Spec};
 resolve_remote_location(first, #{name := StreamId, shared := Shared}) ->
     LocalFirstOffset = osiris_log_shared:first_chunk_id(Shared),
-    case rabbitmq_stream_s3_server:get_manifest(StreamId) of
+    case (rabbitmq_stream_s3_server:backend()):get_manifest(StreamId) of
         #manifest{first_offset = RemoteFirstOffset} when RemoteFirstOffset < LocalFirstOffset ->
             ?LOG_DEBUG(
                 "Attaching remote reader at first offset ~b for spec 'first'",
@@ -203,7 +203,7 @@ resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
                     Offset, StreamId, FirstChunkId
                 ]
             ),
-            case rabbitmq_stream_s3_server:get_manifest(StreamId) of
+            case (rabbitmq_stream_s3_server:backend()):get_manifest(StreamId) of
                 undefined ->
                     {local, next};
                 #manifest{first_offset = FirstOffset} when Offset < FirstOffset ->
@@ -220,7 +220,7 @@ resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
     ]),
     %% We can't cheaply query the first timestamp from `osiris_log_shared`.
     %% Instead try the remote tier first.
-    case rabbitmq_stream_s3_server:get_manifest(StreamId) of
+    case (rabbitmq_stream_s3_server:backend()):get_manifest(StreamId) of
         #manifest{first_offset = FirstOffset, first_timestamp = FirstTs} when Ts < FirstTs ->
             {ok, remote_location_first(FirstOffset)};
         #manifest{entries = Entries} ->
@@ -249,14 +249,14 @@ total_range(#{name := StreamId, shared := Shared}) ->
             empty;
         LocalFirst ->
             LocalLast = osiris_log_shared:committed_offset(Shared),
-            case rabbitmq_stream_s3_server:get_range(StreamId) of
+            case (rabbitmq_stream_s3_server:backend()):get_range(StreamId) of
                 {RemoteFirst, RemoteLast} when RemoteFirst =/= -1 ->
                     {min(LocalFirst, RemoteFirst), max(LocalLast, RemoteLast)};
                 _ ->
                     %% The stream might be starting up and not have a range
                     %% yet. Request the manifest so we can check the values
                     %% ourselves.
-                    case rabbitmq_stream_s3_server:get_manifest(StreamId) of
+                    case (rabbitmq_stream_s3_server:backend()):get_manifest(StreamId) of
                         #manifest{first_offset = RemoteFirst, next_offset = RemoteNext} ->
                             {min(LocalFirst, RemoteFirst), max(LocalLast, RemoteNext - 1)};
                         undefined ->

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -521,8 +521,6 @@ read_header1(
     %% Over-read the chunk header so that the filter (if it exists) is always
     %% included in the binary. Reading from the remote tier takes time, so
     %% over-reading is faster.
-    %% TODO: make sure that over-reading is handled gracefully: as much of the
-    %% binary should be returned as possible.
     case read(Pid, Position, ?CHUNK_HEADER_B + ?MAX_FILTER_SIZE, chunk_boundary) of
         {ok, Header} ->
             read_header2(Remote0, Header);

--- a/src/rabbitmq_stream_s3_machine.erl
+++ b/src/rabbitmq_stream_s3_machine.erl
@@ -124,9 +124,6 @@ for the log manifest server to execute.
 
 -export([execute_retention/4]).
 
-%% Used by tests:
--export([apply_infos/2, new_edit/1]).
-
 -spec writer(#writer_spawned{}) -> writer().
 writer(#writer_spawned{
     pid = Pid,
@@ -267,8 +264,8 @@ apply(
                     State = State0#?MODULE{streams = Streams0#{StreamId := Writer}},
                     {State, []};
                 [_ | _] ->
-                    {ok, Edit} = apply_infos(Finished, Manifest0),
-                    Manifest = apply_edit(Edit, Manifest0),
+                    {ok, Edit} = rabbitmq_stream_s3_manifest:apply_infos(Finished, Manifest0),
+                    Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
                     %% assertion: the finished fragments were applied up to the
                     %% next-tiered-offset we expected from split_uploaded_infos/2.
                     #manifest{next_offset = NextOffset} = Manifest,
@@ -427,12 +424,7 @@ apply(
     end;
 apply(
     _Meta,
-    #group_uploaded{
-        stream = StreamId,
-        entry = Entry,
-        pos = Pos,
-        len = Len
-    },
+    #group_uploaded{stream = StreamId} = Event,
     #?MODULE{streams = Streams0} = State0
 ) ->
     case Streams0 of
@@ -443,8 +435,8 @@ apply(
             %% Because uploads only append to the tail of the entries array,
             %% `Pos` and `Len` point to the same section of entries regardless
             %% of changes to the manifest since the group upload started.
-            Edit = (new_edit(Manifest0))#edit{entries = Entry, pos = Pos, len = Len},
-            Manifest = apply_edit(Edit, Manifest0),
+            Edit = rabbitmq_stream_s3_manifest:rebalance_edit(Event, Manifest0),
+            Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
             Writer1 = Writer0#{manifest := Manifest},
             {Writer2, Effects0} = upload(StreamId, Writer1, []),
             {Writer, Effects} = notify_edits([Edit], false, StreamId, Writer2, Effects0),
@@ -660,7 +652,7 @@ apply(
 ) ->
     case Streams0 of
         #{StreamId := #{kind := writer, manifest := #manifest{} = Manifest0} = Writer0} ->
-            Manifest = apply_edit(Edit, Manifest0),
+            Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
             Writer1 = Writer0#{manifest := Manifest},
             {Writer2, Effects0} = upload(StreamId, Writer1, []),
             {Writer, Effects} = notify_edits([Edit], false, StreamId, Writer2, Effects0),
@@ -726,136 +718,10 @@ split_uploaded_infos(
 split_uploaded_infos(NextTieredOffset, PendingUploaded, Acc) ->
     {NextTieredOffset, PendingUploaded, lists:reverse(Acc)}.
 
--spec new_edit(#manifest{}) -> #edit{}.
-new_edit(#manifest{
-    first_offset = FirstOffset,
-    first_timestamp = FirstTs,
-    first_last_timestamp = FirstLastTs,
-    next_offset = NextOffset
-}) ->
-    #edit{
-        first_offset = FirstOffset,
-        first_timestamp = FirstTs,
-        first_last_timestamp = FirstLastTs,
-        next_offset = NextOffset
-    }.
-
--doc """
-Create an edit that adds successfully uploaded fragments to their manifest
-entries array.
-
-`Infos` is expected to be sorted by offset ascending.
-""".
--spec apply_infos([#fragment_info{}], #manifest{}) ->
-    {ok, #edit{} | undefined} | {error, #fragment_info{}}.
-apply_infos(Infos, #manifest{entries = Entries} = Manifest) ->
-    Edit0 = (new_edit(Manifest))#edit{pos = byte_size(Entries)},
-    apply_infos0(Infos, Edit0).
-
-apply_infos0([], Edit) ->
-    {ok, Edit};
-apply_infos0(
-    [
-        #fragment_info{
-            first_offset = Offset,
-            next_offset = NextOffset,
-            first_timestamp = FirstTs,
-            last_timestamp = LastTs,
-            seq_no = SeqNo,
-            size = Size
-        }
-        | Rest
-    ],
-    #edit{
-        next_offset = Offset,
-        size = Size0,
-        entries = Entries0
-    } = Edit0
-) ->
-    Edit1 =
-        case Offset of
-            0 ->
-                %% For the very first fragment, also set the offset and timestamps.
-                Edit0#edit{
-                    first_offset = Offset,
-                    first_timestamp = FirstTs,
-                    first_last_timestamp = LastTs
-                };
-            _ ->
-                Edit0
-        end,
-    IsSeqZero =
-        case SeqNo of
-            0 -> 1;
-            _ -> 0
-        end,
-    Edit = Edit1#edit{
-        next_offset = NextOffset,
-        size = Size0 + Size,
-        entries = <<Entries0/binary, ?FRAGMENT(Offset, FirstTs, LastTs, IsSeqZero, Size)/binary>>
-    },
-    apply_infos0(Rest, Edit);
-apply_infos0([Info | _], #edit{}) ->
-    {error, Info}.
-
--spec apply_edits([#edit{}], #manifest{}) -> #manifest{}.
+-spec apply_edits([rabbitmq_stream_s3_manifest:edit()], rabbitmq_stream_s3_manifest:t()) ->
+    rabbitmq_stream_s3_manifest:t().
 apply_edits(Edits, Manifest) ->
-    lists:foldl(fun apply_edit/2, Manifest, Edits).
-
--spec apply_edit(#edit{}, #manifest{}) -> #manifest{}.
-apply_edit(
-    #edit{
-        first_offset = FirstOffset,
-        first_timestamp = FirstTs,
-        first_last_timestamp = FirstLastTs,
-        next_offset = EditNextOffset,
-        size = Size,
-        entries = EditEntries,
-        pos = Pos,
-        len = Len
-    },
-    #manifest{
-        next_offset = ManifestNextOffset,
-        total_size = TotalSize0,
-        entries = Entries0
-    } = Manifest0
-) ->
-    Entries =
-        if
-            %% Pure insertion (append)
-            Pos =:= byte_size(Entries0) andalso Len =:= 0 ->
-                <<Entries0/binary, EditEntries/binary>>;
-            %% No-op (empty)
-            Len =:= 0 andalso EditEntries =:= <<>> ->
-                Entries0;
-            %% Pure deletion (truncate)
-            EditEntries =:= <<>> ->
-                %% We only truncate from the beginning. No hole punching.
-                ?assertEqual(0, Pos),
-                binary:part(Entries0, Len, byte_size(Entries0) - Len);
-            %% Replacement (for rebalancing)
-            true ->
-                <<
-                    (binary:part(Entries0, 0, Pos))/binary,
-                    EditEntries/binary,
-                    (binary:part(Entries0, Pos + Len, byte_size(Entries0) - Pos - Len))/binary
-                >>
-        end,
-    NextOffset =
-        case EditNextOffset of
-            undefined ->
-                ManifestNextOffset;
-            _ when is_integer(EditNextOffset) ->
-                EditNextOffset
-        end,
-    Manifest0#manifest{
-        first_offset = FirstOffset,
-        first_timestamp = FirstTs,
-        first_last_timestamp = FirstLastTs,
-        next_offset = NextOffset,
-        total_size = TotalSize0 + Size,
-        entries = Entries
-    }.
+    lists:foldl(fun rabbitmq_stream_s3_manifest:apply_edit/2, Manifest, Edits).
 
 -spec notify_edits([#edit{}], SuggestRetention :: boolean(), stream_id(), writer(), [effect()]) ->
     {writer(), [effect()]}.
@@ -1037,7 +903,7 @@ evaluate_retention(
                             ),
                             {Writer0, Edits0, Effects0};
                         {Edit, Offsets} ->
-                            Manifest = apply_edit(Edit, Manifest0),
+                            Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
                             Writer1 = Writer0#{manifest := Manifest},
                             {Writer, Effects1} = upload(StreamId, Writer1, Effects0),
                             DeleteFragments = #delete_objects{stream = StreamId, objects = Offsets},
@@ -1075,7 +941,7 @@ execute_retention(
     RetentionSpec,
     GetGroupFun
 ) ->
-    Edit0 = new_edit(Manifest),
+    Edit0 = rabbitmq_stream_s3_manifest:new_edit(Manifest),
     %% Retention does not affect the tail of the entries array. Clear
     %% the next_offset to avoid clobbering edits made to the manifest
     %% tail during asynchronous retention evaluation.
@@ -1681,15 +1547,15 @@ apply_infos_test() ->
         ],
     ?assertMatch(
         {ok, #edit{first_timestamp = Ts, next_offset = 60}},
-        apply_infos(Infos, #manifest{})
+        rabbitmq_stream_s3_manifest:apply_infos(Infos, #manifest{})
     ),
     ?assertEqual(
         {error, I2},
-        apply_infos([I2, I3], #manifest{})
+        rabbitmq_stream_s3_manifest:apply_infos([I2, I3], #manifest{})
     ),
     ?assertEqual(
         {error, I3},
-        apply_infos([I1, I3], #manifest{})
+        rabbitmq_stream_s3_manifest:apply_infos([I1, I3], #manifest{})
     ),
     ok.
 
@@ -1897,7 +1763,7 @@ recursive_retention_test() ->
         %% G0
         #group_ref{offset = 0, kind = ?MANIFEST_KIND_GROUP}
     ]} = ExecuteRetention(#{max_bytes => 5 * FragmentSize}),
-    Manifest1 = apply_edit(Edit1, Manifest),
+    Manifest1 = rabbitmq_stream_s3_manifest:apply_edit(Edit1, Manifest),
     ?assertEqual(5 * FragmentSize, Manifest1#manifest.total_size),
     {#edit{first_offset = 80, size = -400, len = ?ENTRY_B} = Edit3, [
         %% G0. Returned because looking it up was successful.
@@ -1911,7 +1777,7 @@ recursive_retention_test() ->
         %% KG0
         #group_ref{offset = 0, kind = ?MANIFEST_KIND_KILO_GROUP}
     ]} = execute_retention(Manifest1, Ts, #{max_bytes => 3 * FragmentSize}, GetGroupFun),
-    Manifest2 = apply_edit(Edit3, Manifest1),
+    Manifest2 = rabbitmq_stream_s3_manifest:apply_edit(Edit3, Manifest1),
     ?assertEqual(3 * FragmentSize, Manifest2#manifest.total_size),
 
     ok.

--- a/src/rabbitmq_stream_s3_manifest.erl
+++ b/src/rabbitmq_stream_s3_manifest.erl
@@ -1,0 +1,176 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_manifest).
+-moduledoc """
+Functions for working with the _manifest_ data structure.
+
+The manifest is a tree structure represented by objects in the remote tier
+which tracks metadata about a stream: total size, oldest data, and pointers to
+fragments (via tree-branch-like "group" objects, for large enough streams).
+""".
+
+-include_lib("stdlib/include/assert.hrl").
+
+-include("include/rabbitmq_stream_s3.hrl").
+
+-type t() :: #manifest{}.
+-type edit() :: #edit{}.
+
+-export_type([t/0, edit/0]).
+
+-export([
+    new_edit/1,
+    rebalance_edit/2,
+    apply_infos/2,
+    apply_edit/2
+]).
+
+%% ---------------------------------------------------------------------------
+
+-doc "Creates a new blank edit from the current manifest metadata".
+-spec new_edit(t()) -> edit().
+new_edit(#manifest{
+    first_offset = FirstOffset,
+    first_timestamp = FirstTs,
+    first_last_timestamp = FirstLastTs,
+    next_offset = NextOffset
+}) ->
+    #edit{
+        first_offset = FirstOffset,
+        first_timestamp = FirstTs,
+        first_last_timestamp = FirstLastTs,
+        next_offset = NextOffset
+    }.
+
+-doc "Create an edit which describes a rebalance from a group being uploaded".
+-spec rebalance_edit(#group_uploaded{}, t()) -> edit().
+rebalance_edit(#group_uploaded{entry = Entry, pos = Pos, len = Len}, #manifest{} = Manifest) ->
+    %% TODO: I'm pretty sure we need to clear next_offset here. Add a test
+    %% case for the machine where rebalancing starts, a fragment is uploaded
+    %% and applied, and then the rebalancing completes.
+    (new_edit(Manifest))#edit{entries = Entry, pos = Pos, len = Len}.
+
+-doc """
+Create an edit that adds successfully uploaded fragments to their manifest
+entries array.
+
+`Infos` is expected to be sorted by offset ascending.
+""".
+-spec apply_infos([#fragment_info{}], t()) -> {ok, edit() | undefined} | {error, #fragment_info{}}.
+apply_infos(Infos, #manifest{entries = Entries} = Manifest) ->
+    Edit0 = (new_edit(Manifest))#edit{pos = byte_size(Entries)},
+    apply_infos0(Infos, Edit0).
+
+apply_infos0([], Edit) ->
+    {ok, Edit};
+apply_infos0(
+    [
+        #fragment_info{
+            first_offset = Offset,
+            next_offset = NextOffset,
+            first_timestamp = FirstTs,
+            last_timestamp = LastTs,
+            seq_no = SeqNo,
+            size = Size
+        }
+        | Rest
+    ],
+    #edit{
+        next_offset = Offset,
+        size = Size0,
+        entries = Entries0
+    } = Edit0
+) ->
+    Edit1 =
+        case Offset of
+            0 ->
+                %% For the very first fragment, also set the offset and timestamps.
+                Edit0#edit{
+                    first_offset = Offset,
+                    first_timestamp = FirstTs,
+                    first_last_timestamp = LastTs
+                };
+            _ ->
+                Edit0
+        end,
+    IsSeqZero =
+        case SeqNo of
+            0 -> 1;
+            _ -> 0
+        end,
+    Edit = Edit1#edit{
+        next_offset = NextOffset,
+        size = Size0 + Size,
+        entries = <<Entries0/binary, ?FRAGMENT(Offset, FirstTs, LastTs, IsSeqZero, Size)/binary>>
+    },
+    apply_infos0(Rest, Edit);
+apply_infos0([Info | _], #edit{}) ->
+    {error, Info}.
+
+-doc """
+Apply an edit to a manifest.
+
+The edit type describes a few kinds of modifications to a manifest:
+
+* Appends from new fragments being uploaded.
+* Updates to first_offset / first_timestamp / etc from evaluating retention
+  when the retention affected a group object. (The group object is not
+  modified, just the top-level metadata in the manifest.)
+* Truncation from fragments being deleted by retention from the beginning of
+  the manifest's array.
+""".
+-spec apply_edit(edit(), t()) -> t().
+apply_edit(
+    #edit{
+        first_offset = FirstOffset,
+        first_timestamp = FirstTs,
+        first_last_timestamp = FirstLastTs,
+        next_offset = EditNextOffset,
+        size = Size,
+        entries = EditEntries,
+        pos = Pos,
+        len = Len
+    },
+    #manifest{
+        next_offset = ManifestNextOffset,
+        total_size = TotalSize0,
+        entries = Entries0
+    } = Manifest0
+) ->
+    Entries =
+        if
+            %% Pure insertion (append)
+            Pos =:= byte_size(Entries0) andalso Len =:= 0 ->
+                <<Entries0/binary, EditEntries/binary>>;
+            %% No-op (empty)
+            Len =:= 0 andalso EditEntries =:= <<>> ->
+                Entries0;
+            %% Pure deletion (truncate)
+            EditEntries =:= <<>> ->
+                %% We only truncate from the beginning. No hole punching.
+                ?assertEqual(0, Pos),
+                binary:part(Entries0, Len, byte_size(Entries0) - Len);
+            %% Replacement (for rebalancing)
+            true ->
+                <<
+                    (binary:part(Entries0, 0, Pos))/binary,
+                    EditEntries/binary,
+                    (binary:part(Entries0, Pos + Len, byte_size(Entries0) - Pos - Len))/binary
+                >>
+        end,
+    NextOffset =
+        case EditNextOffset of
+            undefined ->
+                ManifestNextOffset;
+            _ when is_integer(EditNextOffset) ->
+                EditNextOffset
+        end,
+    Manifest0#manifest{
+        first_offset = FirstOffset,
+        first_timestamp = FirstTs,
+        first_last_timestamp = FirstLastTs,
+        next_offset = NextOffset,
+        total_size = TotalSize0 + Size,
+        entries = Entries
+    }.

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -742,6 +742,13 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
     %% Wait until the current request is complete and then respond with the
     %% newly added data.
     case State of
+        #?MODULE{
+            info = #fragment_info{index_start_pos = IdxStartPos}
+        } when EndPos >= IdxStartPos andalso Offset + ?CHUNK_HEADER_B =< EndPos ->
+            %% The log-reader over-reads the chunk header to try to get the
+            %% full filter. That might be larger than the chunk though. If so,
+            %% we need to cap the read at the index boundary.
+            try_read(State, Offset, EndPos - Offset);
         #?MODULE{requests = Requests} when map_size(Requests) =/= 0 ->
             %% The current fragment's info is being requested. Wait for its arrival.
             {await, State};

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -670,7 +670,7 @@ try_read(
 ) when Offset >= IdxStartPos ->
     %% The request for the next fragment gave a 404. The fragment doesn't exist
     %% or hasn't been uploaded yet.
-    RemoteRange = rabbitmq_stream_s3_server:get_range(StreamId),
+    RemoteRange = (rabbitmq_stream_s3_server:backend()):get_range(StreamId),
     ?LOG_DEBUG(
         "Next fragment (~20..0B) was not found (requested ~b + ~b, idx start ~b). Remote range for this stream is ~w",
         [
@@ -749,7 +749,7 @@ try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes 
             %% The current fragment was deleted by retention while being read.
             %% Requests is empty here (the first case branch catches non-empty).
             %% Jump to the oldest fragment still available in the remote tier.
-            case rabbitmq_stream_s3_server:get_range(StreamId) of
+            case (rabbitmq_stream_s3_server:backend()):get_range(StreamId) of
                 empty ->
                     {end_of_stream, State};
                 {FirstOffset, _} ->

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -65,7 +65,8 @@
     init_writer/3,
     fragment_available/2,
     retention_updated/2,
-    delete_stream/1
+    delete_stream/1,
+    init_counters/0
 ]).
 
 %% Useful for other modules
@@ -75,6 +76,7 @@
     split_fragment_info/1,
     get_group_fun/2,
     get_group/3,
+    local_retention_fun/1,
     backend/0
 ]).
 
@@ -168,13 +170,18 @@
 %% recover replicas before this server is started and writer_manifest/1 will
 %% fail a few times and look messy in the logs.
 start() ->
-    Cnt = seshat:new(rabbitmq_stream_s3, ?MODULE, ?COUNTERS, #{module => ?MODULE}),
-    persistent_term:put(?COUNTER_KEY, Cnt),
+    ok = init_counters(),
 
     ok = rabbitmq_stream_s3_api:init(),
     ok = rabbitmq_stream_s3_db:setup(),
     _ = ets:new(?FIRST_GROUPS, [named_table, public]),
     rabbit_sup:start_child(?MODULE).
+
+-spec init_counters() -> ok.
+init_counters() ->
+    Cnt = seshat:new(rabbitmq_stream_s3, ?MODULE, ?COUNTERS, #{module => ?MODULE}),
+    persistent_term:put(?COUNTER_KEY, Cnt),
+    ok.
 
 -spec backend() -> module().
 backend() ->

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -74,7 +74,8 @@
     get_fragment_info/2,
     split_fragment_info/1,
     get_group_fun/2,
-    get_group/3
+    get_group/3,
+    backend/0
 ]).
 
 %% gen_server
@@ -154,6 +155,12 @@
 %% Need to be exported for `erlang:apply/3`.
 -export([start/0, format_osiris_event/1, execute_task/1, execute_task/2]).
 
+%% Behaviour for modules that can serve manifest queries to the log reader.
+%% The real implementation is this module (via gen_server). Tests can use
+%% `rabbitmq_stream_s3_server_ets` which is backed by an ETS table.
+-callback get_manifest(stream_id()) -> #manifest{} | undefined.
+-callback get_range(stream_id()) -> rabbitmq_stream_s3:range().
+
 %%----------------------------------------------------------------------------
 
 %% This server needs to be started by a boot step so that it is online before
@@ -168,6 +175,10 @@ start() ->
     ok = rabbitmq_stream_s3_db:setup(),
     _ = ets:new(?FIRST_GROUPS, [named_table, public]),
     rabbit_sup:start_child(?MODULE).
+
+-spec backend() -> module().
+backend() ->
+    rabbitmq_stream_s3_config:manifest_server_backend().
 
 -spec get_manifest(stream_id()) -> #manifest{} | undefined.
 get_manifest(StreamId) ->
@@ -1164,11 +1175,10 @@ metadata() ->
 -spec local_retention_fun(stream_id()) -> osiris:retention_fun().
 local_retention_fun(StreamId) ->
     fun(IdxFiles) ->
-        try ets:lookup_element(?RANGE_TABLE, StreamId, 3) of
-            NextTieredOffset ->
-                eval_local_retention(IdxFiles, NextTieredOffset)
-        catch
-            error:badarg ->
+        case (backend()):get_range(StreamId) of
+            {_First, NextTieredOffset} ->
+                eval_local_retention(IdxFiles, NextTieredOffset + 1);
+            empty ->
                 {[], IdxFiles}
         end
     end.

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -32,7 +32,8 @@ all() ->
 groups() ->
     [
         {parallel, [parallel], [
-            read_from_first_with_remote_tier
+            read_from_first_with_remote_tier,
+            read_last_chunk_at_index_boundary
         ]}
     ].
 
@@ -128,6 +129,29 @@ read_from_first_with_remote_tier(Config) ->
     %% After local retention, only the active segment (offset 10) remains.
     Manifest = execute_local_retention(Manifest, Config),
     ?assertEqual([10], local_segments(Config)),
+
+    ReaderCfg = reader_config(Config),
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+
+    Records = read_all(Reader0),
+    ?assertEqual(Messages, Records).
+
+-doc """
+The log reader might attempt to read into the index section of a fragment
+since it over-reads the chunk header to get the full bloom filter. The remote
+reader must cap the read at the index boundary.
+""".
+read_last_chunk_at_index_boundary(Config) ->
+    %% Small messages produce small chunks, making it likely that the last
+    %% chunk header in a fragment falls within ?MAX_FILTER_SIZE bytes of the
+    %% index boundary.
+    Messages = messages(20, 1),
+
+    ok = seed_local_tier(Messages, Config),
+    Manifest = upload_to_remote_tier(#manifest{}, Config),
+    publish_manifest(Manifest, Config),
+    Manifest = execute_local_retention(Manifest, Config),
 
     ReaderCfg = reader_config(Config),
     {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -1,0 +1,304 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(log_reader_SUITE).
+-moduledoc """
+Low-level tests for `rabbitmq_stream_s3_log_reader`.
+
+These tests bypass the full broker stack. They use:
+- `rabbitmq_stream_s3_api_fs` as the storage backend
+- `rabbitmq_stream_s3_server_ets` as the manifest server backend
+- `osiris_log` directly to create local segment data
+- Seed helpers to upload fragments synchronously
+
+This allows precise control over the layout of the local and remote tiers.
+""".
+
+-compile([nowarn_export_all, export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("include/rabbitmq_stream_s3.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+        {group, parallel}
+    ].
+
+groups() ->
+    [
+        {parallel, [parallel], [
+            read_from_first_with_remote_tier
+        ]}
+    ].
+
+init_per_suite(Config) ->
+    _ = application:ensure_all_started(logger),
+    %% Suppress non-error logs sent to stdout. CommonTest is already capturing
+    %% logs independently.
+    logger:set_handler_config(default, level, error),
+    {ok, _} = application:ensure_all_started(seshat),
+    _ = seshat:new_group(rabbitmq_stream_s3),
+    osiris:configure_logger(logger),
+    application:set_env(rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fs),
+    application:set_env(
+        rabbitmq_stream_s3,
+        rabbitmq_stream_s3_server,
+        rabbitmq_stream_s3_server_ets
+    ),
+    application:set_env(osiris, max_segment_size_chunks, 10),
+    PrivDir = ?config(priv_dir, Config),
+    DataDir = filename:join(PrivDir, "shared"),
+    ok = filelib:ensure_path(DataDir),
+    rabbitmq_stream_s3_api_fs:set_data_dir(DataDir),
+    ok = rabbitmq_stream_s3_api:init(),
+    ok = rabbitmq_stream_s3_server:init_counters(),
+    ok = rabbitmq_stream_s3_log_reader:init_counters(),
+    {ok, SupPid} = rabbitmq_stream_s3_remote_reader_sup:start_link(),
+    unlink(SupPid),
+    %% Use a long-living process to create the ETS tables.
+    %% Transfer ETS table ownership to a long-lived process so parallel
+    %% test cases can access them after init_per_suite exits.
+    Holder = spawn(fun() ->
+        ok = rabbitmq_stream_s3_server_ets:setup(),
+        receive
+            stop -> ok
+        end
+    end),
+    [{fs_data_dir, DataDir}, {sup_pid, SupPid}, {ets_holder, Holder} | Config].
+
+end_per_suite(Config) ->
+    ?config(ets_holder, Config) ! stop,
+    Pid = ?config(sup_pid, Config),
+    MRef = erlang:monitor(process, Pid),
+    exit(Pid, shutdown),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after 100 ->
+        ok
+    end.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(TestCase, Config) ->
+    %% Unique stream ID per test so parallel tests don't share remote storage.
+    StreamId = iolist_to_binary(["__", atom_to_list(TestCase), "_1"]),
+    Shared = osiris_log_shared:new(),
+    OsirisCfg = #{
+        dir => filename:join([?config(fs_data_dir, Config), atom_to_list(TestCase), "osiris"]),
+        name => binary_to_list(StreamId),
+        epoch => 1,
+        readers_counter_fun => fun(_) -> ok end,
+        shared => Shared,
+        options => #{},
+        max_segment_size_bytes => 10_000
+    },
+    ok = filelib:ensure_path(maps:get(dir, OsirisCfg)),
+    [{stream_id, StreamId}, {osiris_cfg, OsirisCfg}, {shared, Shared} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+read_from_first_with_remote_tier(Config) ->
+    Messages = messages(20, 500),
+
+    %% Write messages to the local tier and upload to the remote tier.
+    ok = seed_local_tier(Messages, Config),
+    Manifest = upload_to_remote_tier(#manifest{}, Config),
+    publish_manifest(Manifest, Config),
+
+    %% Local tier: 2 segments starting at offsets 0 and 10.
+    %% Remote tier: 2 fragments starting at offsets 0 and 10.
+    ?assertEqual([0, 10], local_segments(Config)),
+    ?assertEqual([0, 10], remote_fragments(Config)),
+
+    %% After local retention, only the active segment (offset 10) remains.
+    Manifest = execute_local_retention(Manifest, Config),
+    ?assertEqual([10], local_segments(Config)),
+
+    ReaderCfg = reader_config(Config),
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+
+    Records = read_all(Reader0),
+    ?assertEqual(Messages, Records).
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+-doc "Generate N messages each padded to the given byte size.".
+messages(N, Size) ->
+    [
+        begin
+            Prefix = <<"msg-", (integer_to_binary(I))/binary, "-">>,
+            Pad = max(0, Size - byte_size(Prefix)),
+            <<Prefix/binary, (binary:copy(<<"x">>, Pad))/binary>>
+        end
+     || I <- lists:seq(1, N)
+    ].
+
+-doc "Write messages to the local osiris log and return the updated manifest placeholder.".
+seed_local_tier(Messages, Config) ->
+    OsirisCfg = ?config(osiris_cfg, Config),
+    Shared = ?config(shared, Config),
+    Log0 = osiris_log:init(OsirisCfg),
+    Log1 = lists:foldl(fun(Msg, L) -> osiris_log:write([Msg], L) end, Log0, Messages),
+    LastOffset = osiris_log:next_offset(Log1) - 1,
+    osiris_log_shared:set_committed_chunk_id(Shared, LastOffset),
+    ok = osiris_log:close(Log1).
+
+-doc "Upload all new local segments to the remote tier and return the updated manifest.".
+upload_to_remote_tier(Manifest0, Config) ->
+    Dir = maps:get(dir, ?config(osiris_cfg, Config)),
+    upload_all_fragments(Dir, Manifest0, Config).
+
+-doc "First offsets of segment files currently in the local osiris log directory.".
+local_segments(Config) ->
+    Dir = maps:get(dir, ?config(osiris_cfg, Config)),
+    {ok, Files} = file:list_dir(Dir),
+    lists:sort([
+        binary_to_integer(list_to_binary(filename:basename(F, ".segment")))
+     || F <- Files, filename:extension(F) =:= ".segment"
+    ]).
+
+-doc "First offsets of fragment files currently stored in the remote tier.".
+remote_fragments(Config) ->
+    rabbitmq_stream_s3_api_fs:list_fragments(?config(stream_id, Config)).
+
+-doc "Upload all segments in the osiris log directory and return the updated manifest".
+upload_all_fragments(Dir, Manifest0, Config) ->
+    StreamId = ?config(stream_id, Config),
+    {ok, Files} = file:list_dir(Dir),
+    IdxFiles = lists:sort([filename:join(Dir, F) || F <- Files, filename:extension(F) =:= ".index"]),
+    NewIdxFiles = [
+        F
+     || F <- IdxFiles,
+        rabbitmq_stream_s3:index_file_offset(F) >= Manifest0#manifest.next_offset
+    ],
+    lists:foldl(
+        fun(IdxFile, ManifestAcc) ->
+            {Fragment, _} = rabbitmq_stream_s3_log_manifest:recover_fragments(IdxFile),
+            Effect = #upload_fragment{stream = StreamId, dir = Dir, fragment = Fragment},
+            #fragment_uploaded{info = Info} = rabbitmq_stream_s3_server:execute_task(Effect),
+            {ok, Edit} = rabbitmq_stream_s3_manifest:apply_infos([Info], ManifestAcc),
+            rabbitmq_stream_s3_manifest:apply_edit(Edit, ManifestAcc)
+        end,
+        Manifest0,
+        NewIdxFiles
+    ).
+
+-doc """
+Evaluate local-tier retention, deleting segments whose data is fully in the
+remote tier and updating the shared ref. Equivalent to the server's
+`#trigger_retention` effect.
+""".
+execute_local_retention(Manifest, Config) ->
+    StreamId = ?config(stream_id, Config),
+    OsirisCfg = ?config(osiris_cfg, Config),
+    Shared = ?config(shared, Config),
+    Dir = maps:get(dir, OsirisCfg),
+    Spec = [{'fun', rabbitmq_stream_s3_server:local_retention_fun(StreamId)}],
+    case osiris_log:evaluate_retention(Dir, Spec) of
+        {{FstOff, _}, _FstTs, _NumSeg} when is_integer(FstOff) ->
+            osiris_log_shared:set_first_chunk_id(Shared, FstOff);
+        _ ->
+            ok
+    end,
+    Manifest.
+
+-doc """
+Evaluate remote-tier retention against the manifest with the given spec,
+deleting fragment objects and updating the ETS manifest and range.
+Equivalent to the server's `#evaluate_retention` task.
+""".
+execute_remote_retention(Spec, Manifest, Config) ->
+    StreamId = ?config(stream_id, Config),
+    Now = erlang:system_time(millisecond),
+    GetGroupFun = rabbitmq_stream_s3_server:get_group_fun(StreamId, retention),
+    {Edit, Deletions} = rabbitmq_stream_s3_machine:execute_retention(
+        Manifest, Now, Spec, GetGroupFun
+    ),
+    case Deletions of
+        [] ->
+            ok;
+        _ ->
+            Effect = #delete_objects{stream = StreamId, objects = Deletions},
+            rabbitmq_stream_s3_server:execute_task(Effect)
+    end,
+    NewManifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest),
+    publish_manifest(NewManifest, Config),
+    NewManifest.
+
+publish_manifest(Manifest, Config) ->
+    StreamId = ?config(stream_id, Config),
+    rabbitmq_stream_s3_server_ets:set_manifest(StreamId, Manifest),
+    publish_range(Manifest#manifest.first_offset, Manifest#manifest.next_offset - 1, Config).
+
+-doc "Update only the range in the ETS server, without changing the manifest.".
+publish_range(First, Last, Config) ->
+    rabbitmq_stream_s3_server_ets:set_range(?config(stream_id, Config), First, Last).
+
+-doc "Delete a fragment from remote storage, simulating remote-tier retention.".
+delete_remote_fragment(FirstOffset, Config) ->
+    Key = rabbitmq_stream_s3:fragment_key(?config(stream_id, Config), FirstOffset),
+    case rabbitmq_stream_s3_api:delete(Key) of
+        ok -> ok;
+        {error, [{Key, {error, enoent}}]} -> ok
+    end.
+
+-doc """
+Re-open the local osiris log to update the shared ref from the actual segment
+files on disk. Use this after remote-tier changes to ensure the local first
+offset reflects reality.
+""".
+refresh_local_tier(Config) ->
+    OsirisCfg = ?config(osiris_cfg, Config),
+    Log = osiris_log:init(OsirisCfg),
+    ok = osiris_log:close(Log).
+
+reader_config(Config) ->
+    #{
+        name => ?config(stream_id, Config),
+        dir => maps:get(dir, ?config(osiris_cfg, Config)),
+        epoch => 1,
+        shared => ?config(shared, Config),
+        options => #{transport => tcp},
+        readers_counter_fun => fun(_) -> ok end
+    }.
+
+-doc "Drain all records from a reader via chunk_iterator + iterator_next".
+read_all(Reader0) ->
+    read_all(Reader0, []).
+
+read_all(Reader0, Acc) ->
+    case rabbitmq_stream_s3_log_reader:chunk_iterator(Reader0, 1, undefined) of
+        {ok, _Header, Iter, Reader1} ->
+            Records = drain_iter(Iter, []),
+            read_all(Reader1, Acc ++ Records);
+        {end_of_stream, _Reader} ->
+            Acc;
+        {error, Reason} ->
+            error({read_error, Reason})
+    end.
+
+drain_iter(Iter, Acc) ->
+    case rabbitmq_stream_s3_log_reader:iterator_next(Iter) of
+        {{_Offset, Record}, Iter1} ->
+            drain_iter(Iter1, [Record | Acc]);
+        end_of_chunk ->
+            lists:reverse(Acc)
+    end.

--- a/test/rabbitmq_stream_s3_machine_SUITE.erl
+++ b/test/rabbitmq_stream_s3_machine_SUITE.erl
@@ -343,7 +343,7 @@ manifest_replication(Config) ->
     Uploaded0 = [#fragment_uploaded{stream = StreamId, info = I} || I <- Infos],
     Uploaded = lists:reverse(Uploaded0),
     {Writer5, Effects6} = handle_events(?META(), Uploaded, Writer4),
-    {ok, Edit0} = ?MAC:apply_infos(Infos, Manifest),
+    {ok, Edit0} = rabbitmq_stream_s3_manifest:apply_infos(Infos, Manifest),
     ManifestEdited = #manifest_edited{
         stream = StreamId,
         edits = [Edit0],
@@ -412,7 +412,7 @@ retention(Config) ->
     ),
     ?assertMatch([#set_range{first_offset = 0, next_offset = 120}], REffects1),
 
-    Edit0 = ?MAC:new_edit(Manifest),
+    Edit0 = rabbitmq_stream_s3_manifest:new_edit(Manifest),
     Edit1 = Edit0#edit{
         first_offset = 40,
         first_timestamp = Ts - 100 + 20,
@@ -501,7 +501,7 @@ retention(Config) ->
     FragmentUploaded = #fragment_uploaded{stream = StreamId, info = Info},
     Manifest1 = ?MAC:get_manifest(StreamId, Writer7),
     {Writer8, Effects8} = ?MAC:apply(?META(), FragmentUploaded, Writer7),
-    {ok, UploadEdit} = ?MAC:apply_infos([Info], Manifest1),
+    {ok, UploadEdit} = rabbitmq_stream_s3_manifest:apply_infos([Info], Manifest1),
     ManifestEdited3 = #manifest_edited{
         stream = StreamId,
         edits = [UploadEdit],
@@ -523,7 +523,7 @@ retention(Config) ->
     {Writer9, Effects9} = ?MAC:apply(?META(), ManifestUploaded3, Writer8),
     ?assertMatch([], Effects9),
 
-    {Replica4, REffects4} = ?MAC:apply(?META(), ManifestEdited3, Replica3),
+    {_Replica4, REffects4} = ?MAC:apply(?META(), ManifestEdited3, Replica3),
     ?assertMatch(
         [
             #set_range{first_offset = 60, next_offset = 140},
@@ -533,8 +533,8 @@ retention(Config) ->
     ),
 
     %% Retention runs on tick and deletes the oldest fragment.
-    {Writer10, Effects10} = ?MAC:apply(?META(), #tick{}, Writer9),
-    RetentionEdit = (?MAC:new_edit(
+    {_Writer10, Effects10} = ?MAC:apply(?META(), #tick{}, Writer9),
+    RetentionEdit = (rabbitmq_stream_s3_manifest:new_edit(
         ?MAC:get_manifest(StreamId, Writer9)
     ))#edit{
         first_offset = 80,
@@ -874,7 +874,7 @@ rebalance_group(Config) ->
     RetentionUpdated = #retention_updated{stream = StreamId, retention = [{max_bytes, 100}]},
     {Writer6, WEffects6} = ?MAC:apply(?META(), RetentionUpdated, Writer5),
     ?assertMatch([#evaluate_retention{}], WEffects6),
-    Edit0 = ?MAC:new_edit(?MAC:get_manifest(StreamId, Writer6)),
+    Edit0 = rabbitmq_stream_s3_manifest:new_edit(?MAC:get_manifest(StreamId, Writer6)),
     Edit = Edit0#edit{
         %% Retention would delete everything except F6.
         first_offset = F6#fragment.first_offset,

--- a/test/rabbitmq_stream_s3_server_ets.erl
+++ b/test/rabbitmq_stream_s3_server_ets.erl
@@ -1,0 +1,60 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_server_ets).
+-moduledoc """
+ETS-backed implementation of the `rabbitmq_stream_s3_server` behaviour.
+Used in tests to control manifest and range data without starting the real server.
+""".
+
+-behaviour(rabbitmq_stream_s3_server).
+
+-include("include/rabbitmq_stream_s3.hrl").
+
+-export([
+    setup/0,
+    teardown/0,
+    set_manifest/2,
+    set_range/3,
+    get_manifest/1,
+    get_range/1
+]).
+
+-define(MANIFEST_TAB, rabbitmq_stream_s3_server_ets_manifests).
+-define(RANGE_TAB, rabbitmq_stream_s3_server_ets_ranges).
+
+-spec setup() -> ok.
+setup() ->
+    _ = ets:new(?MANIFEST_TAB, [named_table, public]),
+    _ = ets:new(?RANGE_TAB, [named_table, public]),
+    ok.
+
+-spec teardown() -> ok.
+teardown() ->
+    ets:delete(?MANIFEST_TAB),
+    ets:delete(?RANGE_TAB),
+    ok.
+
+-spec set_manifest(rabbitmq_stream_s3:stream_id(), #manifest{}) -> ok.
+set_manifest(StreamId, Manifest) ->
+    ets:insert(?MANIFEST_TAB, {StreamId, Manifest}),
+    ok.
+
+-spec set_range(rabbitmq_stream_s3:stream_id(), osiris:offset(), osiris:offset()) -> ok.
+set_range(StreamId, First, Last) ->
+    ets:insert(?RANGE_TAB, {StreamId, First, Last}),
+    ok.
+
+-spec get_manifest(rabbitmq_stream_s3:stream_id()) -> #manifest{} | undefined.
+get_manifest(StreamId) ->
+    case ets:lookup(?MANIFEST_TAB, StreamId) of
+        [{StreamId, Manifest}] -> Manifest;
+        [] -> undefined
+    end.
+
+-spec get_range(rabbitmq_stream_s3:stream_id()) -> rabbitmq_stream_s3:range().
+get_range(StreamId) ->
+    case ets:lookup(?RANGE_TAB, StreamId) of
+        [{StreamId, First, Last}] -> {First, Last};
+        [] -> empty
+    end.


### PR DESCRIPTION
This is a series of commits to add a new test suite for the log reader which we can test very quickly (i.e. without spawning RabbitMQ) and have fine control the local and remote tier logs. This makes it possible to test tricky setups and edge-cases that would otherwise be very complicated to test. This adds two tests to start with. We can expand from there.

* Basic setup where the remote tier has some fragments and then the local tier has data.
* Edge-case where chunks are so small that the log-reader's over-reading behavior would've caused the remote reader to hang.

Connects #36. This is what I was thinking of in https://github.com/amazon-mq/rabbitmq-stream-s3/issues/36#issuecomment-4225993977.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
