### PR TITLE
Fix consumer crash/wedge from premature Fd close, poisoned pool, and pool-growth regression

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -602,8 +602,11 @@ handle_async(
 
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
-    gun:cancel(Conn, StreamRef),
-    ok = finish_async(State).
+    %% On HTTP/1.1, gun:cancel only marks the stream dead; the response body
+    %% continues draining on the wire, blocking subsequent pipelined requests.
+    %% Close the connection so the pool replaces it with a fresh one.
+    gun:close(Conn),
+    ok = finish_async_close(State).
 
 %% Cancel the request timer without checking in the connection or
 %% decrementing the active-request counter. Used when the response

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -190,11 +190,11 @@ handle_call(
             counters:add(Cnt, ?C_CHECKOUTS, 1),
             {reply, Conn, State};
         empty when map_size(Monitors) < MaxSize ->
-            %% Pool has room to grow. Kick off a grow in the background
-            %% and return `busy` immediately so the caller is not held
-            %% past the gen_server:call deadline waiting for a new
-            %% connection. The caller will retry on a later event.
-            {reply, busy, grow(State0)};
+            %% Pool has room to grow. Open one connection in the
+            %% background and return `busy` so the caller retries on a
+            %% later event. grow/1 calculates demand from Pending, which
+            %% is empty for try_checkout callers, so call grow/2 directly.
+            {reply, busy, grow(1, State0)};
         empty ->
             {reply, busy, State0}
     end;

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -190,10 +190,6 @@ handle_call(
             counters:add(Cnt, ?C_CHECKOUTS, 1),
             {reply, Conn, State};
         empty when map_size(Monitors) < MaxSize ->
-            %% Pool has room to grow. Open one connection in the
-            %% background and return `busy` so the caller retries on a
-            %% later event. grow/1 calculates demand from Pending, which
-            %% is empty for try_checkout callers, so call grow/2 directly.
             {reply, busy, grow(1, State0)};
         empty ->
             {reply, busy, State0}

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -25,7 +25,7 @@ tier.
 %% and osiris_log:chunk_iterator/3 than their specs declare, causing false
 %% positives for the {offset_not_found, ...} branches and maybe_become_remote/2.
 %% Remove these suppressions once OTP 28 is required.
--dialyzer({no_match, [send_file/3, chunk_iterator/3]}).
+-dialyzer({no_match, [send_file/4, chunk_iterator/4]}).
 -dialyzer({no_unused, maybe_become_remote/2}).
 
 -define(READ_TIMEOUT, 10000).
@@ -295,10 +295,17 @@ close(#?MODULE{mode = Local}) ->
     counters:add(counter(), ?C_LOCAL_CLOSE, 1),
     ok = osiris_log:close(Local).
 
+close_deferred(undefined) -> ok;
+close_deferred(Local) -> osiris_log:close(Local).
+
+send_file(Socket, State, Callback) ->
+    send_file(Socket, State, Callback, undefined).
+
 send_file(
     Socket,
     #?MODULE{config = Config, mode = #remote{} = Remote0, verify_crc = VerifyCrc} = State0,
-    Callback
+    Callback,
+    DeferredClose
 ) ->
     case read_header(Remote0) of
         {ok,
@@ -324,6 +331,7 @@ send_file(
                     PrefixData = Callback(Header, ToSend + byte_size(HeaderData)),
                     case send(Transport, Socket, [PrefixData, HeaderData, Data]) of
                         ok ->
+                            close_deferred(DeferredClose),
                             Remote = Remote1#remote{
                                 next_offset = ChId + NumRecords,
                                 position = NextPosition
@@ -339,60 +347,71 @@ send_file(
                             position = ?SEGMENT_HEADER_B
                         }
                     },
-                    send_file(Socket, State, Callback);
+                    send_file(Socket, State, Callback, DeferredClose);
                 {become_local, _} ->
+                    close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
                     case init_local_reader(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
-                            send_file(Socket, State, Callback);
+                            send_file(Socket, State, Callback, undefined);
                         {error, _} = Err ->
                             Err
                     end;
                 end_of_stream ->
+                    close_deferred(DeferredClose),
                     {end_of_stream, State0#?MODULE{mode = Remote1}};
                 {error, timeout} = Err ->
                     Err
             end;
         {become_local, _} ->
+            close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
             case init_local_reader(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
-                    send_file(Socket, State, Callback);
+                    send_file(Socket, State, Callback, undefined);
                 {error, _} = Err ->
                     Err
             end;
         {end_of_stream, Remote} ->
+            close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Remote}};
         {error, timeout} = Err ->
             Err
     end;
-send_file(Socket, #?MODULE{mode = Local0} = State0, Callback) ->
+send_file(Socket, #?MODULE{mode = Local0} = State0, Callback, DeferredClose) ->
     case osiris_log:send_file(Socket, Local0, Callback) of
         {ok, Local} ->
+            close_deferred(DeferredClose),
             {ok, State0#?MODULE{mode = Local}};
         {offset_not_found, Local1} ->
             Offset = osiris_log:next_offset(Local1),
             case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
-                {ok, State} ->
-                    send_file(Socket, State, Callback);
+                {ok, State, LocalToClose} ->
+                    send_file(Socket, State, Callback, LocalToClose);
                 false ->
                     case osiris_log:open_next_segment(Local1) of
                         {ok, Local} ->
-                            send_file(Socket, State0#?MODULE{mode = Local}, Callback);
+                            send_file(Socket, State0#?MODULE{mode = Local}, Callback, DeferredClose);
                         not_found ->
+                            close_deferred(DeferredClose),
                             {end_of_stream, State0#?MODULE{mode = Local1}}
                     end
             end;
         {end_of_stream, Local} ->
+            close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
             Err
     end.
 
+chunk_iterator(State, Credit, PrevIter) ->
+    chunk_iterator(State, Credit, PrevIter, undefined).
+
 chunk_iterator(
     #?MODULE{config = Config, mode = #remote{} = Remote0, verify_crc = VerifyCrc} = State0,
     Credit,
-    _PrevIter
+    _PrevIter,
+    DeferredClose
 ) ->
     case read_header(Remote0) of
         {ok,
@@ -410,6 +429,7 @@ chunk_iterator(
             case read(Pid, DataPos, DataSize, within_chunk) of
                 {ok, Data} ->
                     ok = maybe_validate_crc(ChId, Crc, Data, DataSize, VerifyCrc),
+                    close_deferred(DeferredClose),
                     Iter = #remote_iterator{
                         next_offset = ChId,
                         data = Data
@@ -427,51 +447,58 @@ chunk_iterator(
                             position = ?SEGMENT_HEADER_B
                         }
                     },
-                    chunk_iterator(State, Credit, undefined);
+                    chunk_iterator(State, Credit, undefined, DeferredClose);
                 {become_local, _} ->
+                    close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
                     case init_local_reader(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
-                            chunk_iterator(State, Credit, undefined);
+                            chunk_iterator(State, Credit, undefined, undefined);
                         {error, _} = Err ->
                             Err
                     end;
                 end_of_stream ->
+                    close_deferred(DeferredClose),
                     {end_of_stream, State0#?MODULE{mode = Remote1}};
                 {error, timeout} = Err ->
                     Err
             end;
         {become_local, _} ->
+            close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
             case init_local_reader(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
-                    chunk_iterator(State, Credit, undefined);
+                    chunk_iterator(State, Credit, undefined, undefined);
                 {error, _} = Err ->
                     Err
             end;
         {end_of_stream, Remote} ->
+            close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Remote}};
         {error, timeout} = Err ->
             Err
     end;
-chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter) ->
+chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter, DeferredClose) ->
     case osiris_log:chunk_iterator(Local0, Credit, PrevIter) of
         {ok, Header, Iter, Local} ->
+            close_deferred(DeferredClose),
             {ok, Header, Iter, State0#?MODULE{mode = Local}};
         {offset_not_found, Local1} ->
             Offset = osiris_log:next_offset(Local1),
             case maybe_become_remote(Offset, State0#?MODULE{mode = Local1}) of
-                {ok, State} ->
-                    chunk_iterator(State, Credit, undefined);
+                {ok, State, LocalToClose} ->
+                    chunk_iterator(State, Credit, undefined, LocalToClose);
                 false ->
                     case osiris_log:open_next_segment(Local1) of
                         {ok, Local} ->
-                            chunk_iterator(State0#?MODULE{mode = Local}, Credit, undefined);
+                            chunk_iterator(State0#?MODULE{mode = Local}, Credit, undefined, DeferredClose);
                         not_found ->
+                            close_deferred(DeferredClose),
                             {end_of_stream, State0#?MODULE{mode = Local1}}
                     end
             end;
         {end_of_stream, Local} ->
+            close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Local}};
         {error, _} = Err ->
             Err
@@ -707,8 +734,7 @@ maybe_become_remote(Offset, #?MODULE{config = Config, mode = Local}) ->
             case init_remote_reader(Location, Config) of
                 {ok, RemoteState} ->
                     counters:add(counter(), ?C_LOCAL_CLOSE, 1),
-                    osiris_log:close(Local),
-                    {ok, RemoteState};
+                    {ok, RemoteState, Local};
                 {error, _} ->
                     false
             end;

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -391,7 +391,9 @@ send_file(Socket, #?MODULE{mode = Local0} = State0, Callback, DeferredClose) ->
                 false ->
                     case osiris_log:open_next_segment(Local1) of
                         {ok, Local} ->
-                            send_file(Socket, State0#?MODULE{mode = Local}, Callback, DeferredClose);
+                            send_file(
+                                Socket, State0#?MODULE{mode = Local}, Callback, DeferredClose
+                            );
                         not_found ->
                             close_deferred(DeferredClose),
                             {end_of_stream, State0#?MODULE{mode = Local1}}
@@ -491,7 +493,9 @@ chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter, DeferredClose
                 false ->
                     case osiris_log:open_next_segment(Local1) of
                         {ok, Local} ->
-                            chunk_iterator(State0#?MODULE{mode = Local}, Credit, undefined, DeferredClose);
+                            chunk_iterator(
+                                State0#?MODULE{mode = Local}, Credit, undefined, DeferredClose
+                            );
                         not_found ->
                             close_deferred(DeferredClose),
                             {end_of_stream, State0#?MODULE{mode = Local1}}

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -358,8 +358,10 @@ execute_effect(
             Requests = Requests0#{FragOffset => {RequestId, AsyncState}},
             State#state{requests = Requests};
         {error, pool_busy} ->
-            ?LOG_WARNING("remote_reader start_request: pool_busy key=~ts frag=~b",
-                         [Key, FragOffset]),
+            ?LOG_WARNING(
+                "remote_reader start_request: pool_busy key=~ts frag=~b",
+                [Key, FragOffset]
+            ),
             {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
                 Core0, {request_error, make_ref(), FragOffset, pool_busy}
             ),

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -349,7 +349,7 @@ execute_effect({observe, fragment_transition, ReadSize}, State) ->
     State;
 execute_effect(
     {start_request, Key, Range, FragOffset},
-    #state{cfg = #cfg{request_timeout_ms = Timeout}, requests = Requests0} = State
+    #state{cfg = #cfg{request_timeout_ms = Timeout}, core = Core0, requests = Requests0} = State
 ) ->
     case rabbitmq_stream_s3_api:get_range_async(Key, Range, #{timeout => Timeout}) of
         {ok, RequestId, AsyncState} ->
@@ -358,8 +358,12 @@ execute_effect(
             Requests = Requests0#{FragOffset => {RequestId, AsyncState}},
             State#state{requests = Requests};
         {error, pool_busy} ->
-            %% Can't start now. The core will retry on the next event.
-            State
+            ?LOG_WARNING("remote_reader start_request: pool_busy key=~ts frag=~b",
+                         [Key, FragOffset]),
+            {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+                Core0, {request_error, make_ref(), FragOffset, pool_busy}
+            ),
+            execute_effects(Effects, State#state{core = Core1})
     end;
 execute_effect({set_timer, DelayMs}, State) ->
     erlang:send_after(DelayMs, self(), retry_requests),

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -228,9 +228,10 @@ step(
     #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}} = State0,
     {request_error, _RequestId, _Fragment, Reason}
 ) when
-    Reason =:= timeout; Reason =:= stream_error; Reason =:= connection_error
+    Reason =:= timeout; Reason =:= stream_error; Reason =:= connection_error;
+    Reason =:= pool_busy
 ->
-    %% Transient error. Retry immediately with current delay.
+    %% Transient error. Retry with current delay.
     RetryDelay = State0#state.retry_delay,
     NextDelay = min(RetryDelay * 2, MaxDelay),
     State = State0#state{retry_delay = NextDelay, requests_in_flight = #{}},

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -228,7 +228,9 @@ step(
     #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}} = State0,
     {request_error, _RequestId, _Fragment, Reason}
 ) when
-    Reason =:= timeout; Reason =:= stream_error; Reason =:= connection_error;
+    Reason =:= timeout;
+    Reason =:= stream_error;
+    Reason =:= connection_error;
     Reason =:= pool_busy
 ->
     %% Transient error. Retry with current delay.

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -1550,7 +1550,7 @@ gen_rrc_data_event() ->
 gen_rrc_error_event() ->
     ?LET(
         Reason,
-        oneof([timeout, slow_down, connection_error, stream_error, internal_error]),
+        oneof([timeout, slow_down, connection_error, stream_error, internal_error, pool_busy]),
         {request_error, make_ref(), 0, Reason}
     ).
 

--- a/test/rabbitmq_stream_s3_api_aws_SUITE.erl
+++ b/test/rabbitmq_stream_s3_api_aws_SUITE.erl
@@ -94,6 +94,7 @@ init_per_group(integration, Config) ->
         ->
             {ok, _} = application:ensure_all_started(gun),
             ok = application:set_env(rabbitmq_stream_s3, bucket, list_to_binary(Bucket0)),
+            ok = application:set_env(rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws),
             Config;
         {_, false, _, _, _, _} ->
             Skip;
@@ -116,6 +117,7 @@ init_per_group(integration, Config) ->
             ),
             ok = application:set_env(rabbitmq_stream_s3, aws_region, list_to_binary(Region)),
             ok = application:set_env(rabbitmq_stream_s3, bucket, list_to_binary(Bucket1)),
+            ok = application:set_env(rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws),
             Config
     end.
 


### PR DESCRIPTION
## Summary

Fix three bugs that together cause a consumer crash or permanent wedge when the remote reader's pending-read deadline fires during a large fragment download. Also fix a pool-growth regression that prevented connections from ever being created for non-blocking callers.

Closes #182.

## Changes

**`cancel_async`: Close connection instead of checking it back in (Bug 2)**

On HTTP/1.1, `gun:cancel` only marks a stream dead internally; the response body continues draining on the wire and blocks pipelined requests. `cancel_async` was checking the connection back into the pool via `finish_async`, allowing the next caller to immediately pop it (LIFO) and pipeline a request behind the still-draining response. For large fragments (68 MB at ~126 KB/s observed throughput), the drain takes minutes, far exceeding the 50-second deadline window, creating a permanent wedge.

Fix: close the connection (matching the `request_timeout` handler), letting the pool's `'DOWN'` handler grow a fresh replacement.

**log reader: Defer local Fd close until remote path succeeds (Bug 1)**

`maybe_become_remote` closed the local osiris log state (and its segment Fd) before the recursive remote-mode `send_file` returned. If that call failed with `{error, timeout}`, the error propagated to `rabbit_stream_reader:send_chunks` which preserved the original Consumer unchanged, including the now-closed local Log. The next retry called `file:pread` on the closed Fd, producing `{error, einval}` and crashing the reader.

Fix: `maybe_become_remote` returns the local state to the caller instead of closing it. `send_file/4` and `chunk_iterator/4` thread it as a `DeferredClose` argument through recursion, closing only on terminal non-error returns (success, end_of_stream, become_local). On `{error, _}` the Fd remains valid for retry.

**remote reader: Retry on `pool_busy` instead of silently wedging (Bug 3)**

When `get_range_async` returned `{error, pool_busy}`, the shell returned State unchanged. But the core had already added the fragment to its `requests_in_flight` map before emitting the `start_request` effect. The guard in `maybe_start_current_request` prevented any further attempt for that fragment. No data arrives, no timeout fires, no retry occurs. The consumer is permanently wedged.

Fix: feed `{request_error, _, FragOffset, pool_busy}` back into the core from the shell. `pool_busy` is added to the transient-error clause so the core clears `requests_in_flight` and schedules a retry timer with exponential backoff.

**pool: Fix `try_checkout` never growing the pool**

`try_checkout` returns `busy` immediately (non-blocking) and called `grow(State0)` to open a connection in the background. But `grow/1` calculates demand from `queue:len(Pending)`, which is always 0 for `try_checkout` callers (they never queue). The result: `N = 0`, no connection is opened, the pool stays empty forever. This is a regression from 3da765a which made `try_checkout` non-blocking.

Fix: call `grow(1, State0)` directly to unconditionally open one connection when the pool has room.

## Test plan

- [x] `remote_reader_core_SUITE` passes 26/26
- [x] `prop_SUITE` passes 29/29
- [x] `replica_reader_core_SUITE` passes 60/60
- [x] `log_reader_SUITE` passes 9/9
- [x] Dialyzer passes
- [x] `retention-stress-test.sh` 30-minute soak: consumer at 5000+ msg/s the entire run, survived retention drop from 10 GB to 200 MB, 9M messages consumed, zero errors
- [x] `high-throughput-test.sh` 45-minute soak: 6 streams, 12 producers, 12 consumers, sustained 250-450K msg/s with S3 recv at 30-50 MiB/s, full replay verified
