### PR TITLE
Service transfers larger than the governor burst on credit

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -88,6 +88,14 @@ stream_s3.persist_interval_ms = 2000
 # When unlimited, the governor does not pace transfers. Set to a fraction
 # of instance bandwidth on managed deployments to avoid contention with
 # other traffic. Default: unlimited.
+#
+# The ceiling is a long-run average. A single transfer larger than the
+# internal burst allowance (a fragment can exceed its target size when a
+# large chunk lands at the end) is still admitted, on credit, and the
+# governor throttles subsequent transfers to repay it; it never stalls.
+# The `governor_oversized_admissions` metric counts such transfers: a
+# persistently climbing value means the configured rate is low relative
+# to fragment sizes.
 stream_s3.max_transfer_bytes_per_sec = unlimited
 ```
 

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -34,13 +34,18 @@ with no pacing.
 -define(C_SUBMISSIONS_RECEIVED, 1).
 -define(C_TASKS_IN_FLIGHT, 2).
 -define(C_PENDING_SUBMISSIONS, 3).
+-define(C_OVERSIZED_ADMISSIONS, 4).
 -define(COUNTERS, [
     {governor_submissions_received, ?C_SUBMISSIONS_RECEIVED, counter,
         "Total transfer submissions received by the governor"},
     {governor_tasks_in_flight, ?C_TASKS_IN_FLIGHT, gauge,
         "Number of transfer tasks currently executing"},
     {governor_pending_submissions, ?C_PENDING_SUBMISSIONS, gauge,
-        "Number of submissions queued waiting for token-bucket capacity"}
+        "Number of submissions queued waiting for token-bucket capacity"},
+    {governor_oversized_admissions, ?C_OVERSIZED_ADMISSIONS, counter,
+        "Transfers admitted whose size exceeded the token-bucket burst (admitted "
+        "on credit, driving the bucket into debt). A persistently climbing value "
+        "means the configured burst is smaller than typical fragments"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -144,6 +149,7 @@ dispatch(Item, #state{bucket = unlimited} = State) ->
 dispatch({_Fun, Size, _ReplyTo, _Ref} = Item, #state{bucket = Bucket0} = State) ->
     case rabbitmq_stream_s3_token_bucket:request(Size, Bucket0) of
         {ok, Bucket} ->
+            count_oversized(Size, Bucket0),
             spawn_task(Item),
             State#state{bucket = Bucket};
         {insufficient, _, _} ->
@@ -164,6 +170,7 @@ drain_pending(#state{pending = Pending0, bucket = Bucket0} = State) ->
         {value, {_Fun, Size, _ReplyTo, _Ref} = Item} ->
             case rabbitmq_stream_s3_token_bucket:request(Size, Bucket0) of
                 {ok, Bucket} ->
+                    count_oversized(Size, Bucket0),
                     spawn_task(Item),
                     Pending = queue:drop(Pending0),
                     set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
@@ -192,6 +199,17 @@ spawn_task({Fun, _Size, ReplyTo, Ref}) ->
 
 schedule_refill() ->
     erlang:send_after(?REFILL_INTERVAL_MS, self(), refill).
+
+%% Count an admitted transfer whose size exceeds the bucket's burst. Such a
+%% transfer is admitted on credit (the bucket goes into debt) rather than
+%% deadlocking. Bucket0 is the pre-request bucket; burst is invariant across
+%% request/2 so reading it here is correct.
+count_oversized(Size, Bucket) ->
+    #{burst := Burst} = rabbitmq_stream_s3_token_bucket:info(Bucket),
+    case Size > Burst of
+        true -> inc(?C_OVERSIZED_ADMISSIONS, 1);
+        false -> ok
+    end.
 
 %% ------------------------------------------------------------------
 %% Counters
@@ -275,9 +293,27 @@ pacing_delays_when_exhausted_test() ->
     end,
     gen_server:stop(Pid).
 
+%% A transfer larger than the burst must not deadlock the governor. It is
+%% admitted on credit (the bucket goes into debt), and a smaller transfer
+%% queued behind it must still complete once the debt is repaid. Before the
+%% fix the oversized item at the head of the queue blocked everything forever.
+oversized_transfer_does_not_deadlock_test() ->
+    %% rate 1000 B/s, burst 1000 B; transfer of 5000 B exceeds burst.
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    RefBig = make_ref(),
+    RefSmall = make_ref(),
+    submit(fun() -> {ok, big} end, 5000, Self, RefBig),
+    submit(fun() -> {ok, small} end, 100, Self, RefSmall),
+    %% Debt of ~4000 tokens repays at 1000 B/s, so the small item clears in
+    %% ~4-5s. Generous timeout; the point is that it completes at all.
+    Results = collect_results([RefBig, RefSmall], 15000),
+    ?assertEqual({ok, big}, maps:get(RefBig, Results)),
+    ?assertEqual({ok, small}, maps:get(RefSmall, Results)),
+    gen_server:stop(Pid).
+
 collect_results(Refs, Timeout) ->
     collect_results(Refs, Timeout, #{}).
-
 collect_results([], _Timeout, Acc) ->
     Acc;
 collect_results([Ref | Rest], Timeout, Acc) ->

--- a/src/rabbitmq_stream_s3_token_bucket.erl
+++ b/src/rabbitmq_stream_s3_token_bucket.erl
@@ -9,6 +9,18 @@ Tokens represent bytes. The bucket refills at a configured rate
 (bytes per second) and is capped at a burst size. Callers request
 tokens before sending data. If insufficient tokens are available,
 the caller learns the deficit and can wait for the next refill.
+
+`burst` caps how many tokens may be *accumulated* while idle. It does
+not cap the size of an individual request: a request larger than
+`burst` is admitted once the bucket has saved up all it can
+(`available == burst`) and is allowed to drive `available` negative,
+going into debt. Subsequent refills repay the debt before anything
+else is admitted, so the long-run rate is preserved exactly regardless
+of request size. This matters because a transfer is a whole fragment,
+and a fragment is not bounded by `fragment_target_size`: that size is a
+soft floor for *when to cut*, and a single trailing chunk (which batches
+records) can be arbitrarily large. Any assumption that a request fits
+under `burst` would deadlock the day a large batch is written.
 """.
 
 -export([new/2, request/2, refill/1, info/1]).
@@ -38,10 +50,20 @@ new(Rate, Burst) ->
 
 -spec request(Tokens :: non_neg_integer(), t()) ->
     {ok, t()} | {insufficient, Deficit :: non_neg_integer(), t()}.
-request(Tokens, #bucket{available = Available} = Bucket) when Tokens =< Available ->
+%% Admit when the bucket holds at least `min(Tokens, Burst)` tokens.
+%% For a normal request (Tokens =< Burst) this is identical to "have
+%% enough tokens". For an oversized request (Tokens > Burst) the
+%% threshold saturates at Burst, so the request is admitted once the
+%% bucket is fully saved up and then pays its full cost, driving
+%% `available` negative (debt). Refill repays the debt before the next
+%% admission, preserving the long-run rate. `min/2` is allowed in guards
+%% since OTP 26.
+request(Tokens, #bucket{available = Available, burst = Burst} = Bucket) when
+    min(Tokens, Burst) =< Available
+->
     {ok, Bucket#bucket{available = Available - Tokens}};
-request(Tokens, #bucket{available = Available} = Bucket) ->
-    {insufficient, Tokens - Available, Bucket}.
+request(Tokens, #bucket{available = Available, burst = Burst} = Bucket) ->
+    {insufficient, min(Tokens, Burst) - Available, Bucket}.
 
 -spec refill(t()) -> t().
 refill(#bucket{rate = Rate, burst = Burst, available = Available, last_refill = Last} = Bucket) ->
@@ -75,8 +97,12 @@ request_zero_always_succeeds_test() ->
     {ok, _} = request(0, B).
 
 insufficient_returns_deficit_test() ->
-    B = new(1000, 100),
-    {insufficient, 50, _} = request(150, B).
+    %% Drain the bucket below burst first; a full bucket can never report
+    %% insufficient now (a request larger than burst is admitted on credit).
+    %% With 40 tokens left, a 90-token request reports a deficit of 50.
+    B0 = new(1000, 100),
+    {ok, B1} = request(60, B0),
+    {insufficient, 50, _} = request(90, B1).
 
 refill_adds_tokens_test() ->
     B0 = new(10_000_000, 10_000_000),
@@ -93,5 +119,45 @@ refill_caps_at_burst_test() ->
     timer:sleep(10),
     B1 = refill(B0),
     ?assert(B1#bucket.available =< 500).
+
+%% An oversized request (larger than burst) must be serviceable, not a
+%% permanent deadlock. It is admitted once the bucket is full and then
+%% drives `available` negative (debt).
+oversized_request_admitted_when_full_test() ->
+    B = new(1000, 1000),
+    %% 1500 > burst 1000, but the bucket is full (available == burst).
+    {ok, B1} = request(1500, B),
+    ?assertEqual(-500, B1#bucket.available).
+
+%% While in debt (available < burst) nothing is admitted, including a
+%% small request. The bucket must refill back up first.
+oversized_request_blocks_until_debt_repaid_test() ->
+    B = new(1000, 1000),
+    {ok, B1} = request(1500, B),
+    %% available is -500; even a tiny request must wait.
+    {insufficient, _, _} = request(1, B1),
+    %% Another oversized request also waits: threshold saturates at burst,
+    %% and available (-500) is below burst.
+    {insufficient, _, _} = request(5000, B1).
+
+%% No upper bound on serviceable size: a request far larger than burst is
+%% still admitted when the bucket is full, and the debt repays via refill.
+arbitrarily_large_request_serviceable_test() ->
+    B0 = new(1_000_000, 1_000_000),
+    {ok, B1} = request(50_000_000, B0),
+    ?assertEqual(-49_000_000, B1#bucket.available),
+    %% Debt repays over time; eventually the bucket climbs back toward burst.
+    timer:sleep(10),
+    B2 = refill(B1),
+    ?assert(B2#bucket.available > B1#bucket.available).
+
+%% burst = 0 (degenerate config, e.g. rate < 5) must not deadlock either.
+%% With zero burst the threshold is always 0, so the first request is
+%% admitted immediately and pacing is purely rate-driven thereafter.
+zero_burst_paces_without_deadlock_test() ->
+    B0 = new(1000, 0),
+    {ok, B1} = request(500, B0),
+    ?assertEqual(-500, B1#bucket.available),
+    {insufficient, _, _} = request(500, B1).
 
 -endif.


### PR DESCRIPTION
Theoretical bug in the governor - we can smooth it out to always ensure progress by the governor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
