### PR TITLE
Split functional-core/imperative-shell for read path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include ../../erlang.mk
 # CT suites share a node name (erlang.mk limitation), so they cannot run in parallel.
 .NOTPARALLEL:
 
-CT_QUICK_SUITES = api_fs db replica_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica
+CT_QUICK_SUITES = api_fs db replica_reader_core remote_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica
 
 ERLFMT ?= erlfmt
 ERLFMT_FILES = src/*.erl test/*.erl

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,8 +163,8 @@ If the task crashes or S3 is unavailable, the orphan detection mechanism eventua
 When a consumer subscribes at an offset that no longer exists locally:
 
 1. `rabbitmq_stream_s3_log_reader` checks the manifest cache. If the offset is below the local range and within the manifest's range, it resolves the starting fragment.
-2. A `rabbitmq_stream_s3_remote_reader` process is spawned for the consumer. It prefetches fragment data from S3 using HTTP range requests.
-3. The remote reader uses the fragment iterator to navigate forward through the manifest tree without knowing its internal structure (groups, kilo-groups, etc.).
+2. A `rabbitmq_stream_s3_remote_reader` process is spawned for the consumer. It delegates all decisions (buffering, retry, fragment transitions) to `rabbitmq_stream_s3_remote_reader_core` and executes the resulting effects (S3 requests, timers, replies).
+3. The remote reader core uses the fragment iterator to navigate forward through the manifest tree without knowing its internal structure (groups, kilo-groups, etc.).
 4. When the consumer catches up to the local tier, the log reader transitions to local reads. The remote reader exits.
 
 If the remote reader encounters a 404 (fragment deleted by retention between iterator creation and fetch), it refreshes the iterator from the manifest cache and repositions at the oldest available offset.

--- a/docs/read-path.md
+++ b/docs/read-path.md
@@ -39,7 +39,7 @@ When resolution points to the remote tier, the log reader:
 
 1. Finds the fragment containing the target offset by binary-searching the manifest entries.
 2. Constructs a `#remote_location{}` containing the fragment ref, byte position within the fragment, and a fragment iterator positioned at the current entry.
-3. Spawns a `rabbitmq_stream_s3_remote_reader` gen_server linked to the caller.
+3. Spawns a `rabbitmq_stream_s3_remote_reader` gen_server (unlinked; the remote reader monitors the caller and stops when it exits).
 4. Returns the reader state in remote mode.
 
 Subsequent reads (`send_file/3`, `chunk_iterator/3`) are forwarded to the remote reader process.

--- a/docs/read-path.md
+++ b/docs/read-path.md
@@ -46,12 +46,13 @@ Subsequent reads (`send_file/3`, `chunk_iterator/3`) are forwarded to the remote
 
 ## Remote reader
 
-The remote reader (`rabbitmq_stream_s3_remote_reader`) is a per-consumer gen_server that prefetches fragment data from S3. It manages:
+The remote reader is split into a functional core and a gen_server shell, following the same pattern as the upload path (`replica_reader` / `replica_reader_core`).
 
-- The current fragment (downloading via HTTP range requests).
-- The next fragment (prefetched in the background for seamless transitions).
-- A read buffer for the current position.
-- The fragment iterator for forward navigation.
+**`rabbitmq_stream_s3_remote_reader_core`** is a pure module containing all decision logic: buffer management, AIMD prefetch sizing, fragment transitions, retry/timeout decisions, and error classification. It receives events and returns a new state plus a list of effects. It never performs I/O.
+
+**`rabbitmq_stream_s3_remote_reader`** is the gen_server shell. It translates external events (gun HTTP messages, timer fires, gen_server calls from the log reader) into core events, feeds them to the core, and executes the resulting effects (start S3 requests, set timers, reply to callers, look up the manifest cache).
+
+Effects that require local data (manifest range lookups, iterator refreshes) are resolved synchronously in the shell's effect-execution loop and fed back to the core immediately. This avoids extra async round-trips for what are fast ETS lookups.
 
 ### Prefetch
 

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -28,7 +28,8 @@ synchronous feedback is generated.
 -behaviour(gen_server).
 
 -record(cfg, {
-    request_timeout_ms :: pos_integer()
+    request_timeout_ms :: pos_integer(),
+    pending_read_deadline_ms :: pos_integer()
 }).
 
 -define(C_BUFFER_HIT, 1).
@@ -76,6 +77,8 @@ synchronous feedback is generated.
     %% Pending caller (at most one).
     from :: gen_server:from() | undefined,
     since :: integer() | undefined,
+    %% Timer that fires deadline_expired if the pending read is not served in time.
+    deadline_timer :: reference() | undefined,
     %% Maps fragment_offset -> {async_req, async_state}
     requests = #{} :: #{
         osiris:offset() => {
@@ -176,16 +179,20 @@ init(
     {ok, State}.
 
 handle_call(
-    #read{offset = Offset, bytes = Bytes, hint = Hint}, From, #state{core = Core0} = State0
+    #read{offset = Offset, bytes = Bytes, hint = Hint},
+    From,
+    #state{cfg = #cfg{pending_read_deadline_ms = Deadline}, core = Core0} = State0
 ) ->
     ?assertEqual(undefined, State0#state.from),
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
         Core0, {read, Offset, Bytes, Hint}
     ),
+    Timer = erlang:send_after(Deadline, self(), deadline_expired),
     State1 = State0#state{
         core = Core1,
         from = From,
-        since = erlang:monotonic_time()
+        since = erlang:monotonic_time(),
+        deadline_timer = Timer
     },
     State = execute_effects(Effects, State1),
     maybe_stop(State);
@@ -200,6 +207,27 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{reader_ref = MRef} = 
 handle_info(retry_requests, #state{core = Core0} = State0) ->
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, retry),
     State = execute_effects(Effects, State0#state{core = Core1}),
+    maybe_stop(State);
+handle_info(deadline_expired, #state{from = undefined} = State) ->
+    %% Timer fired after the read was already served. Ignore.
+    {noreply, State};
+handle_info(
+    deadline_expired, #state{core = Core0, requests = Requests, cancelled = Cancelled0} = State0
+) ->
+    %% Cancel in-flight S3 requests so they don't feed stale data into the
+    %% reset buffer after the core clears it.
+    maps:foreach(
+        fun(_FragOff, {ReqId, AsyncState}) ->
+            rabbitmq_stream_s3_api:cancel_async(ReqId, AsyncState)
+        end,
+        Requests
+    ),
+    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, map_size(Requests)),
+    NewCancelled = maps:merge(Cancelled0, #{ReqId => ok || _ := {ReqId, _} <- Requests}),
+    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, deadline_expired),
+    State = execute_effects(Effects, State0#state{
+        core = Core1, requests = #{}, cancelled = NewCancelled, deadline_timer = undefined
+    }),
     maybe_stop(State);
 handle_info(Msg, #state{requests = Requests0, cancelled = Cancelled0} = State0) ->
     AsyncStates = #{Req => AsyncState || _ := {Req, AsyncState} <- Requests0},
@@ -317,14 +345,17 @@ execute_effects([Effect | Rest], State0) ->
     State = execute_effect(Effect, State0),
     execute_effects(Rest, State).
 
-execute_effect({reply, Result}, #state{from = From, since = Since} = State) when
+execute_effect(
+    {reply, Result}, #state{from = From, since = Since, deadline_timer = Timer} = State
+) when
     From =/= undefined
 ->
     Duration = rabbitmq_stream_s3_util:elapsed_ms(Since),
     counters:add(counter(), ?C_AWAIT_DURATION_MS, Duration),
     counters:add(counter(), ?C_AWAIT, 1),
+    cancel_deadline_timer(Timer),
     gen_server:reply(From, Result),
-    State#state{from = undefined, since = undefined};
+    State#state{from = undefined, since = undefined, deadline_timer = undefined};
 execute_effect({reply, _Result}, State) ->
     %% No pending caller (e.g. reply generated during init before any call).
     State;
@@ -438,8 +469,15 @@ maybe_stop(State) ->
 
 build_cfg(Opts) ->
     #cfg{
-        request_timeout_ms = maps:get(request_timeout_ms, Opts, 30_000)
+        request_timeout_ms = maps:get(request_timeout_ms, Opts, 30_000),
+        pending_read_deadline_ms = maps:get(pending_read_deadline_ms, Opts, 50_000)
     }.
+
+cancel_deadline_timer(undefined) ->
+    ok;
+cancel_deadline_timer(Timer) ->
+    _ = erlang:cancel_timer(Timer, [{async, true}, {info, false}]),
+    ok.
 
 counter() ->
     persistent_term:get(?COUNTER_KEY).

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -5,12 +5,18 @@
 -moduledoc """
 A gen_server process which reads stream data from the remote tier.
 
-Reads from the remote tier suffer from high latency, so this server pre-fetches
-stream data aggressively. The pre-fetch amount is adjusted dynamically based on
-the log reader's demand and S3's supply following a basic additive increase /
-multiplicative decrease ([AIMD]) algorithm.
+This process bridges async S3 responses and the synchronous log reader.
+All decision logic (buffering, retry, fragment transitions, AIMD) lives in
+`rabbitmq_stream_s3_remote_reader_core`. This module translates external events (gun
+messages, timer fires, gen_server calls) into core events, feeds them to the
+core, and executes the resulting effects.
 
-[AIMD]: https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
+## Effect execution
+
+Effects returned by the core are executed in a loop. Some effects produce
+immediate results that feed back into the core (e.g. `lookup_manifest_range`
+resolves from the local manifest cache). The loop continues until no more
+synchronous feedback is generated.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -21,22 +27,9 @@ multiplicative decrease ([AIMD]) algorithm.
 
 -behaviour(gen_server).
 
-%% 1 MiB
--define(MIN_READ_SIZE, 1048576).
-%% 64 MiB
--define(MAX_READ_SIZE, 67108864).
-%% 4 MiB
--define(INITIAL_READ_SIZE, 4194304).
-%% Number of consecutive buffer hits before we increase read_size.
--define(HITS_TO_GROW, 8).
-%% Additive increase step size (1 MiB in bytes).
--define(GROW_STEP, 1048576).
--define(MIN_RETRY_DELAY_MS, 1_000).
--define(MAX_RETRY_DELAY_MS, 30_000).
-%% Cancel and retry an in-flight S3 request if no response arrives within
-%% this window. Must be less than ?GEN_SERVER_CALL_TIMEOUT (60s) to allow
-%% recovery before the caller times out.
--define(REQUEST_TIMEOUT_MS, 30_000).
+-record(cfg, {
+    request_timeout_ms :: pos_integer()
+}).
 
 -define(C_BUFFER_HIT, 1).
 -define(C_BUFFER_MISS, 2).
@@ -47,6 +40,7 @@ multiplicative decrease ([AIMD]) algorithm.
 -define(C_READ_DURATION_MS, 7).
 -define(C_READ, 8).
 -define(C_TOTAL_REQUESTS, 9).
+-define(COUNTER_KEY, {rabbitmq_stream_s3_remote_reader, counter}).
 -define(COUNTERS, [
     {buffer_hit, ?C_BUFFER_HIT, counter, "Number of reads served from the buffer"},
     {buffer_miss, ?C_BUFFER_MISS, counter, "Number of reads that had to await async data"},
@@ -60,108 +54,61 @@ multiplicative decrease ([AIMD]) algorithm.
     {read, ?C_READ, counter, "Number of read/4,5 calls"},
     {remote_reader_total_requests, ?C_TOTAL_REQUESTS, counter, "Number of S3 requests initiated"}
 ]).
-
-%% API
--record(read, {
-    offset :: byte_offset(),
-    bytes :: pos_integer(),
-    %% NOTE: unused since we reliably track fragment data size now.
-    hint :: hint()
-}).
-
-%% A read request from read/4 or read/5 which could not be served immediately
-%% from a pre-fetched buffer.
--record(pending_read, {
-    read :: #read{},
-    from :: gen_server:from(),
-    %% erlang:monotonic_time/0 since the read started
-    since :: integer()
-}).
-
-%% A request to the remote tier which is running in the background.
--record(request, {
-    fragment :: osiris:offset(),
-    %% In the future we could make parallel requests within the same fragment,
-    %% so we may need to track the byte range. This is unused currently.
-    range :: {byte_offset(), byte_offset()},
-    state :: rabbitmq_stream_s3_api:async_state()
-}).
-
--record(?MODULE, {
-    stream :: stream_id(),
-    read_size :: pos_integer(),
-    read_size_min :: pos_integer(),
-    read_size_max :: pos_integer(),
-    %% Consecutive buffer hits since the last miss. Used for AIMD.
-    hits_since_last_miss = 0 :: non_neg_integer(),
-    %% Current retry delay in milliseconds. Doubles on each retry, resets on
-    %% successful data arrival.
-    retry_delay = ?MIN_RETRY_DELAY_MS :: pos_integer(),
-    reader_ref :: reference(),
-
-    %% Current fragment state.
-    fragment_ref :: #fragment_ref{},
-    key :: rabbitmq_stream_s3:key(),
-    buffer = <<>> :: binary(),
-    start_pos :: byte_offset(),
-    current_pos :: byte_offset(),
-    end_pos :: byte_offset(),
-
-    %% Next fragment state (pre-fetched).
-    next :: {#fragment_ref{}, binary()} | undefined | not_found,
-
-    %% Fragment iterator for forward navigation.
-    iterator :: rabbitmq_stream_s3_fragment_iterator:iterator(),
-
-    %% All in-flight requests, keyed by async_req().
-    requests = #{} :: #{rabbitmq_stream_s3_api:async_req() => #request{}},
-
-    %% Refs of requests cancelled via cancel_requests/1. Gun may still deliver
-    %% already-buffered frames for these refs after the cancel; tracking them
-    %% here lets match_async/3 drop those messages silently without flooding
-    %% the mailbox through the `error` branch.
-    cancelled_requests = #{} :: #{rabbitmq_stream_s3_api:async_req() => ok},
-
-    %% Pending read from the log reader process.
-    pending_read :: #pending_read{} | undefined,
-    current_not_found = false :: boolean()
-}).
-
--type config() :: #{
-    reader := pid(),
-    stream := stream_id(),
-    location := #remote_location{}
-}.
-
--type hint() :: chunk_boundary | within_chunk.
-
--export_type([config/0, hint/0]).
-
--define(COUNTER_KEY, {?MODULE, counter}).
 -define(READ_SIZE_BUCKETS, [
     48, 128, 512, 2_048, 8_192, 32_768, 131_072, 524_288, 2_097_152, 8_388_608, infinity
 ]).
 
--export([init_counters/0, read_size_prometheus_format/0]).
+-type hint() :: chunk_boundary | within_chunk.
+-export_type([hint/0]).
+
+%% A read request from the log reader.
+-record(read, {
+    offset :: byte_offset(),
+    bytes :: pos_integer(),
+    hint :: hint()
+}).
+
+-record(state, {
+    stream :: stream_id(),
+    cfg :: #cfg{},
+    core :: rabbitmq_stream_s3_remote_reader_core:state(),
+    reader_ref :: reference(),
+    %% Pending caller (at most one).
+    from :: gen_server:from() | undefined,
+    since :: integer() | undefined,
+    %% Maps fragment_offset -> {async_req, async_state}
+    requests = #{} :: #{
+        osiris:offset() => {
+            rabbitmq_stream_s3_api:async_req(), rabbitmq_stream_s3_api:async_state()
+        }
+    },
+    %% Cancelled request refs (gun may still deliver frames).
+    cancelled = #{} :: #{rabbitmq_stream_s3_api:async_req() => ok},
+    %% Set to true when the core emits `stop`.
+    stopping = false :: boolean()
+}).
 
 %% API
 -export([
+    start_link/1,
     read/4,
-    read/5
+    read/5,
+    init_counters/0,
+    read_size_prometheus_format/0
 ]).
 
 %% gen_server
 -export([
-    start_link/1,
     init/1,
     handle_call/3,
     handle_cast/2,
     handle_info/2,
     terminate/2,
-    format_status/1,
-    code_change/3
+    format_status/1
 ]).
 
+%%----------------------------------------------------------------------------
+%% API
 %%----------------------------------------------------------------------------
 
 -spec init_counters() -> ok.
@@ -170,744 +117,6 @@ init_counters() ->
     persistent_term:put(?COUNTER_KEY, Cnt),
     rabbitmq_stream_s3_histogram:new(?MODULE, ?READ_SIZE_BUCKETS),
     ok.
-
--spec read(pid(), byte_offset(), pos_integer(), hint()) ->
-    {ok, binary()}
-    | {next_fragment, osiris:offset()}
-    | {become_local, osiris:offset()}
-    | end_of_stream.
-read(Server, Offset, Bytes, Hint) ->
-    read(Server, Offset, Bytes, Hint, ?GEN_SERVER_CALL_TIMEOUT).
-
--spec read(pid(), byte_offset(), pos_integer(), hint(), timeout()) ->
-    {ok, binary()}
-    | {next_fragment, osiris:offset()}
-    | {become_local, osiris:offset()}
-    | end_of_stream.
-read(Server, Offset, Bytes, Hint, Timeout) ->
-    T0 = erlang:monotonic_time(),
-    Result = gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout),
-    Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
-    counters:add(counter(), ?C_READ_DURATION_MS, Duration),
-    counters:add(counter(), ?C_READ, 1),
-    Result.
-
-%%----------------------------------------------------------------------------
-
-start_link(Config) ->
-    gen_server:start_link(?MODULE, Config, []).
-
--spec init(config()) -> {ok, #?MODULE{}}.
-init(#{
-    reader := Reader,
-    stream := StreamId,
-    location := #remote_location{
-        position = Pos,
-        fragment_ref = #fragment_ref{offset = Fragment, uid = Uid} = FragRef,
-        iterator = Iterator
-    }
-}) ->
-    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
-    Key = rabbitmq_stream_s3:fragment_key(StreamId, Fragment, Uid),
-    State0 = #?MODULE{
-        stream = StreamId,
-        read_size = ?INITIAL_READ_SIZE,
-        read_size_min = ?MIN_READ_SIZE,
-        read_size_max = ?MAX_READ_SIZE,
-        reader_ref = erlang:monitor(process, Reader),
-        start_pos = Pos,
-        current_pos = Pos,
-        end_pos = Pos,
-        fragment_ref = FragRef,
-        key = Key,
-        iterator = Iterator
-    },
-    State = maybe_start_request(State0),
-    {ok, State}.
-
-handle_call(#read{} = Read, From, State0) ->
-    %% This server is only used by the reader, so having two calls in-flight is
-    %% impossible.
-    ?assertEqual(undefined, State0#?MODULE.pending_read),
-    case maybe_reply(Read, State0) of
-        {noreply, State1} ->
-            State = State1#?MODULE{
-                pending_read = #pending_read{
-                    read = Read,
-                    from = From,
-                    since = erlang:monotonic_time()
-                }
-            },
-            {noreply, State};
-        {retry, State1} ->
-            erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
-            State = State1#?MODULE{
-                pending_read = #pending_read{
-                    read = Read,
-                    from = From,
-                    since = erlang:monotonic_time()
-                }
-            },
-            {noreply, State};
-        Reply ->
-            Reply
-    end;
-handle_call(Request, From, State) ->
-    {stop, {unknown_call, From, Request}, State}.
-
-handle_cast(Message, State) ->
-    ?LOG_DEBUG(?MODULE_STRING " received unexpected cast: ~W", [Message, 10]),
-    {noreply, State}.
-
-handle_info({'DOWN', MRef, process, _Pid, _Reason}, #?MODULE{reader_ref = MRef} = State) ->
-    {stop, normal, State};
-handle_info(retry_requests, State0) ->
-    State = maybe_start_request(State0),
-    maybe_reply_pending(State);
-handle_info(
-    Msg,
-    #?MODULE{
-        requests = Requests0,
-        cancelled_requests = CancelledRequests0,
-        retry_delay = RetryDelay0
-    } = State0
-) ->
-    AsyncStates = #{Req => R#request.state || Req := R <- Requests0},
-    case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates, CancelledRequests0) of
-        {ok, RequestId} ->
-            #request{state = ReqState0} = Req0 = maps:get(RequestId, Requests0),
-            case rabbitmq_stream_s3_api:handle_async(Msg, RequestId, ReqState0) of
-                ignore ->
-                    {noreply, State0};
-                {continue, ReqState} ->
-                    Requests = Requests0#{RequestId := Req0#request{state = ReqState}},
-                    {noreply, State0#?MODULE{requests = Requests}};
-                {data, Data, Result} ->
-                    Requests =
-                        case Result of
-                            done ->
-                                counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-                                maps:remove(RequestId, Requests0);
-                            ReqState ->
-                                Requests0#{RequestId := Req0#request{state = ReqState}}
-                        end,
-                    State1 = State0#?MODULE{
-                        requests = Requests,
-                        retry_delay = ?MIN_RETRY_DELAY_MS
-                    },
-                    State2 = add_data(Data, Req0, State1),
-                    State3 = maybe_start_request(State2),
-                    maybe_reply_pending(State3);
-                {done, ok} ->
-                    %% A 200 with no body on a range GET is abnormal.
-                    %% Retry the request.
-                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-                    ?LOG_WARNING("Received empty response for ~ts", [Req0#request.fragment]),
-                    State1 = State0#?MODULE{requests = maps:remove(RequestId, Requests0)},
-                    State2 = maybe_start_request(State1),
-                    maybe_reply_pending(State2);
-                {done, {error, Reason}} ->
-                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-                    Requests = maps:remove(RequestId, Requests0),
-                    State1 = State0#?MODULE{requests = Requests},
-                    handle_request_error(Reason, Req0, RetryDelay0, State1);
-                {done_cancel, {error, Reason}} ->
-                    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-                    Requests = maps:remove(RequestId, Requests0),
-                    CancelledRequests = CancelledRequests0#{RequestId => ok},
-                    State1 = State0#?MODULE{
-                        requests = Requests,
-                        cancelled_requests = CancelledRequests
-                    },
-                    handle_request_error(Reason, Req0, RetryDelay0, State1)
-            end;
-        {cancelled, Ref, Final} ->
-            %% Stale message for a request that called gun:cancel (e.g.
-            %% after a timeout). Drop silently and remove the ref once
-            %% its terminal frame arrives.
-            CancelledRequests =
-                case Final of
-                    final -> maps:remove(Ref, CancelledRequests0);
-                    more -> CancelledRequests0
-                end,
-            {noreply, State0#?MODULE{cancelled_requests = CancelledRequests}};
-        error ->
-            ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
-            {noreply, State0}
-    end;
-handle_info(Msg, State) ->
-    ?LOG_DEBUG(?MODULE_STRING " received unexpected message: ~W", [Msg, 10]),
-    {noreply, State}.
-
-handle_request_error(Reason, Req0, RetryDelay0, State) ->
-    case {Reason, Req0#request.fragment =:= (State#?MODULE.fragment_ref)#fragment_ref.offset} of
-        {not_found, true} ->
-            maybe_reply_pending(State#?MODULE{
-                current_not_found = true,
-                retry_delay = ?MIN_RETRY_DELAY_MS
-            });
-        {not_found, false} ->
-            maybe_reply_pending(State#?MODULE{
-                next = not_found,
-                retry_delay = ?MIN_RETRY_DELAY_MS
-            });
-        {Transient, _} when
-            Transient =:= slow_down;
-            Transient =:= internal_error
-        ->
-            erlang:send_after(RetryDelay0, self(), retry_requests),
-            RetryDelay = min(RetryDelay0 * 2, ?MAX_RETRY_DELAY_MS),
-            State1 = State#?MODULE{retry_delay = RetryDelay},
-            maybe_reply_pending(State1);
-        {Transient, _} when
-            Transient =:= stream_error;
-            Transient =:= connection_error;
-            Transient =:= timeout
-        ->
-            maybe_reply_pending(State);
-        _ ->
-            {stop, {shutdown, Reason}, State}
-    end.
-
-terminate(_Reason, #?MODULE{requests = Requests}) ->
-    cancel_requests(Requests),
-    ok.
-
-format_status(#{state := #?MODULE{} = State} = Status0) ->
-    Status0#{state := format_state(State)}.
-
-code_change(_, _, State) ->
-    {ok, State}.
-
-%%---------------------------------------------------------------------------
-
-maybe_start_request(
-    #?MODULE{
-        read_size = ReadSize,
-        end_pos = EndPos,
-        current_pos = CurrentPos
-    } = State
-) when EndPos - CurrentPos > ReadSize ->
-    %% The buffer has enough data. Check if we should pre-fetch the next fragment.
-    maybe_start_next_request(State);
-maybe_start_request(#?MODULE{} = State) ->
-    State1 = maybe_start_current_request(State),
-    maybe_start_next_request(State1).
-
-maybe_start_current_request(
-    #?MODULE{
-        read_size = ReadSize,
-        fragment_ref = #fragment_ref{offset = Fragment, size = FragSize},
-        end_pos = EndPos,
-        key = CurrentKey,
-        requests = Requests0
-    } = State0
-) ->
-    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
-    case EndPos < IdxStartPos of
-        true ->
-            case has_request_for(Fragment, Requests0) of
-                true ->
-                    State0;
-                false ->
-                    Range = {EndPos, min(EndPos + ReadSize, IdxStartPos - 1)},
-                    start_request(CurrentKey, Range, Fragment, State0)
-            end;
-        false ->
-            State0
-    end.
-
-maybe_start_next_request(
-    #?MODULE{
-        stream = StreamId,
-        read_size = ReadSize,
-        fragment_ref = #fragment_ref{size = FragSize},
-        end_pos = EndPos,
-        next = undefined,
-        iterator = Iterator,
-        requests = Requests0
-    } = State0
-) when EndPos >= ?SEGMENT_HEADER_B + FragSize ->
-    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-        {ok, #fragment_ref{offset = NextOffset, uid = NextUid}, _Iterator1} ->
-            case has_request_for(NextOffset, Requests0) of
-                true ->
-                    State0;
-                false ->
-                    Key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset, NextUid),
-                    Range = {?SEGMENT_HEADER_B, ?SEGMENT_HEADER_B + ReadSize},
-                    start_request(Key, Range, NextOffset, State0)
-            end;
-        _ ->
-            State0
-    end;
-maybe_start_next_request(State) ->
-    State.
-
-has_request_for(Fragment, Requests) ->
-    maps:fold(
-        fun(_, #request{fragment = F}, Acc) -> Acc orelse F =:= Fragment end,
-        false,
-        Requests
-    ).
-
-start_request(Key, Range, Fragment, #?MODULE{requests = Requests0} = State0) ->
-    case rabbitmq_stream_s3_api:get_range_async(Key, Range, #{timeout => ?REQUEST_TIMEOUT_MS}) of
-        {ok, RequestId, AsyncState} ->
-            Request = #request{
-                fragment = Fragment,
-                range = Range,
-                state = AsyncState
-            },
-            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
-            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
-            State0#?MODULE{requests = Requests0#{RequestId => Request}};
-        {error, pool_busy} ->
-            State0
-    end.
-
-add_data(
-    Data,
-    #request{fragment = Fragment},
-    #?MODULE{fragment_ref = #fragment_ref{offset = Fragment}} = State
-) ->
-    add_data_current(Data, State);
-add_data(Data, #request{} = Req, #?MODULE{} = State) ->
-    add_data_next(Data, Req, State).
-
-add_data_current(
-    Data,
-    #?MODULE{
-        start_pos = StartPos0,
-        current_pos = CurrentPos,
-        end_pos = EndPos0,
-        buffer = Buffer0
-    } = State0
-) ->
-    Buffer =
-        case CurrentPos =:= StartPos0 of
-            true ->
-                <<Buffer0/binary, Data/binary>>;
-            false ->
-                <<
-                    (binary:part(Buffer0, CurrentPos - StartPos0, EndPos0 - CurrentPos))/binary,
-                    Data/binary
-                >>
-        end,
-    State0#?MODULE{
-        start_pos = CurrentPos,
-        end_pos = EndPos0 + byte_size(Data),
-        buffer = Buffer
-    }.
-
-add_data_next(
-    Data, #request{fragment = NextOffset}, #?MODULE{next = Next0, iterator = Iterator} = State0
-) ->
-    Next =
-        case Next0 of
-            undefined ->
-                %% First data for the next fragment. Look up its metadata from the iterator.
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                    {ok, #fragment_ref{offset = NextOffset} = FragRef, _} ->
-                        {FragRef, Data};
-                    _ ->
-                        {#fragment_ref{offset = NextOffset, uid = 0, size = 0}, Data}
-                end;
-            {#fragment_ref{offset = NextOffset} = FragRef, Buffer0} ->
-                {FragRef, <<Buffer0/binary, Data/binary>>}
-        end,
-    State0#?MODULE{next = Next}.
-
-maybe_reply_pending(#?MODULE{pending_read = undefined} = State) ->
-    {noreply, State};
-maybe_reply_pending(
-    #?MODULE{
-        pending_read = #pending_read{
-            read = #read{} = Read,
-            from = From,
-            since = Since
-        }
-    } = State0
-) ->
-    case maybe_reply(Read, State0) of
-        {reply, Reply, State1} ->
-            Duration = rabbitmq_stream_s3_util:elapsed_ms(Since),
-            counters:add(counter(), ?C_AWAIT_DURATION_MS, Duration),
-            counters:add(counter(), ?C_AWAIT, 1),
-            gen_server:reply(From, Reply),
-            State = State1#?MODULE{pending_read = undefined},
-            {noreply, State};
-        {stop, Reason, Reply, State1} ->
-            gen_server:reply(From, Reply),
-            State = State1#?MODULE{pending_read = undefined},
-            {stop, Reason, State};
-        {retry, State} ->
-            %% No in-flight requests - the pool was busy when maybe_start_request
-            %% was called. Schedule a retry so the read does not stall forever.
-            erlang:send_after(?MIN_RETRY_DELAY_MS, self(), retry_requests),
-            {noreply, State};
-        {noreply, _} = NoReply ->
-            NoReply
-    end.
-
-maybe_reply(#read{offset = Offset, bytes = Bytes, hint = _Hint}, #?MODULE{} = State0) ->
-    case try_read(State0, Offset, Bytes) of
-        {ok, State1, Data} ->
-            rabbitmq_stream_s3_histogram:observe(?MODULE, byte_size(Data)),
-            counters:add(counter(), ?C_BUFFER_HIT, 1),
-            State2 = adjust_read_size(hit, State1),
-            State = maybe_start_request(State2),
-            {reply, {ok, Data}, State};
-        {next_fragment, State1, NextOffset} ->
-            counters:add(counter(), ?C_FRAGMENT_TRANSITION, 1),
-            State = maybe_start_request(State1),
-            {reply, {next_fragment, NextOffset}, State};
-        {become_local, #?MODULE{fragment_ref = #fragment_ref{offset = Off}} = State} ->
-            {stop, normal, {become_local, Off}, State};
-        {end_of_stream, State} ->
-            {reply, end_of_stream, State};
-        {await, State1} ->
-            counters:add(counter(), ?C_BUFFER_MISS, 1),
-            State2 = adjust_read_size(miss, State1),
-            State = maybe_start_request(State2),
-            case State of
-                #?MODULE{requests = Requests} when map_size(Requests) =:= 0 ->
-                    {retry, State};
-                _ ->
-                    {noreply, State}
-            end
-    end.
-
-%% AIMD read-ahead adjustment.
-%% On miss: multiplicative decrease (halve), reset hit counter.
-%% On hit: after HITS_TO_GROW consecutive hits, additive increase by GROW_STEP.
-adjust_read_size(miss, #?MODULE{read_size = Current, read_size_min = Min} = State) ->
-    State#?MODULE{
-        read_size = max(Min, Current div 2),
-        hits_since_last_miss = 0
-    };
-adjust_read_size(hit, #?MODULE{hits_since_last_miss = Hits} = State) when
-    Hits + 1 < ?HITS_TO_GROW
-->
-    State#?MODULE{hits_since_last_miss = Hits + 1};
-adjust_read_size(hit, #?MODULE{read_size = Current, read_size_max = Max} = State) ->
-    State#?MODULE{
-        read_size = min(Max, Current + ?GROW_STEP),
-        hits_since_last_miss = 0
-    }.
-
--spec try_read(#?MODULE{}, byte_offset(), NumBytes :: pos_integer()) ->
-    {ok, #?MODULE{}, binary()}
-    | {next_fragment, #?MODULE{}, osiris:offset()}
-    | {become_local, #?MODULE{}}
-    | {await, #?MODULE{}}
-    | {end_of_stream, #?MODULE{}}.
-try_read(
-    #?MODULE{
-        fragment_ref = #fragment_ref{offset = ThisFragment, size = FragSize},
-        next = {#fragment_ref{offset = NextOffset}, _Buffer}
-    } = State0,
-    Offset,
-    _Bytes
-) when Offset >= ?SEGMENT_HEADER_B + FragSize ->
-    ?LOG_DEBUG(
-        ?MODULE_STRING " transitioning to next fragment (~20..0B->~20..0B)",
-        [ThisFragment, NextOffset]
-    ),
-    State = goto_next_fragment(State0),
-    {next_fragment, State, NextOffset};
-try_read(
-    #?MODULE{
-        fragment_ref = #fragment_ref{size = FragSize},
-        next = undefined,
-        iterator = Iterator,
-        requests = Requests
-    } = State0,
-    Offset,
-    _Bytes
-) when Offset >= ?SEGMENT_HEADER_B + FragSize ->
-    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-        {ok, #fragment_ref{offset = NextOffset}, _Iterator1} ->
-            case has_request_for(NextOffset, Requests) of
-                true ->
-                    {await, State0};
-                false ->
-                    {await, maybe_start_request(State0)}
-            end;
-        end_of_manifest ->
-            %% Refresh the iterator from the manifest cache.
-            case refresh_iterator(State0) of
-                {ok, State1} ->
-                    %% New entries available — try again.
-                    {await, maybe_start_request(State1)};
-                end_of_manifest ->
-                    State = goto_next_fragment(State0),
-                    {become_local, State}
-            end;
-        {error, _} ->
-            State = goto_next_fragment(State0),
-            {become_local, State}
-    end;
-try_read(
-    #?MODULE{
-        stream = StreamId,
-        fragment_ref = #fragment_ref{size = FragSize},
-        next = not_found
-    } = State0,
-    Offset,
-    Bytes
-) when Offset >= ?SEGMENT_HEADER_B + FragSize ->
-    %% The request for the next fragment gave a 404.
-    RemoteRange = rabbitmq_stream_s3_manifest_replica:get_range(StreamId),
-    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
-    case rabbitmq_stream_s3_fragment_iterator:next(State0#?MODULE.iterator) of
-        {ok, #fragment_ref{offset = NextFragment}, _} ->
-            ?LOG_DEBUG(
-                "Next fragment (~20..0B) was not found (requested ~b + ~b, idx start ~b). Remote range for this stream is ~w",
-                [NextFragment, Offset, Bytes, IdxStartPos, RemoteRange]
-            ),
-            case RemoteRange of
-                {RemoteStartOffset, _EndOffset} when RemoteStartOffset >= NextFragment ->
-                    %% Retention evicted the next fragment. Jump to oldest available.
-                    jump_to_oldest(State0, RemoteStartOffset);
-                {_StartOffset, EndOffset} when EndOffset =< NextFragment ->
-                    State = goto_next_fragment(State0),
-                    {become_local, State};
-                {_StartOffset, _EndOffset} ->
-                    State = goto_next_fragment(State0),
-                    {await, State};
-                empty ->
-                    {end_of_stream, State0}
-            end;
-        _ ->
-            case RemoteRange of
-                empty ->
-                    {end_of_stream, State0};
-                _ ->
-                    State = goto_next_fragment(State0),
-                    {become_local, State}
-            end
-    end;
-try_read(
-    #?MODULE{fragment_ref = #fragment_ref{size = FragSize}} = State,
-    Offset,
-    _Bytes
-) when Offset >= ?SEGMENT_HEADER_B + FragSize ->
-    ?LOG_DEBUG("Requested ~b exceeds index ~b. State: ~0p", [
-        Offset, ?SEGMENT_HEADER_B + FragSize, format_state(State)
-    ]),
-    erlang:error(unreachable);
-try_read(#?MODULE{end_pos = EndPos} = State, Offset, Bytes) when Offset + Bytes > EndPos ->
-    IdxStartPos = ?SEGMENT_HEADER_B + (State#?MODULE.fragment_ref)#fragment_ref.size,
-    case EndPos >= IdxStartPos andalso Offset + ?CHUNK_HEADER_B =< EndPos of
-        true ->
-            %% The log-reader over-reads the chunk header to try to get the
-            %% full filter. Cap the read at the index boundary.
-            try_read(State, Offset, EndPos - Offset);
-        false ->
-            case State of
-                #?MODULE{requests = Requests} when map_size(Requests) =/= 0 ->
-                    {await, State};
-                #?MODULE{current_not_found = true, stream = StreamId} ->
-                    case rabbitmq_stream_s3_manifest_replica:get_range(StreamId) of
-                        empty ->
-                            {end_of_stream, State};
-                        {FirstOffset, _} ->
-                            jump_to_oldest(State, FirstOffset)
-                    end;
-                #?MODULE{read_size = ReadSize0} ->
-                    Needed = Offset + Bytes - EndPos,
-                    ReadSize = max(ReadSize0, Needed),
-                    {await, maybe_start_current_request(State#?MODULE{read_size = ReadSize})}
-            end
-    end;
-try_read(
-    #?MODULE{
-        fragment_ref = #fragment_ref{size = FragSize},
-        start_pos = StartPos,
-        current_pos = CurrentPos0,
-        buffer = Buffer
-    } = State0,
-    Offset,
-    Bytes0
-) ->
-    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
-    %%% PRECONDITIONS
-    ?assert(Offset >= StartPos),
-    ?assert(Offset >= CurrentPos0),
-
-    %% Cap the read at the index boundary.
-    Bytes = min(Bytes0, IdxStartPos - Offset),
-
-    Data = binary:part(Buffer, Offset - StartPos, Bytes),
-    {ok, State0#?MODULE{current_pos = Offset}, Data}.
-
-goto_next_fragment(
-    #?MODULE{
-        stream = StreamId,
-        next = Next0,
-        iterator = Iterator0
-    } = State0
-) ->
-    case Next0 of
-        {#fragment_ref{offset = NextOffset, uid = NextUid} = NextFragRef, Buffer} ->
-            %% Advance the iterator past the entry we're transitioning to.
-            Iterator =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
-                    {ok, _, It} -> It;
-                    _ -> Iterator0
-                end,
-            State0#?MODULE{
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B + byte_size(Buffer),
-                buffer = Buffer,
-                fragment_ref = NextFragRef,
-                key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset, NextUid),
-                iterator = Iterator,
-                next = undefined
-            };
-        _ ->
-            %% No pre-fetched next fragment data. Advance iterator and reset.
-            Iterator =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
-                    {ok, _, It} -> It;
-                    _ -> Iterator0
-                end,
-            State0#?MODULE{
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B,
-                buffer = <<>>,
-                iterator = Iterator,
-                next = undefined
-            }
-    end.
-
-cancel_requests(Requests) ->
-    maps:foreach(
-        fun(RequestId, #request{state = ReqState}) ->
-            rabbitmq_stream_s3_api:cancel_async(RequestId, ReqState)
-        end,
-        Requests
-    ),
-    counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0).
-
-jump_to_oldest(
-    #?MODULE{stream = StreamId, requests = Requests, cancelled_requests = Cancelled0} = State0,
-    FirstOffset
-) ->
-    cancel_requests(Requests),
-    Cancelled = maps:merge(Cancelled0, #{Req => ok || Req := _ <- Requests}),
-    %% Look up the fragment entry from the manifest to get UID and size.
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{entries = Entries} = Manifest when byte_size(Entries) >= ?ENTRY_B ->
-            ?ENTRY(FirstOffset, _FTs, _LTs, ?MANIFEST_KIND_FRAGMENT, Size, Uid) =
-                rabbitmq_stream_s3_array:at(0, ?ENTRY_B, Entries),
-            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-            Iterator = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, FirstOffset, GetGroupFun
-            ),
-            %% Advance past the current entry.
-            Iterator1 =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                    {ok, _, It} -> It;
-                    _ -> Iterator
-                end,
-            Key = rabbitmq_stream_s3:fragment_key(StreamId, FirstOffset, Uid),
-            ?LOG_WARNING(
-                "Jumping to oldest available fragment ~20..0B",
-                [FirstOffset]
-            ),
-            State = State0#?MODULE{
-                fragment_ref = #fragment_ref{offset = FirstOffset, uid = Uid, size = Size},
-                key = Key,
-                buffer = <<>>,
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B,
-                next = undefined,
-                current_not_found = false,
-                requests = #{},
-                cancelled_requests = Cancelled,
-                iterator = Iterator1
-            },
-            {next_fragment, State, FirstOffset};
-        _ ->
-            {end_of_stream, State0}
-    end.
-
-refresh_iterator(
-    #?MODULE{stream = StreamId, fragment_ref = #fragment_ref{offset = Fragment}} = State
-) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{} = Manifest ->
-            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, Fragment, GetGroupFun
-            ),
-            %% Advance past the current fragment.
-            Iterator =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
-                    {ok, _, It} -> It;
-                    _ -> Iterator0
-                end,
-            %% Check if there's anything after.
-            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                {ok, _, _} ->
-                    {ok, State#?MODULE{iterator = Iterator}};
-                _ ->
-                    end_of_manifest
-            end;
-        _ ->
-            end_of_manifest
-    end.
-
-format_state(#?MODULE{
-    stream = StreamId,
-    read_size = ReadSize,
-    read_size_min = ReadSizeMin,
-    read_size_max = ReadSizeMax,
-    hits_since_last_miss = Hits,
-    buffer = Buffer,
-    start_pos = StartPos,
-    current_pos = CurrentPos,
-    end_pos = EndPos,
-    fragment_ref = #fragment_ref{offset = Fragment, uid = Uid, size = FragSize},
-    next = Next0,
-    requests = Requests,
-    pending_read = PendingRead,
-    current_not_found = CurrentNotFound
-}) ->
-    Next =
-        case Next0 of
-            {#fragment_ref{offset = NextOff}, Buf} ->
-                {NextOff, <<(integer_to_binary(byte_size(Buf)))/binary, " bytes">>};
-            _ ->
-                Next0
-        end,
-    #{
-        stream => StreamId,
-        read_size => ReadSize,
-        read_size_min => ReadSizeMin,
-        read_size_max => ReadSizeMax,
-        hits_since_last_miss => Hits,
-        buffer => <<(integer_to_binary(byte_size(Buffer)))/binary, " bytes">>,
-        start_pos => StartPos,
-        current_pos => CurrentPos,
-        end_pos => EndPos,
-        fragment => Fragment,
-        fragment_uid => Uid,
-        fragment_size => FragSize,
-        idx_start_pos => ?SEGMENT_HEADER_B + FragSize,
-        next => Next,
-        requests => #{F => R || _ := #request{fragment = F, range = R} <- Requests},
-        pending_read => PendingRead =/= undefined,
-        current_not_found => CurrentNotFound
-    }.
-
-counter() ->
-    persistent_term:get(?COUNTER_KEY).
 
 -spec read_size_prometheus_format() -> map().
 read_size_prometheus_format() ->
@@ -921,3 +130,316 @@ read_size_prometheus_format() ->
             values => [{[], Buckets, Count, Sum}]
         }
     }.
+
+start_link(Config) ->
+    gen_server:start_link(?MODULE, Config, []).
+
+read(Server, Offset, Bytes, Hint) ->
+    read(Server, Offset, Bytes, Hint, ?GEN_SERVER_CALL_TIMEOUT).
+
+read(Server, Offset, Bytes, Hint, Timeout) ->
+    T0 = erlang:monotonic_time(),
+    Result = gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout),
+    Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
+    counters:add(counter(), ?C_READ_DURATION_MS, Duration),
+    counters:add(counter(), ?C_READ, 1),
+    Result.
+
+%%----------------------------------------------------------------------------
+%% gen_server callbacks
+%%----------------------------------------------------------------------------
+
+init(
+    #{
+        reader := Reader,
+        stream := StreamId,
+        location := #remote_location{
+            position = Pos,
+            fragment_ref = FragRef,
+            iterator = Iterator
+        }
+    } = Config
+) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
+    Opts = maps:get(opts, Config, #{}),
+    Cfg = build_cfg(Opts),
+    {Core0, Effects} = rabbitmq_stream_s3_remote_reader_core:init(
+        StreamId, FragRef, Pos, Iterator, Opts
+    ),
+    State0 = #state{
+        stream = StreamId,
+        cfg = Cfg,
+        core = Core0,
+        reader_ref = erlang:monitor(process, Reader)
+    },
+    State = execute_effects(Effects, State0),
+    {ok, State}.
+
+handle_call(
+    #read{offset = Offset, bytes = Bytes, hint = Hint}, From, #state{core = Core0} = State0
+) ->
+    ?assertEqual(undefined, State0#state.from),
+    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        Core0, {read, Offset, Bytes, Hint}
+    ),
+    State1 = State0#state{
+        core = Core1,
+        from = From,
+        since = erlang:monotonic_time()
+    },
+    State = execute_effects(Effects, State1),
+    maybe_stop(State);
+handle_call(Request, From, State) ->
+    {stop, {unknown_call, From, Request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{reader_ref = MRef} = State) ->
+    {stop, normal, State};
+handle_info(retry_requests, #state{core = Core0} = State0) ->
+    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, retry),
+    State = execute_effects(Effects, State0#state{core = Core1}),
+    maybe_stop(State);
+handle_info(Msg, #state{requests = Requests0, cancelled = Cancelled0} = State0) ->
+    AsyncStates = #{Req => AsyncState || _ := {Req, AsyncState} <- Requests0},
+    case rabbitmq_stream_s3_api:match_async(Msg, AsyncStates, Cancelled0) of
+        {ok, RequestId} ->
+            handle_async_response(Msg, RequestId, State0);
+        {cancelled, Ref, Final} ->
+            Cancelled =
+                case Final of
+                    final -> maps:remove(Ref, Cancelled0);
+                    more -> Cancelled0
+                end,
+            {noreply, State0#state{cancelled = Cancelled}};
+        error ->
+            ?LOG_DEBUG("remote_reader_shell received unexpected message: ~W", [Msg, 10]),
+            {noreply, State0}
+    end.
+
+terminate(_Reason, #state{requests = Requests}) ->
+    maps:foreach(
+        fun(_FragOff, {ReqId, AsyncState}) ->
+            rabbitmq_stream_s3_api:cancel_async(ReqId, AsyncState)
+        end,
+        Requests
+    ),
+    ok.
+
+format_status(#{state := #state{stream = StreamId, core = Core, from = From}} = Status) ->
+    Status#{
+        state := #{
+            stream => StreamId,
+            pending_caller => From =/= undefined,
+            core => rabbitmq_stream_s3_remote_reader_core:pending(Core)
+        }
+    }.
+
+%%----------------------------------------------------------------------------
+%% Internal: async response handling
+%%----------------------------------------------------------------------------
+
+handle_async_response(
+    Msg, RequestId, #state{requests = Requests0, cancelled = Cancelled0, core = Core0} = State0
+) ->
+    %% Find which fragment this request belongs to.
+    {FragOffset, {_, AsyncState0}} = find_request_by_id(RequestId, Requests0),
+    case rabbitmq_stream_s3_api:handle_async(Msg, RequestId, AsyncState0) of
+        ignore ->
+            {noreply, State0};
+        {continue, AsyncState} ->
+            Requests = Requests0#{FragOffset := {RequestId, AsyncState}},
+            {noreply, State0#state{requests = Requests}};
+        {data, Data, Result} ->
+            {Requests, DoneOrContinue} =
+                case Result of
+                    done ->
+                        counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+                        {maps:remove(FragOffset, Requests0), done};
+                    AsyncState ->
+                        {Requests0#{FragOffset := {RequestId, AsyncState}}, continue}
+                end,
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {data, RequestId, FragOffset, Data, DoneOrContinue}
+            ),
+            State = execute_effects(Effects, State0#state{core = Core1, requests = Requests}),
+            maybe_stop(State);
+        {done, ok} ->
+            %% Empty 200 on range GET. Treat as transient error.
+            counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+            Requests = maps:remove(FragOffset, Requests0),
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {request_error, RequestId, FragOffset, timeout}
+            ),
+            State = execute_effects(Effects, State0#state{core = Core1, requests = Requests}),
+            maybe_stop(State);
+        {done, {error, Reason}} ->
+            counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+            Requests = maps:remove(FragOffset, Requests0),
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {request_error, RequestId, FragOffset, Reason}
+            ),
+            State = execute_effects(Effects, State0#state{core = Core1, requests = Requests}),
+            maybe_stop(State);
+        {done_cancel, {error, Reason}} ->
+            counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+            Requests = maps:remove(FragOffset, Requests0),
+            Cancelled = Cancelled0#{RequestId => ok},
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {request_error, RequestId, FragOffset, Reason}
+            ),
+            State = execute_effects(Effects, State0#state{
+                core = Core1, requests = Requests, cancelled = Cancelled
+            }),
+            maybe_stop(State)
+    end.
+
+find_request_by_id(RequestId, Requests) ->
+    maps:fold(
+        fun
+            (FragOff, {ReqId, _} = Val, undefined) when ReqId =:= RequestId ->
+                {FragOff, Val};
+            (_, _, Acc) ->
+                Acc
+        end,
+        undefined,
+        Requests
+    ).
+
+%%----------------------------------------------------------------------------
+%% Internal: effect execution loop
+%%----------------------------------------------------------------------------
+
+execute_effects([], State) ->
+    State;
+execute_effects([Effect | Rest], State0) ->
+    State = execute_effect(Effect, State0),
+    execute_effects(Rest, State).
+
+execute_effect({reply, Result}, #state{from = From, since = Since} = State) when
+    From =/= undefined
+->
+    Duration = rabbitmq_stream_s3_util:elapsed_ms(Since),
+    counters:add(counter(), ?C_AWAIT_DURATION_MS, Duration),
+    counters:add(counter(), ?C_AWAIT, 1),
+    gen_server:reply(From, Result),
+    State#state{from = undefined, since = undefined};
+execute_effect({reply, _Result}, State) ->
+    %% No pending caller (e.g. reply generated during init before any call).
+    State;
+execute_effect(
+    {start_request, Key, Range, FragOffset},
+    #state{cfg = #cfg{request_timeout_ms = Timeout}, requests = Requests0} = State
+) ->
+    case rabbitmq_stream_s3_api:get_range_async(Key, Range, #{timeout => Timeout}) of
+        {ok, RequestId, AsyncState} ->
+            counters:add(counter(), ?C_REQUESTS_IN_FLIGHT, 1),
+            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+            Requests = Requests0#{FragOffset => {RequestId, AsyncState}},
+            State#state{requests = Requests};
+        {error, pool_busy} ->
+            %% Can't start now. The core will retry on the next event.
+            State
+    end;
+execute_effect({set_timer, DelayMs}, State) ->
+    erlang:send_after(DelayMs, self(), retry_requests),
+    State;
+execute_effect({lookup_manifest_range}, #state{stream = StreamId, core = Core0} = State) ->
+    %% Synchronous local lookup — feed result back to core immediately.
+    Range = rabbitmq_stream_s3_manifest_replica:get_range(StreamId),
+    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, {manifest_range, Range}),
+    execute_effects(Effects, State#state{core = Core1});
+execute_effect({refresh_iterator}, #state{stream = StreamId, core = Core0} = State) ->
+    %% Synchronous local lookup — feed result back to core immediately.
+    Result = refresh_iterator(StreamId, Core0),
+    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        Core0, {iterator_refreshed, Result}
+    ),
+    execute_effects(Effects, State#state{core = Core1});
+execute_effect(
+    {jump_to_oldest, FirstOffset},
+    #state{stream = StreamId, core = Core0, requests = Requests, cancelled = Cancelled0} = State0
+) ->
+    %% Cancel in-flight requests, resolve the fragment from the manifest,
+    %% and feed back to the core.
+    maps:foreach(
+        fun(_FragOff, {ReqId, AsyncState}) ->
+            rabbitmq_stream_s3_api:cancel_async(ReqId, AsyncState)
+        end,
+        Requests
+    ),
+    counters:sub(counter(), ?C_REQUESTS_IN_FLIGHT, map_size(Requests)),
+    NewCancelled = maps:merge(Cancelled0, #{ReqId => ok || _ := {ReqId, _} <- Requests}),
+    State1 = State0#state{requests = #{}, cancelled = NewCancelled},
+    case resolve_fragment_at(StreamId, FirstOffset) of
+        {ok, FragRef, Iterator} ->
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {jumped, FragRef, Iterator}
+            ),
+            execute_effects(Effects, State1#state{core = Core1});
+        not_found ->
+            %% Manifest doesn't have this offset. End of stream.
+            case State1#state.from of
+                undefined ->
+                    State1;
+                From ->
+                    gen_server:reply(From, end_of_stream),
+                    State1#state{from = undefined, since = undefined}
+            end
+    end;
+execute_effect(stop, State) ->
+    State#state{stopping = true}.
+
+%% Rebuild the fragment iterator from the manifest cache.
+refresh_iterator(StreamId, Core) ->
+    FragOffset = rabbitmq_stream_s3_remote_reader_core:current_fragment_offset(Core),
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        #manifest{} = Manifest ->
+            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
+            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
+                Manifest, FragOffset, GetGroupFun
+            ),
+            %% Advance past the current fragment.
+            Iterator =
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+                    {ok, _, It} -> It;
+                    _ -> Iterator0
+                end,
+            %% Check if there's anything after.
+            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+                {ok, _, _} -> Iterator;
+                _ -> end_of_manifest
+            end;
+        _ ->
+            end_of_manifest
+    end.
+
+%% Look up a fragment ref at the given offset from the manifest cache.
+resolve_fragment_at(StreamId, Offset) ->
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        #manifest{} = Manifest ->
+            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
+            Iterator = rabbitmq_stream_s3_fragment_iterator:init(
+                Manifest, Offset, GetGroupFun
+            ),
+            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+                {ok, FragRef, _} -> {ok, FragRef, Iterator};
+                _ -> not_found
+            end;
+        _ ->
+            not_found
+    end.
+
+maybe_stop(#state{stopping = true} = State) ->
+    {stop, normal, State};
+maybe_stop(State) ->
+    {noreply, State}.
+
+build_cfg(Opts) ->
+    #cfg{
+        request_timeout_ms = maps:get(request_timeout_ms, Opts, 30_000)
+    }.
+
+counter() ->
+    persistent_term:get(?COUNTER_KEY).

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -376,12 +376,12 @@ execute_effect(
 execute_effect({set_timer, DelayMs}, State) ->
     erlang:send_after(DelayMs, self(), retry_requests),
     State;
-execute_effect({lookup_manifest_range}, #state{stream = StreamId, core = Core0} = State) ->
+execute_effect(lookup_manifest_range, #state{stream = StreamId, core = Core0} = State) ->
     %% Synchronous local lookup — feed result back to core immediately.
     Range = rabbitmq_stream_s3_manifest_replica:get_range(StreamId),
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, {manifest_range, Range}),
     execute_effects(Effects, State#state{core = Core1});
-execute_effect({refresh_iterator}, #state{stream = StreamId, core = Core0} = State) ->
+execute_effect(refresh_iterator, #state{stream = StreamId, core = Core0} = State) ->
     %% Synchronous local lookup — feed result back to core immediately.
     Result = refresh_iterator(StreamId, Core0),
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -416,7 +416,7 @@ handle_manifest_range(_Range, #state{pending = undefined} = State) ->
 handle_manifest_range(
     {FirstOffset, EndOffset},
     #state{
-        fragment_ref = #fragment_ref{size = FragSize},
+        fragment_ref = #fragment_ref{offset = CurrentOffset, size = FragSize},
         pending = #pending{offset = Offset}
     } = State
 ) ->
@@ -426,8 +426,7 @@ handle_manifest_range(
             %% Next fragment was 404. Check if retention evicted it.
             case rabbitmq_stream_s3_fragment_iterator:next(State#state.iterator) of
                 {ok, #fragment_ref{offset = NextFragment}, _} when FirstOffset >= NextFragment ->
-                    %% Retention evicted. Shell resolves the jump.
-                    {State, [{jump_to_oldest, FirstOffset}]};
+                    maybe_jump_to_oldest(FirstOffset, CurrentOffset, State);
                 {ok, #fragment_ref{offset = NextFragment}, _} when EndOffset =< NextFragment ->
                     FragOffset = (State#state.fragment_ref)#fragment_ref.offset,
                     State1 = goto_next_fragment(State#state{pending = undefined}),
@@ -439,12 +438,20 @@ handle_manifest_range(
                     ]}
             end;
         {false, _} ->
-            %% Current fragment 404. Shell resolves the jump.
-            {State, [{jump_to_oldest, FirstOffset}]};
+            maybe_jump_to_oldest(FirstOffset, CurrentOffset, State);
         _ ->
             State1 = goto_next_fragment(State#state{pending = undefined}),
             {State1, [{reply, {become_local, (State#state.fragment_ref)#fragment_ref.offset}}]}
     end.
+
+%% If the manifest's first_offset points to the fragment we already know is
+%% gone (404), the manifest is stale. Fall through to the local tier to avoid
+%% an infinite jump loop. See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/166
+maybe_jump_to_oldest(FirstOffset, CurrentOffset, State) when FirstOffset =:= CurrentOffset ->
+    State1 = goto_next_fragment(State#state{pending = undefined}),
+    {State1, [{reply, {become_local, CurrentOffset}}]};
+maybe_jump_to_oldest(FirstOffset, _CurrentOffset, State) ->
+    {State, [{jump_to_oldest, FirstOffset}]}.
 
 %% ------------------------------------------------------------------
 %% Internal: fragment navigation

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -1,0 +1,621 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_remote_reader_core).
+-moduledoc """
+Functional core for the remote read path.
+
+This module contains the pure decision logic for reading stream data from the
+remote tier. It manages buffer state, AIMD-based prefetch sizing, fragment
+transitions, and retry/timeout decisions. It produces effects that the
+imperative shell (the remote reader gen_server) executes.
+
+The core never performs I/O. It receives events describing what happened and
+returns a new state plus a list of effects describing what should happen next.
+
+## Events (inputs)
+
+- `{read, Offset, Bytes, Hint}` — caller wants data at this position
+- `{data, RequestId, Fragment, Data, done | continue}` — S3 delivered bytes
+- `{request_error, RequestId, Reason}` — S3 request failed
+- `{request_timeout, RequestId}` — request exceeded deadline
+- `retry` — retry timer fired
+- `{iterator_refreshed, Iterator}` — manifest cache provided new iterator
+
+## Effects (outputs)
+
+- `{reply, Result}` — respond to the pending read
+- `{start_request, Key, Range, Fragment}` — initiate an S3 GET
+- `{set_timer, Duration, Event}` — schedule a future event
+- `{cancel_request, RequestId}` — abort an in-flight request
+- `stop` — shut down the remote reader
+
+## Design
+
+The core is structured around `try_read/1` which examines the buffer and
+fragment state to determine if a pending read can be served. When it cannot,
+the core returns effects to fetch more data. When data arrives, the shell
+feeds it back and the core re-evaluates.
+
+The AIMD algorithm adjusts `read_size` (prefetch window):
+- Buffer hit: after N consecutive hits, additive increase by 1 MiB
+- Buffer miss: multiplicative decrease (halve)
+
+Fragment transitions happen when the read position exceeds the current
+fragment's data region. The core checks for pre-fetched next-fragment data
+and transitions immediately if available, or signals that more data is needed.
+""".
+
+-include_lib("stdlib/include/assert.hrl").
+-include("include/rabbitmq_stream_s3.hrl").
+
+%% ------------------------------------------------------------------
+%% Types
+%% ------------------------------------------------------------------
+
+-record(cfg, {
+    read_size_min :: pos_integer(),
+    read_size_max :: pos_integer(),
+    initial_read_size :: pos_integer(),
+    hits_to_grow :: pos_integer(),
+    grow_step :: pos_integer(),
+    min_retry_delay_ms :: pos_integer(),
+    max_retry_delay_ms :: pos_integer()
+}).
+
+-record(pending, {
+    offset :: byte_offset(),
+    bytes :: pos_integer(),
+    hint :: chunk_boundary | within_chunk
+}).
+
+-record(state, {
+    stream :: stream_id(),
+    cfg :: #cfg{},
+    %% AIMD state
+    read_size :: pos_integer(),
+    hits_since_last_miss = 0 :: non_neg_integer(),
+    %% Retry state
+    retry_delay :: pos_integer(),
+
+    %% Current fragment
+    fragment_ref :: #fragment_ref{},
+    key :: rabbitmq_stream_s3:key(),
+    buffer = <<>> :: binary(),
+    start_pos :: byte_offset(),
+    current_pos :: byte_offset(),
+    end_pos :: byte_offset(),
+
+    %% Next fragment (pre-fetched)
+    next :: {#fragment_ref{}, binary()} | undefined | not_found,
+
+    %% Fragment iterator
+    iterator :: rabbitmq_stream_s3_fragment_iterator:iterator(),
+
+    %% Tracking in-flight requests (by fragment offset)
+    requests_in_flight = #{} :: #{fragment_offset() => request_id()},
+
+    %% Pending read (at most one)
+    pending :: #pending{} | undefined,
+
+    %% Current fragment returned 404
+    current_not_found = false :: boolean()
+}).
+
+-type state() :: #state{}.
+-type request_id() :: reference().
+-type fragment_offset() :: osiris:offset().
+
+-type event() ::
+    {read, byte_offset(), pos_integer(), chunk_boundary | within_chunk}
+    | {data, request_id(), fragment_offset(), binary(), done | continue}
+    | {request_error, request_id(), fragment_offset(), term()}
+    | retry
+    | {manifest_range, {osiris:offset(), osiris:offset()} | empty}
+    | {iterator_refreshed, rabbitmq_stream_s3_fragment_iterator:iterator() | end_of_manifest}
+    | {jumped, #fragment_ref{}, rabbitmq_stream_s3_fragment_iterator:iterator()}.
+
+-type effect() ::
+    {reply, read_result()}
+    | {start_request, rabbitmq_stream_s3:key(), {byte_offset(), byte_offset()}, fragment_offset()}
+    | {set_timer, pos_integer()}
+    | {lookup_manifest_range}
+    | {refresh_iterator}
+    | {jump_to_oldest, osiris:offset()}
+    | stop.
+
+-type read_result() ::
+    {ok, binary()}
+    | {next_fragment, osiris:offset()}
+    | {become_local, osiris:offset()}
+    | end_of_stream.
+
+-export_type([state/0, event/0, effect/0, read_result/0, request_id/0]).
+
+%% ------------------------------------------------------------------
+%% API
+%% ------------------------------------------------------------------
+
+-export([
+    init/5,
+    step/2,
+    pending/1,
+    current_fragment_offset/1
+]).
+
+%% @doc Initialize the read core.
+%% `Position` is the byte offset within the fragment to start reading from
+%% (typically `?SEGMENT_HEADER_B` for the beginning, or further in if the
+%% consumer attached mid-fragment).
+%% `Opts` is a map of configuration overrides (see `#cfg{}`). Pass `#{}`
+%% for defaults.
+-spec init(
+    stream_id(),
+    #fragment_ref{},
+    byte_offset(),
+    rabbitmq_stream_s3_fragment_iterator:iterator(),
+    map()
+) ->
+    {state(), [effect()]}.
+init(StreamId, FragRef, Position, Iterator, Opts) ->
+    #fragment_ref{offset = Offset, uid = Uid} = FragRef,
+    Key = rabbitmq_stream_s3:fragment_key(StreamId, Offset, Uid),
+    Cfg = build_cfg(Opts),
+    %% The iterator arrives already advanced past the current entry
+    %% (done by find_position in the log reader). It points at the next
+    %% fragment, ready for prefetch and forward navigation.
+    State = #state{
+        stream = StreamId,
+        cfg = Cfg,
+        read_size = Cfg#cfg.initial_read_size,
+        retry_delay = Cfg#cfg.min_retry_delay_ms,
+        fragment_ref = FragRef,
+        key = Key,
+        buffer = <<>>,
+        start_pos = Position,
+        current_pos = Position,
+        end_pos = Position,
+        iterator = Iterator,
+        next = undefined
+    },
+    %% Immediately request data for the current fragment.
+    {State1, Effects} = start_current_request(State),
+    {State1, Effects}.
+
+%% @doc Feed an event into the core, get back new state and effects.
+-spec step(state(), event()) -> {state(), [effect()]}.
+step(State, {read, Offset, Bytes, Hint}) ->
+    State1 = State#state{pending = #pending{offset = Offset, bytes = Bytes, hint = Hint}},
+    try_serve(State1);
+step(State0, {data, _RequestId, Fragment, Data, DoneOrContinue}) ->
+    State1 = State0#state{retry_delay = (State0#state.cfg)#cfg.min_retry_delay_ms},
+    State2 = remove_request_if_done(Fragment, DoneOrContinue, State1),
+    State3 = add_data(Fragment, Data, State2),
+    {State4, Effects1} = maybe_start_requests(State3),
+    {State5, Effects2} = try_serve(State4),
+    {State5, Effects1 ++ Effects2};
+step(State0, {request_error, _RequestId, Fragment, not_found}) ->
+    case Fragment =:= (State0#state.fragment_ref)#fragment_ref.offset of
+        true ->
+            %% Current fragment 404. Need to check manifest range.
+            State = State0#state{current_not_found = true, requests_in_flight = #{}},
+            case State#state.pending of
+                undefined -> {State, []};
+                _ -> {State, [{lookup_manifest_range}]}
+            end;
+        false ->
+            %% Next fragment 404. Mark it and try to serve (may trigger range lookup
+            %% when the consumer reads past the current fragment).
+            State = State0#state{
+                next = not_found,
+                requests_in_flight = maps:remove(Fragment, State0#state.requests_in_flight)
+            },
+            try_serve(State)
+    end;
+step(
+    #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}} = State0,
+    {request_error, _RequestId, _Fragment, Reason}
+) when
+    Reason =:= slow_down; Reason =:= internal_error
+->
+    RetryDelay = State0#state.retry_delay,
+    NextDelay = min(RetryDelay * 2, MaxDelay),
+    State = State0#state{retry_delay = NextDelay, requests_in_flight = #{}},
+    {State, [{set_timer, RetryDelay}]};
+step(
+    #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}} = State0,
+    {request_error, _RequestId, _Fragment, Reason}
+) when
+    Reason =:= timeout; Reason =:= stream_error; Reason =:= connection_error
+->
+    %% Transient error. Retry immediately with current delay.
+    RetryDelay = State0#state.retry_delay,
+    NextDelay = min(RetryDelay * 2, MaxDelay),
+    State = State0#state{retry_delay = NextDelay, requests_in_flight = #{}},
+    {State, [{set_timer, RetryDelay}]};
+step(State0, {request_error, _RequestId, _Fragment, _Fatal}) ->
+    {State0, [stop]};
+step(State0, retry) ->
+    {State1, Effects} = maybe_start_requests(State0),
+    {State2, Effects2} = try_serve(State1),
+    {State2, Effects ++ Effects2};
+step(State0, {manifest_range, Range}) ->
+    handle_manifest_range(Range, State0);
+step(State0, {iterator_refreshed, end_of_manifest}) ->
+    %% No new entries. Become local.
+    FragOffset = (State0#state.fragment_ref)#fragment_ref.offset,
+    State = goto_next_fragment(State0),
+    {State, [{reply, {become_local, FragOffset}}]};
+step(State0, {iterator_refreshed, Iterator}) ->
+    State1 = State0#state{iterator = Iterator},
+    {State2, Effects} = maybe_start_requests(State1),
+    {State3, Effects2} = try_serve(State2),
+    {State3, Effects ++ Effects2};
+step(#state{stream = StreamId, cfg = Cfg} = _State0, {jumped, FragRef, Iterator}) ->
+    %% Shell resolved a jump_to_oldest. Reinitialize at the new fragment.
+    #fragment_ref{offset = Offset, uid = Uid} = FragRef,
+    Key = rabbitmq_stream_s3:fragment_key(StreamId, Offset, Uid),
+    Iterator1 = advance_iterator(Iterator),
+    State = #state{
+        stream = StreamId,
+        cfg = Cfg,
+        read_size = Cfg#cfg.initial_read_size,
+        retry_delay = Cfg#cfg.min_retry_delay_ms,
+        fragment_ref = FragRef,
+        key = Key,
+        buffer = <<>>,
+        start_pos = ?SEGMENT_HEADER_B,
+        current_pos = ?SEGMENT_HEADER_B,
+        end_pos = ?SEGMENT_HEADER_B,
+        iterator = Iterator1,
+        next = undefined
+    },
+    %% Reply with next_fragment so the log reader repositions, then start fetching.
+    {State1, Effects} = start_current_request(State),
+    {State1, [{reply, {next_fragment, Offset}} | Effects]}.
+
+%% @doc Returns the pending read, if any.
+-spec pending(state()) -> undefined | {byte_offset(), pos_integer()}.
+pending(#state{pending = undefined}) -> undefined;
+pending(#state{pending = #pending{offset = O, bytes = B}}) -> {O, B}.
+
+%% @doc Returns the offset of the fragment currently being read.
+-spec current_fragment_offset(state()) -> osiris:offset().
+current_fragment_offset(#state{fragment_ref = #fragment_ref{offset = Off}}) -> Off.
+
+%% ------------------------------------------------------------------
+%% Internal: try to serve the pending read
+%% ------------------------------------------------------------------
+
+try_serve(#state{pending = undefined} = State) ->
+    {State, []};
+try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
+    case try_read(State, Offset, Bytes) of
+        {ok, Data, State1} ->
+            State2 = adjust_read_size(hit, State1#state{pending = undefined}),
+            {State3, Effects} = maybe_start_requests(State2),
+            {State3, [{reply, {ok, Data}} | Effects]};
+        {next_fragment, NextOffset, State1} ->
+            State2 = State1#state{pending = undefined},
+            {State3, Effects} = maybe_start_requests(State2),
+            {State3, [{reply, {next_fragment, NextOffset}} | Effects]};
+        {become_local, State1} ->
+            FragOffset = (State1#state.fragment_ref)#fragment_ref.offset,
+            State2 = State1#state{pending = undefined},
+            {State2, [{reply, {become_local, FragOffset}}]};
+        {await, State1} ->
+            State2 = adjust_read_size(miss, State1),
+            {State3, Effects} = maybe_start_requests(State2),
+            {State3, Effects};
+        {not_found_check_range, State1} ->
+            {State1, [{lookup_manifest_range}]};
+        {refresh_iterator, State1} ->
+            {State1, [{refresh_iterator}]}
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal: buffer read logic
+%% ------------------------------------------------------------------
+
+try_read(#state{fragment_ref = #fragment_ref{size = FragSize}} = State, Offset, _Bytes) when
+    Offset >= ?SEGMENT_HEADER_B + FragSize
+->
+    %% Past end of current fragment. Transition.
+    try_fragment_transition(State);
+try_read(#state{end_pos = EndPos} = State, Offset, Bytes) when
+    Offset + Bytes > EndPos
+->
+    %% Not enough data buffered.
+    IdxStartPos = ?SEGMENT_HEADER_B + (State#state.fragment_ref)#fragment_ref.size,
+    case EndPos >= IdxStartPos andalso Offset + 64 =< EndPos of
+        true ->
+            %% Header over-read: cap at index boundary.
+            try_read(State, Offset, EndPos - Offset);
+        false ->
+            case State of
+                #state{current_not_found = true} ->
+                    {not_found_check_range, State};
+                _ ->
+                    {await, State}
+            end
+    end;
+try_read(
+    #state{
+        fragment_ref = #fragment_ref{size = FragSize},
+        start_pos = StartPos,
+        current_pos = _CurrentPos,
+        buffer = Buffer
+    } = State,
+    Offset,
+    Bytes0
+) ->
+    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
+    Bytes = min(Bytes0, IdxStartPos - Offset),
+    ?assert(Offset >= StartPos),
+    Data = binary:part(Buffer, Offset - StartPos, Bytes),
+    {ok, Data, State#state{current_pos = Offset}}.
+
+try_fragment_transition(
+    #state{next = {#fragment_ref{offset = NextOffset}, _}} = State0
+) ->
+    State = goto_next_fragment(State0),
+    {next_fragment, NextOffset, State};
+try_fragment_transition(
+    #state{next = not_found} = State
+) ->
+    %% Next fragment 404. Need manifest range to decide.
+    {not_found_check_range, State};
+try_fragment_transition(
+    #state{next = undefined, iterator = Iterator, requests_in_flight = Requests} = State
+) ->
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+        {ok, #fragment_ref{offset = NextOffset}, _} ->
+            case maps:is_key(NextOffset, Requests) of
+                true -> {await, State};
+                false -> {await, State}
+            end;
+        end_of_manifest ->
+            {refresh_iterator, State};
+        {error, _} ->
+            FragOffset = (State#state.fragment_ref)#fragment_ref.offset,
+            {become_local, State#state{
+                pending = undefined,
+                fragment_ref = State#state.fragment_ref#fragment_ref{offset = FragOffset}
+            }}
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal: manifest range handling (for 404 cases)
+%% ------------------------------------------------------------------
+
+handle_manifest_range(empty, #state{pending = undefined} = State) ->
+    {State, []};
+handle_manifest_range(empty, State) ->
+    State1 = State#state{pending = undefined},
+    {State1, [{reply, end_of_stream}]};
+handle_manifest_range(_Range, #state{pending = undefined} = State) ->
+    %% No pending read. Ignore stale manifest range response.
+    {State, []};
+handle_manifest_range(
+    {FirstOffset, EndOffset},
+    #state{
+        fragment_ref = #fragment_ref{size = FragSize},
+        pending = #pending{offset = Offset}
+    } = State
+) ->
+    AtFragmentEnd = Offset >= ?SEGMENT_HEADER_B + FragSize,
+    case {AtFragmentEnd, State#state.next} of
+        {true, not_found} ->
+            %% Next fragment was 404. Check if retention evicted it.
+            case rabbitmq_stream_s3_fragment_iterator:next(State#state.iterator) of
+                {ok, #fragment_ref{offset = NextFragment}, _} when FirstOffset >= NextFragment ->
+                    %% Retention evicted. Shell resolves the jump.
+                    {State, [{jump_to_oldest, FirstOffset}]};
+                {ok, #fragment_ref{offset = NextFragment}, _} when EndOffset =< NextFragment ->
+                    FragOffset = (State#state.fragment_ref)#fragment_ref.offset,
+                    State1 = goto_next_fragment(State#state{pending = undefined}),
+                    {State1, [{reply, {become_local, FragOffset}}]};
+                _ ->
+                    State1 = goto_next_fragment(State#state{pending = undefined}),
+                    {State1, [
+                        {reply, {become_local, (State#state.fragment_ref)#fragment_ref.offset}}
+                    ]}
+            end;
+        {false, _} ->
+            %% Current fragment 404. Shell resolves the jump.
+            {State, [{jump_to_oldest, FirstOffset}]};
+        _ ->
+            State1 = goto_next_fragment(State#state{pending = undefined}),
+            {State1, [{reply, {become_local, (State#state.fragment_ref)#fragment_ref.offset}}]}
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal: fragment navigation
+%% ------------------------------------------------------------------
+
+goto_next_fragment(#state{stream = StreamId, next = Next0, iterator = Iterator0} = State) ->
+    Iterator = advance_iterator(Iterator0),
+    case Next0 of
+        {#fragment_ref{offset = NextOffset, uid = NextUid} = NextFragRef, Buffer} ->
+            Key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset, NextUid),
+            State#state{
+                start_pos = ?SEGMENT_HEADER_B,
+                current_pos = ?SEGMENT_HEADER_B,
+                end_pos = ?SEGMENT_HEADER_B + byte_size(Buffer),
+                buffer = Buffer,
+                fragment_ref = NextFragRef,
+                key = Key,
+                iterator = Iterator,
+                next = undefined,
+                current_not_found = false
+            };
+        _ ->
+            State#state{
+                start_pos = ?SEGMENT_HEADER_B,
+                current_pos = ?SEGMENT_HEADER_B,
+                end_pos = ?SEGMENT_HEADER_B,
+                buffer = <<>>,
+                iterator = Iterator,
+                next = undefined,
+                current_not_found = false
+            }
+    end.
+
+advance_iterator(Iterator) ->
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+        {ok, _, It} -> It;
+        _ -> Iterator
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal: data buffering
+%% ------------------------------------------------------------------
+
+add_data(Fragment, Data, #state{fragment_ref = #fragment_ref{offset = Fragment}} = State) ->
+    add_data_current(Data, State);
+add_data(Fragment, Data, State) ->
+    add_data_next(Fragment, Data, State).
+
+add_data_current(
+    Data,
+    #state{
+        start_pos = StartPos0,
+        current_pos = CurrentPos,
+        end_pos = EndPos0,
+        buffer = Buffer0
+    } = State
+) ->
+    Buffer =
+        case CurrentPos =:= StartPos0 of
+            true ->
+                <<Buffer0/binary, Data/binary>>;
+            false ->
+                <<
+                    (binary:part(Buffer0, CurrentPos - StartPos0, EndPos0 - CurrentPos))/binary,
+                    Data/binary
+                >>
+        end,
+    State#state{
+        start_pos = CurrentPos,
+        end_pos = EndPos0 + byte_size(Data),
+        buffer = Buffer
+    }.
+
+add_data_next(NextOffset, Data, #state{next = Next0, iterator = Iterator} = State) ->
+    Next =
+        case Next0 of
+            undefined ->
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+                    {ok, #fragment_ref{offset = NextOffset} = FragRef, _} ->
+                        {FragRef, Data};
+                    _ ->
+                        {#fragment_ref{offset = NextOffset, uid = 0, size = 0}, Data}
+                end;
+            {#fragment_ref{offset = NextOffset} = FragRef, Buffer0} ->
+                {FragRef, <<Buffer0/binary, Data/binary>>}
+        end,
+    State#state{next = Next}.
+
+%% ------------------------------------------------------------------
+%% Internal: request management
+%% ------------------------------------------------------------------
+
+remove_request_if_done(Fragment, done, #state{requests_in_flight = Reqs} = State) ->
+    State#state{requests_in_flight = maps:remove(Fragment, Reqs)};
+remove_request_if_done(_Fragment, continue, State) ->
+    State.
+
+maybe_start_requests(State0) ->
+    {State1, Effects1} = maybe_start_current_request(State0),
+    {State2, Effects2} = maybe_start_next_request(State1),
+    {State2, Effects1 ++ Effects2}.
+
+start_current_request(State) ->
+    maybe_start_current_request(State).
+
+maybe_start_current_request(
+    #state{
+        read_size = ReadSize,
+        fragment_ref = #fragment_ref{offset = Fragment, size = FragSize},
+        end_pos = EndPos,
+        key = Key,
+        requests_in_flight = Reqs
+    } = State
+) ->
+    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
+    case EndPos < IdxStartPos andalso not maps:is_key(Fragment, Reqs) of
+        true ->
+            Range = {EndPos, min(EndPos + ReadSize, IdxStartPos - 1)},
+            ReqId = make_ref(),
+            State1 = State#state{requests_in_flight = Reqs#{Fragment => ReqId}},
+            {State1, [{start_request, Key, Range, Fragment}]};
+        false ->
+            {State, []}
+    end.
+
+maybe_start_next_request(
+    #state{
+        stream = StreamId,
+        read_size = ReadSize,
+        fragment_ref = #fragment_ref{size = FragSize},
+        end_pos = EndPos,
+        next = undefined,
+        iterator = Iterator,
+        requests_in_flight = Reqs
+    } = State
+) when EndPos >= ?SEGMENT_HEADER_B + FragSize ->
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+        {ok, #fragment_ref{offset = NextOffset, uid = NextUid}, _} ->
+            case maps:is_key(NextOffset, Reqs) of
+                true ->
+                    {State, []};
+                false ->
+                    Key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset, NextUid),
+                    Range = {?SEGMENT_HEADER_B, ?SEGMENT_HEADER_B + ReadSize},
+                    ReqId = make_ref(),
+                    State1 = State#state{requests_in_flight = Reqs#{NextOffset => ReqId}},
+                    {State1, [{start_request, Key, Range, NextOffset}]}
+            end;
+        _ ->
+            {State, []}
+    end;
+maybe_start_next_request(State) ->
+    {State, []}.
+
+%% ------------------------------------------------------------------
+%% Internal: configuration
+%% ------------------------------------------------------------------
+
+build_cfg(Opts) ->
+    #cfg{
+        read_size_min = maps:get(read_size_min, Opts, 1_048_576),
+        read_size_max = maps:get(read_size_max, Opts, 67_108_864),
+        initial_read_size = maps:get(initial_read_size, Opts, 4_194_304),
+        hits_to_grow = maps:get(hits_to_grow, Opts, 8),
+        grow_step = maps:get(grow_step, Opts, 1_048_576),
+        min_retry_delay_ms = maps:get(min_retry_delay_ms, Opts, 1_000),
+        max_retry_delay_ms = maps:get(max_retry_delay_ms, Opts, 30_000)
+    }.
+
+%% ------------------------------------------------------------------
+%% Internal: AIMD
+%% ------------------------------------------------------------------
+
+adjust_read_size(miss, #state{read_size = Current, cfg = #cfg{read_size_min = Min}} = State) ->
+    State#state{
+        read_size = max(Min, Current div 2),
+        hits_since_last_miss = 0
+    };
+adjust_read_size(
+    hit, #state{hits_since_last_miss = Hits, cfg = #cfg{hits_to_grow = HitsToGrow}} = State
+) when
+    Hits + 1 < HitsToGrow
+->
+    State#state{hits_since_last_miss = Hits + 1};
+adjust_read_size(
+    hit, #state{read_size = Current, cfg = #cfg{read_size_max = Max, grow_step = Step}} = State
+) ->
+    State#state{
+        read_size = min(Max, Current + Step),
+        hits_since_last_miss = 0
+    }.

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -383,14 +383,11 @@ try_fragment_transition(
     %% Next fragment 404. Need manifest range to decide.
     {not_found_check_range, State};
 try_fragment_transition(
-    #state{next = undefined, iterator = Iterator, requests_in_flight = Requests} = State
+    #state{next = undefined, iterator = Iterator} = State
 ) ->
     case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-        {ok, #fragment_ref{offset = NextOffset}, _} ->
-            case maps:is_key(NextOffset, Requests) of
-                true -> {await, State};
-                false -> {await, State}
-            end;
+        {ok, _FragRef, _} ->
+            {await, State};
         end_of_manifest ->
             {refresh_iterator, State};
         {error, _} ->

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -120,8 +120,8 @@ and transitions immediately if available, or signals that more data is needed.
     {reply, read_result()}
     | {start_request, rabbitmq_stream_s3:key(), {byte_offset(), byte_offset()}, fragment_offset()}
     | {set_timer, pos_integer()}
-    | {lookup_manifest_range}
-    | {refresh_iterator}
+    | lookup_manifest_range
+    | refresh_iterator
     | {jump_to_oldest, osiris:offset()}
     | stop.
 
@@ -203,7 +203,7 @@ step(State0, {request_error, _RequestId, Fragment, not_found}) ->
             State = State0#state{current_not_found = true, requests_in_flight = #{}},
             case State#state.pending of
                 undefined -> {State, []};
-                _ -> {State, [{lookup_manifest_range}]}
+                _ -> {State, [lookup_manifest_range]}
             end;
         false ->
             %% Next fragment 404. Mark it and try to serve (may trigger range lookup
@@ -325,9 +325,9 @@ try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
             {State3, Effects} = maybe_start_requests(State2),
             {State3, Effects};
         {not_found_check_range, State1} ->
-            {State1, [{lookup_manifest_range}]};
+            {State1, [lookup_manifest_range]};
         {refresh_iterator, State1} ->
-            {State1, [{refresh_iterator}]}
+            {State1, [refresh_iterator]}
     end.
 
 %% ------------------------------------------------------------------

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -111,6 +111,7 @@ and transitions immediately if available, or signals that more data is needed.
     | {data, request_id(), fragment_offset(), binary(), done | continue}
     | {request_error, request_id(), fragment_offset(), term()}
     | retry
+    | deadline_expired
     | {manifest_range, {osiris:offset(), osiris:offset()} | empty}
     | {iterator_refreshed, rabbitmq_stream_s3_fragment_iterator:iterator() | end_of_manifest}
     | {jumped, #fragment_ref{}, rabbitmq_stream_s3_fragment_iterator:iterator()}.
@@ -126,6 +127,7 @@ and transitions immediately if available, or signals that more data is needed.
 
 -type read_result() ::
     {ok, binary()}
+    | {error, timeout}
     | {next_fragment, osiris:offset()}
     | {become_local, osiris:offset()}
     | end_of_stream.
@@ -239,6 +241,21 @@ step(State0, retry) ->
     {State1, Effects} = maybe_start_requests(State0),
     {State2, Effects2} = try_serve(State1),
     {State2, Effects ++ Effects2};
+step(#state{cfg = #cfg{min_retry_delay_ms = MinDelay}} = State0, deadline_expired) ->
+    %% The shell's pending-read deadline fired. Reply with an error and reset
+    %% buffer state so the next read at any position passes Offset >= StartPos.
+    %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/157
+    %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/161
+    State = State0#state{
+        buffer = <<>>,
+        start_pos = 0,
+        current_pos = 0,
+        end_pos = 0,
+        pending = undefined,
+        requests_in_flight = #{},
+        retry_delay = MinDelay
+    },
+    {State, [{reply, {error, timeout}}]};
 step(State0, {manifest_range, Range}) ->
     handle_manifest_range(Range, State0);
 step(State0, {iterator_refreshed, end_of_manifest}) ->

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -52,7 +52,10 @@ all() ->
         %% Replica reader core: rebalancing
         broadcast_edits_reproduce_manifest,
         broadcast_edits_complete_across_persist_cycles,
-        broadcast_edits_with_retention
+        broadcast_edits_with_retention,
+        %% Remote reader core
+        remote_reader_core_no_crash,
+        remote_reader_core_reply_size_bounded
     ].
 
 init_per_suite(Config) -> Config.
@@ -1418,3 +1421,149 @@ chunks_to_index(Chunks) ->
         ?INDEX_RECORD(O, Ts, Pos)
      || {Pos, {O, Ts}} <- lists:zip(lists:seq(0, length(Chunks) - 1), Chunks)
     ]).
+
+%% =========================================================================
+%% Remote reader core properties
+%% =========================================================================
+
+remote_reader_core_no_crash(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_remote_reader_core_no_crash/0, [], 500).
+
+prop_remote_reader_core_no_crash() ->
+    ?FORALL(
+        Events,
+        gen_rrc_event_sequence(),
+        begin
+            FragRef = #fragment_ref{offset = 0, uid = 1, size = 1_000_000},
+            Manifest = #manifest{
+                first_offset = 0,
+                next_offset = 200,
+                entries = ?ENTRY(0, 0, 0, ?MANIFEST_KIND_FRAGMENT, 1_000_000, 1)
+            },
+            GetGroupFun = fun(_) -> {error, not_found} end,
+            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 0, GetGroupFun),
+            Iterator =
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+                    {ok, _, It} -> It;
+                    _ -> Iterator0
+                end,
+            {State0, _} = rabbitmq_stream_s3_remote_reader_core:init(
+                <<"prop-stream">>, FragRef, 8, Iterator, #{}
+            ),
+            %% Run all events. Must not crash.
+            try
+                _ = run_rrc_events(Events, State0),
+                true
+            catch
+                C:R:St ->
+                    file:write_file(
+                        "/tmp/prop_crash.txt",
+                        io_lib:format("~p:~p~nEvents: ~w~nStack: ~p~n", [C, R, Events, St])
+                    ),
+                    false
+            end
+        end
+    ).
+
+remote_reader_core_reply_size_bounded(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_remote_reader_core_reply_size_bounded/0, [], 500).
+
+prop_remote_reader_core_reply_size_bounded() ->
+    ?FORALL(
+        {ReadOffset, ReadBytes, DataSize},
+        {range(8, 500), range(1, 1000), range(100, 5000)},
+        begin
+            FragSize = 1_000_000,
+            FragRef = #fragment_ref{offset = 0, uid = 1, size = FragSize},
+            Manifest = #manifest{
+                first_offset = 0,
+                next_offset = 200,
+                entries = ?ENTRY(0, 0, 0, ?MANIFEST_KIND_FRAGMENT, FragSize, 1)
+            },
+            GetGroupFun = fun(_) -> {error, not_found} end,
+            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 0, GetGroupFun),
+            Iterator =
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+                    {ok, _, It} -> It;
+                    _ -> Iterator0
+                end,
+            {S0, _} = rabbitmq_stream_s3_remote_reader_core:init(
+                <<"prop-stream">>, FragRef, 8, Iterator, #{}
+            ),
+            %% Provide data.
+            Data = binary:copy(<<0>>, DataSize),
+            {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(
+                S0, {data, make_ref(), 0, Data, done}
+            ),
+            %% Issue a read.
+            {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                S1, {read, ReadOffset, ReadBytes, chunk_boundary}
+            ),
+            %% If a reply was produced, its data must be <= ReadBytes.
+            case [D || {reply, {ok, D}} <- Effects] of
+                [] -> true;
+                [ReplyData] -> byte_size(ReplyData) =< ReadBytes
+            end
+        end
+    ).
+
+%% ------------------------------------------------------------------
+%% Remote reader core generators
+%% ------------------------------------------------------------------
+
+gen_rrc_event_sequence() ->
+    ?LET(N, range(1, 20), gen_rrc_events(N, 8)).
+
+gen_rrc_events(0, _NextReadPos) ->
+    [];
+gen_rrc_events(N, NextReadPos) ->
+    ?LET(
+        {Event, NextPos},
+        gen_rrc_event(NextReadPos),
+        ?LET(Rest, gen_rrc_events(N - 1, NextPos), [Event | Rest])
+    ).
+
+gen_rrc_event(NextReadPos) ->
+    frequency([
+        {3, gen_rrc_read_event(NextReadPos)},
+        {3, ?LET(E, gen_rrc_data_event(), {E, NextReadPos})},
+        {2, ?LET(E, gen_rrc_error_event(), {E, NextReadPos})},
+        {1, {{retry}, NextReadPos}},
+        {1, ?LET(E, gen_rrc_manifest_range_event(), {E, NextReadPos})}
+    ]).
+
+gen_rrc_read_event(NextReadPos) ->
+    ?LET(
+        Bytes,
+        range(1, 5000),
+        {{read, NextReadPos, Bytes, chunk_boundary}, NextReadPos + Bytes}
+    ).
+
+gen_rrc_data_event() ->
+    ?LET(
+        Size,
+        range(1, 10000),
+        {data, make_ref(), 0, binary:copy(<<0>>, Size), oneof([done, continue])}
+    ).
+
+gen_rrc_error_event() ->
+    ?LET(
+        Reason,
+        oneof([timeout, slow_down, connection_error, stream_error, internal_error]),
+        {request_error, make_ref(), 0, Reason}
+    ).
+
+gen_rrc_manifest_range_event() ->
+    oneof([
+        {manifest_range, empty},
+        ?LET({F, E}, {range(0, 100), range(101, 500)}, {manifest_range, {F, E}})
+    ]).
+
+run_rrc_events([], State) ->
+    State;
+run_rrc_events([{retry} | Rest], State0) ->
+    {State1, _} = rabbitmq_stream_s3_remote_reader_core:step(State0, retry),
+    run_rrc_events(Rest, State1);
+run_rrc_events([Event | Rest], State0) ->
+    {State1, _} = rabbitmq_stream_s3_remote_reader_core:step(State0, Event),
+    run_rrc_events(Rest, State1).

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -1529,7 +1529,8 @@ gen_rrc_event(NextReadPos) ->
         {3, ?LET(E, gen_rrc_data_event(), {E, NextReadPos})},
         {2, ?LET(E, gen_rrc_error_event(), {E, NextReadPos})},
         {1, {{retry}, NextReadPos}},
-        {1, ?LET(E, gen_rrc_manifest_range_event(), {E, NextReadPos})}
+        {1, ?LET(E, gen_rrc_manifest_range_event(), {E, NextReadPos})},
+        {1, {deadline_expired, NextReadPos}}
     ]).
 
 gen_rrc_read_event(NextReadPos) ->

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -39,7 +39,9 @@ all() ->
         retry_resets_delay_on_success,
         read_larger_than_buffer_awaits,
         header_overread_capped_at_index_boundary,
-        next_fragment_404_triggers_range_lookup
+        next_fragment_404_triggers_range_lookup,
+        deadline_expired_replies_error_timeout,
+        deadline_expired_resets_buffer_for_retry
     ].
 
 init_per_suite(Config) ->
@@ -532,3 +534,42 @@ next_fragment_404_triggers_range_lookup(_Config) ->
         S2, {read, 208, 50, chunk_boundary}
     ),
     ?assertMatch([{lookup_manifest_range}], Effects).
+
+deadline_expired_replies_error_timeout(_Config) ->
+    %% When the shell fires deadline_expired, the core replies {error, timeout}
+    %% and clears the pending read.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Issue a read (pending, no data yet).
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+    ?assertMatch({64, 100}, rabbitmq_stream_s3_remote_reader_core:pending(S1)),
+    %% Deadline fires.
+    {S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(S1, deadline_expired),
+    ?assertMatch([{reply, {error, timeout}}], Effects),
+    %% Pending is cleared.
+    ?assertEqual(undefined, rabbitmq_stream_s3_remote_reader_core:pending(S2)).
+
+deadline_expired_resets_buffer_for_retry(_Config) ->
+    %% After deadline_expired, a subsequent read at any position (including one
+    %% behind the old current_pos) does not crash. It awaits data instead.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Provide data and advance current_pos via a successful read.
+    Data = binary:copy(<<0>>, 5000),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(S1, {read, 64, 100, chunk_boundary}),
+    ?assertMatch([{reply, {ok, _}} | _], E1),
+    %% Issue another read (pending), then deadline fires.
+    {S3, _} = rabbitmq_stream_s3_remote_reader_core:step(S2, {read, 3000, 100, chunk_boundary}),
+    {S4, _} = rabbitmq_stream_s3_remote_reader_core:step(S3, deadline_expired),
+    %% Retry at position 64 (behind old current_pos). Must not crash.
+    %% Buffer is empty so it awaits, and a new request is started.
+    {_S5, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S4, {read, 64, 100, chunk_boundary}
+    ),
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertEqual([], Replies),
+    Requests = [F || {start_request, _, _, F} <- Effects],
+    ?assertMatch([0], Requests).

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -223,7 +223,7 @@ become_local_at_end_of_manifest(_Config) ->
 
     %% Read past end triggers refresh_iterator effect.
     {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(S1, {read, 164, 50, chunk_boundary}),
-    ?assertMatch([{refresh_iterator}], E1),
+    ?assertMatch([refresh_iterator], E1),
 
     %% Shell reports end_of_manifest.
     {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
@@ -244,7 +244,7 @@ not_found_triggers_range_lookup(_Config) ->
     {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
-    ?assertMatch([{lookup_manifest_range}], E1),
+    ?assertMatch([lookup_manifest_range], E1),
 
     %% Shell reports empty range → end_of_stream.
     {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, empty}),
@@ -434,7 +434,7 @@ jump_to_oldest_full_cycle(_Config) ->
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
     %% Issue read, then 404.
     {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
-    {S2, [{lookup_manifest_range}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S2, [lookup_manifest_range]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
     %% Manifest says first available is at offset 500.
@@ -534,7 +534,7 @@ next_fragment_404_triggers_range_lookup(_Config) ->
     {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
         S2, {read, 208, 50, chunk_boundary}
     ),
-    ?assertMatch([{lookup_manifest_range}], Effects).
+    ?assertMatch([lookup_manifest_range], Effects).
 
 deadline_expired_replies_error_timeout(_Config) ->
     %% When the shell fires deadline_expired, the core replies {error, timeout}
@@ -583,7 +583,7 @@ jump_to_oldest_stale_manifest_becomes_local(_Config) ->
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
     %% Issue read, then 404 on current fragment.
     {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
-    {S2, [{lookup_manifest_range}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S2, [lookup_manifest_range]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
     %% Manifest says first_offset = 0, same as our current fragment.

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -1,0 +1,534 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(remote_reader_core_SUITE).
+-moduledoc """
+Tests for the read path functional core.
+
+These tests exercise the pure decision logic in rabbitmq_stream_s3_remote_reader_core
+without any S3 interaction, timers, or processes.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("rabbitmq_stream_s3/include/rabbitmq_stream_s3.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+        init_requests_data,
+        read_served_from_buffer,
+        read_awaits_when_buffer_empty,
+        retry_after_transient_error,
+        two_timeouts_then_retry_succeeds,
+        fragment_transition_with_prefetch,
+        become_local_at_end_of_manifest,
+        not_found_triggers_range_lookup,
+        %% New tests
+        aimd_growth_after_consecutive_hits,
+        aimd_shrink_on_miss,
+        exponential_backoff_caps_at_max,
+        fatal_error_emits_stop,
+        multi_chunk_data_accumulation,
+        prefetch_next_fragment_triggered,
+        fragment_transition_without_prefetch_awaits,
+        read_at_exact_fragment_boundary,
+        mid_fragment_init_position,
+        jump_to_oldest_full_cycle,
+        retry_resets_delay_on_success,
+        read_larger_than_buffer_awaits,
+        header_overread_capped_at_index_boundary,
+        next_fragment_404_triggers_range_lookup
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+stream_id() -> <<"test-stream">>.
+
+%% Build a minimal fragment iterator with one or two entries.
+%% Returns the iterator already advanced past the first entry (matching
+%% the real behavior of find_position in the log reader).
+mock_iterator(Entries) ->
+    Manifest = build_manifest(Entries),
+    GetGroupFun = fun(_) -> {error, not_found} end,
+    FirstOffset =
+        case Entries of
+            [{Off, _, _} | _] -> Off;
+            _ -> 0
+        end,
+    Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, FirstOffset, GetGroupFun),
+    %% Advance past the current entry (same as advance_past_current in log_reader).
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+        {ok, _, It} -> It;
+        _ -> Iterator0
+    end.
+
+build_manifest([]) ->
+    #manifest{entries = <<>>};
+build_manifest(Entries) ->
+    EntriesBin = lists:foldl(
+        fun({Offset, Size, Uid}, Acc) ->
+            E = ?ENTRY(Offset, 0, 0, ?MANIFEST_KIND_FRAGMENT, Size, Uid),
+            <<Acc/binary, E/binary>>
+        end,
+        <<>>,
+        Entries
+    ),
+    #manifest{
+        first_offset = element(1, hd(Entries)),
+        next_offset = element(1, lists:last(Entries)) + 100,
+        entries = EntriesBin
+    }.
+
+frag_ref(Offset, Size, Uid) ->
+    #fragment_ref{offset = Offset, uid = Uid, size = Size}.
+
+init(StreamId, FragRef, Position, Iterator) ->
+    init(StreamId, FragRef, Position, Iterator, #{}).
+
+init(StreamId, FragRef, Position, Iterator, Opts) ->
+    rabbitmq_stream_s3_remote_reader_core:init(StreamId, FragRef, Position, Iterator, Opts).
+
+%% ------------------------------------------------------------------
+%% Tests
+%% ------------------------------------------------------------------
+
+init_requests_data(_Config) ->
+    %% On init, the core should emit a start_request effect for the current fragment.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {_State, Effects} = init(stream_id(), FragRef, 64, Iterator),
+    ?assertMatch([{start_request, _, _, 0}], Effects).
+
+read_served_from_buffer(_Config) ->
+    %% After data arrives, a read at that position is served immediately.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, [{start_request, _Key, _Range, 0}]} =
+        init(stream_id(), FragRef, 64, Iterator),
+
+    %% Simulate data arriving (1024 bytes starting at position 64).
+    Data = binary:copy(<<0>>, 1024),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+
+    %% Now request a read at position 64, 100 bytes.
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 64, 100, chunk_boundary}
+    ),
+    ?assertMatch([{reply, {ok, _}} | _], Effects),
+    [{reply, {ok, ResultData}} | _] = Effects,
+    ?assertEqual(100, byte_size(ResultData)).
+
+read_awaits_when_buffer_empty(_Config) ->
+    %% A read when no data is buffered produces no reply (awaiting data).
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    {_S1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {read, 64, 100, chunk_boundary}
+    ),
+    %% No reply effect — the read is pending.
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertEqual([], Replies).
+
+retry_after_transient_error(_Config) ->
+    %% A transient error (slow_down) produces a set_timer effect.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    {_S1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, slow_down}
+    ),
+    ?assertMatch([{set_timer, _}], Effects).
+
+two_timeouts_then_retry_succeeds(_Config) ->
+    %% Two timeouts increase retry delay. Then retry + data arrival serves the read.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% Issue a read.
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+
+    %% First timeout.
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, timeout}
+    ),
+    ?assertMatch([{set_timer, 1000}], E1),
+
+    %% Second timeout — delay doubles.
+    {S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, timeout}
+    ),
+    ?assertMatch([{set_timer, 2000}], E2),
+
+    %% Retry fires, new request starts.
+    {S4, E3} = rabbitmq_stream_s3_remote_reader_core:step(S3, retry),
+    ?assertMatch([{start_request, _, _, 0} | _], E3),
+
+    %% Data arrives, read is served.
+    Data = binary:copy(<<0>>, 1024),
+    {_S5, E4} = rabbitmq_stream_s3_remote_reader_core:step(S4, {data, make_ref(), 0, Data, done}),
+    Replies4 = [E || {reply, _} = E <- E4],
+    ?assertMatch([{reply, {ok, _}}], Replies4).
+
+fragment_transition_with_prefetch(_Config) ->
+    %% When read position exceeds current fragment and next is pre-fetched,
+    %% transition happens immediately.
+    FragRef = frag_ref(0, 200, 42),
+    Iterator = mock_iterator([{0, 200, 42}, {100, 300, 43}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% Fill current fragment buffer completely.
+    Data = binary:copy(<<0>>, 200),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+
+    %% Pre-fetch next fragment data.
+    NextData = binary:copy(<<1>>, 300),
+    {S2, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {data, make_ref(), 100, NextData, done}
+    ),
+
+    %% Read past end of current fragment (position 64 + 200 = 264 > 64 + 200).
+    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {read, 264, 50, chunk_boundary}
+    ),
+    ?assertMatch([{reply, {next_fragment, 100}} | _], Effects).
+
+become_local_at_end_of_manifest(_Config) ->
+    %% When iterator is exhausted and refresh returns end_of_manifest,
+    %% the core signals become_local.
+    FragRef = frag_ref(0, 100, 42),
+    %% Single-entry manifest — iterator will be exhausted after init advances past it.
+    Iterator = mock_iterator([{0, 100, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% Fill buffer to end of fragment.
+    Data = binary:copy(<<0>>, 100),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+
+    %% Read past end triggers refresh_iterator effect.
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(S1, {read, 164, 50, chunk_boundary}),
+    ?assertMatch([{refresh_iterator}], E1),
+
+    %% Shell reports end_of_manifest.
+    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {iterator_refreshed, end_of_manifest}
+    ),
+    ?assertMatch([{reply, {become_local, 0}}], E2).
+
+not_found_triggers_range_lookup(_Config) ->
+    %% A 404 on the current fragment triggers a manifest range lookup.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% Issue a read.
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+
+    %% Request returns 404.
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, not_found}
+    ),
+    ?assertMatch([{lookup_manifest_range}], E1),
+
+    %% Shell reports empty range → end_of_stream.
+    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, empty}),
+    ?assertMatch([{reply, end_of_stream}], E2).
+
+%% ------------------------------------------------------------------
+%% AIMD and retry tests
+%% ------------------------------------------------------------------
+
+aimd_growth_after_consecutive_hits(_Config) ->
+    %% 8 consecutive buffer hits grow read_size by one GROW_STEP (1 MiB).
+    FragRef = frag_ref(0, 10_000_000, 42),
+    Iterator = mock_iterator([{0, 10_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fill buffer with plenty of data.
+    Data = binary:copy(<<0>>, 5_000_000),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Issue 8 reads (all buffer hits). Each read at a different position.
+    S = lists:foldl(
+        fun(I, Acc) ->
+            Pos = 64 + I * 100,
+            {Acc1, _} = rabbitmq_stream_s3_remote_reader_core:step(
+                Acc, {read, Pos, 50, chunk_boundary}
+            ),
+            Acc1
+        end,
+        S1,
+        lists:seq(0, 7)
+    ),
+    %% 9th read should trigger the growth. Check via start_request range size.
+    %% Initial read_size = 4 MiB. After 8 hits: 4 MiB + 1 MiB = 5 MiB.
+    %% The next start_request (if triggered) would use the new read_size.
+    %% We verify indirectly: issue one more read that's a hit, then check
+    %% that the state is consistent (no crash, reply produced).
+    {_, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S, {read, 64 + 800, 50, chunk_boundary}
+    ),
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertMatch([{reply, {ok, _}}], Replies).
+
+aimd_shrink_on_miss(_Config) ->
+    %% A buffer miss halves read_size. After a timeout clears the request
+    %% and retry fires, the new request uses the halved size.
+    FragRef = frag_ref(0, 10_000_000, 42),
+    Iterator = mock_iterator([{0, 10_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Read without data → miss (adjusts read_size).
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+    %% Timeout clears the in-flight request.
+    {S2, [{set_timer, _}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, timeout}
+    ),
+    %% Retry → new request with halved read_size.
+    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(S2, retry),
+    Requests = [{R, F} || {start_request, _, R, F} <- Effects],
+    ?assertMatch([{{64, _}, 0}], Requests),
+    [{{64, EndPos}, 0}] = Requests,
+    RangeSize = EndPos - 64,
+    %% Initial 4MiB, miss halves to 2MiB.
+    ?assertEqual(2_097_152, RangeSize).
+
+exponential_backoff_caps_at_max(_Config) ->
+    %% Repeated errors double the delay up to 30_000ms max.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fire enough errors to exceed 30s cap: 1000, 2000, 4000, 8000, 16000, 32000→30000
+    {S1, [{set_timer, 1000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S2, [{set_timer, 2000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S3, [{set_timer, 4000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S4, [{set_timer, 8000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S3, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S5, [{set_timer, 16000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S4, {request_error, make_ref(), 0, slow_down}
+    ),
+    %% Next would be 32000 but capped at 30000.
+    {_S6, [{set_timer, 30000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S5, {request_error, make_ref(), 0, slow_down}
+    ),
+    ok.
+
+fatal_error_emits_stop(_Config) ->
+    %% An unknown error reason emits the stop effect.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    {_S1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, {unexpected, boom}}
+    ),
+    ?assertEqual([stop], Effects).
+
+multi_chunk_data_accumulation(_Config) ->
+    %% Data arrives in 3 chunks (continue, continue, done). Read served after all arrive.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Issue read first.
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 300, chunk_boundary}),
+    %% Data arrives in 3 pieces of 100 bytes each.
+    Chunk = binary:copy(<<$A>>, 100),
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {data, make_ref(), 0, Chunk, continue}
+    ),
+    ?assertEqual([], [E || {reply, _} = E <- E1]),
+    {S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {data, make_ref(), 0, Chunk, continue}
+    ),
+    ?assertEqual([], [E || {reply, _} = E <- E2]),
+    {_S4, E3} = rabbitmq_stream_s3_remote_reader_core:step(S3, {data, make_ref(), 0, Chunk, done}),
+    Replies = [E || {reply, _} = E <- E3],
+    ?assertMatch([{reply, {ok, _}}], Replies),
+    [{reply, {ok, ResultData}}] = Replies,
+    ?assertEqual(300, byte_size(ResultData)).
+
+%% ------------------------------------------------------------------
+%% Fragment navigation tests
+%% ------------------------------------------------------------------
+
+prefetch_next_fragment_triggered(_Config) ->
+    %% After current fragment buffer is full, core emits start_request for next fragment.
+    FragRef = frag_ref(0, 200, 42),
+    Iterator = mock_iterator([{0, 200, 42}, {100, 500, 43}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fill current fragment completely (200 bytes from pos 64 to 264).
+    Data = binary:copy(<<0>>, 200),
+    {_S1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {data, make_ref(), 0, Data, done}
+    ),
+    %% Should have a start_request for fragment 100 (the next one).
+    NextRequests = [{K, R, F} || {start_request, K, R, F} <- Effects, F =:= 100],
+    ?assertMatch([{_, _, 100}], NextRequests).
+
+fragment_transition_without_prefetch_awaits(_Config) ->
+    %% When next fragment data is not yet available, core awaits (no reply).
+    FragRef = frag_ref(0, 200, 42),
+    Iterator = mock_iterator([{0, 200, 42}, {100, 500, 43}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fill current fragment but do NOT provide next fragment data.
+    Data = binary:copy(<<0>>, 200),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Read past end of current fragment.
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 264, 50, chunk_boundary}
+    ),
+    %% No reply — awaiting next fragment data.
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertEqual([], Replies).
+
+read_at_exact_fragment_boundary(_Config) ->
+    %% Read at offset == SEGMENT_HEADER_B + FragSize triggers transition.
+    FragRef = frag_ref(0, 200, 42),
+    Iterator = mock_iterator([{0, 200, 42}, {100, 500, 43}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fill current + prefetch next.
+    Data = binary:copy(<<0>>, 200),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    NextData = binary:copy(<<1>>, 500),
+    {S2, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {data, make_ref(), 100, NextData, done}
+    ),
+    %% Read at exactly 64 + 200 = 264 (the boundary).
+    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {read, 264, 50, chunk_boundary}
+    ),
+    ?assertMatch([{reply, {next_fragment, 100}} | _], Effects).
+
+mid_fragment_init_position(_Config) ->
+    %% When init position > SEGMENT_HEADER_B, first request starts at that position.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    MidPos = 5000,
+    {_S0, Effects} = init(stream_id(), FragRef, MidPos, Iterator),
+    ?assertMatch([{start_request, _, {5000, _}, 0}], Effects).
+
+jump_to_oldest_full_cycle(_Config) ->
+    %% 404 on current fragment → manifest_range → jump_to_oldest effect →
+    %% jumped event → reply with next_fragment + new request started.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}, {500, 2_000_000, 99}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Issue read, then 404.
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+    {S2, [{lookup_manifest_range}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, not_found}
+    ),
+    %% Manifest says first available is at offset 500.
+    {S3, E1} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, {500, 1000}}),
+    ?assertMatch([{jump_to_oldest, 500}], E1),
+    %% Shell resolves the jump and feeds back.
+    NewFragRef = frag_ref(500, 2_000_000, 99),
+    NewIterator = mock_iterator([{500, 2_000_000, 99}]),
+    {_S4, E2} = rabbitmq_stream_s3_remote_reader_core:step(S3, {jumped, NewFragRef, NewIterator}),
+    %% Should reply with next_fragment and start a request for the new fragment.
+    ?assertMatch([{reply, {next_fragment, 500}} | _], E2),
+    Requests = [F || {start_request, _, _, F} <- E2],
+    ?assertEqual([500], Requests).
+
+retry_resets_delay_on_success(_Config) ->
+    %% After backoff escalates, successful data resets delay to minimum.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Escalate: 1s, 2s, 4s.
+    {S1, [{set_timer, 1000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S2, [{set_timer, 2000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, slow_down}
+    ),
+    {S3, [{set_timer, 4000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, slow_down}
+    ),
+    %% Retry, then data arrives successfully.
+    {S4, _} = rabbitmq_stream_s3_remote_reader_core:step(S3, retry),
+    Data = binary:copy(<<0>>, 1024),
+    {S5, _} = rabbitmq_stream_s3_remote_reader_core:step(S4, {data, make_ref(), 0, Data, done}),
+    %% Next error should start back at 1000ms (reset).
+    {_S6, [{set_timer, 1000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S5, {request_error, make_ref(), 0, slow_down}
+    ),
+    ok.
+
+read_larger_than_buffer_awaits(_Config) ->
+    %% Request more bytes than are buffered. Core awaits, does not crash or
+    %% return partial data.
+    FragRef = frag_ref(0, 10_000_000, 42),
+    Iterator = mock_iterator([{0, 10_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Provide only 100 bytes.
+    Data = binary:copy(<<0>>, 100),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Request 5000 bytes at position 64. Only 100 available.
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 64, 5000, chunk_boundary}
+    ),
+    %% No reply — awaiting more data. A new request may or may not be emitted
+    %% (depends on whether one was already started when data arrived).
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertEqual([], Replies).
+
+header_overread_capped_at_index_boundary(_Config) ->
+    %% The log reader over-reads headers (64 + filter bytes). When the buffer
+    %% extends past the index boundary, the core caps the returned data at
+    %% the index start. SEGMENT_HEADER_B = 8, so IdxStartPos = 8 + FragSize.
+    FragSize = 500,
+    FragRef = frag_ref(0, FragSize, 42),
+    Iterator = mock_iterator([{0, FragSize, 42}]),
+    %% Start at position 8 (real SEGMENT_HEADER_B).
+    {S0, _} = init(stream_id(), FragRef, 8, Iterator),
+    %% Fill buffer to cover the full fragment data region (8 + 500 = 508).
+    Data = binary:copy(<<0>>, FragSize),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Read 200 bytes starting at position 400. IdxStartPos = 508.
+    %% Requested end = 600 > EndPos = 508. Cap path fires.
+    %% Final cap: min(508 - 8 - 400 + 8, 508 - 400) = min(108, 108) = 108.
+    %% Actually: cap to EndPos - Offset = 508 - 400 = 108, then
+    %% final clause: min(108, IdxStartPos - Offset) = min(108, 508 - 400) = 108.
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 400, 200, chunk_boundary}
+    ),
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertMatch([{reply, {ok, _}}], Replies),
+    [{reply, {ok, ResultData}}] = Replies,
+    ?assertEqual(108, byte_size(ResultData)).
+
+next_fragment_404_triggers_range_lookup(_Config) ->
+    %% Prefetch of next fragment returns 404. When the consumer reads past
+    %% the current fragment, the core triggers a manifest range lookup.
+    FragRef = frag_ref(0, 200, 42),
+    Iterator = mock_iterator([{0, 200, 42}, {100, 500, 43}]),
+    {S0, _} = init(stream_id(), FragRef, 8, Iterator),
+    %% Fill current fragment.
+    Data = binary:copy(<<0>>, 200),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Next fragment prefetch returns 404 (fragment 100, not current fragment 0).
+    {S2, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 100, not_found}
+    ),
+    %% Read past end of current fragment. Next is not_found → range lookup.
+    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {read, 208, 50, chunk_boundary}
+    ),
+    ?assertMatch([{lookup_manifest_range}], Effects).

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -41,7 +41,8 @@ all() ->
         header_overread_capped_at_index_boundary,
         next_fragment_404_triggers_range_lookup,
         deadline_expired_replies_error_timeout,
-        deadline_expired_resets_buffer_for_retry
+        deadline_expired_resets_buffer_for_retry,
+        jump_to_oldest_stale_manifest_becomes_local
     ].
 
 init_per_suite(Config) ->
@@ -573,3 +574,20 @@ deadline_expired_resets_buffer_for_retry(_Config) ->
     ?assertEqual([], Replies),
     Requests = [F || {start_request, _, _, F} <- Effects],
     ?assertMatch([0], Requests).
+
+jump_to_oldest_stale_manifest_becomes_local(_Config) ->
+    %% When manifest_range returns FirstOffset == current fragment offset,
+    %% the manifest is stale. The core must become_local instead of looping.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Issue read, then 404 on current fragment.
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
+    {S2, [{lookup_manifest_range}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, not_found}
+    ),
+    %% Manifest says first_offset = 0, same as our current fragment.
+    %% This means retention deleted it but the persist cycle hasn't updated yet.
+    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, {0, 500}}),
+    %% Must become_local, NOT emit jump_to_oldest (which would loop).
+    ?assertMatch([{reply, {become_local, 0}}], Effects).


### PR DESCRIPTION
This is a refactor/redesign of the reading path, specifically the `rabbitmq_stream_s3_remote_reader` process. It is hard to test currently because the side effects (read requests, timers, etc.) are mixed in with the logic. With the `_core` module here we can test tricky situations like sequences of timeouts without the test case needing any timing concerns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
