### PR TITLE
Expand test cases, allow deletion of all fragments

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,7 @@ After each durable commit, the replica reader evaluates the user's retention pol
 
 Remote retention only evaluates fragment entries at the head of the root. If the root starts with a group entry, retention downloads the group object and evaluates the policy against its fragment entries. Fragments are deleted individually. When all fragments in a group are expired, the group entry is removed from the root and the group object is deleted. See [manifest.md](./manifest.md) for details.
 
-At least one entry is always kept in the manifest to preserve the stream's position metadata.
+Retention can delete all entries from the manifest. An empty manifest (`entries = <<>>`) signals "no remote data available" and the remote tier becomes invisible to consumers. The `next_offset` is preserved in the manifest root so the replica reader knows where to resume uploading.
 
 ## Offset listener and event formatter
 

--- a/docs/upload-path.md
+++ b/docs/upload-path.md
@@ -158,7 +158,7 @@ After local retention, the shell evaluates the user's retention policy (max-byte
 3. Send the fragment keys to the reaper for deletion.
 4. Broadcast the edit to replica nodes.
 
-Remote retention keeps at least one entry in the manifest to preserve position metadata.
+Remote retention can delete all entries from the manifest. When the manifest is empty, the remote tier is invisible to consumers and `get_range` returns `empty`.
 
 When the first entry in the root is a group, retention downloads the group object and evaluates the policy against its fragment entries. Fragments are deleted individually. If the entire group is consumed, the group entry is removed from the root and the group object is deleted. If partially consumed, the root's metadata (first_offset, first_timestamp, total_size) is updated to reflect the oldest surviving fragment. See [manifest.md](./manifest.md) "Retention within groups" for details.
 

--- a/src/rabbitmq_stream_s3_manifest.erl
+++ b/src/rabbitmq_stream_s3_manifest.erl
@@ -192,10 +192,10 @@ remove_for_max_bytes(<<>>, _TotalSize, _MaxBytes, N) ->
 remove_for_max_bytes(Entries, TotalSize, MaxBytes, N) ->
     <<_Offset:64, _FirstTs:64, _LastTs:64, Kind:8, Size:40, _Uid:32, Rest/binary>> = Entries,
     case Kind of
-        ?MANIFEST_KIND_FRAGMENT when Rest =/= <<>> ->
+        ?MANIFEST_KIND_FRAGMENT ->
             remove_for_max_bytes(Rest, TotalSize - Size, MaxBytes, N + 1);
         _ ->
-            %% Hit a group entry or last entry. Stop here.
+            %% Hit a group entry. Stop here (group retention handles it).
             N
     end.
 
@@ -205,7 +205,7 @@ remove_for_max_age(Entries, Cutoff, N) ->
     <<_Offset:64, _FirstTs:64/signed, LastTs:64/signed, Kind:8, _Size:40, _Uid:32, Rest/binary>> =
         Entries,
     case Kind of
-        ?MANIFEST_KIND_FRAGMENT when LastTs < Cutoff andalso Rest =/= <<>> ->
+        ?MANIFEST_KIND_FRAGMENT when LastTs < Cutoff ->
             remove_for_max_age(Rest, Cutoff, N + 1);
         _ ->
             N

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -90,6 +90,7 @@ get_manifest(StreamId) ->
 -spec get_range(stream_id()) -> rabbitmq_stream_s3:range().
 get_range(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
+        [{_, #manifest{entries = <<>>}}] -> empty;
         [{_, #manifest{first_offset = First, next_offset = Next}}] -> {First, Next};
         [] -> empty
     end.

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -461,8 +461,10 @@ apply_fragment(
         len = 0
     },
     Edit1 =
-        case Manifest0#manifest.next_offset of
-            0 ->
+        case Manifest0#manifest.entries of
+            <<>> ->
+                %% Empty manifest (fresh stream or fully retained). The first
+                %% fragment sets the manifest's position metadata.
                 Edit#edit{
                     first_offset = FirstOffset,
                     first_timestamp = FirstTs,

--- a/test/fragment_assembly_SUITE.erl
+++ b/test/fragment_assembly_SUITE.erl
@@ -19,7 +19,10 @@ all() ->
         multi_segment_spans,
         metadata_correct,
         index_records_single_span,
-        index_records_multi_span
+        index_records_multi_span,
+        cut_at_segment_boundary,
+        single_chunk_exceeds_target,
+        zero_size_chunk_no_cut
     ].
 
 init_per_suite(Config) -> Config.
@@ -136,6 +139,40 @@ index_records_multi_span(_Config) ->
             500:32/unsigned>>,
         Idx
     ).
+
+cut_at_segment_boundary(_Config) ->
+    %% First chunk in segment 0, second chunk in segment 512000.
+    %% The second chunk also causes the cut (exceeds target).
+    %% Both spans must be recorded in metadata.
+    S0 = rabbitmq_stream_s3_fragment_assembly:new(1000),
+    S1 = rabbitmq_stream_s3_fragment_assembly:add_chunk(
+        chunk(0, 100, 500, 0, 8, 508), S0
+    ),
+    ?assertNot(rabbitmq_stream_s3_fragment_assembly:is_cut(S1)),
+    S2 = rabbitmq_stream_s3_fragment_assembly:add_chunk(
+        chunk(50, 200, 600, 512000, 8, 608), S1
+    ),
+    ?assert(rabbitmq_stream_s3_fragment_assembly:is_cut(S2)),
+    Meta = rabbitmq_stream_s3_fragment_assembly:metadata(S2),
+    ?assertEqual([{0, 8, 508}, {512000, 8, 608}], maps:get(spans, Meta)).
+
+single_chunk_exceeds_target(_Config) ->
+    %% A single chunk whose data_size exceeds the target cuts immediately.
+    S0 = rabbitmq_stream_s3_fragment_assembly:new(1000),
+    S1 = rabbitmq_stream_s3_fragment_assembly:add_chunk(chunk(0, 100, 5000), S0),
+    ?assert(rabbitmq_stream_s3_fragment_assembly:is_cut(S1)),
+    Meta = rabbitmq_stream_s3_fragment_assembly:metadata(S1),
+    ?assertEqual(1, maps:get(num_chunks, Meta)),
+    ?assertEqual(5000, maps:get(size, Meta)).
+
+zero_size_chunk_no_cut(_Config) ->
+    %% A chunk with data_size = 0 (e.g. tracking chunk) must not trigger a cut.
+    S0 = rabbitmq_stream_s3_fragment_assembly:new(1000),
+    S1 = rabbitmq_stream_s3_fragment_assembly:add_chunk(chunk(0, 100, 0), S0),
+    ?assertNot(rabbitmq_stream_s3_fragment_assembly:is_cut(S1)),
+    %% Multiple zero-size chunks still don't cut.
+    S2 = rabbitmq_stream_s3_fragment_assembly:add_chunk(chunk(50, 200, 0), S1),
+    ?assertNot(rabbitmq_stream_s3_fragment_assembly:is_cut(S2)).
 
 %% ------------------------------------------------------------------
 %% Helpers

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -19,7 +19,10 @@ all() ->
         apply_retention_edit,
         range_updates_on_edit,
         sequenced_edits_applied_in_order,
-        gap_triggers_resync
+        gap_triggers_resync,
+        rapid_edits_with_gap_then_resync,
+        stale_edit_after_resync_ignored,
+        retention_and_append_in_same_broadcast
     ].
 
 init_per_suite(Config) ->
@@ -215,8 +218,171 @@ gap_triggers_resync(_Config) ->
     unlink(WriterPid),
     exit(WriterPid, kill).
 
+rapid_edits_with_gap_then_resync(_Config) ->
+    StreamId = <<"stream-rapid">>,
+    {Manifest0, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000}}
+    ]),
+
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer_loop(Self) end),
+    yes = rabbitmq_stream_s3_registry:register_name({StreamId, node()}, WriterPid),
+
+    %% Sync at seq=0, epoch=1.
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 0, 1, Manifest0),
+
+    %% Edit seq=1 applies.
+    Edit1 = append_edit(Manifest0, 50, 1000, 51, 2000, 42),
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, [Edit1], 1, 1),
+    M1 = rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+    ?assertEqual(51, M1#manifest.next_offset),
+
+    %% Edit seq=2 applies.
+    Edit2 = append_edit(M1, 100, 1000, 101, 3000, 43),
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, [Edit2], 2, 1),
+    M2 = rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+    ?assertEqual(101, M2#manifest.next_offset),
+
+    %% Edit seq=4 (gap: expected 3). Triggers resync.
+    Edit4 = append_edit(M2, 200, 1000, 201, 4000, 44),
+    {error, gap} = rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, [Edit4], 4, 1),
+    receive
+        {resync_received, _} -> ok
+    after 1000 -> ct:fail("no resync")
+    end,
+
+    %% Re-sync with a fresh manifest at seq=5.
+    {ManifestNew, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000}},
+        {fragment, #{offset => 50, size => 2000}},
+        {fragment, #{offset => 100, size => 3000}},
+        {fragment, #{offset => 150, size => 4000}},
+        {fragment, #{offset => 200, size => 5000}}
+    ]),
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 5, 1, ManifestNew),
+
+    %% Subsequent edit at seq=6 applies normally.
+    Edit6 = append_edit(ManifestNew, 300, 1000, 301, 6000, 45),
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, [Edit6], 6, 1),
+    M3 = rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+    ?assertEqual(301, M3#manifest.next_offset),
+
+    rabbitmq_stream_s3_registry:unregister_name({StreamId, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill).
+
+stale_edit_after_resync_ignored(_Config) ->
+    StreamId = <<"stream-stale">>,
+    {Manifest0, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000}}
+    ]),
+
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer_loop(Self) end),
+    yes = rabbitmq_stream_s3_registry:register_name({StreamId, node()}, WriterPid),
+
+    %% Sync at seq=0, epoch=1.
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 0, 1, Manifest0),
+
+    %% Edit seq=1 applies.
+    Edit1 = append_edit(Manifest0, 50, 1000, 51, 2000, 42),
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, [Edit1], 1, 1),
+
+    %% Re-sync at seq=10, epoch=2 (new writer after election).
+    {ManifestNew, _} = build_manifest([
+        {fragment, #{offset => 0, size => 5000}},
+        {fragment, #{offset => 100, size => 6000}}
+    ]),
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 10, 2, ManifestNew),
+
+    %% Stale edit from old epoch (seq=2, epoch=1) arrives after re-sync.
+    %% Should be rejected (gap/epoch mismatch).
+    StaleEdit = append_edit(Manifest0, 100, 1000, 101, 3000, 43),
+    {error, gap} = rabbitmq_stream_s3_manifest_replica:apply_edits(
+        StreamId, [StaleEdit], 2, 1
+    ),
+    receive
+        {resync_received, _} -> ok
+    after 1000 -> ct:fail("no resync")
+    end,
+
+    %% Manifest unchanged (stale edit was ignored).
+    ?assertEqual(ManifestNew, rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId)),
+
+    rabbitmq_stream_s3_registry:unregister_name({StreamId, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill).
+
+retention_and_append_in_same_broadcast(_Config) ->
+    StreamId = <<"stream-mixed">>,
+    {Manifest0, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000, uid => 1}},
+        {fragment, #{offset => 50, size => 2000, uid => 2}},
+        {fragment, #{offset => 100, size => 3000, uid => 3}}
+    ]),
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 0, 1, Manifest0),
+
+    %% A single broadcast containing: append (new fragment) then retention (remove first).
+    AppendEdit = #edit{
+        first_offset = 0,
+        first_timestamp = Manifest0#manifest.first_timestamp,
+        first_last_timestamp = Manifest0#manifest.first_last_timestamp,
+        next_offset = 201,
+        size = 4000,
+        entries = ?ENTRY(200, 2000, 2100, ?MANIFEST_KIND_FRAGMENT, 4000, 99),
+        pos = byte_size(Manifest0#manifest.entries),
+        len = 0
+    },
+    RetentionEdit = #edit{
+        first_offset = 50,
+        first_timestamp = 500,
+        first_last_timestamp = 510,
+        next_offset = undefined,
+        size = -1000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    %% Apply both edits in one sequenced call (append first, then retention).
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(
+        StreamId, [AppendEdit, RetentionEdit], 1, 1
+    ),
+
+    M = rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+    %% First offset advanced (retention removed offset 0 entry).
+    ?assertEqual(50, M#manifest.first_offset),
+    %% Next offset advanced (append added offset 200 entry).
+    ?assertEqual(201, M#manifest.next_offset),
+    %% 3 entries remain: offsets 50, 100, 200.
+    ?assertEqual(3 * ?ENTRY_B, byte_size(M#manifest.entries)),
+    %% Total size: original 6000 + 4000 (append) - 1000 (retention) = 9000.
+    ?assertEqual(9000, M#manifest.total_size).
+
 fake_writer(TestPid) ->
     receive
         {'$gen_cast', {resync, Node}} ->
             TestPid ! {resync_received, Node}
     end.
+
+fake_writer_loop(TestPid) ->
+    receive
+        {'$gen_cast', {resync, Node}} ->
+            TestPid ! {resync_received, Node},
+            fake_writer_loop(TestPid)
+    end.
+
+%% Build an append edit for a new fragment at Offset with given Size.
+append_edit(Manifest, Offset, Ts, NextOffset, Size, Uid) ->
+    LastTs = Ts + 100,
+    #edit{
+        first_offset = Manifest#manifest.first_offset,
+        first_timestamp = Manifest#manifest.first_timestamp,
+        first_last_timestamp = Manifest#manifest.first_last_timestamp,
+        next_offset = NextOffset,
+        size = Size,
+        entries = ?ENTRY(Offset, Ts, LastTs, ?MANIFEST_KIND_FRAGMENT, Size, Uid),
+        pos = byte_size(Manifest#manifest.entries),
+        len = 0
+    }.

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -72,6 +72,7 @@ groups() ->
             seed_log_uploads_deterministic,
             local_ahead_discards_manifest,
             stream_deletion_cleans_remote_tier,
+            stream_deletion_during_active_upload,
             discover_attaches_to_existing_writer,
             remote_retention_deletes_fragments,
             remote_retention_survives_multiple_persist_cycles,
@@ -429,6 +430,44 @@ stream_deletion_cleans_remote_tier(Config) ->
     ),
     osiris_log:delete_directory(WriterCfg),
     ?assertNot(filelib:is_dir(Dir)).
+
+stream_deletion_during_active_upload(Config) ->
+    StreamId = ?config(stream_id, Config),
+    WriterCfg = ?config(writer_cfg, Config),
+
+    %% Use a large fragment target so the replica reader accumulates data
+    %% but hasn't finished uploading when we kill the writer.
+    Writer = start_writer(Config, #{}, #{fragment_target_size => 100_000}),
+
+    %% Write enough data to trigger at least one fragment cut and have
+    %% the governor task in flight.
+    Record = binary:copy(<<"D">>, 500),
+    lists:foreach(
+        fun(_) ->
+            osiris_writer:write(Writer, Record),
+            flush_writer(Writer)
+        end,
+        lists:seq(1, 300)
+    ),
+
+    %% Verify the replica reader is alive and has work in progress.
+    ReaderPid = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ?assert(is_pid(ReaderPid)),
+    ReaderMon = monitor(process, ReaderPid),
+
+    %% Stop the writer while uploads may be in flight.
+    ok = osiris_writer:stop(WriterCfg),
+
+    %% The replica reader should terminate cleanly (normal exit).
+    receive
+        {'DOWN', ReaderMon, process, ReaderPid, Reason} ->
+            ?assertEqual(normal, Reason)
+    after 5000 ->
+        ct:fail("replica reader did not stop after writer down")
+    end,
+
+    %% Registry is cleaned up.
+    ?assertEqual(undefined, rabbitmq_stream_s3_registry:whereis_name({StreamId, node()})).
 
 discover_attaches_to_existing_writer(Config) ->
     StreamId = ?config(stream_id, Config),

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -78,6 +78,7 @@ groups() ->
             remote_retention_survives_multiple_persist_cycles,
             uploads_rebalance_into_group,
             remote_retention_deletes_within_group,
+            remote_retention_deletes_all_fragments,
             old_manifest_roots_deleted
         ]},
         {with_replica, [], [
@@ -657,6 +658,38 @@ remote_retention_deletes_within_group(Config) ->
     %% Range reflects the deletion.
     {FirstOffset, NextOffset} = get_range(Config),
     ?assertEqual(20, FirstOffset).
+
+remote_retention_deletes_all_fragments(Config) ->
+    %% 4 segments, each producing a fragment (600 bytes > 500 target).
+    %% Rebalance threshold = 4: all 4 fragments factored into a group.
+    %% The root then has exactly 1 group entry and 0 trailing fragments.
+    %% max_bytes = 1 forces retention to delete all fragments in the group,
+    %% removing the group entry and leaving the manifest empty.
+    %% The system must handle this gracefully: no crash, range becomes empty,
+    %% and the replica reader continues operating.
+    StreamId = ?config(stream_id, Config),
+    #{next_offset := NextOffset} = seed_log(Config, [
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]}
+    ]),
+    _Writer = start_writer(
+        Config,
+        #{retention => [{max_bytes, 1}]},
+        #{fragment_target_size => 500, rebalance_threshold => 4}
+    ),
+    await_offset(Config, NextOffset),
+
+    %% Remote retention should delete all fragments and the group.
+    %% The range becomes empty (no remote data).
+    ?awaitMatch(empty, get_range(Config), 2000),
+
+    %% No fragment objects remain.
+    ?awaitMatch([], list_fragment_offsets(Config), 2000),
+
+    %% The replica reader is still alive.
+    ?assert(is_pid(rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}))).
 
 old_manifest_roots_deleted(Config) ->
     StreamId = ?config(stream_id, Config),

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -79,7 +79,8 @@ groups() ->
             uploads_rebalance_into_group,
             remote_retention_deletes_within_group,
             remote_retention_deletes_all_fragments,
-            old_manifest_roots_deleted
+            old_manifest_roots_deleted,
+            attach_to_stream_with_prior_retention
         ]},
         {with_replica, [], [
             replication_happy_path
@@ -716,6 +717,52 @@ old_manifest_roots_deleted(Config) ->
         end,
         2000
     ).
+
+attach_to_stream_with_prior_retention(Config) ->
+    %% Simulates enabling the plugin on a stream that has already undergone
+    %% local retention. Start a writer without hooks, write enough to trigger
+    %% retention, then restart with hooks enabled.
+    WriterCfg0 = ?config(writer_cfg, Config),
+
+    %% Phase 1: writer without plugin hooks, small segments, tight retention.
+    WriterCfg1 = maps:merge(WriterCfg0, #{
+        max_segment_size_bytes => 500,
+        retention => [{max_bytes, 1000}],
+        log_hooks => undefined
+    }),
+    {ok, Writer1} = osiris_writer:start(WriterCfg1),
+    Record = binary:copy(<<"R">>, 300),
+    lists:foreach(
+        fun(_) ->
+            osiris_writer:write(Writer1, Record),
+            flush_writer(Writer1)
+        end,
+        lists:seq(1, 20)
+    ),
+    %% Wait for retention to delete old segments.
+    ?awaitMatch(
+        [First | _] when First > 0,
+        list_segment_offsets(Config),
+        1000
+    ),
+    ok = osiris_writer:stop(WriterCfg1),
+
+    %% Phase 2: restart with plugin hooks. The replica reader discovers the
+    %% log starts at a non-zero offset and uploads from there.
+    _Writer2 = start_writer(
+        Config,
+        #{max_segment_size_bytes => 500},
+        #{fragment_target_size => 500}
+    ),
+    %% await_offset(20) ensures the replica reader has uploaded ALL remaining
+    %% data (20 records were written in phase 1).
+    await_offset(Config, 20),
+
+    %% The manifest's first_offset must be > 0, proving the plugin started
+    %% at the local log's non-zero first offset rather than offset 0.
+    {FirstOffset, NextOffset} = get_range(Config),
+    ?assert(FirstOffset > 0),
+    ?assertEqual(20, NextOffset).
 
 replication_happy_path(Config) ->
     StreamId = ?config(stream_id, Config),

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -69,7 +69,9 @@ all() ->
         fatal_front_drains_buffered_completions,
         await_offset_satisfied_during_cascading_persist,
         tick_fires_at_exact_interval_boundary,
-        retention_and_rebalance_same_persist_cycle
+        retention_and_rebalance_same_persist_cycle,
+        retention_deletes_all_entries,
+        new_fragment_after_empty_manifest
     ].
 
 init_per_suite(Config) -> Config.
@@ -1103,6 +1105,54 @@ retention_and_rebalance_same_persist_cycle(_Config) ->
     To = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S7),
     [Edits] = [Es || {broadcast, _, Es} <- Effects],
     assert_edits_reproduce_manifest(From, To, Edits).
+
+retention_deletes_all_entries(_Config) ->
+    %% Retention removes all entries. Manifest becomes empty.
+    {S0, _} = init_core(#{persist_threshold => 100}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    %% Remove both entries.
+    RetEdit = #edit{
+        first_offset = 200,
+        first_timestamp = -1,
+        first_last_timestamp = -1,
+        next_offset = undefined,
+        size = -128_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = 2 * ?ENTRY_B
+    },
+    {S3, _Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S2),
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(S3),
+    ?assertEqual(<<>>, Manifest#manifest.entries),
+    ?assertEqual(200, Manifest#manifest.first_offset),
+    ?assertEqual(200, Manifest#manifest.next_offset).
+
+new_fragment_after_empty_manifest(_Config) ->
+    %% After retention empties the manifest, new fragments append correctly.
+    %% The first fragment sets first_offset (same as a fresh manifest).
+    {S0, _} = init_core(#{persist_threshold => 100}),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    RetEdit = #edit{
+        first_offset = 100,
+        first_timestamp = -1,
+        first_last_timestamp = -1,
+        next_offset = undefined,
+        size = -64_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S2, _} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S1),
+    %% Manifest is empty.
+    M1 = rabbitmq_stream_s3_replica_reader_core:manifest(S2),
+    ?assertEqual(<<>>, M1#manifest.entries),
+    %% New fragment appends successfully and sets first_offset.
+    S3 = cut_and_complete(S2, 200, 300, 1002),
+    M2 = rabbitmq_stream_s3_replica_reader_core:manifest(S3),
+    ?assertEqual(?ENTRY_B, byte_size(M2#manifest.entries)),
+    ?assertEqual(200, M2#manifest.first_offset),
+    ?assertEqual(300, M2#manifest.next_offset).
 
 %% ------------------------------------------------------------------
 %% Helpers

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -65,6 +65,7 @@ all() ->
         retention_failed_clears_flag,
         persist_failed_during_rebalance_retries_after,
         recursive_rebalance_three_levels_deep,
+        multiple_persist_conflicts_reinitialize,
         %% Edge cases
         fatal_front_drains_buffered_completions,
         await_offset_satisfied_during_cascading_persist,
@@ -1006,6 +1007,70 @@ retention_failed_clears_flag(_Config) ->
     {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
     Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertMatch([_], Persists).
+
+multiple_persist_conflicts_reinitialize(_Config) ->
+    %% 3 consecutive persist conflicts. Each triggers reinitialize.
+    %% After each reinit, the core is re-initialized with the "resolved"
+    %% manifest and continues operating normally. No leaked state.
+    Opts = #{persist_threshold => 1},
+    %% Cycle 1: cut, complete, persist fires, conflict.
+    {S0, _} = init_core(Opts),
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    {_S2, E1} = rabbitmq_stream_s3_replica_reader_core:persist_failed(conflict, S1),
+    ?assertEqual([reinitialize], E1),
+    %% Reinit with manifest at next_offset=100 (simulating resolved manifest).
+    Manifest1 = #manifest{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 99000,
+        next_offset = 100,
+        total_size = 64_000_000,
+        entries = ?ENTRY(0, 0, 99000, ?MANIFEST_KIND_FRAGMENT, 64_000_000, 1001)
+    },
+    {S3, _} = init_core_with_manifest(Manifest1, Opts),
+    %% Cycle 2: cut, complete, persist fires, conflict.
+    S4 = cut_and_complete(S3, 100, 200, 1002),
+    {_S5, E2} = rabbitmq_stream_s3_replica_reader_core:persist_failed(conflict, S4),
+    ?assertEqual([reinitialize], E2),
+    %% Reinit with manifest at next_offset=200.
+    Manifest2 = #manifest{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 199000,
+        next_offset = 200,
+        total_size = 128_000_000,
+        entries = <<
+            (Manifest1#manifest.entries)/binary,
+            (?ENTRY(100, 100000, 199000, ?MANIFEST_KIND_FRAGMENT, 64_000_000, 1002))/binary
+        >>
+    },
+    {S6, _} = init_core_with_manifest(Manifest2, Opts),
+    %% Cycle 3: same pattern.
+    S7 = cut_and_complete(S6, 200, 300, 1003),
+    {_S8, E3} = rabbitmq_stream_s3_replica_reader_core:persist_failed(conflict, S7),
+    ?assertEqual([reinitialize], E3),
+    %% Reinit and verify normal operation resumes.
+    Manifest3 = #manifest{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 299000,
+        next_offset = 300,
+        total_size = 192_000_000,
+        entries = <<
+            (Manifest2#manifest.entries)/binary,
+            (?ENTRY(200, 200000, 299000, ?MANIFEST_KIND_FRAGMENT, 64_000_000, 1003))/binary
+        >>
+    },
+    {S9, _} = init_core_with_manifest(Manifest3, Opts),
+    %% After 3 conflicts, the core operates normally.
+    S10 = cut_and_complete(S9, 300, 400, 1004),
+    %% Persist fires (threshold=1). Complete it successfully this time.
+    {S11, PEffects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S10),
+    ?assertMatch([_ | _], [E || {update_range, _, _} = E <- PEffects]),
+    ?assertMatch([_ | _], [E || {broadcast, _, _} = E <- PEffects]),
+    ?assertEqual(
+        400, (rabbitmq_stream_s3_replica_reader_core:persisted_manifest(S11))#manifest.next_offset
+    ).
 
 %% ------------------------------------------------------------------
 %% Edge case tests

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -63,6 +63,8 @@ all() ->
         retention_defers_persist,
         retention_edit_broadcast_on_persist_complete,
         retention_failed_clears_flag,
+        persist_failed_during_rebalance_retries_after,
+        recursive_rebalance_three_levels_deep,
         %% Edge cases
         fatal_front_drains_buffered_completions,
         await_offset_satisfied_during_cascading_persist,
@@ -776,6 +778,107 @@ group_upload_failed_fatal_abandons(_Config) ->
     Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertEqual([], UploadGroups),
     ?assertMatch([_], Persists).
+
+persist_failed_during_rebalance_retries_after(_Config) ->
+    %% Persist fires (threshold=2), then rebalance triggers (threshold=4).
+    %% Persist fails with a transient error while rebalance_in_flight = true.
+    %% The retry is blocked. After group_upload_complete, persist fires.
+    Threshold = 4,
+    {S0, _} = init_core(#{persist_threshold => 2, rebalance_threshold => Threshold}),
+    %% Apply 2 fragments → persist fires.
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    %% Persist is now in flight. Apply 2 more → rebalance triggers.
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    {S4, Ref4, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(300, 400), S3),
+    {S5, Effects5} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref4, 1004, S4),
+    %% Rebalance should have triggered.
+    ?assertMatch([_], [E || {upload_group, _, _, _, _, _} = E <- Effects5]),
+    %% Persist fails with transient error. Retry is blocked by rebalance.
+    {S6, FailEffects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(s3_error, S5),
+    %% Should get a timer (fallback) but no start_persist.
+    ?assertEqual([], [E || {start_persist, _, _, _, _, _} = E <- FailEffects]),
+    ?assertMatch([{start_persist_timer, _}], [E || {start_persist_timer, _} = E <- FailEffects]),
+    %% Tick is also blocked by rebalance_in_flight.
+    Now = erlang:system_time(millisecond) + 100000,
+    {S7, TickEffects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S6),
+    ?assertEqual([], TickEffects),
+    %% Group upload completes. Persist should now fire.
+    {_S8, CompleteEffects} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(
+        9999, S7
+    ),
+    ?assertMatch([_], [E || {start_persist, _, _, _, _, _} = E <- CompleteEffects]).
+
+recursive_rebalance_three_levels_deep(_Config) ->
+    %% Start with a manifest that has Threshold-1 kilo-group entries and
+    %% Threshold-1 group entries. Adding Threshold fragments triggers:
+    %% 1. fragments → group (brings group count to Threshold)
+    %% 2. groups → kilo-group (brings kilo-group count to Threshold)
+    %% 3. kilo-groups → mega-group
+    Threshold = 4,
+    %% Build Threshold-1 kilo-group entries.
+    KiloEntries = lists:foldl(
+        fun(I, Acc) ->
+            Offset = I * 1_000_000,
+            FTs = I * 100_000,
+            LTs = (I + 1) * 100_000,
+            Uid = 7000 + I,
+            E = ?ENTRY(Offset, FTs, LTs, ?MANIFEST_KIND_KILO_GROUP, 0, Uid),
+            <<Acc/binary, E/binary>>
+        end,
+        <<>>,
+        lists:seq(0, Threshold - 2)
+    ),
+    %% Then Threshold-1 group entries after the kilo-groups.
+    KiloEnd = (Threshold - 1) * 1_000_000,
+    GroupEntries = lists:foldl(
+        fun(I, Acc) ->
+            Offset = KiloEnd + I * 10_000,
+            FTs = (Threshold - 1) * 100_000 + I * 1000,
+            LTs = (Threshold - 1) * 100_000 + (I + 1) * 1000,
+            Uid = 8000 + I,
+            E = ?ENTRY(Offset, FTs, LTs, ?MANIFEST_KIND_GROUP, 0, Uid),
+            <<Acc/binary, E/binary>>
+        end,
+        <<>>,
+        lists:seq(0, Threshold - 2)
+    ),
+    AllEntries = <<KiloEntries/binary, GroupEntries/binary>>,
+    BaseOffset = KiloEnd + (Threshold - 1) * 10_000,
+    Manifest = #manifest{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 100_000,
+        next_offset = BaseOffset,
+        total_size = 0,
+        entries = AllEntries
+    },
+    {S0, _} = init_core_with_manifest(Manifest, #{
+        rebalance_threshold => Threshold, persist_threshold => 100
+    }),
+    %% Apply Threshold fragments → triggers fragments→group.
+    S1 = lists:foldl(
+        fun(I, Acc) ->
+            Offset = BaseOffset + I * 100,
+            cut_and_complete(Acc, Offset, Offset + 100, 3000 + I)
+        end,
+        S0,
+        lists:seq(0, Threshold - 1)
+    ),
+    %% Complete group upload (fragments→group). Now Threshold groups exist → kilo-group.
+    {S2, E1} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(8888, S1),
+    ?assertMatch([_], [E || {upload_group, _, ?MANIFEST_KIND_KILO_GROUP, _, _, _} = E <- E1]),
+    %% Complete kilo-group upload. Now Threshold kilo-groups exist → mega-group.
+    {S3, E2} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(7777, S2),
+    ?assertMatch([_], [E || {upload_group, _, ?MANIFEST_KIND_MEGA_GROUP, _, _, _} = E <- E2]),
+    %% Complete mega-group upload. No further rebalancing needed.
+    {S4, E3} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(6666, S3),
+    ?assertEqual([], [E || {upload_group, _, _, _, _, _} = E <- E3]),
+    %% Final manifest should have 1 mega-group entry.
+    M = rabbitmq_stream_s3_replica_reader_core:manifest(S4),
+    ?assertEqual(?ENTRY_B, byte_size(M#manifest.entries)),
+    <<_:64, _:64/signed, _:64/signed, Kind:8, _:40, _:32>> = M#manifest.entries,
+    ?assertEqual(?MANIFEST_KIND_MEGA_GROUP, Kind).
 
 %% ------------------------------------------------------------------
 %% Retention tests


### PR DESCRIPTION
Continued work towards #36.

This also hit on an inconsistency: it was possible (through a kind of convoluted setup) to end up with no fragments, but we also guarded against that elsewhere. Now the replica reader allows the remote tier to become empty if the configured retention policy can clean everything up. This should work gracefully for the local and remote tier.

Otherwise this PR is mostly focused on testing edge cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
