### PR TITLE
Expand CLI tools for replica reader processes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -426,6 +426,53 @@ A single `rabbitmq_stream_s3_archival_lag_bytes` metric would not give this deco
 
 ## Debugging
 
+### CLI commands
+
+The plugin adds commands to `rabbitmq-streams` for debugging the upload pipeline.
+
+**Stream S3 status** shows the current state of the tiered storage replica reader for a stream: manifest offsets, pipeline state, assembly progress, and whether persist/rebalance/retention operations are in flight.
+
+```bash
+rabbitmq-streams stream_s3_status my-stream --vhost /
+# Status of tiered storage for stream sq in vhost / ...
+# stream:	<<"__sq_1781016420026141262">>
+# fragment_target_size:	67108864
+# log_next_offset:	1421556
+# manifest_first_offset:	0
+# manifest_next_offset:	1317635
+# manifest_total_size:	1339723340
+# persisted_next_offset:	1317635
+# transfers_in_flight:	1
+# transfers_pending_order:	0
+# since_persist:	0
+# persist_in_flight:	false
+# rebalance_in_flight:	false
+# retention_in_flight:	false
+# waiters:	0
+# assembly_payload_size:	38043104
+# assembly_target_size:	67108864
+# assembly_num_chunks:	6661
+# assembly_cut:	false
+```
+
+**Evaluate local retention** triggers the local retention job for a stream. Useful to determine whether retention is correctly reclaiming segments after upload.
+
+```bash
+rabbitmq-streams evaluate_local_retention my-stream --vhost /
+```
+
+**Evaluate remote retention** triggers the remote retention job for a stream. Useful when the retention policy has changed and you want immediate effect, or to verify that remote retention is not stuck.
+
+```bash
+rabbitmq-streams evaluate_remote_retention my-stream --vhost /
+```
+
+**Force fragment cut** forces the current in-progress fragment to cut and upload immediately, regardless of whether it has reached the target size. Useful to verify that the upload pipeline works end-to-end without waiting for data to accumulate.
+
+```bash
+rabbitmq-streams force_fragment_cut my-stream --vhost /
+```
+
 ### Inspect a replica reader
 
 ```erlang

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
@@ -1,0 +1,73 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+    scopes/0,
+    usage/0,
+    usage_additional/0,
+    banner/2,
+    validate/2,
+    merge_defaults/2,
+    run/2,
+    output/2,
+    description/0,
+    help_section/0
+]).
+
+scopes() ->
+    [streams].
+
+description() ->
+    <<"Triggers retention evaluation for a stream's remote tier storage">>.
+
+help_section() ->
+    {plugin, stream}.
+
+validate([], _Opts) ->
+    {validation_failure, not_enough_args};
+validate([_Name], _Opts) ->
+    ok;
+validate(_, _Opts) ->
+    {validation_failure, too_many_args}.
+
+merge_defaults(Args, Opts) ->
+    {Args, maps:merge(#{vhost => <<"/">>}, Opts)}.
+
+usage() ->
+    <<"evaluate_remote_retention <stream> [--vhost <vhost>]">>.
+
+usage_additional() ->
+    [
+        [<<"<stream>">>, <<"The name of the stream.">>],
+        [<<"--vhost <vhost>">>, <<"The virtual host of the stream.">>]
+    ].
+
+run([Name], #{node := NodeName, vhost := VHost, timeout := Timeout}) ->
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_replica_reader,
+        evaluate_remote_retention,
+        [VHost, Name],
+        Timeout
+    ).
+
+banner([Name], #{vhost := VHost}) ->
+    erlang:iolist_to_binary(
+        io_lib:format(
+            "Evaluating remote retention for stream ~ts in vhost ~ts ...",
+            [Name, VHost]
+        )
+    ).
+
+output(ok, _Opts) ->
+    {ok, <<"Remote retention evaluated successfully.">>};
+output({error, {not_found, _}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"Stream not found or replica reader not running on this node.">>};
+output({error, Reason}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ForceFragmentCutCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ForceFragmentCutCommand.erl
@@ -1,0 +1,79 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.ForceFragmentCutCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+    scopes/0,
+    usage/0,
+    usage_additional/0,
+    banner/2,
+    validate/2,
+    merge_defaults/2,
+    run/2,
+    output/2,
+    description/0,
+    help_section/0
+]).
+
+scopes() ->
+    [streams].
+
+description() ->
+    <<"Forces the current in-progress fragment to cut and upload immediately">>.
+
+help_section() ->
+    {plugin, stream}.
+
+validate([], _Opts) ->
+    {validation_failure, not_enough_args};
+validate([_Name], _Opts) ->
+    ok;
+validate(_, _Opts) ->
+    {validation_failure, too_many_args}.
+
+merge_defaults(Args, Opts) ->
+    {Args, maps:merge(#{vhost => <<"/">>}, Opts)}.
+
+usage() ->
+    <<"force_fragment_cut <stream> [--vhost <vhost>]">>.
+
+usage_additional() ->
+    [
+        [<<"<stream>">>, <<"The name of the stream.">>],
+        [<<"--vhost <vhost>">>, <<"The virtual host of the stream.">>]
+    ].
+
+run([Name], #{node := NodeName, vhost := VHost, timeout := Timeout}) ->
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_replica_reader,
+        force_fragment_cut,
+        [VHost, Name],
+        Timeout
+    ).
+
+banner([Name], #{vhost := VHost}) ->
+    erlang:iolist_to_binary(
+        io_lib:format(
+            "Forcing fragment cut for stream ~ts in vhost ~ts ...",
+            [Name, VHost]
+        )
+    ).
+
+output(ok, _Opts) ->
+    {ok, <<"Fragment cut forced successfully.">>};
+output({error, no_assembly}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"No assembly in progress (stream may not be reading yet).">>};
+output({error, empty_assembly}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"Assembly is empty (no chunks accumulated yet).">>};
+output({error, {not_found, _}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"Stream not found or replica reader not running on this node.">>};
+output({error, Reason}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
@@ -1,0 +1,119 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+    scopes/0,
+    usage/0,
+    usage_additional/0,
+    banner/2,
+    validate/2,
+    merge_defaults/2,
+    run/2,
+    output/2,
+    description/0,
+    help_section/0
+]).
+
+scopes() ->
+    [streams].
+
+description() ->
+    <<"Shows the tiered storage status for a stream">>.
+
+help_section() ->
+    {plugin, stream}.
+
+validate([], _Opts) ->
+    {validation_failure, not_enough_args};
+validate([_Name], _Opts) ->
+    ok;
+validate(_, _Opts) ->
+    {validation_failure, too_many_args}.
+
+merge_defaults(Args, Opts) ->
+    {Args, maps:merge(#{vhost => <<"/">>}, Opts)}.
+
+usage() ->
+    <<"stream_s3_status <stream> [--vhost <vhost>]">>.
+
+usage_additional() ->
+    [
+        [<<"<stream>">>, <<"The name of the stream.">>],
+        [<<"--vhost <vhost>">>, <<"The virtual host of the stream.">>]
+    ].
+
+run([Name], #{node := NodeName, vhost := VHost, timeout := Timeout}) ->
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_replica_reader,
+        status,
+        [VHost, Name],
+        Timeout
+    ).
+
+banner([Name], #{vhost := VHost}) ->
+    erlang:iolist_to_binary(
+        io_lib:format(
+            "Status of tiered storage for stream ~ts in vhost ~ts ...",
+            [Name, VHost]
+        )
+    ).
+
+output({ok, Info}, #{formatter := <<"json">>}) ->
+    {ok, flatten(Info)};
+output({ok, Info}, _Opts) ->
+    KVs = flatten(Info),
+    Lines = [io_lib:format("~s:\t~tp", [K, V]) || {K, V} <- KVs],
+    {ok, erlang:iolist_to_binary(lists:join($\n, Lines))};
+output({error, {not_found, _}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        <<"Stream not found or replica reader not running on this node.">>};
+output({error, Reason}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.
+
+%% ------------------------------------------------------------------
+%% Internal
+%% ------------------------------------------------------------------
+
+flatten(
+    #{stream := StreamId, core := Core, assembly := Assembly, log_next_offset := LogNext} = Info
+) ->
+    Target = maps:get(fragment_target_size, Info),
+    Base = [
+        {stream, StreamId},
+        {fragment_target_size, Target},
+        {log_next_offset, LogNext}
+    ],
+    Base ++ flatten_core(Core) ++ flatten_assembly(Assembly).
+
+flatten_core(undefined) ->
+    [{core, <<"not initialized">>}];
+flatten_core(Core) ->
+    [
+        {manifest_first_offset, maps:get(manifest_first_offset, Core)},
+        {manifest_next_offset, maps:get(manifest_next_offset, Core)},
+        {manifest_total_size, maps:get(manifest_total_size, Core)},
+        {persisted_next_offset, maps:get(persisted_next_offset, Core)},
+        {transfers_in_flight, maps:get(transfers_in_flight, Core)},
+        {transfers_pending_order, maps:get(transfers_pending_order, Core)},
+        {since_persist, maps:get(since_persist, Core)},
+        {persist_in_flight, maps:get(persist_in_flight, Core)},
+        {rebalance_in_flight, maps:get(rebalance_in_flight, Core)},
+        {retention_in_flight, maps:get(retention_in_flight, Core)},
+        {waiters, maps:get(waiters, Core)}
+    ].
+
+flatten_assembly(undefined) ->
+    [{assembly, <<"not initialized">>}];
+flatten_assembly(Assembly) ->
+    [
+        {assembly_payload_size, maps:get(payload_size, Assembly)},
+        {assembly_target_size, maps:get(target_size, Assembly)},
+        {assembly_num_chunks, maps:get(num_chunks, Assembly)},
+        {assembly_cut, maps:get(cut, Assembly)}
+    ].

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -17,8 +17,10 @@ returned by the functional core module.
 -include("include/logging.hrl").
 -include("include/rabbitmq_stream_s3.hrl").
 
--export([start_link/1, format_state/1]).
+-export([start_link/1, format_state/1, status/1, status/2]).
 -export([evaluate_local_retention/1, evaluate_local_retention/2]).
+-export([evaluate_remote_retention/1, evaluate_remote_retention/2]).
+-export([force_fragment_cut/1, force_fragment_cut/2]).
 -export([identity_formatter/1]).
 -export([counter_fields/0, init_counters/0]).
 -export([
@@ -254,27 +256,51 @@ start_link(#{stream := StreamId} = Args) ->
         []
     ).
 
+-doc "Return the formatted status of the replica reader for a stream.".
+-spec status(stream_id()) -> {ok, map()} | {error, term()}.
+status(StreamId) ->
+    case call(StreamId, status) of
+        {error, _} = Err -> Err;
+        Result -> {ok, Result}
+    end.
+
+-doc "Return the formatted status by vhost and queue name.".
+-spec status(rabbit_types:vhost(), binary()) -> {ok, map()} | {error, term()}.
+status(VHost, QueueName) ->
+    case call(VHost, QueueName, status) of
+        {error, _} = Err -> Err;
+        Result -> {ok, Result}
+    end.
+
 -doc "Trigger local retention evaluation for a stream on the current node.".
 -spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
 evaluate_local_retention(StreamId) ->
-    case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
-        undefined ->
-            {error, {not_found, StreamId}};
-        Pid ->
-            gen_server:call(Pid, evaluate_local_retention)
-    end.
+    call(StreamId, evaluate_local_retention).
 
 -doc "Trigger local retention evaluation by vhost and queue name.".
 -spec evaluate_local_retention(rabbit_types:vhost(), binary()) -> ok | {error, term()}.
 evaluate_local_retention(VHost, QueueName) ->
-    QName = rabbit_misc:r(VHost, queue, QueueName),
-    case rabbit_amqqueue:lookup(QName) of
-        {ok, Q} ->
-            #{name := StreamId} = amqqueue:get_type_state(Q),
-            evaluate_local_retention(iolist_to_binary(StreamId));
-        {error, not_found} ->
-            {error, {not_found, QueueName}}
-    end.
+    call(VHost, QueueName, evaluate_local_retention).
+
+-doc "Trigger remote retention evaluation for a stream on the current node.".
+-spec evaluate_remote_retention(stream_id()) -> ok | {error, term()}.
+evaluate_remote_retention(StreamId) ->
+    call(StreamId, evaluate_remote_retention).
+
+-doc "Trigger remote retention evaluation by vhost and queue name.".
+-spec evaluate_remote_retention(rabbit_types:vhost(), binary()) -> ok | {error, term()}.
+evaluate_remote_retention(VHost, QueueName) ->
+    call(VHost, QueueName, evaluate_remote_retention).
+
+-doc "Force the current in-progress fragment to cut and upload immediately.".
+-spec force_fragment_cut(stream_id()) -> ok | {error, term()}.
+force_fragment_cut(StreamId) ->
+    call(StreamId, force_fragment_cut).
+
+-doc "Force fragment cut by vhost and queue name.".
+-spec force_fragment_cut(rabbit_types:vhost(), binary()) -> ok | {error, term()}.
+force_fragment_cut(VHost, QueueName) ->
+    call(VHost, QueueName, force_fragment_cut).
 
 init(
     #{
@@ -321,10 +347,46 @@ init(
 handle_call({await_offset, Offset}, From, #state{core = Core0} = State) ->
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:await_offset(Offset, From, Core0),
     {noreply, execute_effects(Effects, State#state{core = Core})};
+handle_call(status, _From, State) ->
+    {reply, format_state(State), State};
 handle_call(evaluate_local_retention, _From, #state{core = Core} = State) ->
     Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
     maybe_evaluate_retention(Manifest, State),
     {reply, ok, State};
+handle_call(
+    evaluate_remote_retention,
+    _From,
+    #state{core = Core, retention = Retention, cfg = #cfg{stream = StreamId}} = State
+) ->
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+    State1 = maybe_evaluate_remote_retention(Manifest, Retention, StreamId, State),
+    {reply, ok, State1};
+handle_call(force_fragment_cut, _From, #state{assembly = undefined} = State) ->
+    {reply, {error, no_assembly}, State};
+handle_call(
+    force_fragment_cut,
+    _From,
+    #state{assembly = Assembly0, core = Core0, cfg = #cfg{fragment_target_size = TargetSize}} =
+        State
+) ->
+    Meta = rabbitmq_stream_s3_fragment_assembly:metadata(Assembly0),
+    case maps:get(num_chunks, Meta) of
+        0 ->
+            {reply, {error, empty_assembly}, State};
+        _ ->
+            IdxRecords = rabbitmq_stream_s3_fragment_assembly:index_records(Assembly0),
+            {Core, _Ref, Effects} =
+                rabbitmq_stream_s3_replica_reader_core:fragment_cut(
+                    Meta#{index_records => IdxRecords}, Core0
+                ),
+            FragmentSize = maps:get(size, Meta),
+            dec(State, ?C_BYTES_IN_ASSEMBLY, FragmentSize),
+            Assembly1 = rabbitmq_stream_s3_fragment_assembly:new(TargetSize),
+            State1 = execute_effects(
+                Effects, State#state{assembly = Assembly1, core = Core}
+            ),
+            {reply, ok, State1}
+    end;
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 
@@ -588,6 +650,22 @@ format_state(#state{
 %% ------------------------------------------------------------------
 %% Internal
 %% ------------------------------------------------------------------
+
+call(StreamId, Msg) ->
+    case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
+        undefined -> {error, {not_found, StreamId}};
+        Pid -> gen_server:call(Pid, Msg)
+    end.
+
+call(VHost, QueueName, Msg) ->
+    QName = rabbit_misc:r(VHost, queue, QueueName),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            #{name := StreamId} = amqqueue:get_type_state(Q),
+            call(iolist_to_binary(StreamId), Msg);
+        {error, not_found} ->
+            {error, {not_found, QueueName}}
+    end.
 
 identity_formatter(Evt) -> Evt.
 


### PR DESCRIPTION
These might be useful eventually for debugging the upload pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
