### PR TITLE
Add garbage collection command

### DIFF
--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -182,4 +182,12 @@ aws s3 ls "s3://${BUCKET}/rabbitmq/stream/${STREAM_ID}/data/" --recursive
 
 **Mitigation.** None needed urgently. Orphans do not affect operation. For unbounded accumulation (typically only after data-directory resets), operators can manually delete S3 prefixes for streams that no longer exist in Khepri.
 
-**Resolution.** A periodic garbage collection mechanism is planned (see `redesign.md` "Orphan cleanup"); it is not yet implemented. The intended design lists stream ID prefixes under the bucket's `rabbitmq/stream/` path on the Khepri leader and removes prefixes with no matching Khepri entry. Orphan storage cost is bounded: typically a few fragments worth of bytes per leadership election.
+**Resolution.** The `rabbitmq_stream_s3_gc` module identifies and optionally deletes orphaned objects. Run it via the CLI:
+
+```bash
+rabbitmq-streams stream_s3_gc
+rabbitmq-streams stream_s3_gc --formatter json
+rabbitmq-streams stream_s3_gc --mode delete
+```
+
+See [operations.md](./operations.md#garbage-collection) for details on the GC mechanism, its safety guarantees, and current scope limitations.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -477,6 +477,16 @@ rabbitmq-streams evaluate_remote_retention my-stream --vhost /
 rabbitmq-streams force_fragment_cut my-stream --vhost /
 ```
 
+**Garbage collection** identifies (and optionally deletes) dangling S3 objects that are not referenced by any manifest. Defaults to `dry_run` mode which reports orphans without deleting them. Pass `--mode delete` to actually remove the objects.
+
+```bash
+rabbitmq-streams stream_s3_gc
+rabbitmq-streams stream_s3_gc --formatter json
+rabbitmq-streams stream_s3_gc --mode delete
+```
+
+See [Garbage collection](#garbage-collection) below for the mechanism and safety guarantees.
+
 ### Inspect a replica reader
 
 ```erlang
@@ -521,6 +531,49 @@ Per-stream metrics live behind `/metrics/per-object`. Scrape this endpoint for d
 ```bash
 curl http://node:15692/metrics/per-object | grep 'queue="my-stream"'
 ```
+
+## Garbage collection
+
+Objects in S3 can become orphaned (not referenced by any manifest) in several scenarios: a deposed writer uploads a fragment but loses the Khepri race, a manifest persist fails or the process crashes before completion, or retention deletes entries from the manifest but the corresponding object deletion does not complete.
+
+The GC mechanism identifies these orphans by listing S3 objects and comparing their keys against current authoritative state. It is invoked on demand via the CLI.
+
+### Safety guarantee: monotonicity
+
+The correctness of GC depends on a single structural property: the values used as barriers (`first_offset`, `epoch`) only ever increase. This makes false positives (deleting a live object) structurally impossible, regardless of timing or consistency:
+
+- `first_offset` advances monotonically as retention removes data from the front of the manifest. An object whose offset is below first_offset was already removed by retention. It can never become live again.
+- `epoch` advances monotonically with each new writer. A manifest root whose epoch is below the current epoch belongs to a deposed writer. The new writer's manifest is authoritative and the old root can never become active again.
+
+Eventually-consistent reads (from Khepri or the manifest replica ETS cache) can only return stale values that are lower than or equal to the true current value. A stale barrier is more conservative: it classifies fewer objects as garbage. The GC may miss orphans on a given run (false negatives) but can never delete live objects (false positives).
+
+### Classifying garbage
+
+| Object type   | Key format                                                  | Condition for "garbage"
+|---            |---                                                          |---
+| Fragment      | `rabbitmq/stream/<id>/data/<offset>.<uid>.fragment`         | offset < manifest first_offset
+| Group         | `rabbitmq/stream/<id>/metadata/<offset>.<uid>.<kind>`       | offset < manifest first_offset
+| Manifest root | `rabbitmq/stream/<id>/metadata/root.<epoch>.<uid>.manifest` | epoch < current epoch according to Khepri
+
+Note that objects belonging to an unknown stream ID are not currently considered garbage. Handling this case is planned.
+
+### Modes
+
+- `dry_run` (default): lists S3 objects, classifies orphans, logs each finding at info level, returns the list. No deletions.
+- `delete`: same as dry_run, but also sends each orphan's key to the reaper for batched deletion as it is discovered.
+
+### Output
+
+With `--formatter json`, the output is a JSON array of objects:
+
+```json
+[
+  {"stream_id": "...", "key": "rabbitmq/stream/.../00000000000000000042.abcd1234.fragment", "reason": "below_first_offset"},
+  {"stream_id": "...", "key": "rabbitmq/stream/.../metadata/root.1.deadbeef.manifest", "reason": "stale_epoch"}
+]
+```
+
+Without `--formatter json`, the output is tab-separated with a summary line.
 
 ## Cost considerations
 

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3GcCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3GcCommand.erl
@@ -1,0 +1,83 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3GcCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+    scopes/0,
+    usage/0,
+    usage_additional/0,
+    banner/2,
+    validate/2,
+    merge_defaults/2,
+    run/2,
+    output/2,
+    description/0,
+    help_section/0
+]).
+
+scopes() ->
+    [streams].
+
+description() ->
+    <<"Identifies (or deletes) dangling objects in the remote tier">>.
+
+help_section() ->
+    {plugin, stream}.
+
+validate([], _Opts) ->
+    ok;
+validate(_, _Opts) ->
+    {validation_failure, too_many_args}.
+
+merge_defaults(Args, Opts) ->
+    {Args, maps:merge(#{mode => <<"dry_run">>}, Opts)}.
+
+usage() ->
+    <<"stream_s3_gc [--mode <dry_run|delete>]">>.
+
+usage_additional() ->
+    [
+        [
+            <<"--mode <mode>">>,
+            <<"dry_run (default) to report only, delete to remove dangling objects.">>
+        ]
+    ].
+
+run([], #{node := NodeName, mode := ModeBin, timeout := Timeout}) ->
+    Mode = parse_mode(ModeBin),
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_gc,
+        run,
+        [#{mode => Mode}],
+        Timeout
+    ).
+
+banner([], #{mode := Mode}) ->
+    erlang:iolist_to_binary(
+        io_lib:format("Running tiered storage GC (mode=~ts) ...", [Mode])
+    ).
+
+output({ok, Findings}, #{formatter := <<"json">>}) ->
+    {ok, Findings};
+output({ok, Findings}, _Opts) ->
+    Lines = [format_finding(F) || F <- Findings],
+    Summary = io_lib:format("~b dangling object(s) found.", [length(Findings)]),
+    {ok, erlang:iolist_to_binary(lists:join($\n, Lines ++ [Summary]))};
+output({error, Reason}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
+        erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.
+
+%% ------------------------------------------------------------------
+%% Internal
+%% ------------------------------------------------------------------
+
+parse_mode(<<"dry_run">>) -> dry_run;
+parse_mode(<<"delete">>) -> delete;
+parse_mode(_) -> dry_run.
+
+format_finding(#{stream_id := StreamId, key := Key, reason := Reason}) ->
+    io_lib:format("~ts\t~ts\t~p", [StreamId, Key, Reason]).

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -1,0 +1,267 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_gc).
+-moduledoc """
+Garbage-collects dangling remote tier objects.
+
+LISTs S3 objects under `rabbitmq/stream/` and identifies orphans by comparing
+object keys against current state in Khepri (epoch) and the manifest replica
+ETS cache (first_offset).
+
+Safety relies on monotonicity: epoch and first_offset only move forward.
+Eventually-consistent reads from Khepri or ETS can only return stale (lower)
+values, which makes the GC more conservative (false negatives), never less safe
+(false positives are structurally impossible).
+
+Streams with no local manifest replica are skipped (cannot verify first_offset).
+Unknown stream prefixes (stream not in Khepri) are skipped (no safe deletion
+signal without Khepri restructuring).
+""".
+
+-include("include/rabbitmq_stream_s3.hrl").
+-include("include/logging.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([run/0, run/1]).
+
+-type mode() :: dry_run | delete.
+-type config() :: #{mode => mode()}.
+-type reason() :: below_first_offset | stale_epoch.
+-type finding() :: #{stream_id := stream_id(), key := rabbitmq_stream_s3:key(), reason := reason()}.
+
+-export_type([mode/0, config/0, finding/0]).
+
+run() ->
+    run(#{mode => dry_run}).
+
+-doc """
+Run garbage collection. In `dry_run` mode, identifies and logs orphans without
+deleting. In `delete` mode, deletes identified orphans via the reaper.
+""".
+-spec run(config()) -> {ok, [finding()]}.
+run(Config) when is_map(Config) ->
+    Mode = maps:get(mode, Config, dry_run),
+    {ok, Streams} = rabbitmq_stream_s3_db:list(),
+    Lookup = build_lookup(Streams),
+    Fun = make_handler(Mode),
+    Findings = list_and_classify(<<"rabbitmq/stream/">>, start, Lookup, Fun, []),
+    ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
+    {ok, Findings}.
+
+make_handler(dry_run) ->
+    fun(Finding, Acc) ->
+        log_finding(Finding),
+        [Finding | Acc]
+    end;
+make_handler(delete) ->
+    fun(#{stream_id := StreamId, key := Key} = Finding, Acc) ->
+        log_finding(Finding),
+        rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]),
+        [Finding | Acc]
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal
+%% ------------------------------------------------------------------
+
+build_lookup(Streams) ->
+    maps:fold(
+        fun(StreamId, #{epoch := Epoch}, Acc) ->
+            case rabbitmq_stream_s3_manifest_replica:get_range(StreamId) of
+                {FirstOffset, _NextOffset} ->
+                    Acc#{StreamId => #{epoch => Epoch, first_offset => FirstOffset}};
+                empty ->
+                    Acc
+            end
+        end,
+        #{},
+        Streams
+    ).
+
+list_and_classify(_Prefix, done, _Lookup, _Fun, Acc) ->
+    lists:reverse(Acc);
+list_and_classify(Prefix, Continuation, Lookup, Fun, Acc) ->
+    case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
+        {ok, [], done} ->
+            lists:reverse(Acc);
+        {ok, Keys, NextContinuation} ->
+            Orphans = classify_page(Keys, Lookup),
+            NewAcc = lists:foldl(Fun, Acc, Orphans),
+            list_and_classify(Prefix, NextContinuation, Lookup, Fun, NewAcc);
+        {error, Reason} ->
+            ?LOG_WARNING("GC: failed to list objects under ~ts: ~p", [Prefix, Reason]),
+            lists:reverse(Acc)
+    end.
+
+classify_page(Keys, Lookup) ->
+    lists:filtermap(
+        fun(Key) ->
+            case classify(Key, Lookup) of
+                {ok, Finding} -> {true, Finding};
+                skip -> false
+            end
+        end,
+        Keys
+    ).
+
+-spec classify(rabbitmq_stream_s3:key(), map()) -> {ok, finding()} | skip.
+classify(Key, Lookup) ->
+    case parse_key(Key) of
+        {data, StreamId, Offset} ->
+            case Lookup of
+                #{StreamId := #{first_offset := FirstOffset}} when Offset < FirstOffset ->
+                    {ok, #{stream_id => StreamId, key => Key, reason => below_first_offset}};
+                _ ->
+                    skip
+            end;
+        {manifest, StreamId, Epoch} ->
+            case Lookup of
+                #{StreamId := #{epoch := CurrentEpoch}} when Epoch < CurrentEpoch ->
+                    {ok, #{stream_id => StreamId, key => Key, reason => stale_epoch}};
+                _ ->
+                    skip
+            end;
+        unknown ->
+            %% Key belongs to a stream not in the lookup (either unknown to
+            %% Khepri or missing a local manifest replica). Not safe to delete
+            %% without a positive "stream deleted" signal. See #149 for the
+            %% planned Khepri restructuring that would make stream-prefix
+            %% sweep safe.
+            skip
+    end.
+
+%% Parse an S3 key into its components.
+%%
+%% Fragment keys: rabbitmq/stream/<StreamId>/data/<offset>.<uid>.fragment
+%% Group keys:   rabbitmq/stream/<StreamId>/metadata/<offset>.<uid>.<kind>
+%% Manifest keys: rabbitmq/stream/<StreamId>/metadata/root.<epoch>.<uid>.manifest
+-spec parse_key(rabbitmq_stream_s3:key()) ->
+    {data, stream_id(), osiris:offset()}
+    | {manifest, stream_id(), osiris:epoch()}
+    | unknown.
+parse_key(<<"rabbitmq/stream/", Rest/binary>>) ->
+    case binary:split(Rest, <<"/">>) of
+        [StreamId, <<"data/", Filename/binary>>] ->
+            parse_data_filename(StreamId, Filename);
+        [StreamId, <<"metadata/", Filename/binary>>] ->
+            parse_metadata_filename(StreamId, Filename);
+        _ ->
+            unknown
+    end;
+parse_key(_) ->
+    unknown.
+
+parse_data_filename(StreamId, Filename) ->
+    %% <offset>.<uid>.fragment
+    case binary:split(Filename, <<".">>, [global]) of
+        [OffsetBin, _Uid, <<"fragment">>] ->
+            {data, StreamId, binary_to_integer(OffsetBin)};
+        _ ->
+            unknown
+    end.
+
+parse_metadata_filename(StreamId, Filename) ->
+    case binary:split(Filename, <<".">>, [global]) of
+        [<<"root">>, EpochBin, _Uid, <<"manifest">>] ->
+            {manifest, StreamId, binary_to_integer(EpochBin)};
+        [OffsetBin, _Uid, Kind] when
+            Kind =:= <<"group">> orelse Kind =:= <<"kgroup">> orelse Kind =:= <<"mgroup">>
+        ->
+            %% Group objects have the same offset-based safety as fragments.
+            {data, StreamId, binary_to_integer(OffsetBin)};
+        _ ->
+            unknown
+    end.
+
+log_finding(#{stream_id := StreamId, key := Key, reason := Reason}) ->
+    ?LOG_INFO("GC: dangling object ~ts (stream=~ts, reason=~p)", [Key, StreamId, Reason]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+parse_key_fragment_test() ->
+    Key = <<"rabbitmq/stream/my_stream/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual({data, <<"my_stream">>, 100}, parse_key(Key)).
+
+parse_key_fragment_zero_test() ->
+    Key = <<"rabbitmq/stream/s/data/00000000000000000000.00000001.fragment">>,
+    ?assertEqual({data, <<"s">>, 0}, parse_key(Key)).
+
+parse_key_group_test() ->
+    Key = <<"rabbitmq/stream/s/metadata/00000000000000000500.aabbccdd.group">>,
+    ?assertEqual({data, <<"s">>, 500}, parse_key(Key)).
+
+parse_key_kilo_group_test() ->
+    Key = <<"rabbitmq/stream/s/metadata/00000000000000001000.aabbccdd.kgroup">>,
+    ?assertEqual({data, <<"s">>, 1000}, parse_key(Key)).
+
+parse_key_mega_group_test() ->
+    Key = <<"rabbitmq/stream/s/metadata/00000000000000005000.aabbccdd.mgroup">>,
+    ?assertEqual({data, <<"s">>, 5000}, parse_key(Key)).
+
+parse_key_manifest_test() ->
+    Key = <<"rabbitmq/stream/my_stream/metadata/root.3.aabb0011.manifest">>,
+    ?assertEqual({manifest, <<"my_stream">>, 3}, parse_key(Key)).
+
+parse_key_manifest_epoch_zero_test() ->
+    Key = <<"rabbitmq/stream/s/metadata/root.0.aabb0011.manifest">>,
+    ?assertEqual({manifest, <<"s">>, 0}, parse_key(Key)).
+
+parse_key_unknown_test() ->
+    ?assertEqual(unknown, parse_key(<<"some/other/key">>)),
+    ?assertEqual(unknown, parse_key(<<"rabbitmq/stream/s/other/file">>)).
+
+%% Round-trip: keys generated by rabbitmq_stream_s3 are parseable.
+parse_key_roundtrip_fragment_test() ->
+    StreamId = <<"__vhost_stream_123">>,
+    Key = rabbitmq_stream_s3:fragment_key(StreamId, 42, 16#deadbeef),
+    ?assertEqual({data, StreamId, 42}, parse_key(Key)).
+
+parse_key_roundtrip_manifest_test() ->
+    StreamId = <<"__vhost_stream_123">>,
+    Ref = #manifest_ref{epoch = 7, uid = 16#aabbccdd},
+    Key = rabbitmq_stream_s3:manifest_key(StreamId, Ref),
+    ?assertEqual({manifest, StreamId, 7}, parse_key(Key)).
+
+parse_key_roundtrip_group_test() ->
+    StreamId = <<"__vhost_stream_123">>,
+    Ref = #group_ref{offset = 999, kind = ?MANIFEST_KIND_GROUP, uid = 16#11223344},
+    Key = rabbitmq_stream_s3:group_key(StreamId, Ref),
+    ?assertEqual({data, StreamId, 999}, parse_key(Key)).
+
+classify_fragment_below_first_offset_test() ->
+    Lookup = #{<<"s">> => #{epoch => 5, first_offset => 200}},
+    Key = <<"rabbitmq/stream/s/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual(
+        {ok, #{stream_id => <<"s">>, key => Key, reason => below_first_offset}},
+        classify(Key, Lookup)
+    ).
+
+classify_fragment_at_first_offset_test() ->
+    %% At or above first_offset is NOT garbage.
+    Lookup = #{<<"s">> => #{epoch => 5, first_offset => 100}},
+    Key = <<"rabbitmq/stream/s/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual(skip, classify(Key, Lookup)).
+
+classify_manifest_stale_epoch_test() ->
+    Lookup = #{<<"s">> => #{epoch => 5, first_offset => 0}},
+    Key = <<"rabbitmq/stream/s/metadata/root.3.aabb0011.manifest">>,
+    ?assertEqual(
+        {ok, #{stream_id => <<"s">>, key => Key, reason => stale_epoch}},
+        classify(Key, Lookup)
+    ).
+
+classify_manifest_current_epoch_test() ->
+    %% Current epoch is NOT garbage.
+    Lookup = #{<<"s">> => #{epoch => 3, first_offset => 0}},
+    Key = <<"rabbitmq/stream/s/metadata/root.3.aabb0011.manifest">>,
+    ?assertEqual(skip, classify(Key, Lookup)).
+
+classify_unknown_stream_skipped_test() ->
+    %% Stream not in lookup -> skip (not safe to delete).
+    Lookup = #{},
+    Key = <<"rabbitmq/stream/unknown/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual(skip, classify(Key, Lookup)).
+
+-endif.


### PR DESCRIPTION
This is most of the machinery to perform garbage collection. It's only wired into the `rabbitmq-streams` CLI currently. In the long run we can have a periodic automatic trigger. We could also hold a global lock so that GC is only performed by one process at one time.

GC sweeps through all objects and identifies dangling objects:

* Fragment and group objects which have an offset before the first offset in the stream.
* Manifest root objects with an epoch number less than the current epoch of the stream.

These conditions make false-negatives possible (i.e. objects might not be flagged as garbage which are actually dangling) but false-negatives structurally impossible - the GC can never delete a live object.

*Issue #, if available:* fixes #149.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
