### PR TITLE
Extract elapsed-time calculation into `rabbitmq_stream_s3_util`

### DIFF
--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -226,7 +226,7 @@ stream_data({StartTs, BackendState}, Data) ->
 -spec stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
 stream_finish({StartTs, BackendState}, Crc32) ->
     Result = (backend()):stream_finish(BackendState, Crc32),
-    Ms = erlang:convert_time_unit(erlang:monotonic_time() - StartTs, native, millisecond),
+    Ms = rabbitmq_stream_s3_util:elapsed_ms(StartTs),
     rabbitmq_stream_s3_histogram:observe({?MODULE, request_duration, write}, Ms),
     Result.
 
@@ -298,7 +298,7 @@ cancel_async(Req, {StartTs, BackendState}) ->
     ok = finish_async(StartTs).
 
 finish_async(StartTs) ->
-    Ms = erlang:convert_time_unit(erlang:monotonic_time() - StartTs, native, millisecond),
+    Ms = rabbitmq_stream_s3_util:elapsed_ms(StartTs),
     rabbitmq_stream_s3_histogram:observe({?MODULE, request_duration, read}, Ms),
     ok.
 
@@ -307,9 +307,7 @@ observe(Kind, Fun) ->
     try
         Fun()
     after
-        DurationMs = erlang:convert_time_unit(
-            erlang:monotonic_time() - T0, native, millisecond
-        ),
+        DurationMs = rabbitmq_stream_s3_util:elapsed_ms(T0),
         rabbitmq_stream_s3_histogram:observe({?MODULE, request_duration, Kind}, DurationMs)
     end.
 

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -1375,8 +1375,7 @@ start_timeout_window(_Timeout) ->
 end_timeout_window(infinity = Timeout, none) ->
     Timeout;
 end_timeout_window(Timeout, T0) ->
-    T1 = erlang:monotonic_time(),
-    TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
+    TDiff = rabbitmq_stream_s3_util:elapsed_ms(T0),
     Remaining = Timeout - TDiff,
     erlang:max(Remaining, 0).
 

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -129,7 +129,7 @@ counter() ->
 
 record_resolve(T0, Tier, OffsetSpec) ->
     Cnt = counter(),
-    Duration = erlang:convert_time_unit(erlang:monotonic_time() - T0, native, millisecond),
+    Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
     counters:add(Cnt, ?C_RESOLVE_DURATION_MS, Duration),
     counters:add(Cnt, ?C_RESOLVE, 1),
     case Tier of

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -187,7 +187,7 @@ read(Server, Offset, Bytes, Hint) ->
 read(Server, Offset, Bytes, Hint, Timeout) ->
     T0 = erlang:monotonic_time(),
     Result = gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout),
-    Duration = erlang:convert_time_unit(erlang:monotonic_time() - T0, native, millisecond),
+    Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
     counters:add(counter(), ?C_READ_DURATION_MS, Duration),
     counters:add(counter(), ?C_READ, 1),
     Result.
@@ -531,11 +531,7 @@ maybe_reply_pending(
 ) ->
     case maybe_reply(Read, State0) of
         {reply, Reply, State1} ->
-            Duration = erlang:convert_time_unit(
-                erlang:monotonic_time() - Since,
-                native,
-                millisecond
-            ),
+            Duration = rabbitmq_stream_s3_util:elapsed_ms(Since),
             counters:add(counter(), ?C_AWAIT_DURATION_MS, Duration),
             counters:add(counter(), ?C_AWAIT, 1),
             gen_server:reply(From, Reply),

--- a/src/rabbitmq_stream_s3_token_bucket.erl
+++ b/src/rabbitmq_stream_s3_token_bucket.erl
@@ -46,7 +46,7 @@ request(Tokens, #bucket{available = Available} = Bucket) ->
 -spec refill(t()) -> t().
 refill(#bucket{rate = Rate, burst = Burst, available = Available, last_refill = Last} = Bucket) ->
     Now = erlang:monotonic_time(),
-    Elapsed = erlang:convert_time_unit(Now - Last, native, millisecond),
+    Elapsed = rabbitmq_stream_s3_util:elapsed_ms(Now, Last),
     Added = (Rate * Elapsed) div 1000,
     NewAvailable = min(Burst, Available + Added),
     Bucket#bucket{available = NewAvailable, last_refill = Now}.

--- a/src/rabbitmq_stream_s3_util.erl
+++ b/src/rabbitmq_stream_s3_util.erl
@@ -1,0 +1,15 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_util).
+-moduledoc "Shared utility functions.".
+
+-export([elapsed_ms/1, elapsed_ms/2]).
+
+-spec elapsed_ms(integer()) -> non_neg_integer().
+elapsed_ms(StartTs) ->
+    erlang:convert_time_unit(erlang:monotonic_time() - StartTs, native, millisecond).
+
+-spec elapsed_ms(integer(), integer()) -> non_neg_integer().
+elapsed_ms(Now, StartTs) ->
+    erlang:convert_time_unit(Now - StartTs, native, millisecond).


### PR DESCRIPTION
## Summary

- Add `rabbitmq_stream_s3_util` module with `elapsed_ms/1` and `elapsed_ms/2`
- Replace all `erlang:convert_time_unit(erlang:monotonic_time() - T0, native, millisecond)` calls across the codebase

## Motivation

The elapsed-time pattern appeared 8 times across 5 modules. A shared utility reduces noise and makes intent clearer.

- `elapsed_ms/1` captures monotonic time internally (most common case)
- `elapsed_ms/2` accepts a pre-captured `Now` for callers that also store the timestamp (e.g. token_bucket's `last_refill`)

Closes #164.
