### PR TITLE
Reduce remote reader deadline to 18s to unblock gen_statem (#191)

### DIFF
--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -130,10 +130,11 @@ read_size_prometheus_format() ->
 start(Config) ->
     gen_server:start(?MODULE, Config, []).
 
-%% The gen_server:call timeout must exceed pending_read_deadline_ms so the
+%% The gen_server:call timeout must exceed PENDING_READ_DEADLINE_MS so the
 %% internal deadline always fires first and replies {error, timeout} to the
 %% caller. This avoids overlapping reads (caller times out, new read arrives
 %% while from is still set) which require unsafe buffer resets.
+-define(PENDING_READ_DEADLINE_MS, 18_000).
 -define(SEND_FILE_READ_TIMEOUT_MS, 20_000).
 
 read(Server, Offset, Bytes, Hint) ->
@@ -426,7 +427,9 @@ maybe_stop(State) ->
 build_cfg(Opts) ->
     #cfg{
         request_timeout_ms = maps:get(request_timeout_ms, Opts, 15_000),
-        pending_read_deadline_ms = maps:get(pending_read_deadline_ms, Opts, 18_000)
+        pending_read_deadline_ms = maps:get(
+            pending_read_deadline_ms, Opts, ?PENDING_READ_DEADLINE_MS
+        )
     }.
 
 cancel_all_requests(#state{requests = Requests, cancelled = Cancelled0} = State) ->

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -21,7 +21,6 @@ synchronous feedback is generated.
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("stdlib/include/assert.hrl").
--include_lib("rabbit_common/include/rabbit.hrl").
 -include("include/rabbitmq_stream_s3.hrl").
 -include("include/logging.hrl").
 
@@ -131,12 +130,23 @@ read_size_prometheus_format() ->
 start(Config) ->
     gen_server:start(?MODULE, Config, []).
 
+%% The gen_server:call timeout must exceed pending_read_deadline_ms so the
+%% internal deadline always fires first and replies {error, timeout} to the
+%% caller. This avoids overlapping reads (caller times out, new read arrives
+%% while from is still set) which require unsafe buffer resets.
+-define(SEND_FILE_READ_TIMEOUT_MS, 20_000).
+
 read(Server, Offset, Bytes, Hint) ->
-    read(Server, Offset, Bytes, Hint, ?GEN_SERVER_CALL_TIMEOUT).
+    read(Server, Offset, Bytes, Hint, ?SEND_FILE_READ_TIMEOUT_MS).
 
 read(Server, Offset, Bytes, Hint, Timeout) ->
     T0 = erlang:monotonic_time(),
-    Result = gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout),
+    Result =
+        try
+            gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout)
+        catch
+            exit:{timeout, _} -> {error, timeout}
+        end,
     Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
     counters:add(counter(), ?C_READ_DURATION_MS, Duration),
     counters:add(counter(), ?C_READ, 1),
@@ -333,7 +343,6 @@ execute_effect(
     gen_server:reply(From, Result),
     State#state{from = undefined, deadline_timer = undefined};
 execute_effect({reply, _Result}, State) ->
-    %% No pending caller (e.g. reply generated during init before any call).
     State;
 execute_effect({observe, hit, ReadSize}, State) ->
     counters:add(counter(), ?C_BUFFER_HIT, 1),
@@ -417,7 +426,7 @@ maybe_stop(State) ->
 build_cfg(Opts) ->
     #cfg{
         request_timeout_ms = maps:get(request_timeout_ms, Opts, 15_000),
-        pending_read_deadline_ms = maps:get(pending_read_deadline_ms, Opts, 50_000)
+        pending_read_deadline_ms = maps:get(pending_read_deadline_ms, Opts, 18_000)
     }.
 
 cancel_all_requests(#state{requests = Requests, cancelled = Cancelled0} = State) ->

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
@@ -237,7 +237,7 @@ public class HighThroughputTest implements Runnable {
           s3ObjectCount = s3Snap.objectCount;
           s3ObjectInfo =
               String.format(" s3-objects=%d (delta=%+d)", s3Snap.objectCount, s3Snap.delta);
-          if (s3Snap.retentionActive()) {
+          if (s3Snap.retentionActive() || snap.deltaDeleteMany > 0) {
             retentionSeen = true;
           }
           // Only check for retention stalls after enough data has been sent to
@@ -312,7 +312,8 @@ public class HighThroughputTest implements Runnable {
 
     if (s3Monitor != null && !retentionSeen) {
       LOG.warn(
-          "Retention was never observed during the publish phase (no S3 object count decrease)");
+          "Retention was never observed during the publish phase"
+              + " (no S3 object count decrease and no delete_many activity)");
     }
 
     return totalPublished.get();

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/MetricsClient.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/MetricsClient.java
@@ -20,11 +20,15 @@ class MetricsClient {
   private static final Pattern BYTES_SENT_PATTERN =
       Pattern.compile(
           "^rabbitmq_stream_s3_bytes_sent(?:\\{[^}]*\\})?\\s+(\\d+)", Pattern.MULTILINE);
+  private static final Pattern DELETE_MANY_PATTERN =
+      Pattern.compile(
+          "^rabbitmq_stream_s3_delete_many(?:\\{[^}]*\\})?\\s+(\\d+)", Pattern.MULTILINE);
 
   private final List<String> endpoints;
   private final HttpClient client;
   private long previousBytesReceived = -1;
   private long previousBytesSent = -1;
+  private long previousDeleteMany = -1;
   private int previousEndpointsScraped = 0;
 
   MetricsClient(List<String> endpoints) {
@@ -35,14 +39,24 @@ class MetricsClient {
   static class Snapshot {
     final long bytesReceived;
     final long bytesSent;
+    final long deleteMany;
     final long deltaBytesReceived;
     final long deltaBytesSent;
+    final long deltaDeleteMany;
 
-    Snapshot(long bytesReceived, long bytesSent, long deltaReceived, long deltaSent) {
+    Snapshot(
+        long bytesReceived,
+        long bytesSent,
+        long deleteMany,
+        long deltaReceived,
+        long deltaSent,
+        long deltaDeleteMany) {
       this.bytesReceived = bytesReceived;
       this.bytesSent = bytesSent;
+      this.deleteMany = deleteMany;
       this.deltaBytesReceived = deltaReceived;
       this.deltaBytesSent = deltaSent;
+      this.deltaDeleteMany = deltaDeleteMany;
     }
 
     double receivedMiBPerS(long intervalSeconds) {
@@ -59,6 +73,7 @@ class MetricsClient {
   Snapshot snapshot() {
     long totalReceived = 0;
     long totalSent = 0;
+    long totalDeleteMany = 0;
     int endpointsScraped = 0;
 
     for (String endpoint : endpoints) {
@@ -73,6 +88,7 @@ class MetricsClient {
           String body = response.body();
           totalReceived += extractMetric(body, BYTES_RECEIVED_PATTERN);
           totalSent += extractMetric(body, BYTES_SENT_PATTERN);
+          totalDeleteMany += extractMetric(body, DELETE_MANY_PATTERN);
           endpointsScraped++;
         }
       } catch (Exception e) {
@@ -85,15 +101,19 @@ class MetricsClient {
     // on the next full scrape.
     long deltaReceived = 0;
     long deltaSent = 0;
+    long deltaDeleteMany = 0;
     if (previousBytesReceived >= 0 && endpointsScraped == previousEndpointsScraped) {
       deltaReceived = totalReceived - previousBytesReceived;
       deltaSent = totalSent - previousBytesSent;
+      deltaDeleteMany = totalDeleteMany - previousDeleteMany;
     }
     previousBytesReceived = totalReceived;
     previousBytesSent = totalSent;
+    previousDeleteMany = totalDeleteMany;
     previousEndpointsScraped = endpointsScraped;
 
-    return new Snapshot(totalReceived, totalSent, deltaReceived, deltaSent);
+    return new Snapshot(
+        totalReceived, totalSent, totalDeleteMany, deltaReceived, deltaSent, deltaDeleteMany);
   }
 
   private long extractMetric(String body, Pattern pattern) {


### PR DESCRIPTION
Mitigates #191

## Summary

- Lower `pending_read_deadline_ms` from 50s to 18s so the remote reader's internal deadline fires before the `gen_server:call` timeout (20s). This guarantees the caller receives `{error, timeout}` via a normal reply, keeping `from` cleared before the next read arrives.
- Add a 20s `gen_server:call` timeout with `try/catch exit:{timeout, _}` as a safety net (should never fire under normal operation since the internal deadline fires first at 18s).
- The `rabbit_stream_reader` gen_statem unblocks after 18s instead of blocking for up to 60s, allowing it to process pending subscribe/unsubscribe/credit frames.

## Approach

The previous implementation attempted to handle overlapping reads (caller times out at the `gen_server:call` level while `from` is still set) by resetting buffer state (`discard_stale_pending`). This caused data corruption on the wire - chunks already sent before the timeout were re-sent from the reverted log position.

The correct fix is simpler: ensure the internal deadline always fires first. The server replies `{error, timeout}` to the caller within the call timeout window, so the caller never exits via `exit:{timeout, _}`, `from` is always cleared, and the existing `?assertEqual(undefined, State0#state.from)` assertion remains valid. No buffer resets, no overlapping reads, no duplicate delivery.

## Test plan

- [x] `remote_reader_core_SUITE` passes
- [x] Property-based tests pass
- [ ] 45-minute high-throughput integration test (pending)
