### PR TITLE
Drop, do not reuse, a connection whose caller died holding it

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -295,13 +295,20 @@ handle_info(
         _ ->
             case CheckoutsRev0 of
                 #{MRef := Conn} ->
-                    %% A caller process is down which has a conn checked out.
-                    %% Return the conn.
+                    %% A caller process is down while holding a checked-out
+                    %% connection. The connection may be in any state on the
+                    %% wire (e.g. mid-body in a chunked PUT if the caller
+                    %% died between `gun:headers/4` and `gun:data/4 fin`).
+                    %% Reusing it would land a `headers` cast on a connection
+                    %% whose `out` field is not `head`, crashing gun's
+                    %% gen_statem with `function_clause`. Drop the connection
+                    %% and grow a replacement.
+                    %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/177
                     State1 = State0#?MODULE{
                         checkouts = maps:remove(Conn, Checkouts0),
                         checkouts_rev = maps:remove(MRef, CheckoutsRev0)
                     },
-                    {noreply, make_available(Conn, State1)};
+                    {noreply, grow(close_connection(Conn, State1))};
                 _ ->
                     %% A pending caller process is down. Remove it from the
                     %% pending queue.
@@ -312,21 +319,14 @@ handle_info(
                     {noreply, State}
             end
     end;
-handle_info({idle_timeout, Conn}, #?MODULE{idle_timers = Timers, monitors = Monitors} = State0) ->
+handle_info({idle_timeout, Conn}, #?MODULE{idle_timers = Timers} = State0) ->
     case Timers of
         #{Conn := _} ->
             %% Timer is still active (wasn't cancelled by a checkout), so the
             %% connection has been idle too long. Close it.
             State1 = State0#?MODULE{idle_timers = maps:remove(Conn, Timers)},
             State2 = cancel(Conn, State1),
-            case Monitors of
-                #{Conn := ConnMRef} ->
-                    erlang:demonitor(ConnMRef, [flush]),
-                    gun:close(Conn),
-                    {noreply, State2#?MODULE{monitors = maps:remove(Conn, Monitors)}};
-                _ ->
-                    {noreply, State2}
-            end;
+            {noreply, close_connection(Conn, State2)};
         _ ->
             %% Timer was already cancelled (stale message). Ignore.
             {noreply, State0}
@@ -489,6 +489,19 @@ make_available(Conn, #?MODULE{available = Available, idle_timers = Timers} = Sta
         available = [Conn | Available],
         idle_timers = Timers#{Conn => TRef}
     }).
+
+%% Close a connection and stop monitoring it. Used when the connection has
+%% been idle too long, or when its caller died holding it (and we cannot
+%% trust its on-wire state). A no-op if the connection is not in `monitors`.
+close_connection(Conn, #?MODULE{monitors = Monitors} = State) ->
+    case Monitors of
+        #{Conn := ConnMRef} ->
+            erlang:demonitor(ConnMRef, [flush]),
+            gun:close(Conn),
+            State#?MODULE{monitors = maps:remove(Conn, Monitors)};
+        _ ->
+            State
+    end.
 
 cancel_idle_timer(Conn, #?MODULE{idle_timers = Timers0} = State) ->
     case Timers0 of


### PR DESCRIPTION
## Summary

Stop reusing an S3 upload pool connection whose caller died holding it. The old behavior put the connection back on the available list, which crashed gun's gen_statem on the next checkout (when the connection was still mid-PUT on a chunked body) and OOM'd the writer node.

Closes #177.

## Changes

- In the pool's `'DOWN'` handler (caller-down branch), close the connection and call `grow/1` to replace it instead of `make_available/2`
- Extract `close_connection/2` helper for the demonitor + `gun:close` + `monitors` cleanup pattern; the `idle_timeout` handler now uses it too

## Test plan

- [x] `gmake` compiles cleanly
- [x] `gmake dialyze` passes
- [x] All existing CT suites pass (`replica_reader_SUITE` 21/21, `replica_reader_core_SUITE` 60/60, `remote_reader_core_SUITE` 25/25, `prop_SUITE` 29/29, others)
- [x] Re-run the retention-stress soak test to confirm the writer no longer OOMs on a sharp `osiris:update_retention/2` drop. Reproduced cleanly twice on the parent commit; expect the fix to make it pass

A unit-test regression check is not included because exercising the pool's `'DOWN'` handler without a real S3 endpoint requires injecting a fake connection. Tracked as a follow-up in #178.
