### PR TITLE
Fix remote reader stall after S3 request timeout (HTTP/1.1 HOL blocking)

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -632,8 +632,13 @@ handle_async(
 ) ->
     ?LOG_WARNING("S3 request timed out on ~tw/~tw", [Conn, StreamRef]),
     counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
-    gun:cancel(Conn, StreamRef),
-    finish_async(State),
+    %% gun cannot cancel an HTTP/1.1 stream on the wire - it only stops
+    %% forwarding events to the owner. The cancelled stream continues to
+    %% occupy the connection, blocking subsequent requests until its full
+    %% response is received. Close the whole connection instead; the pool
+    %% observes the 'DOWN' and opens a fresh replacement.
+    gun:close(Conn),
+    finish_async_close(State),
     {done_cancel, {error, timeout}}.
 
 -spec cancel_async(async_req(), async_state()) -> ok.
@@ -678,6 +683,27 @@ finish_async(#{conn := Conn, pool := Pool} = State) ->
     end,
     counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
     ok = rabbitmq_stream_s3_api_aws_pool:checkin(Pool, Conn).
+
+%% Finish an async request when the connection is being closed (e.g. on
+%% timeout). Same bookkeeping as `finish_async` but omits the pool checkin -
+%% the pool's 'DOWN' handler removes the conn and grows a replacement.
+finish_async_close(State) ->
+    case State of
+        #{timer_ref := TimerRef, stream_ref := StreamRef} ->
+            case erlang:cancel_timer(TimerRef) of
+                false ->
+                    receive
+                        {request_timeout, StreamRef} -> ok
+                    after 0 -> ok
+                    end;
+                _ ->
+                    ok
+            end;
+        _ ->
+            ok
+    end,
+    counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
+    ok.
 
 -spec request(http_method(), key(), req_headers(), iodata(), request_opts()) ->
     {ok, http_response()}


### PR DESCRIPTION
## Summary

On S3 request timeout, `rabbitmq_stream_s3_remote_reader` called `gun:cancel(Conn, StreamRef)` and checked the connection back into the pool. In an HTTP/1.1 client, `gun:cancel` does not cancel the stream on the wire - it only stops forwarding events to the owner. The cancelled stream continues to occupy the connection until its full response is received.

When the reader then started a new request on the same connection (often taken back from the pool), the new request pipelined after the cancelled one and could not complete until the cancelled response fully arrived. If the original request was stalled on the S3 side, the new request stalled too, causing the reader's pending read to miss its 60-second `gen_server:call` deadline and the consumer connection to terminate.

The fix closes the whole connection on timeout. The pool observes the `'DOWN'` message, removes the dead connection, and opens a fresh replacement. The next `try_checkout` returns a healthy connection.

Fixes #133.

Does not fix #135. A separate failure mode exists where retention deletes fragments faster than the reader can chase them; that is tracked in #135.

## Testing

Two-hour high-throughput load runs (6 streams, 2 producers and 2 consumers per stream) before and after the fix.

Before the fix (branch at `d9370c8`): 11 `gen_server:call` timeout crashes across 3 nodes in 2 hours.

After the fix (this PR): 0 crashes on 2 of 3 nodes. 5 crashes on 1 node all attributable to the separate retention-chase issue tracked in #135, not to HTTP/1.1 HOL blocking. In the same run, readers recovered from S3 request timeouts in 10-20 seconds (close connection, pool grows a new one, new request succeeds). Pre-fix, these stalled for 30 seconds and usually killed the consumer.

Evidence that the fix works under the observed failure path: reader `<0.30833.0>` on one node hit five S3 request timeouts in four minutes and recovered successfully after the first four (visible via `transitioning to next fragment` log lines immediately following each timeout). Only the fifth timeout coincided with the caller's 60-second deadline, and that interaction is the `#135` case.

## What this does not change

- `cancel_async/2` still uses `gun:cancel` rather than `gun:close`. It is called during reader termination and retention jumps, and the minimal fix is scoped to the `request_timeout` path. If the same HOL-blocking argument applies there and causes measurable issues, a follow-up can extend the same pattern.

## Deep dive

<details>
<summary>Gun HTTP/1.1 cancel semantics, pool interaction, and fix walkthrough</summary>

### Why `gun:cancel` does not cancel on HTTP/1.1

From `deps/gun/src/gun_event.erl` (verbatim):

> In the case of HTTP/1.1 we cannot actually cancel the stream, we only silence the stream to the user. Further response events may therefore be received and they provide a useful metric as these canceled requests monopolize the connection.

From `deps/gun/src/gun_http.erl`:

```erlang
%% We can't cancel anything, we can just stop forwarding messages to the owner.
cancel(State0, StreamRef, ReplyTo, EvHandler, EvHandlerState0) ->
    case is_stream(State0, StreamRef) of
        true ->
            State = cancel_stream(State0, StreamRef),
            ...
```

`cancel_stream` flips `is_alive` to `false` on the stream but leaves it in the streams list. Gun still parses the server's response from the wire and discards it, but the stream continues to occupy its position in the pipeline.

### Pool does not share connections across concurrent callers

`rabbitmq_stream_s3_api_aws_pool`'s `take_available/2` removes a `Conn` from the `available` list and records it in `checkouts`. One caller at a time. The pool is not serving multiple concurrent requests on one connection.

### Why the fix works despite one-at-a-time-per-connection semantics

Even though only one caller holds a connection at a time, the HTTP/1.1 stream from the cancelled request is still on the wire. When the caller checks the connection back into the pool and either itself or a different caller checks it out again, the new request gets pipelined on the same TCP connection, behind the cancelled-but-still-open stream. Gun's HTTP/1.1 handler cannot begin the new stream's response until it consumes the previous stream's response in full.

If the previous stream was slow for a genuine reason (S3 returning slowly), the new stream waits for that full response too. The reader's pending-read caller sees no data arrive, and its 60-second `gen_server:call` deadline fires.

Closing the connection instead forces the pool to open a fresh TCP connection with no stale stream state.

### Interaction with the pool

`gun:close(Conn)` causes the connection process to exit. The pool monitors each connection via `erlang:monitor(process, ConnPid)`. When the `'DOWN'` message arrives:

```erlang
handle_info({'DOWN', _MRef, process, Pid, _Reason}, ...) ->
    case Monitors0 of
        #{Pid := MRef} ->
            %% A connection is down. Forget it and maybe grow a new one.
            Conn = Pid,
            State1 = ..., State2 = cancel(Pid, State1),
            {noreply, grow(State2)};
```

The pool drops the dead connection from its `monitors` map, cancels any pending checkouts waiting on it, and calls `grow/1` to open a replacement. Subsequent `try_checkout` calls return a healthy connection.

### Why the reader does not receive the dead connection on the next `try_checkout`

The dead connection is in `checkouts` (the caller had it checked out), not `available`. `try_checkout` only draws from `available`. Even if the pool has not yet processed the `'DOWN'` by the time the reader calls `try_checkout` on the next request, the reader gets a different healthy connection.

### Code change

In `rabbitmq_stream_s3_api_aws.erl`:

```erlang
handle_async(
    {request_timeout, StreamRef},
    StreamRef,
    #{conn := Conn, stream_ref := StreamRef} = State
) ->
    ?LOG_WARNING("S3 request timed out on ~tw/~tw", [Conn, StreamRef]),
    counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
    gun:close(Conn),
    finish_async_close(State),
    {done_cancel, {error, timeout}}.
```

`finish_async_close/1` is a new helper that does the same bookkeeping as `finish_async/1` (cancels the request timer, drains any late `request_timeout` message, decrements `?C_ACTIVE_REQUESTS`) but omits the pool checkin. The pool's `'DOWN'` handler will clean up the now-dead connection.

### Test evidence that #135 is a different issue

Before this PR, every `gen_server:call` timeout was preceded by 30 seconds of complete reader silence after an S3 request timeout. After this PR, readers continue to log `transitioning to next fragment` or `Fragment NNN was deleted by retention` messages right up until the caller's deadline fires. The failure mode has changed. The remaining 5 crashes (on one node, none on the other two) all involve aggressive retention-jump chasing consuming most of the caller's budget before an S3 request timeout consumes the remainder. That behavior is tracked in #135.

</details>
