### PR TITLE
remote reader: Reply {error, timeout} instead of crashing the caller

### DIFF
--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -728,20 +728,26 @@ find_position(Spec, #manifest{} = Manifest, StreamId) ->
         find_fragment(Manifest#manifest.entries, Spec, GetGroupFun),
     %% Download the index from the fragment to find the exact chunk position.
     IdxStartPos = ?SEGMENT_HEADER_B + Size,
-    IndexData = index_data(StreamId, FragmentOffset, Uid, IdxStartPos),
-    {ChunkId, _, FragPos} = find_index_position(IndexData, Spec),
-    %% Position within the fragment object (after the 8-byte header).
-    Position = ?SEGMENT_HEADER_B + FragPos,
-    %% Create an iterator positioned at this fragment for forward navigation.
-    Iterator = rabbitmq_stream_s3_fragment_iterator:init(Manifest, FragmentOffset, GetGroupFun),
-    %% Advance past the current entry so the iterator is ready for `next`.
-    Iterator1 = advance_past_current(Iterator),
-    {ok, #remote_location{
-        chunk_id = ChunkId,
-        position = Position,
-        fragment_ref = FragRef,
-        iterator = Iterator1
-    }}.
+    case index_data(StreamId, FragmentOffset, Uid, IdxStartPos) of
+        {ok, IndexData} ->
+            {ChunkId, _, FragPos} = find_index_position(IndexData, Spec),
+            %% Position within the fragment object (after the 8-byte header).
+            Position = ?SEGMENT_HEADER_B + FragPos,
+            %% Create an iterator positioned at this fragment for forward navigation.
+            Iterator = rabbitmq_stream_s3_fragment_iterator:init(
+                Manifest, FragmentOffset, GetGroupFun
+            ),
+            %% Advance past the current entry so the iterator is ready for `next`.
+            Iterator1 = advance_past_current(Iterator),
+            {ok, #remote_location{
+                chunk_id = ChunkId,
+                position = Position,
+                fragment_ref = FragRef,
+                iterator = Iterator1
+            }};
+        {error, _} = Err ->
+            Err
+    end.
 
 -doc """
 Finds the manifest entry which contains the requested offset or timestamp.
@@ -829,12 +835,11 @@ saturating_decr(N) -> N - 1.
 index_data(StreamId, FragmentOffset, Uid, IdxStartPos) ->
     Key = rabbitmq_stream_s3:fragment_key(StreamId, FragmentOffset, Uid),
     ?LOG_DEBUG("Looking up key ~ts (~ts)", [Key, ?FUNCTION_NAME], ?DOMAIN),
-    {ok, Data} = rabbitmq_stream_s3_api:get_range(
+    rabbitmq_stream_s3_api:get_range(
         Key,
         {IdxStartPos, undefined},
         #{timeout => ?READ_TIMEOUT}
-    ),
-    Data.
+    ).
 
 %% Advance the iterator past the current entry (so next/1 returns the
 %% entry *after* the one we resolved to).

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -349,7 +349,9 @@ send_file(
                             Err
                     end;
                 end_of_stream ->
-                    {end_of_stream, State0#?MODULE{mode = Remote1}}
+                    {end_of_stream, State0#?MODULE{mode = Remote1}};
+                {error, timeout} = Err ->
+                    Err
             end;
         {become_local, _} ->
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
@@ -360,7 +362,9 @@ send_file(
                     Err
             end;
         {end_of_stream, Remote} ->
-            {end_of_stream, State0#?MODULE{mode = Remote}}
+            {end_of_stream, State0#?MODULE{mode = Remote}};
+        {error, timeout} = Err ->
+            Err
     end;
 send_file(Socket, #?MODULE{mode = Local0} = State0, Callback) ->
     case osiris_log:send_file(Socket, Local0, Callback) of
@@ -433,7 +437,9 @@ chunk_iterator(
                             Err
                     end;
                 end_of_stream ->
-                    {end_of_stream, State0#?MODULE{mode = Remote1}}
+                    {end_of_stream, State0#?MODULE{mode = Remote1}};
+                {error, timeout} = Err ->
+                    Err
             end;
         {become_local, _} ->
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
@@ -444,7 +450,9 @@ chunk_iterator(
                     Err
             end;
         {end_of_stream, Remote} ->
-            {end_of_stream, State0#?MODULE{mode = Remote}}
+            {end_of_stream, State0#?MODULE{mode = Remote}};
+        {error, timeout} = Err ->
+            Err
     end;
 chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter) ->
     case osiris_log:chunk_iterator(Local0, Credit, PrevIter) of
@@ -508,7 +516,8 @@ send(ssl, Socket, Data) ->
 -spec read_header(#remote{}) ->
     {ok, osiris_log:header_map(), #remote{}}
     | {become_local, osiris:offset()}
-    | {end_of_stream, #remote{}}.
+    | {end_of_stream, #remote{}}
+    | {error, timeout}.
 read_header(#remote{shared = Shared, next_offset = NextOffset} = Remote) ->
     CanReadNext =
         osiris_log_shared:last_chunk_id(Shared) >= NextOffset andalso
@@ -538,7 +547,9 @@ read_header1(
         {become_local, Offset} ->
             {become_local, Offset};
         end_of_stream ->
-            {end_of_stream, Remote0}
+            {end_of_stream, Remote0};
+        {error, timeout} = Err ->
+            Err
     end.
 
 read_header2(
@@ -860,7 +871,8 @@ resolve_first(StreamId, FirstOffset) ->
     {ok, binary()}
     | {next_fragment, osiris:offset()}
     | {become_local, osiris:offset()}
-    | end_of_stream.
+    | end_of_stream
+    | {error, timeout}.
 read(RemoteReader, Offset, Bytes, Hint) ->
     {Ms, Result} = timer:tc(
         rabbitmq_stream_s3_remote_reader,

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -34,9 +34,13 @@ multiplicative decrease ([AIMD]) algorithm.
 -define(MIN_RETRY_DELAY_MS, 1_000).
 -define(MAX_RETRY_DELAY_MS, 30_000).
 %% Cancel and retry an in-flight S3 request if no response arrives within
-%% this window. Must be less than ?GEN_SERVER_CALL_TIMEOUT (60s) to allow
-%% recovery before the caller times out.
--define(REQUEST_TIMEOUT_MS, 30_000).
+%% this window. Sized to allow multiple retries within
+%% ?PENDING_READ_DEADLINE_MS before giving up.
+-define(REQUEST_TIMEOUT_MS, 15_000).
+%% Maximum time a pending read can wait before the remote reader replies
+%% {error, timeout}. Must be less than ?GEN_SERVER_CALL_TIMEOUT (60s) to
+%% avoid crashing the caller.
+-define(PENDING_READ_DEADLINE_MS, 50_000).
 
 -define(C_BUFFER_HIT, 1).
 -define(C_BUFFER_MISS, 2).
@@ -175,7 +179,8 @@ init_counters() ->
     {ok, binary()}
     | {next_fragment, osiris:offset()}
     | {become_local, osiris:offset()}
-    | end_of_stream.
+    | end_of_stream
+    | {error, timeout}.
 read(Server, Offset, Bytes, Hint) ->
     read(Server, Offset, Bytes, Hint, ?GEN_SERVER_CALL_TIMEOUT).
 
@@ -183,7 +188,8 @@ read(Server, Offset, Bytes, Hint) ->
     {ok, binary()}
     | {next_fragment, osiris:offset()}
     | {become_local, osiris:offset()}
-    | end_of_stream.
+    | end_of_stream
+    | {error, timeout}.
 read(Server, Offset, Bytes, Hint, Timeout) ->
     T0 = erlang:monotonic_time(),
     Result = gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout),
@@ -364,7 +370,9 @@ handle_request_error(Reason, Req0, RetryDelay0, State) ->
             Transient =:= connection_error;
             Transient =:= timeout
         ->
-            maybe_reply_pending(State);
+            erlang:send_after(RetryDelay0, self(), retry_requests),
+            RetryDelay = min(RetryDelay0 * 2, ?MAX_RETRY_DELAY_MS),
+            maybe_reply_pending(State#?MODULE{retry_delay = RetryDelay});
         _ ->
             {stop, {shutdown, Reason}, State}
     end.
@@ -529,25 +537,38 @@ maybe_reply_pending(
         }
     } = State0
 ) ->
-    case maybe_reply(Read, State0) of
-        {reply, Reply, State1} ->
-            Duration = rabbitmq_stream_s3_util:elapsed_ms(Since),
-            counters:add(counter(), ?C_AWAIT_DURATION_MS, Duration),
+    Elapsed = rabbitmq_stream_s3_util:elapsed_ms(Since),
+    case Elapsed >= ?PENDING_READ_DEADLINE_MS of
+        true ->
+            ?LOG_WARNING(
+                "Remote read deadline exceeded (~bms), replying {error, timeout}",
+                [Elapsed]
+            ),
+            counters:add(counter(), ?C_AWAIT_DURATION_MS, Elapsed),
             counters:add(counter(), ?C_AWAIT, 1),
-            gen_server:reply(From, Reply),
-            State = State1#?MODULE{pending_read = undefined},
-            {noreply, State};
-        {stop, Reason, Reply, State1} ->
-            gen_server:reply(From, Reply),
-            State = State1#?MODULE{pending_read = undefined},
-            {stop, Reason, State};
-        {retry, State} ->
-            %% No in-flight requests - the pool was busy when maybe_start_request
-            %% was called. Schedule a retry so the read does not stall forever.
-            erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
-            {noreply, State};
-        {noreply, _} = NoReply ->
-            NoReply
+            gen_server:reply(From, {error, timeout}),
+            {noreply, State0#?MODULE{pending_read = undefined}};
+        false ->
+            case maybe_reply(Read, State0) of
+                {reply, Reply, State1} ->
+                    counters:add(counter(), ?C_AWAIT_DURATION_MS, Elapsed),
+                    counters:add(counter(), ?C_AWAIT, 1),
+                    gen_server:reply(From, Reply),
+                    State = State1#?MODULE{pending_read = undefined},
+                    {noreply, State};
+                {stop, Reason, Reply, State1} ->
+                    gen_server:reply(From, Reply),
+                    State = State1#?MODULE{pending_read = undefined},
+                    {stop, Reason, State};
+                {retry, State} ->
+                    %% No in-flight requests - the pool was busy when
+                    %% maybe_start_request was called. Schedule a retry so
+                    %% the read does not stall forever.
+                    erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
+                    {noreply, State};
+                {noreply, _} = NoReply ->
+                    NoReply
+            end
     end.
 
 maybe_reply(#read{offset = Offset, bytes = Bytes, hint = _Hint}, #?MODULE{} = State0) ->

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -547,7 +547,22 @@ maybe_reply_pending(
             counters:add(counter(), ?C_AWAIT_DURATION_MS, Elapsed),
             counters:add(counter(), ?C_AWAIT, 1),
             gen_server:reply(From, {error, timeout}),
-            {noreply, State0#?MODULE{pending_read = undefined}};
+            %% Reset buffer to position 0 and cancel in-flight requests.
+            %% The caller may retry at any position (send_chunks reverts
+            %% the consumer to its pre-loop state on error), so the buffer
+            %% must not have a start_pos that would violate the
+            %% Offset >= StartPos assertion in try_read.
+            cancel_requests(State0#?MODULE.requests),
+            {noreply, State0#?MODULE{
+                pending_read = undefined,
+                buffer = <<>>,
+                start_pos = 0,
+                current_pos = 0,
+                end_pos = 0,
+                requests = #{},
+                cancelled_requests = #{},
+                retry_delay = ?MIN_RETRY_DELAY_MS
+            }};
         false ->
             case maybe_reply(Read, State0) of
                 {reply, Reply, State1} ->


### PR DESCRIPTION
## Summary

- Reduce `?REQUEST_TIMEOUT_MS` from 30s to 15s, allowing multiple retries within the caller's budget
- Add exponential backoff to the `timeout`/`stream_error`/`connection_error` error handler
- Add a 50-second `?PENDING_READ_DEADLINE_MS` that replies `{error, timeout}` instead of holding the pending read forever
- Reset buffer state (position 0, cancel requests) on deadline to prevent assertion failures when the caller retries at an old position
- Propagate `{error, timeout}` through `read_header` and `send_file` in the log reader
- Handle `{error, not_found}` in `index_data/4` to prevent badmatch crash when retention deletes a fragment during consumer attach

## Problem

Three bugs in the read path:

**Bug 1 (#157):** Two consecutive 30-second S3 request timeouts exhaust the caller's 60-second `gen_server:call` budget. The caller exits with `{timeout, {gen_server, call, ...}}`, crashing the log reader and the stream connection.

**Bug 2 (#161):** After replying `{error, timeout}`, the remote reader's buffer can be compacted by arriving async data (setting `start_pos = current_pos`). The caller retries at its pre-loop position (because `send_chunks` reverts the consumer on error), which is now behind `start_pos`, triggering `?assert(Offset >= StartPos)`.

**Bug 3 (#163):** `index_data/4` uses a bare pattern match `{ok, Data} = get_range(...)` that crashes with `{badmatch, {error, not_found}}` when retention deletes a fragment between the manifest lookup and the S3 fetch during consumer attach.

## Fix

Under sustained S3 latency, the remote reader retries with backoff (15s timeout, 1s/2s/4s/.../30s delays) until the 50-second deadline. At the deadline:

1. Reply `{error, timeout}` to the caller (instead of holding forever)
2. Reset buffer to position 0 and cancel in-flight requests (so any retry position passes the assertion)

The log reader propagates `{error, timeout}` through `send_file`, which the stream reader handles gracefully: logs the error and returns the consumer unchanged. On the next osiris offset event, delivery retries from the same position with a fresh buffer. No crash, no data loss, just a delivery stall until S3 recovers.

For the retention race (#163), `index_data/4` handles `{error, not_found}` and propagates it so the consumer can jump to the oldest available fragment instead of crashing.

## Test plan

- [x] Compiles cleanly (`make -C deps/rabbitmq_stream_s3`)
- [x] No trailing whitespace
- [ ] Deploy to test cluster and run 2-hour high-throughput soak test
- [ ] Verify: no assertion failures, no `case_clause` crashes, no `badmatch` crashes, no `reached_max_restart_intensity`; consumers survive S3 latency and recover

Closes #157. Closes #161. Closes #163.
