### PR TITLE
Defer retention reaping until manifest is persisted

### DIFF
--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -73,6 +73,7 @@ efficiently using the `rabbitmq_stream_s3_array` module.
     uid/0,
     format_uid/1,
     offset_filename/2,
+    ref_key/2,
     manifest_key/2,
     group_key/2,
     group_name/1,
@@ -118,6 +119,12 @@ pad_zeroes(Offset) ->
         false ->
             Num
     end.
+
+-doc "Returns the S3 key for any ref type.".
+-spec ref_key(stream_id(), #fragment_ref{} | #group_ref{} | #manifest_ref{}) -> key().
+ref_key(StreamId, #fragment_ref{} = Ref) -> fragment_key(StreamId, Ref);
+ref_key(StreamId, #group_ref{} = Ref) -> group_key(StreamId, Ref);
+ref_key(StreamId, #manifest_ref{} = Ref) -> manifest_key(StreamId, Ref).
 
 -doc "Creates the key for the given stream and manifest ref".
 -spec manifest_key(stream_id(), #manifest_ref{}) -> key().

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -362,57 +362,34 @@ execute_effect(
 execute_effect({set_timer, DelayMs}, State) ->
     erlang:send_after(DelayMs, self(), retry_requests),
     State;
-execute_effect(lookup_manifest_range, #state{stream = StreamId, core = Core0} = State) ->
-    %% Synchronous local lookup — feed result back to core immediately.
-    Range = rabbitmq_stream_s3_manifest_replica:get_range(StreamId),
-    {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, {manifest_range, Range}),
-    execute_effects(Effects, State#state{core = Core1});
-execute_effect(refresh_iterator, #state{stream = StreamId, core = Core0} = State) ->
-    %% Synchronous local lookup — feed result back to core immediately.
-    Result = refresh_iterator(StreamId, Core0),
+execute_effect(
+    {refresh_iterator, NotFoundOffset},
+    #state{stream = StreamId, core = Core0} = State0
+) ->
+    %% Cancel in-flight requests. The core will reinitialize at a new fragment.
+    State1 = cancel_all_requests(State0),
+    %% Synchronous local lookup. Rebuild iterator past the 404'd offset.
+    Result = refresh_iterator(StreamId, NotFoundOffset),
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
         Core0, {iterator_refreshed, Result}
     ),
-    execute_effects(Effects, State#state{core = Core1});
-execute_effect(
-    {jump_to_oldest, FirstOffset},
-    #state{stream = StreamId, core = Core0} = State0
-) ->
-    %% Cancel in-flight requests, resolve the fragment from the manifest,
-    %% and feed back to the core.
-    State1 = cancel_all_requests(State0),
-    case resolve_fragment_at(StreamId, FirstOffset) of
-        {ok, FragRef, Iterator} ->
-            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
-                Core0, {jumped, FragRef, Iterator}
-            ),
-            execute_effects(Effects, State1#state{core = Core1});
-        not_found ->
-            %% Manifest doesn't have this offset. End of stream.
-            case State1#state.from of
-                undefined ->
-                    State1;
-                From ->
-                    gen_server:reply(From, end_of_stream),
-                    State1#state{from = undefined, since = undefined}
-            end
-    end;
+    execute_effects(Effects, State1#state{core = Core1});
 execute_effect(stop, State) ->
     State#state{stopping = true}.
 
-%% Rebuild the fragment iterator from the manifest cache.
-refresh_iterator(StreamId, Core) ->
-    FragOffset = rabbitmq_stream_s3_remote_reader_core:current_fragment_offset(Core),
+%% Rebuild the fragment iterator from the manifest cache, advancing past
+%% the given offset (the fragment known to be 404).
+refresh_iterator(StreamId, NotFoundOffset) ->
     case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
         #manifest{} = Manifest ->
             GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
             Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, FragOffset, GetGroupFun
+                Manifest, NotFoundOffset, GetGroupFun
             ),
-            %% Advance past the current fragment.
+            %% Advance past the 404'd fragment.
             Iterator =
                 case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
-                    {ok, _, It} -> It;
+                    {ok, #fragment_ref{offset = O}, It} when O =< NotFoundOffset -> It;
                     _ -> Iterator0
                 end,
             %% Check if there's anything after.
@@ -422,22 +399,6 @@ refresh_iterator(StreamId, Core) ->
             end;
         _ ->
             end_of_manifest
-    end.
-
-%% Look up a fragment ref at the given offset from the manifest cache.
-resolve_fragment_at(StreamId, Offset) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{} = Manifest ->
-            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-            Iterator = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, Offset, GetGroupFun
-            ),
-            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                {ok, FragRef, _} -> {ok, FragRef, Iterator};
-                _ -> not_found
-            end;
-        _ ->
-            not_found
     end.
 
 maybe_stop(#state{stopping = true} = State) ->

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -403,10 +403,22 @@ try_fragment_transition(
 %% Internal: fragment navigation
 %% ------------------------------------------------------------------
 
-%% Returns the offset of the next fragment in the iterator (the one that 404'd).
-%% Only called from the `not_found_check_range` branch of `try_serve`, where
-%% `next = not_found` guarantees the iterator is positioned at the 404'd entry
-%% and `next/1` will always return `{ok, _, _}`.
+%% Returns the offset of the next fragment in the iterator. Called from the
+%% `not_found_check_range` branch of `try_serve`. There are two paths into
+%% that branch:
+%%
+%%  1. `try_fragment_transition` matching `next = not_found`: the consumer
+%%     read past the current fragment and the prefetched-next 404'd. The
+%%     iterator is positioned at the 404'd entry, so this returns the
+%%     404'd offset. `next/1` always succeeds with `{ok, _, _}`.
+%%
+%%  2. `try_read` matching `current_not_found = true`: the *current*
+%%     fragment 404'd while no read was pending; a later read wants bytes
+%%     past the partial buffer. The iterator was already advanced past
+%%     the current fragment, so it points at the entry AFTER the 404'd
+%%     one. This function then returns a live fragment's offset, which
+%%     the shell uses to refresh the iterator and ends up skipping the
+%%     live fragment. Tracked by issue #173.
 next_fragment_offset(#state{iterator = Iterator}) ->
     {ok, #fragment_ref{offset = Offset}, _} = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
     Offset.

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -404,6 +404,9 @@ try_fragment_transition(
 %% ------------------------------------------------------------------
 
 %% Returns the offset of the next fragment in the iterator (the one that 404'd).
+%% Only called from the `not_found_check_range` branch of `try_serve`, where
+%% `next = not_found` guarantees the iterator is positioned at the 404'd entry
+%% and `next/1` will always return `{ok, _, _}`.
 next_fragment_offset(#state{iterator = Iterator}) ->
     {ok, #fragment_ref{offset = Offset}, _} = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
     Offset.

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -15,20 +15,20 @@ returns a new state plus a list of effects describing what should happen next.
 
 ## Events (inputs)
 
-- `{read, Offset, Bytes, Hint}` — caller wants data at this position
-- `{data, RequestId, Fragment, Data, done | continue}` — S3 delivered bytes
-- `{request_error, RequestId, Reason}` — S3 request failed
-- `{request_timeout, RequestId}` — request exceeded deadline
-- `retry` — retry timer fired
-- `{iterator_refreshed, Iterator}` — manifest cache provided new iterator
+- `{read, Offset, Bytes, Hint}` - caller wants data at this position
+- `{data, RequestId, Fragment, Data, done | continue}` - S3 delivered bytes
+- `{request_error, RequestId, Fragment, Reason}` - S3 request failed
+- `retry` - retry timer fired
+- `deadline_expired` - pending read exceeded its deadline
+- `{iterator_refreshed, Iterator}` - manifest cache provided new iterator
 
 ## Effects (outputs)
 
-- `{reply, Result}` — respond to the pending read
-- `{start_request, Key, Range, Fragment}` — initiate an S3 GET
-- `{set_timer, Duration, Event}` — schedule a future event
-- `{cancel_request, RequestId}` — abort an in-flight request
-- `stop` — shut down the remote reader
+- `{reply, Result}` - respond to the pending read
+- `{start_request, Key, Range, Fragment}` - initiate an S3 GET
+- `{set_timer, Duration}` - schedule a retry timer
+- `{refresh_iterator, Offset}` - rebuild iterator past the given offset
+- `stop` - shut down the remote reader
 
 ## Design
 
@@ -112,17 +112,13 @@ and transitions immediately if available, or signals that more data is needed.
     | {request_error, request_id(), fragment_offset(), term()}
     | retry
     | deadline_expired
-    | {manifest_range, {osiris:offset(), osiris:offset()} | empty}
-    | {iterator_refreshed, rabbitmq_stream_s3_fragment_iterator:iterator() | end_of_manifest}
-    | {jumped, #fragment_ref{}, rabbitmq_stream_s3_fragment_iterator:iterator()}.
+    | {iterator_refreshed, rabbitmq_stream_s3_fragment_iterator:iterator() | end_of_manifest}.
 
 -type effect() ::
     {reply, read_result()}
     | {start_request, rabbitmq_stream_s3:key(), {byte_offset(), byte_offset()}, fragment_offset()}
     | {set_timer, pos_integer()}
-    | lookup_manifest_range
-    | refresh_iterator
-    | {jump_to_oldest, osiris:offset()}
+    | {refresh_iterator, osiris:offset()}
     | stop.
 
 -type read_result() ::
@@ -199,14 +195,14 @@ step(State0, {data, _RequestId, Fragment, Data, DoneOrContinue}) ->
 step(State0, {request_error, _RequestId, Fragment, not_found}) ->
     case Fragment =:= (State0#state.fragment_ref)#fragment_ref.offset of
         true ->
-            %% Current fragment 404. Need to check manifest range.
+            %% Current fragment 404. Refresh the iterator past this offset.
             State = State0#state{current_not_found = true, requests_in_flight = #{}},
             case State#state.pending of
                 undefined -> {State, []};
-                _ -> {State, [lookup_manifest_range]}
+                _ -> {State, [{refresh_iterator, Fragment}]}
             end;
         false ->
-            %% Next fragment 404. Mark it and try to serve (may trigger range lookup
+            %% Next fragment 404. Mark it and try to serve (may trigger refresh
             %% when the consumer reads past the current fragment).
             State = State0#state{
                 next = not_found,
@@ -256,40 +252,41 @@ step(#state{cfg = #cfg{min_retry_delay_ms = MinDelay}} = State0, deadline_expire
         retry_delay = MinDelay
     },
     {State, [{reply, {error, timeout}}]};
-step(State0, {manifest_range, Range}) ->
-    handle_manifest_range(Range, State0);
 step(State0, {iterator_refreshed, end_of_manifest}) ->
     %% No new entries. Become local.
     FragOffset = (State0#state.fragment_ref)#fragment_ref.offset,
     State = goto_next_fragment(State0),
     {State, [{reply, {become_local, FragOffset}}]};
 step(State0, {iterator_refreshed, Iterator}) ->
-    State1 = State0#state{iterator = Iterator},
-    {State2, Effects} = maybe_start_requests(State1),
-    {State3, Effects2} = try_serve(State2),
-    {State3, Effects ++ Effects2};
-step(#state{stream = StreamId, cfg = Cfg} = _State0, {jumped, FragRef, Iterator}) ->
-    %% Shell resolved a jump_to_oldest. Reinitialize at the new fragment.
-    #fragment_ref{offset = Offset, uid = Uid} = FragRef,
-    Key = rabbitmq_stream_s3:fragment_key(StreamId, Offset, Uid),
-    Iterator1 = advance_iterator(Iterator),
-    State = #state{
-        stream = StreamId,
-        cfg = Cfg,
-        read_size = Cfg#cfg.initial_read_size,
-        retry_delay = Cfg#cfg.min_retry_delay_ms,
-        fragment_ref = FragRef,
-        key = Key,
-        buffer = <<>>,
-        start_pos = ?SEGMENT_HEADER_B,
-        current_pos = ?SEGMENT_HEADER_B,
-        end_pos = ?SEGMENT_HEADER_B,
-        iterator = Iterator1,
-        next = undefined
-    },
-    %% Reply with next_fragment so the log reader repositions, then start fetching.
-    {State1, Effects} = start_current_request(State),
-    {State1, [{reply, {next_fragment, Offset}} | Effects]}.
+    %% Iterator has been refreshed past the 404'd fragment. Reinitialize
+    %% at the next available fragment.
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+        {ok, FragRef, Iterator1} ->
+            #fragment_ref{offset = Offset, uid = Uid} = FragRef,
+            StreamId = State0#state.stream,
+            Cfg = State0#state.cfg,
+            Key = rabbitmq_stream_s3:fragment_key(StreamId, Offset, Uid),
+            State = #state{
+                stream = StreamId,
+                cfg = Cfg,
+                read_size = Cfg#cfg.initial_read_size,
+                retry_delay = Cfg#cfg.min_retry_delay_ms,
+                fragment_ref = FragRef,
+                key = Key,
+                buffer = <<>>,
+                start_pos = ?SEGMENT_HEADER_B,
+                current_pos = ?SEGMENT_HEADER_B,
+                end_pos = ?SEGMENT_HEADER_B,
+                iterator = Iterator1,
+                next = undefined
+            },
+            {State1, Effects} = start_current_request(State),
+            {State1, [{reply, {next_fragment, Offset}} | Effects]};
+        _ ->
+            %% Iterator exhausted after refresh. Become local.
+            FragOffset = (State0#state.fragment_ref)#fragment_ref.offset,
+            {State0, [{reply, {become_local, FragOffset}}]}
+    end.
 
 %% @doc Returns the pending read, if any.
 -spec pending(state()) -> undefined | {byte_offset(), pos_integer()}.
@@ -325,9 +322,13 @@ try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
             {State3, Effects} = maybe_start_requests(State2),
             {State3, Effects};
         {not_found_check_range, State1} ->
-            {State1, [lookup_manifest_range]};
+            %% Next fragment was 404. Refresh iterator past it.
+            NotFoundOffset = next_fragment_offset(State1),
+            {State1, [{refresh_iterator, NotFoundOffset}]};
         {refresh_iterator, State1} ->
-            {State1, [refresh_iterator]}
+            %% Iterator exhausted. Refresh past current fragment.
+            CurrentOffset = (State1#state.fragment_ref)#fragment_ref.offset,
+            {State1, [{refresh_iterator, CurrentOffset}]}
     end.
 
 %% ------------------------------------------------------------------
@@ -399,60 +400,13 @@ try_fragment_transition(
     end.
 
 %% ------------------------------------------------------------------
-%% Internal: manifest range handling (for 404 cases)
-%% ------------------------------------------------------------------
-
-handle_manifest_range(empty, #state{pending = undefined} = State) ->
-    {State, []};
-handle_manifest_range(empty, State) ->
-    State1 = State#state{pending = undefined},
-    {State1, [{reply, end_of_stream}]};
-handle_manifest_range(_Range, #state{pending = undefined} = State) ->
-    %% No pending read. Ignore stale manifest range response.
-    {State, []};
-handle_manifest_range(
-    {FirstOffset, EndOffset},
-    #state{
-        fragment_ref = #fragment_ref{offset = CurrentOffset, size = FragSize},
-        pending = #pending{offset = Offset}
-    } = State
-) ->
-    AtFragmentEnd = Offset >= ?SEGMENT_HEADER_B + FragSize,
-    case {AtFragmentEnd, State#state.next} of
-        {true, not_found} ->
-            %% Next fragment was 404. Check if retention evicted it.
-            case rabbitmq_stream_s3_fragment_iterator:next(State#state.iterator) of
-                {ok, #fragment_ref{offset = NextFragment}, _} when FirstOffset >= NextFragment ->
-                    maybe_jump_to_oldest(FirstOffset, CurrentOffset, State);
-                {ok, #fragment_ref{offset = NextFragment}, _} when EndOffset =< NextFragment ->
-                    FragOffset = (State#state.fragment_ref)#fragment_ref.offset,
-                    State1 = goto_next_fragment(State#state{pending = undefined}),
-                    {State1, [{reply, {become_local, FragOffset}}]};
-                _ ->
-                    State1 = goto_next_fragment(State#state{pending = undefined}),
-                    {State1, [
-                        {reply, {become_local, (State#state.fragment_ref)#fragment_ref.offset}}
-                    ]}
-            end;
-        {false, _} ->
-            maybe_jump_to_oldest(FirstOffset, CurrentOffset, State);
-        _ ->
-            State1 = goto_next_fragment(State#state{pending = undefined}),
-            {State1, [{reply, {become_local, (State#state.fragment_ref)#fragment_ref.offset}}]}
-    end.
-
-%% If the manifest's first_offset points to the fragment we already know is
-%% gone (404), the manifest is stale. Fall through to the local tier to avoid
-%% an infinite jump loop. See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/166
-maybe_jump_to_oldest(FirstOffset, CurrentOffset, State) when FirstOffset =:= CurrentOffset ->
-    State1 = goto_next_fragment(State#state{pending = undefined}),
-    {State1, [{reply, {become_local, CurrentOffset}}]};
-maybe_jump_to_oldest(FirstOffset, _CurrentOffset, State) ->
-    {State, [{jump_to_oldest, FirstOffset}]}.
-
-%% ------------------------------------------------------------------
 %% Internal: fragment navigation
 %% ------------------------------------------------------------------
+
+%% Returns the offset of the next fragment in the iterator (the one that 404'd).
+next_fragment_offset(#state{iterator = Iterator}) ->
+    {ok, #fragment_ref{offset = Offset}, _} = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
+    Offset.
 
 goto_next_fragment(#state{stream = StreamId, next = Next0, iterator = Iterator0} = State) ->
     Iterator = advance_iterator(Iterator0),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -595,15 +595,7 @@ delete_manifest_objects(StreamId, Manifest) ->
             end
         end,
         Refs = rabbitmq_stream_s3_fragment_iterator:all_refs(Manifest, GetGroupFun),
-        Keys = lists:map(
-            fun
-                (#fragment_ref{} = FRef) ->
-                    rabbitmq_stream_s3:fragment_key(StreamId, FRef);
-                (#group_ref{} = GroupRef) ->
-                    rabbitmq_stream_s3:group_key(StreamId, GroupRef)
-            end,
-            Refs
-        ),
+        Keys = [rabbitmq_stream_s3:ref_key(StreamId, Ref) || Ref <- Refs],
         rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys)
     end),
     ok.
@@ -686,7 +678,7 @@ commit_khepri(StreamId, Epoch, Reference, ExpectedRevision, Uid) ->
 delete_old_manifest(_StreamId, undefined) ->
     ok;
 delete_old_manifest(StreamId, #manifest_ref{} = Ref) ->
-    Key = rabbitmq_stream_s3:manifest_key(StreamId, Ref),
+    Key = rabbitmq_stream_s3:ref_key(StreamId, Ref),
     rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]).
 
 -spec serialize_manifest(#manifest{}) -> binary().
@@ -1369,15 +1361,7 @@ on_persist_completed(#manifest{} = Manifest, State) ->
 flush_deferred_deletions(#state{deferred_deletions = []}) ->
     ok;
 flush_deferred_deletions(#state{deferred_deletions = Refs, cfg = #cfg{stream = StreamId}}) ->
-    Keys = lists:map(
-        fun
-            (#fragment_ref{} = FRef) ->
-                rabbitmq_stream_s3:fragment_key(StreamId, FRef);
-            (#group_ref{} = GRef) ->
-                rabbitmq_stream_s3:group_key(StreamId, GRef)
-        end,
-        Refs
-    ),
+    Keys = [rabbitmq_stream_s3:ref_key(StreamId, Ref) || Ref <- Refs],
     rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys).
 
 update_manifest_gauges(

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1359,9 +1359,18 @@ on_persist_completed(#manifest{} = Manifest, State) ->
     %% Persist succeeded. Now safe to delete objects that retention removed
     %% from the manifest. The manifest cache is updated, so readers will no
     %% longer reference these objects.
-    %% Flushing all deferred deletions is safe: retention_in_flight prevents
-    %% persist from starting until the retention edit is in edits_since_persist,
-    %% so every ref here is covered by this persist's snapshot.
+    %%
+    %% Flushing all deferred deletions is intentional even when some refs
+    %% belong to retention edits that arrived after this persist's snapshot
+    %% and are still queued in `edits_since_persist`. Those objects are
+    %% deleted from S3 here, but the persisted manifest does not reflect
+    %% their removal until persist N+1 lands. If we crash in this window,
+    %% on restart the persisted manifest will list fragments whose S3
+    %% objects are gone. Readers hitting those fragments get 404s, which
+    %% `rabbitmq_stream_s3_remote_reader` handles by refreshing the
+    %% iterator past the missing offset. End-state is consistent: the
+    %% next retention pass will re-emit the edit and a subsequent persist
+    %% will reconcile the manifest.
     flush_deferred_deletions(State),
     State#state{persisting_bytes = 0, deferred_deletions = []}.
 

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -319,9 +319,13 @@ handle_cast(
             rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
             {noreply, State#state{replicas = Replicas#{Node => MonRef}}}
     end;
-handle_cast({retention_updated, Retention}, State) ->
+handle_cast(
+    {retention_updated, Retention}, #state{core = Core, cfg = #cfg{stream = StreamId}} = State
+) ->
     UserRetention = [S || S <- Retention, element(1, S) =/= 'fun'],
-    {noreply, State#state{retention = UserRetention}};
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+    State1 = State#state{retention = UserRetention},
+    {noreply, maybe_evaluate_remote_retention(Manifest, UserRetention, StreamId, State1)};
 handle_cast(
     {resync, Node},
     #state{

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1359,6 +1359,9 @@ on_persist_completed(#manifest{} = Manifest, State) ->
     %% Persist succeeded. Now safe to delete objects that retention removed
     %% from the manifest. The manifest cache is updated, so readers will no
     %% longer reference these objects.
+    %% Flushing all deferred deletions is safe: retention_in_flight prevents
+    %% persist from starting until the retention edit is in edits_since_persist,
+    %% so every ref here is covered by this persist's snapshot.
     flush_deferred_deletions(State),
     State#state{persisting_bytes = 0, deferred_deletions = []}.
 

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -234,7 +234,13 @@ returned by the functional core module.
     %% Kind of the group upload currently in flight. Cleared when the
     %% group_upload_result message arrives. Only one rebalance is in
     %% flight at a time so a single slot suffices.
-    pending_group_kind :: rabbitmq_stream_s3:kind() | undefined
+    pending_group_kind :: rabbitmq_stream_s3:kind() | undefined,
+    %% Keys queued for deletion after the next successful persist.
+    %% Retention computes which objects to delete but we defer the actual
+    %% S3 DELETE until the manifest persist that records their removal
+    %% completes. This eliminates the race where a reader sees a stale
+    %% manifest pointing to already-deleted objects (issue #166).
+    deferred_deletions = [] :: [#fragment_ref{} | #group_ref{}]
 }).
 
 -doc "Start a remote replica reader for the given stream.".
@@ -820,7 +826,11 @@ execute_effect(reinitialize, #state{cfg = #cfg{stream = StreamId}} = State0) ->
         assembly = undefined,
         transfer_sizes = #{},
         persist_pending_bytes = 0,
-        persisting_bytes = 0
+        persisting_bytes = 0,
+        %% Discard deferred deletions: the retention edit was not persisted,
+        %% so the objects must remain. The new writer will re-evaluate
+        %% retention and delete them after its own persist.
+        deferred_deletions = []
     }).
 
 cancel_timer(undefined) -> ok;
@@ -877,18 +887,12 @@ maybe_evaluate_remote_retention(Manifest, Retention, StreamId, #state{core = Cor
     #state{}.
 on_remote_retention(Edit, Refs, StreamId, Core0, State) ->
     on_remote_retention_deleted(Refs, StreamId, State),
-    Keys = lists:map(
-        fun
-            (#fragment_ref{} = FRef) ->
-                rabbitmq_stream_s3:fragment_key(StreamId, FRef);
-            (#group_ref{} = GRef) ->
-                rabbitmq_stream_s3:group_key(StreamId, GRef)
-        end,
-        Refs
-    ),
-    rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys),
+    %% Defer deletion until the persist that includes this retention edit
+    %% completes. Deleting now would leave a window where the manifest cache
+    %% still lists these objects but S3 has already removed them (issue #166).
+    Deferred = Refs ++ State#state.deferred_deletions,
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(Edit, Core0),
-    execute_effects(Effects, State#state{core = Core}).
+    execute_effects(Effects, State#state{core = Core, deferred_deletions = Deferred}).
 
 %% Spawn an async task to evaluate retention within a group object.
 -spec maybe_spawn_group_retention(
@@ -1356,7 +1360,25 @@ on_persist_completed(#manifest{} = Manifest, State) ->
     dec(State, ?C_BYTES_IN_PERSIST, PersistedBytes),
     inc(State, ?C_BYTES_PERSISTED, PersistedBytes),
     update_manifest_gauges(Manifest, State),
-    State#state{persisting_bytes = 0}.
+    %% Persist succeeded. Now safe to delete objects that retention removed
+    %% from the manifest. The manifest cache is updated, so readers will no
+    %% longer reference these objects.
+    flush_deferred_deletions(State),
+    State#state{persisting_bytes = 0, deferred_deletions = []}.
+
+flush_deferred_deletions(#state{deferred_deletions = []}) ->
+    ok;
+flush_deferred_deletions(#state{deferred_deletions = Refs, cfg = #cfg{stream = StreamId}}) ->
+    Keys = lists:map(
+        fun
+            (#fragment_ref{} = FRef) ->
+                rabbitmq_stream_s3:fragment_key(StreamId, FRef);
+            (#group_ref{} = GRef) ->
+                rabbitmq_stream_s3:group_key(StreamId, GRef)
+        end,
+        Refs
+    ),
+    rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys).
 
 update_manifest_gauges(
     #manifest{

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -205,35 +205,38 @@ read_from_remote_offset(Config) ->
     assert_sequential(Records, TargetOffset, N - 1).
 
 read_repositions_on_fragment_not_found(Config) ->
-    %% 3 fragments (600 bytes each, target 500). Remote retention with
-    %% max_bytes=1000 deletes the first two, leaving only offset 10.
-    %% A reader requesting offset 0 gets 404 and repositions at 10.
+    %% 3 fragments (600 bytes each, target 500). A reader opens while all
+    %% fragments exist, then retention deletes the first two. The reader's
+    %% iterator still points to the deleted fragments. When it tries to
+    %% fetch them it gets 404s and must advance to the surviving fragment.
     #{next_offset := NextOffset} = seed_log(Config, [
         {segment, [{chunk, #{records => 5, size => 600}}]},
         {segment, [{chunk, #{records => 5, size => 600}}]},
         {segment, [{chunk, #{records => 5, size => 600}}]}
     ]),
-    Writer = start_writer(
-        Config,
-        #{retention => [{max_bytes, 1000}]},
-        #{fragment_target_size => 500}
-    ),
+    Writer = start_writer(Config, #{}, #{fragment_target_size => 500}),
     flush_writer(Writer),
     await_offset(Config, NextOffset),
 
-    %% Wait for remote retention to delete the first two fragments.
-    ?awaitMatch([10], list_fragment_offsets(Config), 2000),
-
-    %% Wait for local retention to reclaim uploaded segments.
+    %% Wait for local retention to reclaim uploaded segments so the reader
+    %% enters remote mode.
     ReaderCfg = reader_config(Writer, Config),
     #{shared := Shared} = ReaderCfg,
     ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
 
-    %% Open a reader at offset 0. The fragment is gone (retention deleted it).
-    %% The reader should reposition at the oldest available offset (10).
+    %% Open a reader at offset 0 while all 3 fragments still exist.
+    %% The reader's iterator references all of them.
     {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(0, ReaderCfg),
     ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
 
+    %% Now tighten retention. This triggers immediate evaluation and a
+    %% persist cycle that flushes the deletions.
+    osiris:update_retention(Writer, [{max_bytes, 700}]),
+    ?awaitMatch([10], list_fragment_offsets(Config), 5000),
+
+    %% Read from the reader. Its iterator points to the now-deleted
+    %% fragments at offsets 0 and 5. It gets 404s, refreshes its iterator,
+    %% and advances to the surviving fragment at offset 10.
     Records = read_all(Reader0, 10),
     assert_sequential(Records, 10, NextOffset - 1).
 

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -1529,7 +1529,7 @@ gen_rrc_event(NextReadPos) ->
         {3, ?LET(E, gen_rrc_data_event(), {E, NextReadPos})},
         {2, ?LET(E, gen_rrc_error_event(), {E, NextReadPos})},
         {1, {{retry}, NextReadPos}},
-        {1, ?LET(E, gen_rrc_manifest_range_event(), {E, NextReadPos})},
+        {1, ?LET(E, gen_rrc_iterator_refreshed_event(), {E, NextReadPos})},
         {1, {deadline_expired, NextReadPos}}
     ]).
 
@@ -1554,10 +1554,30 @@ gen_rrc_error_event() ->
         {request_error, make_ref(), 0, Reason}
     ).
 
-gen_rrc_manifest_range_event() ->
+gen_rrc_iterator_refreshed_event() ->
     oneof([
-        {manifest_range, empty},
-        ?LET({F, E}, {range(0, 100), range(101, 500)}, {manifest_range, {F, E}})
+        {iterator_refreshed, end_of_manifest},
+        ?LET(
+            {Offset, Size, Uid},
+            {range(0, 500), range(100_000, 5_000_000), range(1, 16#FFFFFFFF)},
+            begin
+                Manifest = #manifest{
+                    first_offset = Offset,
+                    next_offset = Offset + 1,
+                    entries = ?ENTRY(Offset, 0, 0, ?MANIFEST_KIND_FRAGMENT, Size, Uid)
+                },
+                GetGroupFun = fun(_) -> {error, not_found} end,
+                Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
+                    Manifest, Offset, GetGroupFun
+                ),
+                Iterator =
+                    case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+                        {ok, _, It} -> It;
+                        _ -> Iterator0
+                    end,
+                {iterator_refreshed, Iterator}
+            end
+        )
     ]).
 
 run_rrc_events([], State) ->

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -24,7 +24,7 @@ all() ->
         two_timeouts_then_retry_succeeds,
         fragment_transition_with_prefetch,
         become_local_at_end_of_manifest,
-        not_found_triggers_range_lookup,
+        not_found_triggers_refresh_iterator,
         %% New tests
         aimd_growth_after_consecutive_hits,
         aimd_shrink_on_miss,
@@ -35,14 +35,14 @@ all() ->
         fragment_transition_without_prefetch_awaits,
         read_at_exact_fragment_boundary,
         mid_fragment_init_position,
-        jump_to_oldest_full_cycle,
+        fragment_404_advances_to_next_fragment,
         retry_resets_delay_on_success,
         read_larger_than_buffer_awaits,
         header_overread_capped_at_index_boundary,
-        next_fragment_404_triggers_range_lookup,
+        next_fragment_404_triggers_refresh_iterator,
         deadline_expired_replies_error_timeout,
         deadline_expired_resets_buffer_for_retry,
-        jump_to_oldest_stale_manifest_becomes_local
+        fragment_404_emits_refresh_iterator
     ].
 
 init_per_suite(Config) ->
@@ -223,7 +223,7 @@ become_local_at_end_of_manifest(_Config) ->
 
     %% Read past end triggers refresh_iterator effect.
     {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(S1, {read, 164, 50, chunk_boundary}),
-    ?assertMatch([refresh_iterator], E1),
+    ?assertMatch([{refresh_iterator, 0}], E1),
 
     %% Shell reports end_of_manifest.
     {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
@@ -231,8 +231,9 @@ become_local_at_end_of_manifest(_Config) ->
     ),
     ?assertMatch([{reply, {become_local, 0}}], E2).
 
-not_found_triggers_range_lookup(_Config) ->
-    %% A 404 on the current fragment triggers a manifest range lookup.
+not_found_triggers_refresh_iterator(_Config) ->
+    %% A 404 on the current fragment triggers a refresh_iterator effect.
+    %% If the refreshed iterator is exhausted, become_local.
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
@@ -244,11 +245,13 @@ not_found_triggers_range_lookup(_Config) ->
     {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
-    ?assertMatch([lookup_manifest_range], E1),
+    ?assertMatch([{refresh_iterator, 0}], E1),
 
-    %% Shell reports empty range → end_of_stream.
-    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, empty}),
-    ?assertMatch([{reply, end_of_stream}], E2).
+    %% Shell reports no more fragments → become_local.
+    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {iterator_refreshed, end_of_manifest}
+    ),
+    ?assertMatch([{reply, {become_local, 0}}], E2).
 
 %% ------------------------------------------------------------------
 %% AIMD and retry tests
@@ -426,27 +429,26 @@ mid_fragment_init_position(_Config) ->
     {_S0, Effects} = init(stream_id(), FragRef, MidPos, Iterator),
     ?assertMatch([{start_request, _, {5000, _}, 0}], Effects).
 
-jump_to_oldest_full_cycle(_Config) ->
-    %% 404 on current fragment → manifest_range → jump_to_oldest effect →
-    %% jumped event → reply with next_fragment + new request started.
+fragment_404_advances_to_next_fragment(_Config) ->
+    %% 404 on current fragment → refresh_iterator → iterator_refreshed with
+    %% next fragment → reply with next_fragment + new request started.
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}, {500, 2_000_000, 99}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
     %% Issue read, then 404.
     {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
-    {S2, [lookup_manifest_range]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S2, [{refresh_iterator, 0}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
-    %% Manifest says first available is at offset 500.
-    {S3, E1} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, {500, 1000}}),
-    ?assertMatch([{jump_to_oldest, 500}], E1),
-    %% Shell resolves the jump and feeds back.
-    NewFragRef = frag_ref(500, 2_000_000, 99),
-    NewIterator = mock_iterator([{500, 2_000_000, 99}]),
-    {_S4, E2} = rabbitmq_stream_s3_remote_reader_core:step(S3, {jumped, NewFragRef, NewIterator}),
+    %% Shell refreshes iterator past offset 0. The iterator's next entry
+    %% is fragment 500. Build an iterator where next/1 returns fragment 500.
+    Manifest500 = build_manifest([{500, 2_000_000, 99}]),
+    GetGroupFun = fun(_) -> {error, not_found} end,
+    NewIterator = rabbitmq_stream_s3_fragment_iterator:init(Manifest500, 0, GetGroupFun),
+    {_S3, E1} = rabbitmq_stream_s3_remote_reader_core:step(S2, {iterator_refreshed, NewIterator}),
     %% Should reply with next_fragment and start a request for the new fragment.
-    ?assertMatch([{reply, {next_fragment, 500}} | _], E2),
-    Requests = [F || {start_request, _, _, F} <- E2],
+    ?assertMatch([{reply, {next_fragment, 500}} | _], E1),
+    Requests = [F || {start_request, _, _, F} <- E1],
     ?assertEqual([500], Requests).
 
 retry_resets_delay_on_success(_Config) ->
@@ -517,9 +519,10 @@ header_overread_capped_at_index_boundary(_Config) ->
     [{reply, {ok, ResultData}}] = Replies,
     ?assertEqual(108, byte_size(ResultData)).
 
-next_fragment_404_triggers_range_lookup(_Config) ->
+next_fragment_404_triggers_refresh_iterator(_Config) ->
     %% Prefetch of next fragment returns 404. When the consumer reads past
-    %% the current fragment, the core triggers a manifest range lookup.
+    %% the current fragment, the core triggers a refresh_iterator past the
+    %% 404'd fragment's offset.
     FragRef = frag_ref(0, 200, 42),
     Iterator = mock_iterator([{0, 200, 42}, {100, 500, 43}]),
     {S0, _} = init(stream_id(), FragRef, 8, Iterator),
@@ -530,11 +533,11 @@ next_fragment_404_triggers_range_lookup(_Config) ->
     {S2, _} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 100, not_found}
     ),
-    %% Read past end of current fragment. Next is not_found → range lookup.
+    %% Read past end of current fragment. Next is not_found → refresh past offset 100.
     {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
         S2, {read, 208, 50, chunk_boundary}
     ),
-    ?assertMatch([lookup_manifest_range], Effects).
+    ?assertMatch([{refresh_iterator, 100}], Effects).
 
 deadline_expired_replies_error_timeout(_Config) ->
     %% When the shell fires deadline_expired, the core replies {error, timeout}
@@ -575,19 +578,15 @@ deadline_expired_resets_buffer_for_retry(_Config) ->
     Requests = [F || {start_request, _, _, F} <- Effects],
     ?assertMatch([0], Requests).
 
-jump_to_oldest_stale_manifest_becomes_local(_Config) ->
-    %% When manifest_range returns FirstOffset == current fragment offset,
-    %% the manifest is stale. The core must become_local instead of looping.
+fragment_404_emits_refresh_iterator(_Config) ->
+    %% When the current fragment returns 404, the core emits
+    %% {refresh_iterator, Offset} to advance past the dead fragment.
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
     %% Issue read, then 404 on current fragment.
     {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 100, chunk_boundary}),
-    {S2, [lookup_manifest_range]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, not_found}
     ),
-    %% Manifest says first_offset = 0, same as our current fragment.
-    %% This means retention deleted it but the persist cycle hasn't updated yet.
-    {_S3, Effects} = rabbitmq_stream_s3_remote_reader_core:step(S2, {manifest_range, {0, 500}}),
-    %% Must become_local, NOT emit jump_to_oldest (which would loop).
-    ?assertMatch([{reply, {become_local, 0}}], Effects).
+    ?assertMatch([{refresh_iterator, 0}], Effects).

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -76,6 +76,7 @@ groups() ->
             stream_deletion_during_active_upload,
             discover_attaches_to_existing_writer,
             remote_retention_deletes_fragments,
+            remote_retention_on_update,
             remote_retention_survives_multiple_persist_cycles,
             uploads_rebalance_into_group,
             remote_retention_deletes_within_group,
@@ -528,6 +529,28 @@ remote_retention_deletes_fragments(Config) ->
     ),
 
     %% Manifest reflects the deletion (after the retention persist completes).
+    ?awaitMatch({10, NextOffset}, get_range(Config), 2000).
+
+remote_retention_on_update(Config) ->
+    %% Updating retention on a running writer triggers remote retention
+    %% evaluation without requiring new writes.
+    #{next_offset := NextOffset} = seed_log(Config, [
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]}
+    ]),
+    Writer = start_writer(Config, #{}, #{fragment_target_size => 500}),
+    flush_writer(Writer),
+    await_offset(Config, NextOffset),
+
+    %% All 3 fragments exist.
+    ?assertEqual([0, 5, 10], list_fragment_offsets(Config)),
+
+    %% Update retention. No new writes needed.
+    osiris:update_retention(Writer, [{max_bytes, 700}]),
+
+    %% Retention is kicked off without needing to write extra documents.
+    ?awaitMatch([10], list_fragment_offsets(Config), 5000),
     ?awaitMatch({10, NextOffset}, get_range(Config), 2000).
 
 remote_retention_survives_multiple_persist_cycles(Config) ->


### PR DESCRIPTION
Connects #166

This is a bit of a behavior change for retention and the remote reader. The main change is that the replica reader only triggers deletion of objects from retention _after_ it has persisted the newly updated manifest with the retention edits. This reduces the window where a reader could get a 404, re-read the manifest, and still see the old data. (It doesn't eliminate the window when reading from replica nodes, though.)

With this change I've also updated the reader's behavior when it gets a 404. The "Refresh fragment iterator in 404s" commit has details and a scenario to consider. By refreshing the fragment iterator on a 404, we get a bit of delayed retry on re-reading the manifest and can sometimes catch up to where fragments actually exist. Overall this lets a lagging reader which is slower than retention read the parts of the remote tier that still exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
