### PR TITLE
replica reader: Prepend edits, time out retention, fix flake

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -40,6 +40,24 @@ The manifest stores entries as a flat binary (34 bytes per entry) rather than a 
 
 Use binary arrays for any fixed-size record collection that needs binary search or sequential access. Do not convert to lists of records for processing.
 
+## List accumulation
+
+Do not use `List ++ [Element]` to build lists incrementally. Tail-append copies the entire list on every call, making N appends O(N²).
+
+Use the prepend-and-reverse idiom instead: accumulate with `[Element | Acc]` (O(1) per element), then call `lists:reverse/1` once when the final order is needed (O(N) total).
+
+```erlang
+%% Bad: O(N²) over the accumulation cycle.
+Edits ++ [Edit]
+
+%% Good: O(1) prepend, O(N) reverse at consumption time.
+[Edit | Edits]
+...
+lists:reverse(Edits)
+```
+
+More generally, avoid `++/2` in loops or recursive accumulation. It is fine for one-off concatenation of short, bounded lists (e.g. merging effect lists from two calls).
+
 ## Storage backend abstraction
 
 The `rabbitmq_stream_s3_api` behaviour abstracts the remote tier. Production uses `rabbitmq_stream_s3_api_aws` (real S3). Tests use `rabbitmq_stream_s3_api_fs` (local filesystem).

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -38,6 +38,7 @@ lives here. Callers use these functions instead of calling
     task_retry_delay_exponent/0,
     verbose_logging/0,
     segment_upload_timeout/0,
+    retention_task_timeout/0,
     tick_timeout_milliseconds/0,
     max_transfer_bytes_per_sec/0,
     max_transfer_burst_bytes/0,
@@ -168,6 +169,10 @@ verbose_logging() ->
 segment_upload_timeout() ->
     application:get_env(?APP, segment_upload_timeout, 45_000).
 
+-spec retention_task_timeout() -> non_neg_integer().
+retention_task_timeout() ->
+    application:get_env(?APP, retention_task_timeout, 60_000).
+
 -spec tick_timeout_milliseconds() -> non_neg_integer().
 tick_timeout_milliseconds() ->
     application:get_env(?APP, tick_timeout_milliseconds, 5000).
@@ -215,6 +220,7 @@ defaults_test_() ->
         ?_assertEqual(2, task_retry_delay_exponent()),
         ?_assertEqual(false, verbose_logging()),
         ?_assertEqual(45_000, segment_upload_timeout()),
+        ?_assertEqual(60_000, retention_task_timeout()),
         ?_assertEqual(5000, tick_timeout_milliseconds()),
         ?_assertEqual(false, verify_crc_on_read())
     ].

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -227,6 +227,10 @@ returned by the functional core module.
     group_mon :: reference() | undefined,
     %% Monitor ref for the in-flight retention evaluation task.
     retention_mon :: reference() | undefined,
+    %% PID of the in-flight retention evaluation task.
+    retention_pid :: pid() | undefined,
+    %% Timer ref for the retention task timeout.
+    retention_timer :: reference() | undefined,
     %% Kind of the group upload currently in flight. Cleared when the
     %% group_upload_result message arrives. Only one rebalance is in
     %% flight at a time so a single slot suffices.
@@ -368,16 +372,49 @@ handle_info(
         execute_effects(Effects, State0#state{
             core = Core, group_mon = undefined, pending_group_kind = undefined
         })};
-handle_info({retention_result, unchanged}, #state{core = Core0, retention_mon = Mon} = State0) ->
-    demonitor(Mon, [flush]),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(unchanged, Core0),
-    {noreply, execute_effects(Effects, State0#state{core = Core, retention_mon = undefined})};
 handle_info(
-    {retention_result, {Edit, Refs}},
-    #state{core = Core0, retention_mon = Mon, cfg = #cfg{stream = StreamId}} = State0
+    {retention_result, unchanged},
+    #state{core = Core0, retention_mon = Mon, retention_timer = TRef} = State0
 ) ->
     demonitor(Mon, [flush]),
-    State = on_remote_retention(Edit, Refs, StreamId, Core0, State0#state{retention_mon = undefined}),
+    _ = cancel_timer(TRef),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(unchanged, Core0),
+    {noreply,
+        execute_effects(Effects, State0#state{
+            core = Core,
+            retention_mon = undefined,
+            retention_pid = undefined,
+            retention_timer = undefined
+        })};
+handle_info(
+    {retention_result, {Edit, Refs}},
+    #state{core = Core0, retention_mon = Mon, retention_timer = TRef, cfg = #cfg{stream = StreamId}} =
+        State0
+) ->
+    demonitor(Mon, [flush]),
+    _ = cancel_timer(TRef),
+    State = on_remote_retention(Edit, Refs, StreamId, Core0, State0#state{
+        retention_mon = undefined, retention_pid = undefined, retention_timer = undefined
+    }),
+    {noreply, State};
+handle_info(
+    retention_timeout,
+    #state{retention_mon = Mon, retention_pid = Pid, core = Core0, cfg = #cfg{stream = StreamId}} =
+        State0
+) when Mon =/= undefined ->
+    ?LOG_WARNING("~ts retention evaluation task timed out, killing", [StreamId]),
+    exit(Pid, kill),
+    demonitor(Mon, [flush]),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, Core0),
+    {noreply,
+        execute_effects(Effects, State0#state{
+            core = Core,
+            retention_mon = undefined,
+            retention_pid = undefined,
+            retention_timer = undefined
+        })};
+handle_info(retention_timeout, State) ->
+    %% Stale timeout after normal completion; ignore.
     {noreply, State};
 handle_info(persist_timer, #state{core = Core0} = State0) ->
     Now = erlang:system_time(millisecond),
@@ -445,11 +482,19 @@ handle_info(
         })};
 handle_info(
     {'DOWN', Mon, process, _, Reason},
-    #state{retention_mon = Mon, core = Core0, cfg = #cfg{stream = StreamId}} = State0
+    #state{retention_mon = Mon, retention_timer = TRef, core = Core0, cfg = #cfg{stream = StreamId}} =
+        State0
 ) ->
     ?LOG_WARNING("~ts retention evaluation task crashed: ~p", [StreamId, Reason]),
+    _ = cancel_timer(TRef),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(Reason, Core0),
-    {noreply, execute_effects(Effects, State0#state{core = Core, retention_mon = undefined})};
+    {noreply,
+        execute_effects(Effects, State0#state{
+            core = Core,
+            retention_mon = undefined,
+            retention_pid = undefined,
+            retention_timer = undefined
+        })};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -858,7 +903,7 @@ maybe_spawn_group_retention(
 ) when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
     Self = self(),
     GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-    {_Pid, MonRef} = spawn_monitor(fun() ->
+    {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result =
             try
@@ -875,7 +920,9 @@ maybe_spawn_group_retention(
         Self ! {retention_result, Result}
     end),
     Core = rabbitmq_stream_s3_replica_reader_core:retention_started(State#state.core),
-    State#state{core = Core, retention_mon = MonRef};
+    Timeout = rabbitmq_stream_s3_config:retention_task_timeout(),
+    TRef = erlang:send_after(Timeout, Self, retention_timeout),
+    State#state{core = Core, retention_mon = MonRef, retention_pid = Pid, retention_timer = TRef};
 maybe_spawn_group_retention(_Manifest, _Retention, _Now, _StreamId, State) ->
     State.
 

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -224,10 +224,11 @@ persist_complete(
     } = State0
 ) ->
     Manifest = CommittingManifest#manifest{revision = Revision},
-    %% Only discard the edits that were captured in the persisting batch.
-    %% Edits that arrived during the in-flight persist were appended after
-    %% start_persist captured its snapshot; those must be preserved.
-    RemainingEdits = lists:nthtail(Committed, State0#state.edits_since_persist),
+    %% edits_since_persist is stored reversed (newest first). The first
+    %% (N - Committed) elements are edits that arrived *after* start_persist
+    %% captured its snapshot; those must be preserved.
+    Remaining = N - Committed,
+    RemainingEdits = lists:sublist(State0#state.edits_since_persist, Remaining),
     State1 = State0#state{
         persist_in_flight = false,
         last_persisted_manifest = Manifest,
@@ -334,7 +335,7 @@ group_upload_complete(
         manifest = Manifest,
         rebalance_in_flight = false,
         since_persist = State0#state.since_persist + 1,
-        edits_since_persist = State0#state.edits_since_persist ++ [Edit]
+        edits_since_persist = [Edit | State0#state.edits_since_persist]
     },
     %% Check for recursive rebalancing (e.g. too many groups → kilo-group).
     {State2, RebalanceEffects} = maybe_start_rebalance(State1),
@@ -382,7 +383,7 @@ retention_complete(Edit, #state{manifest = Manifest0} = State0) ->
         manifest = Manifest,
         retention_in_flight = false,
         since_persist = State0#state.since_persist + 1,
-        edits_since_persist = State0#state.edits_since_persist ++ [Edit]
+        edits_since_persist = [Edit | State0#state.edits_since_persist]
     },
     {State2, PersistEffects} = maybe_start_persist(State1),
     {State2, PersistEffects}.
@@ -474,7 +475,7 @@ apply_fragment(
     State#state{
         manifest = Manifest,
         since_persist = N + 1,
-        edits_since_persist = Edits ++ [Edit1]
+        edits_since_persist = [Edit1 | Edits]
     }.
 
 -spec maybe_start_persist(state()) -> {state(), [core_effect()]}.
@@ -504,10 +505,13 @@ start_persist(
         manifest = Manifest,
         last_persisted_manifest = LastManifest,
         since_persist = N,
-        edits_since_persist = Edits
+        edits_since_persist = EditsRev
     } =
         State
 ) ->
+    %% edits_since_persist is stored in reverse (newest first) for O(1) prepend.
+    %% Reverse to temporal order for broadcast and persist.
+    Edits = lists:reverse(EditsRev),
     Effect =
         {start_persist, Manifest, Cfg#cfg.epoch, Cfg#cfg.reference, LastManifest#manifest.revision,
             Edits},

--- a/test/broker_SUITE.erl
+++ b/test/broker_SUITE.erl
@@ -47,7 +47,7 @@ init_per_group(cluster_size_3, Config) ->
     Config2 = rabbit_ct_helpers:merge_app_env(Config1, [
         {rabbitmq_stream_s3, [
             {rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fs},
-            {fragment_target_size, 1000},
+            {fragment_target_size, 1},
             {persist_threshold, 1},
             {api_fs_data_dir, DataDir}
         ]}


### PR DESCRIPTION
Fixes #155, fixes #156.

A hodge podge of fixes. This also fixes the flake we've been seeing in the `broker_SUITE`. (#154 added logging showing what the issue was.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
