### PR TITLE
Position the fragment iterator by the requested offset inside groups

### DIFF
--- a/src/rabbitmq_stream_s3_fragment_iterator.erl
+++ b/src/rabbitmq_stream_s3_fragment_iterator.erl
@@ -30,9 +30,15 @@ as it descends into branches.
     index :: non_neg_integer(),
     stack :: [{binary(), non_neg_integer()}],
     get_group_fun :: get_group_fun(),
-    %% The manifest's first_offset. Used to skip deleted entries when
-    %% descending into groups after partial retention.
-    first_offset :: osiris:offset()
+    %% The offset to position at, at every level of the tree: the caller's
+    %% requested offset clamped up to the manifest's first_offset. The clamp
+    %% serves two roles at once. It positions descent at the requested offset
+    %% (so a read starting mid-group lands on the right child, not the group's
+    %% first child), and the first_offset floor skips leading entries that
+    %% retention has deleted (whose objects are gone). Reusing one value at
+    %% every level is correct because the iterator only moves forward: a group
+    %% entirely after this offset resolves to its first child (index 0).
+    start_offset :: osiris:offset()
 }).
 
 -opaque iterator() :: #iterator{}.
@@ -42,13 +48,14 @@ Create an iterator positioned at the entry containing or following `Offset`.
 """.
 -spec init(#manifest{}, osiris:offset(), get_group_fun()) -> iterator().
 init(#manifest{entries = Entries, first_offset = FirstOffset}, Offset, GetGroupFun) ->
-    Idx = find_start_index(Entries, Offset),
+    StartOffset = max(Offset, FirstOffset),
+    Idx = find_start_index(Entries, StartOffset),
     #iterator{
         entries = Entries,
         index = Idx,
         stack = [],
         get_group_fun = GetGroupFun,
-        first_offset = FirstOffset
+        start_offset = StartOffset
     }.
 
 -doc """
@@ -110,13 +117,13 @@ descend(
         index = Idx,
         stack = Stack,
         get_group_fun = GetGroupFun,
-        first_offset = FirstOffset
+        start_offset = StartOffset
     } = It,
     GroupRef
 ) ->
     case GetGroupFun(GroupRef) of
         {ok, ChildEntries} ->
-            ChildIdx = find_start_index(ChildEntries, FirstOffset),
+            ChildIdx = find_start_index(ChildEntries, StartOffset),
             It1 = It#iterator{
                 entries = ChildEntries,
                 index = ChildIdx,

--- a/test/fragment_iterator_SUITE.erl
+++ b/test/fragment_iterator_SUITE.erl
@@ -32,6 +32,10 @@ all() ->
         all_refs_with_groups,
         descend_skips_retained_entries,
         descend_skips_retained_entries_kilo_group,
+        init_mid_group_positions_at_requested_offset,
+        init_between_group_children_positions_at_containing_child,
+        init_mid_kilo_group_positions_at_requested_offset,
+        mid_group_descent_respects_retention_floor,
         init_at_group_boundary,
         group_fetch_failed_mid_traversal,
         empty_group_ascends_immediately,
@@ -384,6 +388,104 @@ descend_skips_retained_entries_kilo_group(_Config) ->
     {ok, #fragment_ref{offset = 400, uid = 16#b4}, It6} =
         rabbitmq_stream_s3_fragment_iterator:next(It5),
     ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It6)).
+
+init_mid_group_positions_at_requested_offset(_Config) ->
+    %% Regression for the mid-group descent bug (R2-1). A read starting inside
+    %% a group, above the group's first child, must land on the child that
+    %% contains the requested offset, not the group's first child. Here
+    %% first_offset = 0 (nothing retained) and init is at offset 200 over a
+    %% group [F0, F100, F200, F300]: the first result must be F200. The bug
+    %% descended at first_offset (0) and returned F0, then F100, ... —
+    %% delivering already-seen, out-of-order fragments to the consumer.
+    {Manifest, GetGroup} = build_manifest([
+        {group, [
+            {fragment, #{offset => 0, uid => 16#a0}},
+            {fragment, #{offset => 100, uid => 16#a1}},
+            {fragment, #{offset => 200, uid => 16#a2}},
+            {fragment, #{offset => 300, uid => 16#a3}}
+        ]},
+        {fragment, #{offset => 400, uid => 16#a4}}
+    ]),
+    %% Precondition that distinguishes this from the retention tests: the
+    %% requested offset (200) is strictly above first_offset (0).
+    ?assertEqual(0, Manifest#manifest.first_offset),
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 200, GetGroup),
+    {ok, #fragment_ref{offset = 200, uid = 16#a2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 300, uid = 16#a3}, It2} =
+        rabbitmq_stream_s3_fragment_iterator:next(It1),
+    {ok, #fragment_ref{offset = 400, uid = 16#a4}, It3} =
+        rabbitmq_stream_s3_fragment_iterator:next(It2),
+    ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It3)).
+
+init_between_group_children_positions_at_containing_child(_Config) ->
+    %% Requested offset 250 falls between F200 and F300; it must resolve to
+    %% F200 (the child whose range contains 250), exercising the
+    %% partition_point/saturating_decr path for a non-boundary offset.
+    {Manifest, GetGroup} = build_manifest([
+        {group, [
+            {fragment, #{offset => 0, uid => 16#a0}},
+            {fragment, #{offset => 100, uid => 16#a1}},
+            {fragment, #{offset => 200, uid => 16#a2}},
+            {fragment, #{offset => 300, uid => 16#a3}}
+        ]},
+        {fragment, #{offset => 400, uid => 16#a4}}
+    ]),
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 250, GetGroup),
+    {ok, #fragment_ref{offset = 200, uid = 16#a2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 300, uid = 16#a3}, _} =
+        rabbitmq_stream_s3_fragment_iterator:next(It1).
+
+init_mid_kilo_group_positions_at_requested_offset(_Config) ->
+    %% Nested case: the requested offset must steer find_start_index correctly
+    %% at *every* level. init at 200 over
+    %% [KiloGroup([Group([F0,F100]), Group([F200,F300])]), F400] must descend
+    %% the kilo-group to its *second* child group and then to F200. The bug
+    %% (descend at first_offset = 0) picked the first group and returned F0.
+    {Manifest, GetGroup} = build_manifest([
+        {kilo_group, [
+            {group, [
+                {fragment, #{offset => 0, uid => 16#b0}},
+                {fragment, #{offset => 100, uid => 16#b1}}
+            ]},
+            {group, [
+                {fragment, #{offset => 200, uid => 16#b2}},
+                {fragment, #{offset => 300, uid => 16#b3}}
+            ]}
+        ]},
+        {fragment, #{offset => 400, uid => 16#b4}}
+    ]),
+    ?assertEqual(0, Manifest#manifest.first_offset),
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 200, GetGroup),
+    {ok, #fragment_ref{offset = 200, uid = 16#b2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 300, uid = 16#b3}, It2} =
+        rabbitmq_stream_s3_fragment_iterator:next(It1),
+    {ok, #fragment_ref{offset = 400, uid = 16#b4}, It3} =
+        rabbitmq_stream_s3_fragment_iterator:next(It2),
+    ?assertEqual(end_of_manifest, rabbitmq_stream_s3_fragment_iterator:next(It3)).
+
+mid_group_descent_respects_retention_floor(_Config) ->
+    %% Retention and mid-group descent combined: first_offset = 100 (F0 gone)
+    %% and the requested offset is 250. The clamp is max(250, 100) = 250, so
+    %% the first result is F200. The bug descended at first_offset (100) and
+    %% returned F100 — below where the consumer asked to start.
+    {Manifest0, GetGroup} = build_manifest([
+        {group, [
+            {fragment, #{offset => 0, uid => 16#c0}},
+            {fragment, #{offset => 100, uid => 16#c1}},
+            {fragment, #{offset => 200, uid => 16#c2}},
+            {fragment, #{offset => 300, uid => 16#c3}}
+        ]},
+        {fragment, #{offset => 400, uid => 16#c4}}
+    ]),
+    Manifest = Manifest0#manifest{first_offset = 100, first_timestamp = 100},
+    It0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 250, GetGroup),
+    {ok, #fragment_ref{offset = 200, uid = 16#c2}, It1} =
+        rabbitmq_stream_s3_fragment_iterator:next(It0),
+    {ok, #fragment_ref{offset = 300, uid = 16#c3}, _} =
+        rabbitmq_stream_s3_fragment_iterator:next(It1).
 
 init_at_group_boundary(_Config) ->
     %% Init at offset that is exactly the first offset of a group entry.


### PR DESCRIPTION
The forward iterator positioned the root index by the caller's requested offset but descended into every group at the manifest's first_offset. A consumer starting a read inside a group, above the group's first surviving child, was therefore handed the group's first child and walked forward from there: after the first fragment boundary it received earlier, already-seen fragments, out-of-order and with duplicate offsets, and no error was raised. This triggered only for a stream large enough to hold a group entry and a subscription landing mid-group (replay from an old offset, or a lagging consumer), which is the core tiered-read case.

Position descent by max(requested_offset, first_offset) at every level, precomputed once as the iterator's start_offset. The first_offset floor still skips leading entries deleted by retention; the requested offset now selects the correct child. Reusing one value at every level is correct because the iterator only moves forward, so a group entirely after the requested offset resolves to its first child.

The fix is confined to the iterator: find_position, refresh_iterator, and resolve_first already pass the correct offset into init/3. Adds four fragment_iterator_SUITE regression tests (mid-group, between children, nested kilo-group, and mid-group with a retention floor); each fails when descent uses first_offset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
