### PR TITLE
Improve testing and core operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,16 @@ include ../../erlang.mk
 
 CT_QUICK_SUITES = api_fs db replica_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica
 
+ERLFMT ?= erlfmt
+ERLFMT_FILES = src/*.erl test/*.erl
+
+.PHONY: fmt fmt-check
+fmt:
+	$(verbose) $(ERLFMT) -w $(ERLFMT_FILES)
+
+fmt-check:
+	$(verbose) $(ERLFMT) -c $(ERLFMT_FILES)
+
 .PHONY: ct-quick
 ct-quick: test-build
 	$(verbose) mkdir -p $(CT_LOGS_DIR)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -95,10 +95,16 @@ All Erlang source is formatted with `erlfmt`:
 
 ```bash
 # Check formatting (fails if anything needs reformatting)
-erlfmt -c src/*.erl test/*.erl
+gmake fmt-check
 
 # Apply formatting
-erlfmt -w src/*.erl test/*.erl
+gmake fmt
+```
+
+If `erlfmt` is not on your PATH, set the `ERLFMT` variable:
+
+```bash
+gmake fmt ERLFMT=/path/to/erlfmt
 ```
 
 Format after finishing a change, not during debugging.

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -612,6 +612,9 @@ select_amount_to_send(_ChunkSelector, #{
 }) ->
     {FilterSize, DataSize + TrailerSize}.
 
+verify_crc(Config) ->
+    maps:get(verify_crc_on_read, Config, rabbitmq_stream_s3_config:verify_crc_on_read()).
+
 %% Validates the CRC32 of chunk record data read from the remote tier.
 %% In send_file, Data may include the trailer (DataSize + TrailerSize bytes);
 %% the CRC only covers the first DataSize bytes.
@@ -638,7 +641,7 @@ init_local_reader(OffsetSpec, Config) ->
             {ok, #?MODULE{
                 config = Config,
                 mode = Local,
-                verify_crc = rabbitmq_stream_s3_config:verify_crc_on_read()
+                verify_crc = verify_crc(Config)
             }};
         {error, _} = Err ->
             Err
@@ -669,7 +672,7 @@ init_remote_reader(
             counters:add(counter(), ?C_REMOTE_INIT, 1),
             Reader = #?MODULE{
                 config = Config,
-                verify_crc = rabbitmq_stream_s3_config:verify_crc_on_read(),
+                verify_crc = verify_crc(Config),
                 mode = #remote{
                     pid = Pid,
                     stream = StreamId,

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -849,7 +849,7 @@ on_remote_retention(Edit, Refs, StreamId, Core0, State) ->
     #manifest{}, [osiris:retention_spec()], integer(), stream_id(), #state{}
 ) -> #state{}.
 maybe_spawn_group_retention(
-    #manifest{entries = <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32, _/binary>>},
+    #manifest{entries = <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32, _/binary>>} = Manifest,
     Retention,
     Now,
     StreamId,
@@ -857,7 +857,6 @@ maybe_spawn_group_retention(
 ) when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
     Self = self(),
     GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(State#state.core),
     {_Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result =

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -750,7 +750,7 @@ execute_effect(
     {evaluate_retention, _StreamId, _Dir},
     #state{core = Core, retention = Retention, cfg = Cfg} = State
 ) ->
-    Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
     maybe_evaluate_retention(Manifest, State),
     maybe_evaluate_remote_retention(Manifest, Retention, Cfg#cfg.stream, State);
 execute_effect({reply_waiters, Replies}, State) ->

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -849,7 +849,8 @@ on_remote_retention(Edit, Refs, StreamId, Core0, State) ->
     #manifest{}, [osiris:retention_spec()], integer(), stream_id(), #state{}
 ) -> #state{}.
 maybe_spawn_group_retention(
-    #manifest{entries = <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32, _/binary>>} = Manifest,
+    #manifest{entries = <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32, _/binary>>} =
+        Manifest,
     Retention,
     Now,
     StreamId,

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -225,6 +225,8 @@ returned by the functional core module.
     persisting_bytes = 0 :: non_neg_integer(),
     %% Monitor ref for the in-flight group upload task.
     group_mon :: reference() | undefined,
+    %% Monitor ref for the in-flight retention evaluation task.
+    retention_mon :: reference() | undefined,
     %% Kind of the group upload currently in flight. Cleared when the
     %% group_upload_result message arrives. Only one rebalance is in
     %% flight at a time so a single slot suffices.
@@ -366,6 +368,17 @@ handle_info(
         execute_effects(Effects, State0#state{
             core = Core, group_mon = undefined, pending_group_kind = undefined
         })};
+handle_info({retention_result, unchanged}, #state{core = Core0, retention_mon = Mon} = State0) ->
+    demonitor(Mon, [flush]),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(unchanged, Core0),
+    {noreply, execute_effects(Effects, State0#state{core = Core, retention_mon = undefined})};
+handle_info(
+    {retention_result, {Edit, Refs}},
+    #state{core = Core0, retention_mon = Mon, cfg = #cfg{stream = StreamId}} = State0
+) ->
+    demonitor(Mon, [flush]),
+    State = on_remote_retention(Edit, Refs, StreamId, Core0, State0#state{retention_mon = undefined}),
+    {noreply, State};
 handle_info(persist_timer, #state{core = Core0} = State0) ->
     Now = erlang:system_time(millisecond),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, Core0),
@@ -430,6 +443,13 @@ handle_info(
         execute_effects(Effects, State0#state{
             core = Core, group_mon = undefined, pending_group_kind = undefined
         })};
+handle_info(
+    {'DOWN', Mon, process, _, Reason},
+    #state{retention_mon = Mon, core = Core0, cfg = #cfg{stream = StreamId}} = State0
+) ->
+    ?LOG_WARNING("~ts retention evaluation task crashed: ~p", [StreamId, Reason]),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(Reason, Core0),
+    {noreply, execute_effects(Effects, State0#state{core = Core, retention_mon = undefined})};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -796,31 +816,68 @@ maybe_evaluate_remote_retention(_Manifest, [], _StreamId, State) ->
 maybe_evaluate_remote_retention(Manifest, Retention, StreamId, #state{core = Core0} = State) ->
     inc(State, ?C_REMOTE_TIER_RETENTION_EVALUATIONS, 1),
     Now = erlang:system_time(millisecond),
-    GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-    case
-        rabbitmq_stream_s3_manifest:evaluate_remote_retention(Manifest, Retention, Now, GetGroupFun)
-    of
+    %% First try without group download (handles fragments-only case synchronously).
+    case rabbitmq_stream_s3_manifest:evaluate_remote_retention(Manifest, Retention, Now) of
         unchanged ->
-            State;
+            %% No leading fragments to remove. If the first entry is a group,
+            %% spawn an async task to download it and evaluate retention within.
+            maybe_spawn_group_retention(Manifest, Retention, Now, StreamId, State);
         {Edit, Refs} ->
-            on_remote_retention_deleted(Refs, State),
-            %% Delete the objects in the background.
-            Keys = lists:map(
-                fun
-                    (#fragment_ref{} = FRef) ->
-                        rabbitmq_stream_s3:fragment_key(StreamId, FRef);
-                    (#group_ref{} = GRef) ->
-                        rabbitmq_stream_s3:group_key(StreamId, GRef)
-                end,
-                Refs
-            ),
-            rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys),
-            %% Apply the edit to the core's manifest and execute effects.
-            {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:apply_retention_edit(
-                Edit, Core0
-            ),
-            execute_effects(Effects, State#state{core = Core})
+            on_remote_retention(Edit, Refs, StreamId, Core0, State)
     end.
+
+%% Handle a retention result (synchronous fragments-only case or async completion).
+-spec on_remote_retention(#edit{}, [#fragment_ref{} | #group_ref{}], stream_id(), term(), #state{}) ->
+    #state{}.
+on_remote_retention(Edit, Refs, StreamId, Core0, State) ->
+    on_remote_retention_deleted(Refs, State),
+    Keys = lists:map(
+        fun
+            (#fragment_ref{} = FRef) ->
+                rabbitmq_stream_s3:fragment_key(StreamId, FRef);
+            (#group_ref{} = GRef) ->
+                rabbitmq_stream_s3:group_key(StreamId, GRef)
+        end,
+        Refs
+    ),
+    rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(Edit, Core0),
+    execute_effects(Effects, State#state{core = Core}).
+
+%% Spawn an async task to evaluate retention within a group object.
+-spec maybe_spawn_group_retention(
+    #manifest{}, [osiris:retention_spec()], integer(), stream_id(), #state{}
+) -> #state{}.
+maybe_spawn_group_retention(
+    #manifest{entries = <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32, _/binary>>},
+    Retention,
+    Now,
+    StreamId,
+    State
+) when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
+    Self = self(),
+    GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(State#state.core),
+    {_Pid, MonRef} = spawn_monitor(fun() ->
+        logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
+        Result =
+            try
+                rabbitmq_stream_s3_manifest:evaluate_remote_retention(
+                    Manifest, Retention, Now, GetGroupFun
+                )
+            catch
+                Class:Reason:Stack ->
+                    ?LOG_WARNING(
+                        "Retention evaluation crashed: ~p:~p~n~p", [Class, Reason, Stack]
+                    ),
+                    unchanged
+            end,
+        Self ! {retention_result, Result}
+    end),
+    Core = rabbitmq_stream_s3_replica_reader_core:retention_started(State#state.core),
+    State#state{core = Core, retention_mon = MonRef};
+maybe_spawn_group_retention(_Manifest, _Retention, _Now, _StreamId, State) ->
+    State.
 
 %% ------------------------------------------------------------------
 %% Reading

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -26,7 +26,9 @@ testable without mocks or timing.
     persist_failed/2,
     tick/2,
     await_offset/3,
-    apply_retention_edit/2
+    retention_started/1,
+    retention_complete/2,
+    retention_failed/2
 ]).
 
 -export_type([state/0, cfg/0, core_effect/0]).
@@ -50,9 +52,9 @@ testable without mocks or timing.
     in_flight :: queue:queue({reference(), fragment_meta()}),
     %% Completions that arrived out of order.
     pending_completions :: #{reference() => {rabbitmq_stream_s3:uid(), fragment_meta()}},
-    %% Fragments applied since last durable persist.
+    %% Number of edits applied since last durable persist.
     since_persist :: non_neg_integer(),
-    %% Number of fragments included in the current in-flight persist.
+    %% Number of edits included in the current in-flight persist.
     in_persist_count = 0 :: non_neg_integer(),
     %% Timestamp (milliseconds) of last durable persist.
     last_persist_ts :: integer(),
@@ -68,12 +70,10 @@ testable without mocks or timing.
     waiters :: [{osiris:offset(), gen_server:from()}],
     %% Whether a group upload is currently in flight.
     rebalance_in_flight = false :: boolean(),
-    %% Edits from rebalancing since last persist. Tracked so that broadcast
-    %% produces the correct edit sequence (rebalance edits first, then appends).
-    rebalance_edits = [] :: [#edit{}],
-    %% Fragment entries appended since last persist (pre-rebalance binary).
-    %% Used to produce the correct append edit for broadcast.
-    appended_since_persist = <<>> :: binary()
+    %% Whether a retention evaluation is currently in flight (async group download).
+    retention_in_flight = false :: boolean(),
+    %% All edits (appends, rebalance, retention) since last persist, in order.
+    edits_since_persist = [] :: [#edit{}]
 }).
 
 -opaque state() :: #state{}.
@@ -86,6 +86,7 @@ testable without mocks or timing.
     ]}
     | {upload_group, stream_id(), rabbitmq_stream_s3:kind(), binary(), non_neg_integer(),
         non_neg_integer()}
+    | {start_retention_eval, stream_id(), directory()}
     | {update_range, osiris:offset(), osiris:offset()}
     | {broadcast, stream_id(), [#edit{}]}
     | {evaluate_retention, stream_id(), directory()}
@@ -151,6 +152,7 @@ format_state(#state{
     last_persist_ts = LastPersistTs,
     persist_in_flight = PersistInFlight,
     rebalance_in_flight = RebalanceInFlight,
+    retention_in_flight = RetentionInFlight,
     waiters = Waiters
 }) ->
     #{
@@ -165,6 +167,7 @@ format_state(#state{
         persist_in_flight => PersistInFlight,
         last_persist_ts => LastPersistTs,
         rebalance_in_flight => RebalanceInFlight,
+        retention_in_flight => RetentionInFlight,
         waiters => length(Waiters)
     }.
 
@@ -221,13 +224,10 @@ persist_complete(
     } = State0
 ) ->
     Manifest = CommittingManifest#manifest{revision = Revision},
-    %% Only discard the portion of appended_since_persist that was captured
-    %% in the persisting edits. Fragments that arrived during the in-flight
-    %% persist appended to appended_since_persist after start_persist
-    %% captured its snapshot; those bytes must be preserved for the next
-    %% persist's broadcast.
-    PersistedBytes = Committed * ?ENTRY_B,
-    <<_:PersistedBytes/binary, Remaining/binary>> = State0#state.appended_since_persist,
+    %% Only discard the edits that were captured in the persisting batch.
+    %% Edits that arrived during the in-flight persist were appended after
+    %% start_persist captured its snapshot; those must be preserved.
+    RemainingEdits = lists:nthtail(Committed, State0#state.edits_since_persist),
     State1 = State0#state{
         persist_in_flight = false,
         last_persisted_manifest = Manifest,
@@ -235,8 +235,7 @@ persist_complete(
         since_persist = N - Committed,
         in_persist_count = 0,
         last_persist_ts = erlang:system_time(millisecond),
-        rebalance_edits = [],
-        appended_since_persist = Remaining
+        edits_since_persist = RemainingEdits
     },
     Effects0 = [
         {update_range, Manifest#manifest.first_offset, Manifest#manifest.next_offset},
@@ -246,7 +245,7 @@ persist_complete(
     ],
     {State2, WaiterEffects} = notify_waiters(State1),
     Effects1 = Effects0 ++ WaiterEffects,
-    %% If more fragments applied while persist was in flight, trigger another.
+    %% If more edits applied while persist was in flight, trigger another.
     case State2#state.since_persist > 0 of
         true ->
             {State3, CommitEffects} = maybe_start_persist(State2),
@@ -279,6 +278,7 @@ tick(
         since_persist = SinceCommit,
         persist_in_flight = false,
         rebalance_in_flight = false,
+        retention_in_flight = false,
         last_persist_ts = LastTs,
         cfg = #cfg{persist_interval_ms = Interval}
     } = State
@@ -304,7 +304,7 @@ rebalancing is needed, trigger persist if warranted.
 """.
 -spec group_upload_complete(rabbitmq_stream_s3:uid(), state()) -> {state(), [core_effect()]}.
 group_upload_complete(
-    Uid, #state{cfg = Cfg, manifest = Manifest0, rebalance_edits = Edits} = State0
+    Uid, #state{cfg = Cfg, manifest = Manifest0} = State0
 ) ->
     %% The pending rebalance info is encoded in the effect that was emitted.
     %% We reconstruct the edit from the current manifest state: the leading
@@ -333,7 +333,8 @@ group_upload_complete(
     State1 = State0#state{
         manifest = Manifest,
         rebalance_in_flight = false,
-        rebalance_edits = [Edit | Edits]
+        since_persist = State0#state.since_persist + 1,
+        edits_since_persist = State0#state.edits_since_persist ++ [Edit]
     },
     %% Check for recursive rebalancing (e.g. too many groups → kilo-group).
     {State2, RebalanceEffects} = maybe_start_rebalance(State1),
@@ -363,21 +364,36 @@ group_upload_failed(Reason, #state{cfg = Cfg, manifest = Manifest} = State) ->
     end.
 
 -doc """
-Apply a remote retention edit to the manifest. Updates both the in-memory
-and last-persisted manifests. Returns effects to broadcast and update range.
+-doc """
+Mark that an async retention evaluation has been spawned.
 """.
--spec apply_retention_edit(#edit{}, state()) -> {state(), [core_effect()]}.
-apply_retention_edit(
-    Edit, #state{cfg = Cfg, manifest = Manifest0, last_persisted_manifest = Committed0} = State
-) ->
+-spec retention_started(state()) -> state().
+retention_started(State) ->
+    State#state{retention_in_flight = true}.
+
+-doc """
+Apply a remote retention edit to the manifest. The edit is tracked in
+edits_since_persist and will be broadcast on the next persist_complete.
+""".
+-spec retention_complete(#edit{}, state()) -> {state(), [core_effect()]}.
+retention_complete(Edit, #state{manifest = Manifest0} = State0) ->
     Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
-    Committed = rabbitmq_stream_s3_manifest:apply_edit(Edit, Committed0),
-    State1 = State#state{manifest = Manifest, last_persisted_manifest = Committed},
-    Effects = [
-        {broadcast, Cfg#cfg.stream, [Edit]},
-        {update_range, Manifest#manifest.first_offset, Manifest#manifest.next_offset}
-    ],
-    {State1, Effects}.
+    State1 = State0#state{
+        manifest = Manifest,
+        retention_in_flight = false,
+        since_persist = State0#state.since_persist + 1,
+        edits_since_persist = State0#state.edits_since_persist ++ [Edit]
+    },
+    {State2, PersistEffects} = maybe_start_persist(State1),
+    {State2, PersistEffects}.
+
+-doc """
+A retention evaluation failed (e.g. group download failed). Clear the flag
+so the next persist_complete can re-trigger evaluation.
+""".
+-spec retention_failed(term(), state()) -> {state(), [core_effect()]}.
+retention_failed(_Reason, State) ->
+    {State#state{retention_in_flight = false}, []}.
 
 %% ------------------------------------------------------------------
 %% Internal
@@ -423,7 +439,7 @@ drain_completions(#state{in_flight = Q, pending_completions = PC} = State0) ->
 apply_fragment(
     Uid,
     Meta,
-    #state{manifest = Manifest0, since_persist = N, appended_since_persist = Appended} = State
+    #state{manifest = Manifest0, since_persist = N, edits_since_persist = Edits} = State
 ) ->
     #{
         first_offset := FirstOffset,
@@ -458,13 +474,15 @@ apply_fragment(
     State#state{
         manifest = Manifest,
         since_persist = N + 1,
-        appended_since_persist = <<Appended/binary, Entry/binary>>
+        edits_since_persist = Edits ++ [Edit1]
     }.
 
 -spec maybe_start_persist(state()) -> {state(), [core_effect()]}.
 maybe_start_persist(#state{persist_in_flight = true} = State) ->
     {State, []};
 maybe_start_persist(#state{rebalance_in_flight = true} = State) ->
+    {State, []};
+maybe_start_persist(#state{retention_in_flight = true} = State) ->
     {State, []};
 maybe_start_persist(#state{since_persist = 0} = State) ->
     {State, []};
@@ -482,11 +500,14 @@ maybe_start_persist(State) ->
 -spec start_persist(state()) -> {state(), [core_effect()]}.
 start_persist(
     #state{
-        cfg = Cfg, manifest = Manifest, last_persisted_manifest = LastManifest, since_persist = N
+        cfg = Cfg,
+        manifest = Manifest,
+        last_persisted_manifest = LastManifest,
+        since_persist = N,
+        edits_since_persist = Edits
     } =
         State
 ) ->
-    Edits = edits_since_persist(State),
     Effect =
         {start_persist, Manifest, Cfg#cfg.epoch, Cfg#cfg.reference, LastManifest#manifest.revision,
             Edits},
@@ -565,41 +586,6 @@ pending_rebalance(#manifest{entries = Entries}, Threshold) ->
     %% The rebalance that was in flight must still be detectable.
     {Kind, Pos, Len} = needs_rebalance(Entries, Threshold),
     {Kind, Pos, Len}.
-
--spec edits_since_persist(state()) -> [#edit{}].
-edits_since_persist(#state{
-    manifest = Manifest,
-    last_persisted_manifest = Last,
-    rebalance_edits = RebalanceEdits,
-    appended_since_persist = Appended
-}) ->
-    %% Ordering constraint: append edits MUST precede rebalance edits.
-    %%
-    %% Replicas apply edits sequentially. A rebalance edit replaces entries
-    %% at a byte position with a group pointer. Those entries must already
-    %% exist in the replica's array for the replacement to be valid. The
-    %% append edit creates them. If the rebalance came first, the replica
-    %% would attempt to replace bytes that don't exist yet.
-    AppendEdits = compute_append_edits(Last, Manifest, Appended),
-    AppendEdits ++ lists:reverse(RebalanceEdits).
-
-%% Compute the append edit from the tracked appended entries.
--spec compute_append_edits(#manifest{}, #manifest{}, binary()) -> [#edit{}].
-compute_append_edits(_From, _To, <<>>) ->
-    [];
-compute_append_edits(From, To, Appended) ->
-    [
-        #edit{
-            first_offset = To#manifest.first_offset,
-            first_timestamp = To#manifest.first_timestamp,
-            first_last_timestamp = To#manifest.first_last_timestamp,
-            next_offset = To#manifest.next_offset,
-            size = To#manifest.total_size - From#manifest.total_size,
-            entries = Appended,
-            pos = byte_size(From#manifest.entries),
-            len = 0
-        }
-    ].
 
 -spec notify_waiters(state()) -> {state(), [core_effect()]}.
 notify_waiters(#state{last_persisted_manifest = Committed, waiters = Waiters} = State) ->

--- a/test/fragment_iterator_SUITE.erl
+++ b/test/fragment_iterator_SUITE.erl
@@ -29,7 +29,11 @@ all() ->
         all_refs_fragments_only,
         all_refs_with_groups,
         descend_skips_retained_entries,
-        descend_skips_retained_entries_kilo_group
+        descend_skips_retained_entries_kilo_group,
+        init_at_group_boundary,
+        group_fetch_failed_mid_traversal,
+        empty_group_ascends_immediately,
+        all_refs_deep_tree
     ].
 
 init_per_suite(Config) ->
@@ -332,3 +336,103 @@ descend_skips_retained_entries_kilo_group(_Config) ->
     {ok, #fragment_ref{offset = 400, uid = 16#b4}, It6} =
         rabbitmq_stream_s3_fragment_iterator:next(It5),
     ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It6)).
+
+init_at_group_boundary(_Config) ->
+    %% Init at offset that is exactly the first offset of a group entry.
+    %% The iterator should descend into the group immediately.
+    {Manifest, GetGroup} = build_manifest([
+        {fragment, #{offset => 0, uid => 1}},
+        {group, [
+            {fragment, #{offset => 100, uid => 2}},
+            {fragment, #{offset => 200, uid => 3}}
+        ]},
+        {fragment, #{offset => 300, uid => 4}}
+    ]),
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 100, GetGroup),
+    {ok, #fragment_ref{offset = 100, uid = 2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 200, uid = 3}, It2} =
+        rabbitmq_stream_s3_fragment_iterator:next(It1),
+    {ok, #fragment_ref{offset = 300, uid = 4}, It3} =
+        rabbitmq_stream_s3_fragment_iterator:next(It2),
+    ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It3)).
+
+group_fetch_failed_mid_traversal(_Config) ->
+    %% First group succeeds, second group fails. The iterator has already
+    %% descended and ascended once, so the error occurs mid-traversal.
+    {Manifest, GoodGetGroup} = build_manifest([
+        {group, [
+            {fragment, #{offset => 0, uid => 16#a1}},
+            {fragment, #{offset => 100, uid => 16#a2}}
+        ]},
+        {group, [
+            {fragment, #{offset => 200, uid => 16#a3}}
+        ]}
+    ]),
+    %% get_group_fun that succeeds on first call, fails on second.
+    CallCount = counters:new(1, []),
+    GetGroup = fun(Ref) ->
+        case counters:get(CallCount, 1) of
+            0 ->
+                counters:add(CallCount, 1, 1),
+                GoodGetGroup(Ref);
+            _ ->
+                {error, timeout}
+        end
+    end,
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 0, GetGroup),
+    %% First group traverses fine.
+    {ok, #fragment_ref{offset = 0}, It1} = rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 100}, It2} = rabbitmq_stream_s3_fragment_iterator:next(It1),
+    %% Second group fetch fails.
+    ?assertMatch(
+        {error, {group_fetch_failed, timeout}},
+        rabbitmq_stream_s3_fragment_iterator:next(It2)
+    ).
+
+empty_group_ascends_immediately(_Config) ->
+    %% A group with zero entries. The iterator should ascend immediately
+    %% and continue with the next entry in the root.
+    {Manifest, GetGroup0} = build_manifest([
+        {group, [
+            {fragment, #{offset => 0, uid => 1}}
+        ]},
+        {fragment, #{offset => 100, uid => 2}}
+    ]),
+    %% Override get_group_fun to return empty entries for the first group.
+    GetGroup = fun
+        (#group_ref{offset = 0}) -> {ok, <<>>};
+        (Ref) -> GetGroup0(Ref)
+    end,
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 0, GetGroup),
+    %% Should skip the empty group and return the root fragment.
+    {ok, #fragment_ref{offset = 100, uid = 2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It1)).
+
+all_refs_deep_tree(_Config) ->
+    %% MegaGroup containing KiloGroups containing Groups containing Fragments.
+    %% Verify all_refs collects every fragment ref and every group ref at
+    %% every level.
+    {Manifest, GetGroup} = build_manifest([
+        {mega_group, [
+            {kilo_group, [
+                {group, [
+                    {fragment, #{offset => 0, uid => 16#01}},
+                    {fragment, #{offset => 100, uid => 16#02}}
+                ]},
+                {group, [
+                    {fragment, #{offset => 200, uid => 16#03}}
+                ]}
+            ]}
+        ]},
+        {fragment, #{offset => 300, uid => 16#04}}
+    ]),
+    Refs = rabbitmq_stream_s3_fragment_iterator:all_refs(Manifest, GetGroup),
+    %% Expected: 1 mega_group_ref + 1 kilo_group_ref + 2 group_refs + 4 fragment_refs = 8
+    FragRefs = [R || #fragment_ref{} = R <- Refs],
+    GroupRefs = [R || #group_ref{} = R <- Refs],
+    ?assertEqual(4, length(FragRefs)),
+    ?assertEqual(4, length(GroupRefs)),
+    FragOffsets = [O || #fragment_ref{offset = O} <- FragRefs],
+    ?assertEqual([0, 100, 200, 300], FragOffsets).

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -59,7 +59,8 @@ groups() ->
             read_across_fragment_boundaries,
             read_from_remote_offset,
             read_repositions_on_fragment_not_found,
-            read_through_group
+            read_through_group,
+            read_detects_crc_corruption
         ]},
         {with_replica, [], [
             read_from_replica_node
@@ -263,6 +264,30 @@ read_through_group(Config) ->
     Records = read_all(Reader0),
     assert_sequential(Records, NextOffset).
 
+read_detects_crc_corruption(Config) ->
+    %% When verify_crc_on_read is enabled, reading a corrupted fragment
+    %% must exit with {crc_validation_failure, _}.
+    Writer = start_writer(Config, #{fragment_target_size => 1000}),
+    N = 50,
+    write_sequential(Writer, N, 5),
+
+    ReaderCfg0 = reader_config(Writer, Config),
+    ReaderCfg = ReaderCfg0#{verify_crc_on_read => true},
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch([S] when S > 0, list_segment_offsets(Config), 1000),
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+
+    %% Corrupt the first fragment file on disk.
+    corrupt_first_fragment(Config),
+
+    %% Reading should fail with CRC validation error.
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+    ?assertExit(
+        {crc_validation_failure, _},
+        read_all(Reader0)
+    ).
+
 read_from_replica_node(Config) ->
     StreamId = ?config(stream_id, Config),
     ReplicaNode = ?config(replica_node, Config),
@@ -301,3 +326,27 @@ read_from_replica_node(Config) ->
         rabbitmq_stream_s3_test_helpers:read_all(Reader0)
     end),
     assert_sequential(Records, N).
+
+%% ------------------------------------------------------------------
+%% Internal helpers
+%% ------------------------------------------------------------------
+
+corrupt_first_fragment(Config) ->
+    RemoteDir = ?config(remote_dir, Config),
+    StreamId = ?config(stream_id, Config),
+    Pattern = filename:join([
+        RemoteDir,
+        "rabbitmq",
+        "stream",
+        binary_to_list(StreamId),
+        "data",
+        "*.fragment"
+    ]),
+    [First | _] = lists:sort(filelib:wildcard(binary_to_list(iolist_to_binary(Pattern)))),
+    {ok, Bin} = file:read_file(First),
+    %% Flip a byte in the record data region (past 8-byte fragment header +
+    %% 48-byte chunk header). This ensures the CRC will not match.
+    Pos = 8 + 48 + 16,
+    <<Pre:Pos/binary, Byte:8, Post/binary>> = Bin,
+    Corrupted = <<Pre/binary, (Byte bxor 16#FF):8, Post/binary>>,
+    ok = file:write_file(First, Corrupted).

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -51,7 +51,8 @@ all() ->
         find_index_position_timestamp,
         %% Replica reader core: rebalancing
         broadcast_edits_reproduce_manifest,
-        broadcast_edits_complete_across_persist_cycles
+        broadcast_edits_complete_across_persist_cycles,
+        broadcast_edits_with_retention
     ].
 
 init_per_suite(Config) -> Config.
@@ -381,6 +382,145 @@ drain_persists(State0, Rev, Acc) ->
             drain_persists(State1, Rev + 1, Acc ++ BroadcastEdits);
         [] ->
             {State1, Rev + 1, Acc ++ BroadcastEdits}
+    end.
+
+%% =========================================================================
+%% Replica reader core: retention interleaved with appends and rebalancing
+%% =========================================================================
+
+broadcast_edits_with_retention(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun prop_broadcast_edits_with_retention/0, [], 500
+    ).
+
+%% Property: for any interleaving of fragment appends and retention edits
+%% (possibly triggering rebalancing), the concatenation of all broadcast
+%% edits across all persist cycles reproduces the final persisted manifest.
+prop_broadcast_edits_with_retention() ->
+    ?FORALL(
+        {RebalanceThreshold, Ops},
+        {integer(3, 6), gen_ops_with_retention()},
+        begin
+            Opts = #{
+                stream => <<"stream">>,
+                dir => <<"/dir">>,
+                epoch => 1,
+                reference => test_ref,
+                persist_threshold => 3,
+                persist_interval_ms => 999999,
+                rebalance_threshold => RebalanceThreshold
+            },
+            {S0, _} = rabbitmq_stream_s3_replica_reader_core:init(#manifest{}, Opts),
+            {FinalState, AllEdits} = run_ops_with_retention(
+                Ops, S0, 0, 1, RebalanceThreshold, []
+            ),
+            FinalPersisted = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(
+                FinalState
+            ),
+            Replicated = lists:foldl(
+                fun(Edit, M) ->
+                    rabbitmq_stream_s3_manifest:apply_edit(Edit, M)
+                end,
+                #manifest{},
+                AllEdits
+            ),
+            Replicated#manifest.entries =:= FinalPersisted#manifest.entries andalso
+                Replicated#manifest.first_offset =:= FinalPersisted#manifest.first_offset andalso
+                Replicated#manifest.next_offset =:= FinalPersisted#manifest.next_offset andalso
+                Replicated#manifest.total_size =:= FinalPersisted#manifest.total_size
+        end
+    ).
+
+%% Generate a sequence of operations weighted toward fragments.
+gen_ops_with_retention() ->
+    ?LET(
+        N,
+        integer(4, 20),
+        [frequency([{4, fragment}, {1, retention}]) || _ <- lists:seq(1, N)]
+    ).
+
+%% Execute operations, draining persists as they trigger.
+run_ops_with_retention([], State0, _Offset, Rev, _Threshold, Edits) ->
+    %% Final persist to flush remaining edits.
+    Now = erlang:system_time(millisecond) + 999999,
+    case rabbitmq_stream_s3_replica_reader_core:tick(Now, State0) of
+        {S1, [{start_persist, _, _, _, _, _}]} ->
+            {S2, FinalEdits} = drain_all_persists(S1, Rev),
+            {S2, Edits ++ FinalEdits};
+        {S1, []} ->
+            {S1, Edits}
+    end;
+run_ops_with_retention([fragment | Rest], State0, Offset, Rev, Threshold, Edits) ->
+    Meta = #{
+        first_offset => Offset,
+        first_timestamp => Offset * 1000,
+        last_timestamp => (Offset + 99) * 1000,
+        next_offset => Offset + 100,
+        size => 64_000_000,
+        num_chunks => 100,
+        spans => [{0, 8, 64_000_008}]
+    },
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(Meta, State0),
+    {S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(
+        Ref, erlang:unique_integer([positive]), S1
+    ),
+    %% Complete any rebalance that triggered.
+    S3 = complete_pending_rebalances(Effects, S2, Threshold),
+    %% Drain any persist that triggered.
+    {S4, NewRev, NewEdits} = maybe_drain_persist(S3, Effects, Rev),
+    run_ops_with_retention(Rest, S4, Offset + 100, NewRev, Threshold, Edits ++ NewEdits);
+run_ops_with_retention([retention | Rest], State0, Offset, Rev, Threshold, Edits) ->
+    %% Only apply retention if the manifest has more than one entry.
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(State0),
+    case byte_size(Manifest#manifest.entries) > ?ENTRY_B of
+        true ->
+            %% Remove the first entry.
+            <<_:64, _:64/signed, _:64/signed, _:8, Size:40, _:32, _/binary>> =
+                Manifest#manifest.entries,
+            <<_:?ENTRY_B/binary, NewFirst/binary>> = Manifest#manifest.entries,
+            <<NewFirstOff:64, NewFirstTs:64/signed, NewFirstLTs:64/signed, _/binary>> = NewFirst,
+            RetEdit = #edit{
+                first_offset = NewFirstOff,
+                first_timestamp = NewFirstTs,
+                first_last_timestamp = NewFirstLTs,
+                next_offset = undefined,
+                size = -Size,
+                entries = <<>>,
+                pos = 0,
+                len = ?ENTRY_B
+            },
+            {S1, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(
+                RetEdit, State0
+            ),
+            %% Drain any persist that triggered.
+            {S2, NewRev, NewEdits} = maybe_drain_persist(S1, Effects, Rev),
+            run_ops_with_retention(Rest, S2, Offset, NewRev, Threshold, Edits ++ NewEdits);
+        false ->
+            %% Skip retention if only one entry (must keep at least one).
+            run_ops_with_retention(Rest, State0, Offset, Rev, Threshold, Edits)
+    end.
+
+%% If a persist was triggered in the effects, drain it (and any cascading persists).
+maybe_drain_persist(State, Effects, Rev) ->
+    case [E || {start_persist, _, _, _, _, _} = E <- Effects] of
+        [_ | _] ->
+            {S1, NewEdits} = drain_all_persists(State, Rev),
+            {S1, Rev + 1, NewEdits};
+        [] ->
+            {State, Rev, []}
+    end.
+
+drain_all_persists(State0, Rev) ->
+    drain_all_persists(State0, Rev, []).
+
+drain_all_persists(State0, Rev, Acc) ->
+    {State1, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(Rev, State0),
+    BroadcastEdits = lists:append([Es || {broadcast, _, Es} <- Effects]),
+    case [E || {start_persist, _, _, _, _, _} = E <- Effects] of
+        [_ | _] ->
+            drain_all_persists(State1, Rev + 1, Acc ++ BroadcastEdits);
+        [] ->
+            {State1, Acc ++ BroadcastEdits}
     end.
 
 %% =========================================================================

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -497,9 +497,8 @@ remote_retention_deletes_fragments(Config) ->
         2000
     ),
 
-    %% Manifest reflects the deletion.
-    {FirstOffset, NextOffset} = get_range(Config),
-    ?assertEqual(10, FirstOffset).
+    %% Manifest reflects the deletion (after the retention persist completes).
+    ?awaitMatch({10, NextOffset}, get_range(Config), 2000).
 
 uploads_rebalance_into_group(Config) ->
     %% 5 segments, each producing a fragment (600 bytes > 500 target).

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -74,6 +74,7 @@ groups() ->
             stream_deletion_cleans_remote_tier,
             discover_attaches_to_existing_writer,
             remote_retention_deletes_fragments,
+            remote_retention_survives_multiple_persist_cycles,
             uploads_rebalance_into_group,
             remote_retention_deletes_within_group,
             old_manifest_roots_deleted
@@ -499,6 +500,37 @@ remote_retention_deletes_fragments(Config) ->
 
     %% Manifest reflects the deletion (after the retention persist completes).
     ?awaitMatch({10, NextOffset}, get_range(Config), 2000).
+
+remote_retention_survives_multiple_persist_cycles(Config) ->
+    %% Exercises the scenario where multiple persist_complete cycles fire
+    %% before the retention edit is persisted. With persist_threshold=1,
+    %% every fragment triggers a persist. Retention must not produce
+    %% duplicate edits (which would crash the replica reader).
+    #{next_offset := NextOffset} = seed_log(Config, [
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]}
+    ]),
+    _Writer = start_writer(
+        Config,
+        #{retention => [{max_bytes, 1000}]},
+        #{fragment_target_size => 500, persist_threshold => 1}
+    ),
+    await_offset(Config, NextOffset),
+
+    %% Remote retention should delete fragments until <= 1000 bytes remain.
+    %% Each fragment is ~600 bytes, so only the last one should survive.
+    ?awaitMatch(
+        [20],
+        list_fragment_offsets(Config),
+        2000
+    ),
+
+    %% The replica reader must still be alive (no crash from duplicate edits).
+    %% get_range advancing proves the retention persist completed successfully.
+    ?awaitMatch({20, NextOffset}, get_range(Config), 2000).
 
 uploads_rebalance_into_group(Config) ->
     %% 5 segments, each producing a fragment (600 bytes > 500 target).

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -56,7 +56,13 @@ all() ->
         recursive_rebalance_groups_to_kilo_group,
         rebalance_tick_defers_while_in_flight,
         group_upload_failed_retriable_retries,
-        group_upload_failed_fatal_abandons
+        group_upload_failed_fatal_abandons,
+        %% Retention
+        retention_complete_applies_edit,
+        retention_complete_triggers_persist,
+        retention_defers_persist,
+        retention_edit_broadcast_on_persist_complete,
+        retention_failed_clears_flag
     ].
 
 init_per_suite(Config) -> Config.
@@ -405,10 +411,11 @@ multiple_transfers_during_persist_all_broadcast(_Config) ->
     {S9, E1} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S8),
     [Edits1] = [Edits || {broadcast, _, Edits} <- E1],
     ?assertMatch([#edit{next_offset = 100}], Edits1),
-    %% Second persist completes (must cover B+C+D).
+    %% Second persist completes (must cover B+C+D as individual edits).
     {_S10, E2} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S9),
     [Edits2] = [Edits || {broadcast, _, Edits} <- E2],
-    ?assertMatch([#edit{next_offset = 400}], Edits2),
+    ?assertEqual(3, length(Edits2)),
+    ?assertMatch(#edit{next_offset = 400}, lists:last(Edits2)),
     %% Full chain reproduces the manifest.
     FinalManifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(_S10),
     assert_edits_reproduce_manifest(#manifest{}, FinalManifest, Edits1 ++ Edits2).
@@ -607,13 +614,19 @@ rebalance_edits_in_broadcast(_Config) ->
     From = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S2),
     {S3, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S2),
     To = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S3),
-    %% Broadcast should contain the append edit then the rebalance edit.
+    %% Broadcast should contain Threshold append edits then the rebalance edit.
     [Edits] = [Es || {broadcast, _, Es} <- Effects],
-    ?assertMatch([_, _], Edits),
-    [AppendEdit, RebalanceEdit] = Edits,
-    %% Append edit: len=0, entries = fragment entries.
-    ?assertEqual(0, AppendEdit#edit.len),
-    ?assert(byte_size(AppendEdit#edit.entries) > 0),
+    ?assertEqual(Threshold + 1, length(Edits)),
+    AppendEdits = lists:sublist(Edits, Threshold),
+    [RebalanceEdit] = lists:nthtail(Threshold, Edits),
+    %% Append edits: len=0, each has one entry.
+    lists:foreach(
+        fun(E) ->
+            ?assertEqual(0, E#edit.len),
+            ?assertEqual(?ENTRY_B, byte_size(E#edit.entries))
+        end,
+        AppendEdits
+    ),
     %% Rebalance edit: len > 0, entries = one group entry.
     ?assert(RebalanceEdit#edit.len > 0),
     ?assertEqual(?ENTRY_B, byte_size(RebalanceEdit#edit.entries)),
@@ -757,6 +770,131 @@ group_upload_failed_fatal_abandons(_Config) ->
     UploadGroups = [E || {upload_group, _, _, _, _, _} = E <- Effects],
     Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertEqual([], UploadGroups),
+    ?assertMatch([_], Persists).
+
+%% ------------------------------------------------------------------
+%% Retention tests
+%% ------------------------------------------------------------------
+
+retention_complete_applies_edit(_Config) ->
+    %% A retention edit removes the first fragment from the manifest.
+    {S0, _} = init_core(#{persist_threshold => 100}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    %% Remove the first entry.
+    RetEdit = #edit{
+        first_offset = 100,
+        first_timestamp = 100 * 1000,
+        first_last_timestamp = 199 * 1000,
+        next_offset = undefined,
+        size = -64_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S4, _Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S3),
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(S4),
+    ?assertEqual(100, Manifest#manifest.first_offset),
+    ?assertEqual(300, Manifest#manifest.next_offset),
+    ?assertEqual(2 * ?ENTRY_B, byte_size(Manifest#manifest.entries)).
+
+retention_complete_triggers_persist(_Config) ->
+    %% retention_complete increments since_persist. With threshold=1 it
+    %% should trigger a persist.
+    {S0, _} = init_core(#{persist_threshold => 3}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    %% Persist fires (threshold=3). Complete it.
+    {S4, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S3),
+    %% Now apply retention. since_persist goes to 1. Use tick to trigger.
+    RetEdit = #edit{
+        first_offset = 100,
+        first_timestamp = 100 * 1000,
+        first_last_timestamp = 199 * 1000,
+        next_offset = undefined,
+        size = -64_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S4),
+    %% Tick with enough time elapsed should trigger persist.
+    Now = erlang:system_time(millisecond) + 10000,
+    {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
+    Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
+    ?assertMatch([_], Persists).
+
+retention_defers_persist(_Config) ->
+    %% While retention_in_flight is true, persist must not start.
+    {S0, _} = init_core(#{persist_threshold => 1}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    %% Persist fires (threshold=1). Complete it.
+    {S2, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S1),
+    %% Mark retention as started.
+    S3 = rabbitmq_stream_s3_replica_reader_core:retention_started(S2),
+    %% Apply another fragment. Persist should be deferred.
+    {S4, Effects} = cut_and_complete_effects(S3, 100, 200, 1002),
+    Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
+    ?assertEqual([], Persists),
+    %% Tick should also not trigger persist.
+    Now = erlang:system_time(millisecond) + 10000,
+    {_S5, TickEffects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S4),
+    ?assertEqual([], TickEffects).
+
+retention_edit_broadcast_on_persist_complete(_Config) ->
+    %% The retention edit must appear in the broadcast only after persist.
+    {S0, _} = init_core(#{persist_threshold => 3}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    %% Persist fires (threshold=3). Complete it to establish baseline.
+    {S4, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S3),
+    %% Apply retention (removes first entry).
+    RetEdit = #edit{
+        first_offset = 100,
+        first_timestamp = 100 * 1000,
+        first_last_timestamp = 199 * 1000,
+        next_offset = undefined,
+        size = -64_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S5, RetEffects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S4),
+    %% retention_complete must NOT emit broadcast or update_range.
+    ?assertEqual([], [E || {broadcast, _, _} = E <- RetEffects]),
+    ?assertEqual([], [E || {update_range, _, _} = E <- RetEffects]),
+    %% Force persist via tick.
+    Now = erlang:system_time(millisecond) + 10000,
+    {S6, PersistEffects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
+    ?assertMatch([{start_persist, _, _, _, _, _}], PersistEffects),
+    %% Complete persist. NOW the retention edit should be broadcast.
+    From = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S6),
+    {S7, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S6),
+    To = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S7),
+    [Edits] = [Es || {broadcast, _, Es} <- Effects],
+    %% The retention edit should be in the broadcast.
+    RetEdits = [E || #edit{len = L} = E <- Edits, L > 0],
+    ?assertMatch([_], RetEdits),
+    %% The invariant must hold.
+    assert_edits_reproduce_manifest(From, To, Edits).
+
+retention_failed_clears_flag(_Config) ->
+    %% After retention_failed, persist should be unblocked.
+    {S0, _} = init_core(#{persist_threshold => 1}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    {S2, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S1),
+    %% Mark retention started, then apply a fragment.
+    S3 = rabbitmq_stream_s3_replica_reader_core:retention_started(S2),
+    S4 = cut_and_complete(S3, 100, 200, 1002),
+    %% Retention fails. Persist should now be possible.
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, S4),
+    %% Tick should trigger persist (since_persist > 0, interval elapsed).
+    Now = erlang:system_time(millisecond) + 10000,
+    {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
+    Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertMatch([_], Persists).
 
 %% ------------------------------------------------------------------

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -62,7 +62,12 @@ all() ->
         retention_complete_triggers_persist,
         retention_defers_persist,
         retention_edit_broadcast_on_persist_complete,
-        retention_failed_clears_flag
+        retention_failed_clears_flag,
+        %% Edge cases
+        fatal_front_drains_buffered_completions,
+        await_offset_satisfied_during_cascading_persist,
+        tick_fires_at_exact_interval_boundary,
+        retention_and_rebalance_same_persist_cycle
     ].
 
 init_per_suite(Config) -> Config.
@@ -896,6 +901,105 @@ retention_failed_clears_flag(_Config) ->
     {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
     Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertMatch([_], Persists).
+
+%% ------------------------------------------------------------------
+%% Edge case tests
+%% ------------------------------------------------------------------
+
+fatal_front_drains_buffered_completions(_Config) ->
+    %% Cut 3 fragments. Complete 2 and 3 (out of order). Then fragment 1
+    %% fails fatally. Fragments 2 and 3 should drain immediately since
+    %% they were already buffered in pending_completions.
+    {S0, _} = init_core(#{persist_threshold => 10}),
+    {S1, Ref1, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, Ref2, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
+    {S3, Ref3, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(200, 300), S2),
+    %% Complete 2 and 3 (not 1). Nothing should apply yet.
+    {S4, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref2, 2002, S3),
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref3, 3003, S4),
+    ?assertEqual(0, manifest_next_offset(S5)),
+    %% Fragment 1 fails fatally. 2 and 3 should drain.
+    {S6, _} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref1, enoent, S5),
+    ?assertEqual(300, manifest_next_offset(S6)).
+
+await_offset_satisfied_during_cascading_persist(_Config) ->
+    %% Waiter at 150 (satisfied by first persist covering 0..200).
+    %% Waiter at 350 (needs second persist covering 200..400).
+    %% Persist threshold=2. Apply 2 → triggers persist, then 2 more during it.
+    {S0, _} = init_core(#{persist_threshold => 2}),
+    {S1, []} = rabbitmq_stream_s3_replica_reader_core:await_offset(150, from1, S0),
+    {S2, []} = rabbitmq_stream_s3_replica_reader_core:await_offset(350, from2, S1),
+    %% Apply 2 fragments → triggers persist.
+    S3 = cut_and_complete(S2, 0, 100, 1001),
+    S4 = cut_and_complete(S3, 100, 200, 1002),
+    %% Apply 2 more during the in-flight persist.
+    S5 = cut_and_complete(S4, 200, 300, 1003),
+    S6 = cut_and_complete(S5, 300, 400, 1004),
+    %% First persist completes. from1 should be notified, cascading persist starts.
+    {S7, E1} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S6),
+    Replies1 = lists:flatten([Rs || {reply_waiters, Rs} <- E1]),
+    ?assertMatch([{from1, ok}], Replies1),
+    ?assertMatch([_], [E || {start_persist, _, _, _, _, _} = E <- E1]),
+    %% Second persist completes. from2 should be notified.
+    {_S8, E2} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S7),
+    Replies2 = lists:flatten([Rs || {reply_waiters, Rs} <- E2]),
+    ?assertMatch([{from2, ok}], Replies2).
+
+tick_fires_at_exact_interval_boundary(_Config) ->
+    %% Tick should fire when (Now - LastTs) == Interval exactly.
+    {S0, _} = init_core(#{persist_threshold => 100, persist_interval_ms => 5000}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    %% Tick at exactly the interval boundary.
+    Now = erlang:system_time(millisecond) + 5000,
+    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S1),
+    Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
+    ?assertMatch([_], Persists).
+
+retention_and_rebalance_same_persist_cycle(_Config) ->
+    %% Scenario: apply enough fragments to trigger rebalance, complete the
+    %% group upload, then apply a retention edit removing the group entry.
+    %% All in one persist cycle. The broadcast must reproduce the manifest.
+    Threshold = 4,
+    {S0, _} = init_core(#{rebalance_threshold => Threshold, persist_threshold => 100}),
+    %% Apply Threshold fragments → triggers rebalance.
+    S1 = lists:foldl(
+        fun(I, Acc) ->
+            cut_and_complete(Acc, I * 100, (I + 1) * 100, 1000 + I)
+        end,
+        S0,
+        lists:seq(0, Threshold - 1)
+    ),
+    %% Complete the group upload. Now manifest has 1 group entry.
+    {S2, _} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(9999, S1),
+    %% Apply more fragments so there's something after the group.
+    S3 = cut_and_complete(S2, Threshold * 100, (Threshold + 1) * 100, 2001),
+    S4 = cut_and_complete(S3, (Threshold + 1) * 100, (Threshold + 2) * 100, 2002),
+    %% Now apply retention that removes the group entry (pos=0, len=ENTRY_B).
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(S4),
+    <<_:64, _:64/signed, _:64/signed, _:8, _:40, _:32, Rest/binary>> =
+        Manifest#manifest.entries,
+    <<NewFirstOff:64, NewFirstTs:64/signed, NewFirstLTs:64/signed, _/binary>> = Rest,
+    RetEdit = #edit{
+        first_offset = NewFirstOff,
+        first_timestamp = NewFirstTs,
+        first_last_timestamp = NewFirstLTs,
+        next_offset = undefined,
+        size = 0,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S4),
+    %% Force persist via tick.
+    Now = erlang:system_time(millisecond) + 999999,
+    {S6, PersistEffects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
+    ?assertMatch([{start_persist, _, _, _, _, _}], PersistEffects),
+    %% Complete persist and verify the invariant.
+    From = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S6),
+    {S7, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S6),
+    To = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S7),
+    [Edits] = [Es || {broadcast, _, Es} <- Effects],
+    assert_edits_reproduce_manifest(From, To, Edits).
 
 %% ------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
This is working towards #36 gradually. I wanted to submit this hodge-podge of changes for you to look at @lukebakken since our work might overlap a little bit, like with https://github.com/amazon-mq/rabbitmq-stream-s3/pull/152.

Mainly this adds tests. A few other things:

1. `make fmt` and `make fmt-check`. Conveniences over `erlfmt`.
2. Refactors for the replica reader core so that retention is performed asynchronously when there are group objects. If there are group objects we need to download objects from the remote tier to know what to delete, so it shouldn't block the replica reader.
3. Along with that, fix the edit ordering. There were some bugs with that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
