### PR TITLE
Add xref step to CI workflow

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -57,3 +57,5 @@ jobs:
           path: ${{ github.workspace }}/rabbitmq-server/logs/
       - name: dialyze
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 dialyze
+      - name: xref
+        run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 xref


### PR DESCRIPTION
## Summary

Add an xref step to the CI workflow, after dialyze.

The existing "unresolved calls" in the xref output are not errors. They are informational warnings from xref about dynamic dispatch calls (`apply/3`, `spawn/3`, etc.) that xref cannot statically resolve. The actual xref analysis (`undefined_function_calls`) passes cleanly with exit status 0.

No Makefile tuning is needed. The erlang.mk default `XREF_CHECKS = [undefined_function_calls]` is the correct check for catching real problems (calls to functions that do not exist).

Closes #115.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
