### PR TITLE
pool: Replace dead connections unconditionally in DOWN handler

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -275,11 +275,13 @@ handle_info(
 ) ->
     case Monitors0 of
         #{Pid := MRef} ->
-            %% A connection is down. Forget it and maybe grow a new one.
+            %% A connection is down. Replace it unconditionally: the connection
+            %% was in use (or at least monitored), so demand exists regardless
+            %% of whether anyone is in the Pending queue.
             Conn = Pid,
             State1 = State0#?MODULE{monitors = maps:remove(Conn, Monitors0)},
             State2 = cancel(Pid, State1),
-            {noreply, grow(State2)};
+            {noreply, grow(1, State2)};
         _ ->
             case CheckoutsRev0 of
                 #{MRef := Conn} ->


### PR DESCRIPTION
## Summary

Fix the connection pool's DOWN handler to replace dead connections unconditionally, preventing the pool from draining to zero under `try_checkout` workloads.

Follow-up to PR #183 which fixed the same class of bug in the `try_checkout` handler. This is the same root cause in a different code path.

## Changes

The DOWN handler called `grow(State)` which calculates demand from `queue:len(Pending)`. For `try_checkout` callers (non-blocking), Pending is always empty, so `grow/1` computes N=0 and never replaces the dead connection. When a connection dies (e.g. from `gun:close` on request timeout or cancel), the pool drains to zero and stays there.

Fix: call `grow(1, State)` to unconditionally open one replacement connection.

## Test plan

- [x] `remote_reader_core_SUITE` passes 27/27
- [x] `prop_SUITE` passes 29/29
- [x] Integration test: `remote-only-read` consumed 1M messages from S3 in 196 seconds with steady progress and no pool starvation
