### PR TITLE
Add a metric for HTTP 403 from the object store

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -256,6 +256,7 @@ Owned by `rabbitmq_stream_s3_api_aws`.
 |-------------------------------------|---------|-------------------------------------------------------------------|
 | `rabbitmq_stream_s3_active_requests`                   | gauge   | Current in-flight S3 requests                                     |
 | `rabbitmq_stream_s3_total_requests`                    | counter | Total S3 API requests (includes internal pagination)              |
+| `rabbitmq_stream_s3_response_403`                      | counter | HTTP 403 responses                                                |
 | `rabbitmq_stream_s3_response_500`                      | counter | HTTP 500 responses                                                |
 | `rabbitmq_stream_s3_response_503`                      | counter | HTTP 503 responses                                                |
 | `rabbitmq_stream_s3_request_timeouts`                  | counter | Request timeouts                                                  |

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -53,12 +53,14 @@ A wrapper around the AWS S3 HTTP API.
 
 -define(C_ACTIVE_REQUESTS, 1).
 -define(C_TOTAL_REQUESTS, 2).
--define(C_RESPONSE_500, 3).
--define(C_RESPONSE_503, 4).
--define(C_REQUEST_TIMEOUTS, 5).
+-define(C_RESPONSE_403, 3).
+-define(C_RESPONSE_500, 4).
+-define(C_RESPONSE_503, 5).
+-define(C_REQUEST_TIMEOUTS, 6).
 -define(COUNTERS, [
     {active_requests, ?C_ACTIVE_REQUESTS, gauge, "Current number of requests to S3"},
     {total_requests, ?C_TOTAL_REQUESTS, counter, "Total number of requests to S3"},
+    {response_403, ?C_RESPONSE_403, counter, "Number of HTTP 403 responses"},
     {response_500, ?C_RESPONSE_500, counter, "Number of HTTP 500 responses"},
     {response_503, ?C_RESPONSE_503, counter, "Number of HTTP 503 responses"},
     {request_timeouts, ?C_REQUEST_TIMEOUTS, counter, "Number of S3 requests that timed out"}
@@ -759,6 +761,8 @@ await_response(Conn, StreamRef, Timeout) ->
             Err
     end.
 
+postprocess_response(#{status := 403}) ->
+    counters:add(counter(), ?C_RESPONSE_403, 1);
 postprocess_response(#{status := 503}) ->
     counters:add(counter(), ?C_RESPONSE_503, 1);
 postprocess_response(#{status := 500}) ->


### PR DESCRIPTION
This can help identify auth errors - bad creds or lack of assume role permissions, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
