### PR TITLE
remote reader: Break jump_to_oldest loop when manifest is stale

### DIFF
--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -830,6 +830,25 @@ cancel_requests(Requests) ->
     counters:put(counter(), ?C_REQUESTS_IN_FLIGHT, 0).
 
 jump_to_oldest(
+    #?MODULE{
+        fragment_ref = #fragment_ref{offset = CurrentOffset},
+        requests = Requests,
+        cancelled_requests = Cancelled0
+    } = State0,
+    FirstOffset
+) when FirstOffset =:= CurrentOffset ->
+    %% The manifest's first_offset points to the fragment we already know
+    %% is gone (404). The manifest is stale - retention deleted the
+    %% fragment but the persist cycle hasn't updated the manifest yet.
+    %% Fall through to the local tier to avoid an infinite loop.
+    cancel_requests(Requests),
+    Cancelled = maps:merge(Cancelled0, #{Req => ok || Req := _ <- Requests}),
+    State = goto_next_fragment(State0#?MODULE{
+        requests = #{},
+        cancelled_requests = Cancelled
+    }),
+    {become_local, State};
+jump_to_oldest(
     #?MODULE{stream = StreamId, requests = Requests, cancelled_requests = Cancelled0} = State0,
     FirstOffset
 ) ->


### PR DESCRIPTION
## Summary

- Add a guard clause to `jump_to_oldest` that detects when the manifest's `first_offset` points to the fragment we're already on (and got a 404 for)
- Transition to `become_local` instead of looping, allowing the consumer to stall briefly until the manifest is updated

## Problem

When retention deletes a fragment from S3 before the manifest persist cycle updates `first_offset`, the remote reader enters an infinite loop:

1. Jump to the manifest's first fragment
2. S3 returns 404
3. Query manifest range (returns the same stale offset)
4. Jump again - goto 1

The loop runs at S3 404 round-trip speed (~10ms/iteration), generating millions of log entries and consuming CPU while delivering zero data. Observed 1,828,523 "Jumping to oldest available fragment" events targeting the same offset in a single 2-hour test run.

## Fix

A guard clause on `jump_to_oldest` checks if `FirstOffset =:= CurrentOffset` (the fragment we're currently on and already know is gone). If so, cancel requests and transition to `become_local` instead of looping. The consumer stalls briefly until the manifest is updated on the next persist cycle, then resumes normally on the next attach.

## Test plan

- [x] Compiles cleanly
- [x] No trailing whitespace
- [ ] Deploy to test cluster and run 2-hour high-throughput soak test
- [ ] Verify: no "Jumping to oldest" loop, consumers recover after retention fires, replay succeeds

Closes #166.
