### PR TITLE
Fix management UI message count for tiered streams

### DIFF
--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -17,6 +17,7 @@ retention is updated.
 -export([
     on_init/3,
     on_retention_updated/2,
+    on_retention_evaluated/2,
     local_retention_fun/1,
     discover/0
 ]).
@@ -83,6 +84,29 @@ on_retention_updated(Retention, #{name := Name}) ->
         Pid -> gen_server:cast(Pid, {retention_updated, Retention})
     end,
     [{'fun', local_retention_fun(StreamId)} | Retention].
+
+-doc """
+Called after retention evaluation sets the first_offset counter.
+
+Overrides `?C_FIRST_OFFSET` with the manifest's first offset when the
+remote tier holds older data than the local tier. Without this, the
+management UI reports only the local segment window as the message count.
+""".
+-spec on_retention_evaluated(counters:counters_ref(), map()) -> ok.
+on_retention_evaluated(Cnt, #{name := Name}) ->
+    StreamId = iolist_to_binary(Name),
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        #manifest{first_offset = ManifestFirst} when ManifestFirst > 0 ->
+            LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
+            case ManifestFirst < LocalFirst of
+                true ->
+                    counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, ManifestFirst);
+                false ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.
 
 -doc """
 Discover existing osiris writers and replicas on this node and attach

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -267,7 +267,7 @@ request_resync(StreamId, WriterNode) ->
 maybe_evaluate_retention(
     StreamId,
     #manifest{next_offset = OldManifestNextOffset},
-    #manifest{next_offset = NewManifestNextOffset},
+    #manifest{first_offset = ManifestFirstOffset, next_offset = NewManifestNextOffset},
     #state{contexts = Ctxs}
 ) when NewManifestNextOffset > OldManifestNextOffset ->
     case maps:get(StreamId, Ctxs, undefined) of
@@ -276,7 +276,11 @@ maybe_evaluate_retention(
             EvalFun = fun
                 ({{FstOff, _}, _FstTs, NumSegLeft}) when is_integer(FstOff) ->
                     osiris_log_shared:set_first_chunk_id(Shared, FstOff),
-                    counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, FstOff),
+                    counters:put(
+                        Cnt,
+                        ?C_OSIRIS_LOG_FIRST_OFFSET,
+                        min(FstOff, ManifestFirstOffset)
+                    ),
                     counters:put(Cnt, ?C_OSIRIS_LOG_SEGMENTS, NumSegLeft);
                 (_) ->
                     ok

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -838,7 +838,8 @@ cancel_timer(Ref) -> erlang:cancel_timer(Ref).
 
 -spec maybe_evaluate_retention(#manifest{}, #state{}) -> ok.
 maybe_evaluate_retention(
-    #manifest{next_offset = ManifestNextOffset}, #state{cfg = Cfg} = State
+    #manifest{first_offset = ManifestFirstOffset, next_offset = ManifestNextOffset},
+    #state{cfg = Cfg} = State
 ) when ManifestNextOffset > 0 ->
     #cfg{stream = StreamId, dir = Dir, shared = Shared, counter = Cnt} = Cfg,
     Spec = [{'fun', rabbitmq_stream_s3_hooks:local_retention_fun(StreamId)}],
@@ -846,7 +847,7 @@ maybe_evaluate_retention(
     EvalFun = fun
         ({{FstOff, _}, _FstTs, NumSegLeft}) when is_integer(FstOff) ->
             osiris_log_shared:set_first_chunk_id(Shared, FstOff),
-            update_counter(Cnt, FstOff, NumSegLeft);
+            update_counter(Cnt, min(FstOff, ManifestFirstOffset), NumSegLeft);
         (_) ->
             ok
     end,

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -68,6 +68,7 @@ groups() ->
             fragment_spans_segment_boundary,
             range_advances_monotonically,
             retention_reclaims_uploaded_segments,
+            message_count_reflects_remote_tier,
             resumes_after_restart,
             large_record_cuts_immediately,
             seed_log_uploads_deterministic,
@@ -262,6 +263,49 @@ retention_reclaims_uploaded_segments(Config) ->
 
     %% Retention will eventually reclaim everything but the current segment.
     ?awaitMatch([_], list_segment_offsets(Config), 1_000).
+
+message_count_reflects_remote_tier(Config) ->
+    StreamId = ?config(stream_id, Config),
+
+    _Writer = start_writer(Config, #{max_segment_size_bytes => 5000}, #{
+        fragment_target_size => 10000
+    }),
+
+    %% Write enough to produce multiple segments and fragments.
+    Record = binary:copy(<<"x">>, 50),
+    lists:foreach(
+        fun(_) -> osiris_writer:write(_Writer, Record) end,
+        lists:seq(1, 501)
+    ),
+    flush_writer(_Writer),
+    ?assert(length(list_segment_offsets(Config)) > 1),
+
+    %% Wait for uploads to advance past the first segment.
+    CurrentSegment = lists:last(list_segment_offsets(Config)),
+    await_offset(StreamId, CurrentSegment),
+
+    %% Wait for local retention to trim uploaded segments.
+    ?awaitMatch([_], list_segment_offsets(Config), 1_000),
+
+    %% After local retention, only one segment remains. Its offset is the
+    %% local tier's first offset and must be > 0 (earlier segments were
+    %% trimmed). The manifest covers from offset 0, so the counter should
+    %% report 0 (the manifest's first_offset), not the local segment offset.
+    [LocalFirst] = list_segment_offsets(Config),
+    ?assert(LocalFirst > 0),
+
+    #manifest{first_offset = ManifestFirst} =
+        rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+
+    %% The counter must report the manifest's first_offset (the overall
+    %% stream first), not the local segment's first offset. This is what
+    %% rabbit_osiris_metrics reads for the management UI message count.
+    ?awaitMatch(
+        #{first_offset := FO} when FO =:= ManifestFirst,
+        osiris_counters:overview({osiris_writer, StreamId}),
+        1_000
+    ),
+    ?assert(ManifestFirst < LocalFirst).
 
 resumes_after_restart(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
## Summary

Fixes #185. The management UI message count was reporting only the local segment window (~120K messages) instead of the full readable range (~9.8M) for streams with tiered storage active.

- Override `?C_FIRST_OFFSET` with the manifest's `first_offset` when the remote tier holds older data than the local tier
- Add `on_retention_evaluated/2` hook to osiris so the plugin gets the last word after `trigger_retention_eval` sets counters
- Writer-side and replica-side `maybe_evaluate_retention` use `min(FstOff, ManifestFirstOffset)` for their own EvalFuns
- `first_chunk_id` (reader routing) is unchanged everywhere

## Osiris dependency

Requires amazon-mq/upstream-to-osiris@b16b80d (`tiered-storage-abstractions` branch) which adds the `on_retention_evaluated/2` optional callback to `osiris_log_hooks`.

## Test plan

- [ ] Deploy to test cluster, verify management UI shows correct message count (~9.8M not ~120K)
- [ ] Verify `osiris_counters:overview()` `first_offset` matches manifest `first_offset` after retention fires
- [ ] Verify consumers still enter remote mode (reader routing unaffected)
- [ ] Run 4-hour high-throughput soak test, confirm no regressions
