### PR TITLE
CLI: Add a command to trigger local retention

### DIFF
--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateLocalRetentionCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateLocalRetentionCommand.erl
@@ -1,0 +1,73 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateLocalRetentionCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+    scopes/0,
+    usage/0,
+    usage_additional/0,
+    banner/2,
+    validate/2,
+    merge_defaults/2,
+    run/2,
+    output/2,
+    description/0,
+    help_section/0
+]).
+
+scopes() ->
+    [streams].
+
+description() ->
+    <<"Triggers local retention evaluation for a stream's tiered storage plugin">>.
+
+help_section() ->
+    {plugin, stream}.
+
+validate([], _Opts) ->
+    {validation_failure, not_enough_args};
+validate([_Name], _Opts) ->
+    ok;
+validate(_, _Opts) ->
+    {validation_failure, too_many_args}.
+
+merge_defaults(Args, Opts) ->
+    {Args, maps:merge(#{vhost => <<"/">>}, Opts)}.
+
+usage() ->
+    <<"evaluate_local_retention <stream> [--vhost <vhost>]">>.
+
+usage_additional() ->
+    [
+        [<<"<stream>">>, <<"The name of the stream.">>],
+        [<<"--vhost <vhost>">>, <<"The virtual host of the stream.">>]
+    ].
+
+run([Name], #{node := NodeName, vhost := VHost, timeout := Timeout}) ->
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_replica_reader,
+        evaluate_local_retention,
+        [VHost, Name],
+        Timeout
+    ).
+
+banner([Name], #{vhost := VHost}) ->
+    erlang:iolist_to_binary(
+        io_lib:format(
+            "Evaluating local retention for stream ~ts in vhost ~ts ...",
+            [Name, VHost]
+        )
+    ).
+
+output(ok, _Opts) ->
+    {ok, <<"Local retention evaluated successfully.">>};
+output({error, {not_found, _}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"Stream not found or replica reader not running on this node.">>};
+output({error, Reason}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -18,6 +18,7 @@ returned by the functional core module.
 -include("include/rabbitmq_stream_s3.hrl").
 
 -export([start_link/1, format_state/1]).
+-export([evaluate_local_retention/1, evaluate_local_retention/2]).
 -export([identity_formatter/1]).
 -export([counter_fields/0, init_counters/0]).
 -export([
@@ -253,6 +254,28 @@ start_link(#{stream := StreamId} = Args) ->
         []
     ).
 
+-doc "Trigger local retention evaluation for a stream on the current node.".
+-spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
+evaluate_local_retention(StreamId) ->
+    case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
+        undefined ->
+            {error, {not_found, StreamId}};
+        Pid ->
+            gen_server:call(Pid, evaluate_local_retention)
+    end.
+
+-doc "Trigger local retention evaluation by vhost and queue name.".
+-spec evaluate_local_retention(rabbit_types:vhost(), binary()) -> ok | {error, term()}.
+evaluate_local_retention(VHost, QueueName) ->
+    QName = rabbit_misc:r(VHost, queue, QueueName),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            #{name := StreamId} = amqqueue:get_type_state(Q),
+            evaluate_local_retention(iolist_to_binary(StreamId));
+        {error, not_found} ->
+            {error, {not_found, QueueName}}
+    end.
+
 init(
     #{
         stream := StreamId,
@@ -298,6 +321,10 @@ init(
 handle_call({await_offset, Offset}, From, #state{core = Core0} = State) ->
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:await_offset(Offset, From, Core0),
     {noreply, execute_effects(Effects, State#state{core = Core})};
+handle_call(evaluate_local_retention, _From, #state{core = Core} = State) ->
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+    maybe_evaluate_retention(Manifest, State),
+    {reply, ok, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 


### PR DESCRIPTION
`rabbitmq-streams evaluate_local_retention <stream name> [--vhost vhost]` kicks off the local retention job. This should let us debug situations where the plugin is leaving more in the local tier because of possible race conditions with retention. By evaluating retention and seeing whether or not it results in a segment file being deleted we can know whether or not retention is the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
