### PR TITLE
Set `stream_s3` logger domain on gen_server processes

### DIFF
--- a/include/logging.hrl
+++ b/include/logging.hrl
@@ -1,0 +1,3 @@
+-include_lib("rabbit_common/include/logging.hrl").
+
+-define(RMQLOG_DOMAIN_STREAM_S3, ?DEFINE_RMQLOG_DOMAIN(stream_s3)).

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -15,6 +15,7 @@ the reader pool avoids reader starvation.
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include("include/logging.hrl").
 
 -behaviour(gen_server).
 
@@ -152,6 +153,7 @@ start_link(Name, Config) ->
     gen_server:start_link({local, Name}, ?MODULE, Config, []).
 
 init(#{min_size := MinSize, max_size := MaxSize, name := Name}) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
     case rabbitmq_stream_s3_api:backend() of
         rabbitmq_stream_s3_api_aws ->
             Cnt = seshat:new(rabbitmq_stream_s3, Name, ?COUNTERS, #{

--- a/src/rabbitmq_stream_s3_membership_reconciliation.erl
+++ b/src/rabbitmq_stream_s3_membership_reconciliation.erl
@@ -6,6 +6,7 @@
 -behaviour(gen_server).
 
 -include_lib("kernel/include/logger.hrl").
+-include("include/logging.hrl").
 
 -record(?MODULE, {timer :: reference()}).
 
@@ -60,6 +61,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
     case is_enabled() of
         true ->
             ?LOG_INFO(?MODULE_STRING " is enabled. Scheduling membership evaluation."),

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -17,6 +17,7 @@ multiplicative decrease ([AIMD]) algorithm.
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("include/rabbitmq_stream_s3.hrl").
+-include("include/logging.hrl").
 
 -behaviour(gen_server).
 
@@ -204,6 +205,7 @@ init(#{
         fragment_info = Info
     }
 }) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
     Key = rabbitmq_stream_s3:fragment_key(StreamId, Fragment),
     State0 = #?MODULE{
         stream = StreamId,

--- a/src/rabbitmq_stream_s3_server.erl
+++ b/src/rabbitmq_stream_s3_server.erl
@@ -8,6 +8,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("include/rabbitmq_stream_s3.hrl").
+-include("include/logging.hrl").
 
 -define(SERVER, ?MODULE).
 %% Protected set of {stream_id(), FirstOffset, NextOffset} used to quickly
@@ -222,6 +223,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
     %% Table keyed by stream ID. This is used for local retention: segments
     %% with all offsets less than or equal to the last tiered offset can be
     %% deleted by retention since they are stored in the remote tier.


### PR DESCRIPTION
## Summary

Add a logger domain so that stream_s3 log messages can be filtered and routed independently, following the pattern established by Shovel, LDAP, and Federation.

Create `include/logging.hrl` defining `?RMQLOG_DOMAIN_STREAM_S3` as `[rabbitmq, stream_s3]` via the `?DEFINE_RMQLOG_DOMAIN` macro from `rabbit_common`.

Call `logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3})` in the `init` callback of the four gen_server processes that emit log messages: the server, remote reader, connection pool, and membership reconciliation. Modules that execute inside these processes (the API backend, log manifest) inherit the domain automatically.

## What is not covered

The log reader and Ra machine modules run in processes owned by other plugins (`rabbit_stream_reader` and Ra respectively). Their log messages do not get the `stream_s3` domain. Shovel has the same situation - modules like `rabbit_amqp091_shovel` and `rabbit_shovel_parameters` log without setting the domain and rely on inheriting it from the calling process. This PR follows the same approach.

Closes #78.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
