### PR TITLE
Stop pool checkout timeouts from crashing reaper and remote_reader

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -122,20 +122,14 @@ checkin(Pool, Conn) ->
     gen_server:cast(Pool, {checkin, Conn}).
 
 -doc """
-Non-blocking checkout. Returns `{ok, Conn}` if a connection is immediately
-available, or `busy` if the pool is at capacity. If the pool has room to grow,
-queues the caller and waits for a new connection (like `checkout/2`).
+Non-blocking checkout. Returns `Conn` if a connection is immediately available,
+or `busy` if no connection is available. If the pool has room to grow, the
+grow is kicked off in the background and `busy` is returned immediately so the
+caller can retry on a later event.
 """.
 -spec try_checkout(pool()) -> conn() | busy.
 try_checkout(Pool) ->
-    Checkout = erlang:make_ref(),
-    try
-        gen_server:call(Pool, {try_checkout, Checkout}, 5000)
-    catch
-        C:E:Stack ->
-            gen_server:cast(Pool, {cancel_checkout, Checkout}),
-            erlang:raise(C, E, Stack)
-    end.
+    gen_server:call(Pool, try_checkout).
 
 -spec with(pool(), timeout(), fun((conn()) -> term())) -> term().
 with(Pool, Timeout, Fun) ->
@@ -183,12 +177,11 @@ handle_call(
             {noreply, grow(State1)}
     end;
 handle_call(
-    {try_checkout, Checkout},
-    {Pid, _} = From,
+    try_checkout,
+    {Pid, _},
     #?MODULE{
         max_size = MaxSize,
         monitors = Monitors,
-        pending = Pending0,
         counter = Cnt
     } = State0
 ) ->
@@ -197,12 +190,11 @@ handle_call(
             counters:add(Cnt, ?C_CHECKOUTS, 1),
             {reply, Conn, State};
         empty when map_size(Monitors) < MaxSize ->
-            counters:add(Cnt, ?C_CHECKOUT_QUEUED, 1),
-            %% Pool has room to grow — queue the caller and grow.
-            MRef = erlang:monitor(process, Pid),
-            P = #pending{from = From, checkout = Checkout, mref = MRef},
-            State1 = State0#?MODULE{pending = queue:in(P, Pending0)},
-            {noreply, grow(State1)};
+            %% Pool has room to grow. Kick off a grow in the background
+            %% and return `busy` immediately so the caller is not held
+            %% past the gen_server:call deadline waiting for a new
+            %% connection. The caller will retry on a later event.
+            {reply, busy, grow(State0)};
         empty ->
             {reply, busy, State0}
     end;

--- a/src/rabbitmq_stream_s3_reaper.erl
+++ b/src/rabbitmq_stream_s3_reaper.erl
@@ -26,6 +26,11 @@ for batched deletion. The task exits when the listing is exhausted.
 -export([init_counters/0]).
 
 -define(MAX_BATCH, 1000).
+%% The reaper has no upstream caller waiting on a deadline. Under sustained
+%% S3 throttling the pool's default 5s checkout timeout can starve the reaper
+%% and crash the gen_batch_server. Use a generous timeout consistent with
+%% other write-side background work (see `retention_task_timeout`).
+-define(DELETE_TIMEOUT_MS, 60_000).
 
 -define(C_OBJECTS_DELETED, 1).
 -define(C_STREAMS_DELETED, 2).
@@ -81,11 +86,11 @@ delete_batched([]) ->
     ok;
 delete_batched(Keys) when length(Keys) =< ?MAX_BATCH ->
     inc(?C_OBJECTS_DELETED, length(Keys)),
-    rabbitmq_stream_s3_api:delete(Keys);
+    rabbitmq_stream_s3_api:delete(Keys, #{timeout => ?DELETE_TIMEOUT_MS});
 delete_batched(Keys) ->
     {Batch, Rest} = lists:split(?MAX_BATCH, Keys),
     inc(?C_OBJECTS_DELETED, length(Batch)),
-    _ = rabbitmq_stream_s3_api:delete(Batch),
+    _ = rabbitmq_stream_s3_api:delete(Batch, #{timeout => ?DELETE_TIMEOUT_MS}),
     delete_batched(Rest).
 
 list_and_delete(StreamId) ->


### PR DESCRIPTION
## Summary

When the S3 connection pool is saturated under throttling, two callers crash on the pool's `gen_server:call(..., 5000)` deadline. Fix both:

- `pool:try_checkout/1` is now truly non-blocking. The empty-but-growable branch kicks off a grow in the background and returns `busy` immediately, instead of queuing the caller and waiting up to 5s for the new connection. Existing callers (`api_aws:start_async_request/6`, `remote_reader:execute_effect({start_request, ...})`) already treat `busy` as a transient retry condition.
- The reaper passes `#{timeout => 60_000}` on its `delete/2` calls. It has no upstream caller waiting on a deadline, and 60s matches the precedent set by `retention_task_timeout` for other write-side background work.

Closes #172.
Closes #174.

## Changes

- `try_checkout/1` simplified: bare `try_checkout` atom on the wire, no caller-side timeout, no `cancel_checkout` cast (the `gen_server:call` is now strictly synchronous from the caller's perspective). Updated docstring.
- `try_checkout` `handle_call` empty-and-growable branch now `{reply, busy, grow(State0)}`. The blocking `checkout/2` path is unchanged.
- Reaper defines `?DELETE_TIMEOUT_MS = 60_000` and passes it on both `delete_batched/1` paths.

## Test plan

- [x] `gmake` compiles cleanly
- [x] `gmake dialyze` passes
- [x] `remote_reader_core_SUITE` 27/27, `replica_reader_core_SUITE` 60/60, `prop_SUITE` 29/29, `log_reader_SUITE` 9/9
- [ ] Verify on a soak run: no reaper or remote_reader crashes from pool checkout timeouts under sustained S3 throttling
