### PR TITLE
hooks: Fix condition check for an empty manifest on retention eval

### DIFF
--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -95,15 +95,10 @@ management UI reports only the local segment window as the message count.
 -spec on_retention_evaluated(counters:counters_ref(), map()) -> ok.
 on_retention_evaluated(Cnt, #{name := Name}) ->
     StreamId = iolist_to_binary(Name),
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = ManifestFirst} when ManifestFirst > 0 ->
+    case rabbitmq_stream_s3_manifest_replica:get_range(StreamId) of
+        {RemoteFirst, _} ->
             LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
-            case ManifestFirst < LocalFirst of
-                true ->
-                    counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, ManifestFirst);
-                false ->
-                    ok
-            end;
+            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst));
         _ ->
             ok
     end.


### PR DESCRIPTION
This would cause spurious mismeasurements of message count (based on this first offset counter) while a queue was growing and not yet hitting remote tier retention.

Neither first or next offsets are reliable for detecting an empty manifest - the remote tier is only really empty if the manifest points to zero fragments.

This caused a pattern like so in message count:

<img width="1498" height="442" alt="Screenshot 2026-06-09 at 19 52 58" src="https://github.com/user-attachments/assets/1f6653ef-9f79-4ac0-b3b7-06fb18f0d9be" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
