### PR TITLE
S3: Allow configuring a KMS key ARN

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -106,6 +106,21 @@ stream_s3.verify_crc_on_read = false
 
 Osiris does not validate CRC when sending chunk data to consumers via `send_file` or the chunk iterator. The CRC in each chunk header is validated on the write path (when replicas accept chunks) and during `read_chunk/1`, but not on the streaming read paths used for consumer delivery. This setting adds validation on the remote read path where data has traversed an additional network hop (S3) beyond the original replication.
 
+### Server-side encryption
+
+The plugin sends an `x-amz-server-side-encryption: AES256` header on every PUT request. This is a no-op on default S3 buckets (S3 encrypts all objects with SSE-S3 automatically) but satisfies bucket policies or SCPs that deny uploads without an explicit encryption header.
+
+When the bucket requires SSE-KMS, configure the key ARN:
+
+```ini
+# KMS key ARN for server-side encryption. When set, the plugin uses
+# SSE-KMS (aws:kms) instead of SSE-S3 (AES256) for all uploads.
+# Type: binary. Default: not set (uses AES256).
+stream_s3.kms_key_id = arn:aws:kms:us-east-1:123456789012:key/example-key-id
+```
+
+For more information on S3 server-side encryption options, see [Protecting data with server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html).
+
 ## Monitoring
 
 The plugin exposes its metrics via Prometheus through the existing `rabbitmq_prometheus` plugin. Enabling `rabbitmq_stream_s3` implicitly enables `rabbitmq_prometheus`, which opens the Prometheus metrics endpoint on port 15692 (TCP) or 15691 (TLS).

--- a/priv/schema/rabbitmq_stream_s3.schema
+++ b/priv/schema/rabbitmq_stream_s3.schema
@@ -202,3 +202,19 @@ end}.
 {mapping, "stream_s3.verify_crc_on_read", "rabbitmq_stream_s3.verify_crc_on_read", [
     {datatype, {enum, [true, false]}}
 ]}.
+
+%%
+%% Server-side encryption (KMS)
+%%
+
+{mapping, "stream_s3.kms_key_id", "rabbitmq_stream_s3.kms_key_id", [
+    {datatype, binary}
+]}.
+
+{translation, "rabbitmq_stream_s3.kms_key_id",
+fun(Conf) ->
+    case cuttlefish:conf_get("stream_s3.kms_key_id", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -197,12 +197,13 @@ get_range_async(Key, Range, Opts) when is_binary(Key) andalso is_map(Opts) ->
 -doc "Uploads the given `Data` as an object at key `Key`".
 -spec put(key(), iodata(), request_opts()) -> ok | {error, any()}.
 put(Key, Data, Opts) when is_binary(Key) andalso is_map(Opts) ->
+    Headers0 = sse_headers(),
     Headers =
         case Opts of
             #{crc32 := Checksum} ->
-                #{<<"x-amz-checksum-crc32">> => base64:encode(<<Checksum:32/unsigned>>)};
+                Headers0#{<<"x-amz-checksum-crc32">> => base64:encode(<<Checksum:32/unsigned>>)};
             _ ->
-                #{}
+                Headers0
         end,
     case request(<<"PUT">>, key_to_path(Key), Headers, Data, Opts) of
         {ok, #{status := 200}} ->
@@ -219,7 +220,7 @@ stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) 
     Method = <<"PUT">>,
     Path = key_to_path(Key),
     EncodedLength = aws_chunked_encoded_length(ContentLength),
-    Headers0 = #{
+    Headers0 = (sse_headers())#{
         <<"content-length">> => integer_to_binary(EncodedLength),
         <<"content-encoding">> => <<"aws-chunked">>,
         <<"x-amz-decoded-content-length">> => integer_to_binary(ContentLength),
@@ -1396,6 +1397,21 @@ delete_many_body(Keys) when is_list(Keys) ->
 -spec key_to_path(rabbitmq_stream_s3:key()) -> binary().
 key_to_path(Key) ->
     <<$/, (uri_string:quote(Key, "/"))/binary>>.
+
+%% Server-side encryption headers for PUT requests. Always requests SSE-S3
+%% (AES256) to satisfy bucket policies that deny uploads without an explicit
+%% encryption header. When a KMS key is configured, uses SSE-KMS instead.
+-spec sse_headers() -> req_headers().
+sse_headers() ->
+    case rabbitmq_stream_s3_config:kms_key_id() of
+        undefined ->
+            #{<<"x-amz-server-side-encryption">> => <<"AES256">>};
+        KeyId ->
+            #{
+                <<"x-amz-server-side-encryption">> => <<"aws:kms">>,
+                <<"x-amz-server-side-encryption-aws-kms-key-id">> => KeyId
+            }
+    end.
 
 %% Computes the aws-chunked framing overhead for a single chunk of DataSize bytes.
 %% Each chunk is framed as: <hex-size>\r\n<data>\r\n

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -42,7 +42,8 @@ lives here. Callers use these functions instead of calling
     tick_timeout_milliseconds/0,
     max_transfer_bytes_per_sec/0,
     max_transfer_burst_bytes/0,
-    verify_crc_on_read/0
+    verify_crc_on_read/0,
+    kms_key_id/0
 ]).
 
 -define(APP, rabbitmq_stream_s3).
@@ -189,6 +190,10 @@ max_transfer_burst_bytes() ->
 verify_crc_on_read() ->
     application:get_env(?APP, verify_crc_on_read, false).
 
+-spec kms_key_id() -> binary() | undefined.
+kms_key_id() ->
+    application:get_env(?APP, kms_key_id, undefined).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -222,7 +227,8 @@ defaults_test_() ->
         ?_assertEqual(45_000, segment_upload_timeout()),
         ?_assertEqual(60_000, retention_task_timeout()),
         ?_assertEqual(5000, tick_timeout_milliseconds()),
-        ?_assertEqual(false, verify_crc_on_read())
+        ?_assertEqual(false, verify_crc_on_read()),
+        ?_assertEqual(undefined, kms_key_id())
     ].
 
 configured_test_() ->

--- a/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
@@ -73,4 +73,8 @@
  {stream_s3_verify_crc_on_read,
   "stream_s3.verify_crc_on_read = true",
   [{rabbitmq_stream_s3, [{verify_crc_on_read, true}]}],
+  []},
+ {stream_s3_kms_key_id,
+  "stream_s3.kms_key_id = arn:aws:kms:us-east-1:123456789012:key/example-key-id",
+  [{rabbitmq_stream_s3, [{kms_key_id, <<"arn:aws:kms:us-east-1:123456789012:key/example-key-id">>}]}],
   []}].


### PR DESCRIPTION
This enables a defense-in-depth mechanism where you can configure a bucket (through CloudFormation for example) to deny an upload which does not specify server-side-encryption (SSE). Generally you should configure your bucket to use SSE, and SSE is enabled by default since 2023 anyways. But you can prevent against the accidental upload of unencrypted data if those measures fall through.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
