### PR TITLE
Retry fatally-failed fragment uploads instead of dropping them

### DIFF
--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -36,6 +36,7 @@ lives here. Callers use these functions instead of calling
     task_retry_delay_exponent/0,
     verbose_logging/0,
     segment_upload_timeout/0,
+    upload_retry_delay_ms/0,
     retention_task_timeout/0,
     tick_timeout_milliseconds/0,
     max_transfer_bytes_per_sec/0,
@@ -160,6 +161,13 @@ verbose_logging() ->
 segment_upload_timeout() ->
     application:get_env(?APP, segment_upload_timeout, 45_000).
 
+%% Delay before retrying a fragment upload that failed with a non-transient
+%% error. The upload pipeline stalls at the failed offset until the retry
+%% succeeds, so this bounds how often a persistently failing upload is retried.
+-spec upload_retry_delay_ms() -> non_neg_integer().
+upload_retry_delay_ms() ->
+    application:get_env(?APP, upload_retry_delay_ms, 1000).
+
 -spec retention_task_timeout() -> non_neg_integer().
 retention_task_timeout() ->
     application:get_env(?APP, retention_task_timeout, 60_000).
@@ -213,6 +221,7 @@ defaults_test_() ->
         ?_assertEqual(2, task_retry_delay_exponent()),
         ?_assertEqual(false, verbose_logging()),
         ?_assertEqual(45_000, segment_upload_timeout()),
+        ?_assertEqual(1000, upload_retry_delay_ms()),
         ?_assertEqual(60_000, retention_task_timeout()),
         ?_assertEqual(5000, tick_timeout_milliseconds()),
         ?_assertEqual(false, verify_crc_on_read()),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -835,7 +835,7 @@ execute_effect(
     {resubmit_transfer_delayed, Ref, _StreamId, Dir, Meta, Reason}, #state{cfg = Cfg} = State0
 ) ->
     StreamId = Cfg#cfg.stream,
-    Delay = application:get_env(rabbitmq_stream_s3, upload_retry_delay_ms, 1000),
+    Delay = rabbitmq_stream_s3_config:upload_retry_delay_ms(),
     ?LOG_WARNING(
         "~ts fragment upload at offset ~b failed with non-transient error ~p; "
         "retrying in ~bms. The upload pipeline and local-tier cleanup are "

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -455,6 +455,12 @@ handle_info({transfer_result, Ref, {error, Reason}}, #state{core = Core0} = Stat
     State1 = on_transfer_result(Ref, {error, Reason}, State0),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, Reason, Core0),
     {noreply, execute_effects(Effects, State1#state{core = Core})};
+handle_info({retry_transfer, Ref, Dir, Meta}, #state{cfg = #cfg{stream = StreamId}} = State) ->
+    %% A previously failed fragment upload is being retried after its backoff
+    %% delay. The in-flight gauges were already restored when the delayed
+    %% resubmit effect was executed, so only re-submit the upload here.
+    submit_upload(Ref, Dir, StreamId, Meta),
+    {noreply, State};
 handle_info({group_upload_result, {ok, Uid}}, #state{core = Core0, group_mon = Mon} = State0) ->
     demonitor(Mon, [flush]),
     State1 = on_group_upload_completed(State0),
@@ -816,31 +822,30 @@ execute_effects([Effect | Rest], State0) ->
 
 execute_effect({submit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} = State0) ->
     StreamId = Cfg#cfg.stream,
-    Size = maps:get(size, Meta),
-    Self = self(),
-    Fun = fun() ->
-        case upload_fragment(Dir, StreamId, Meta) of
-            {ok, Uid} -> {ok, Uid};
-            {error, _} = Err -> Err
-        end
-    end,
-    rabbitmq_stream_s3_governor:submit(Fun, Size, Self, Ref),
-    on_transfer_submitted(Ref, Size, State0);
+    submit_upload(Ref, Dir, StreamId, Meta),
+    on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect({resubmit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} = State0) ->
     StreamId = Cfg#cfg.stream,
-    Size = maps:get(size, Meta),
-    Self = self(),
-    Fun = fun() ->
-        case upload_fragment(Dir, StreamId, Meta) of
-            {ok, Uid} -> {ok, Uid};
-            {error, _} = Err -> Err
-        end
-    end,
-    rabbitmq_stream_s3_governor:submit(Fun, Size, Self, Ref),
+    submit_upload(Ref, Dir, StreamId, Meta),
     %% on_transfer_result already decremented the gauges and removed Ref
     %% from transfer_sizes. Restore them so the eventual completion is
     %% accounted for correctly.
-    on_transfer_submitted(Ref, Size, State0);
+    on_transfer_submitted(Ref, maps:get(size, Meta), State0);
+execute_effect(
+    {resubmit_transfer_delayed, Ref, _StreamId, Dir, Meta, Reason}, #state{cfg = Cfg} = State0
+) ->
+    StreamId = Cfg#cfg.stream,
+    Delay = application:get_env(rabbitmq_stream_s3, upload_retry_delay_ms, 1000),
+    ?LOG_WARNING(
+        "~ts fragment upload at offset ~b failed with non-transient error ~p; "
+        "retrying in ~bms. The upload pipeline and local-tier cleanup are "
+        "stalled at this offset until the fragment is durable in S3.",
+        [StreamId, maps:get(first_offset, Meta), Reason, Delay]
+    ),
+    erlang:send_after(Delay, self(), {retry_transfer, Ref, Dir, Meta}),
+    %% on_transfer_result already decremented the gauges. Restore them: the
+    %% fragment is still pending and its bytes are still in the pipeline.
+    on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect(
     {upload_group, StreamId, Kind, Entries, _Pos, _Len},
     State0
@@ -1395,6 +1400,14 @@ dec(#state{metrics = Cnt}, Idx, N) when is_integer(N), N > 0 ->
     counters:sub(Cnt, Idx, N);
 dec(_, _, _) ->
     ok.
+
+%% Submit a fragment upload to the governor. Shared by the initial submit
+%% and the immediate/delayed retry paths.
+submit_upload(Ref, Dir, StreamId, Meta) ->
+    Self = self(),
+    Size = maps:get(size, Meta),
+    Fun = fun() -> upload_fragment(Dir, StreamId, Meta) end,
+    rabbitmq_stream_s3_governor:submit(Fun, Size, Self, Ref).
 
 %% Called from execute_effect/2 for {submit_transfer, ...}.
 on_transfer_submitted(Ref, Size, #state{transfer_sizes = Sizes} = State) ->

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -94,6 +94,7 @@ testable without mocks or timing.
     | {start_persist_timer, non_neg_integer()}
     | cancel_persist_timer
     | {resubmit_transfer, reference(), stream_id(), directory(), fragment_meta()}
+    | {resubmit_transfer_delayed, reference(), stream_id(), directory(), fragment_meta(), term()}
     | reinitialize.
 
 %% ------------------------------------------------------------------
@@ -203,14 +204,22 @@ transfer_complete(Ref, Uid, #state{pending_completions = PC} = State0) ->
 
 -spec transfer_failed(reference(), term(), state()) -> {state(), [core_effect()]}.
 transfer_failed(Ref, Reason, #state{cfg = Cfg} = State) ->
+    Meta = get_meta(Ref, State),
     case is_retriable(Reason) of
         true ->
-            Meta = get_meta(Ref, State),
+            %% Transient error. Retry immediately.
             {State, [{resubmit_transfer, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta}]};
         false ->
-            %% Fatal: remove from queue, accept gap, drain subsequent.
-            State1 = remove_in_flight(Ref, State),
-            drain_completions(State1)
+            %% A confirmed fragment must never be abandoned. Dropping it would
+            %% let drain_completions advance next_offset over the subsequent
+            %% (already durable) fragments, past a range that is not durable in
+            %% S3. The manifest would then claim that range as tiered, the
+            %% local-tier cleanup (which keys off next_offset) would free the
+            %% only remaining copy, and the result is a silent, permanent hole
+            %% in the middle of the stream (see issue #206). Instead, keep the
+            %% fragment at its place in the queue and retry it with a backoff
+            %% delay, stalling the pipeline until it is durable.
+            {State, [{resubmit_transfer_delayed, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta, Reason}]}
     end.
 
 -spec persist_complete(rabbitmq_stream_s3_db:revision(), state()) -> {state(), [core_effect()]}.
@@ -479,6 +488,9 @@ apply_fragment(
                     first_last_timestamp = LastTs
                 };
             _ ->
+                %% Belt-and-suspenders guard for the invariant that protects
+                %% next_offset from advancing past a non-durable range.
+                assert_contiguous(Manifest0#manifest.next_offset, FirstOffset),
                 Edit
         end,
     Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit1, Manifest0),
@@ -623,10 +635,21 @@ get_meta(Ref, #state{in_flight = Q}) ->
 get_meta_from_queue(Ref, [{Ref, Meta} | _]) -> Meta;
 get_meta_from_queue(Ref, [_ | Rest]) -> get_meta_from_queue(Ref, Rest).
 
--spec remove_in_flight(reference(), state()) -> state().
-remove_in_flight(Ref, #state{in_flight = Q} = State) ->
-    Q1 = queue:from_list([E || {R, _} = E <- queue:to_list(Q), R =/= Ref]),
-    State#state{in_flight = Q1}.
+%% A fragment must begin exactly where the manifest currently ends.
+%% Appending a non-contiguous fragment would advance next_offset past a
+%% range that was never made durable in S3, producing a silent, permanent
+%% hole in the stream (issue #206). Fail loudly instead: on restart the
+%% reader re-resolves the durable manifest rather than recording the gap.
+-spec assert_contiguous(osiris:offset(), osiris:offset()) -> ok.
+assert_contiguous(NextOffset, NextOffset) ->
+    ok;
+assert_contiguous(NextOffset, FragmentFirstOffset) ->
+    erlang:error(
+        {non_contiguous_fragment, #{
+            manifest_next_offset => NextOffset,
+            fragment_first_offset => FragmentFirstOffset
+        }}
+    ).
 
 -spec is_retriable(term()) -> boolean().
 is_retriable({http, 500}) -> true;

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -31,8 +31,9 @@ all() ->
         persist_failed_conflict_returns_reinitialize,
         persist_failed_transient_retries,
         transfer_failed_retriable_resubmits,
-        transfer_failed_fatal_accepts_gap,
-        fatal_failure_drains_subsequent,
+        transfer_failed_fatal_retries_no_gap,
+        fatal_failure_does_not_drain_subsequent,
+        fatal_failure_retry_then_complete_no_gap,
         fatal_failure_mid_sequence,
         await_offset_satisfied_immediately,
         await_offset_blocks_until_applied,
@@ -44,7 +45,7 @@ all() ->
         transfer_during_persist_broadcast_in_next_persist,
         multiple_transfers_during_persist_all_broadcast,
         many_in_flight_reverse_completion,
-        fatal_only_transfer_then_new_cut_restarts_timer,
+        fatal_only_transfer_retries_keeps_queue,
         %% Rebalancing
         rebalance_detected_at_threshold,
         rebalance_not_detected_below_threshold,
@@ -67,7 +68,7 @@ all() ->
         recursive_rebalance_three_levels_deep,
         multiple_persist_conflicts_reinitialize,
         %% Edge cases
-        fatal_front_drains_buffered_completions,
+        fatal_front_does_not_drain_buffered_completions,
         await_offset_satisfied_during_cascading_persist,
         tick_fires_at_exact_interval_boundary,
         retention_and_rebalance_same_persist_cycle,
@@ -253,25 +254,70 @@ transfer_failed_retriable_resubmits(_Config) ->
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, {http, 503}, S1),
     ?assertMatch([{resubmit_transfer, Ref, _, _, _}], Effects).
 
-transfer_failed_fatal_accepts_gap(_Config) ->
+transfer_failed_fatal_retries_no_gap(_Config) ->
+    %% A non-transient upload failure must NOT advance the manifest. The
+    %% fragment is retried (with a backoff delay) rather than dropped, so
+    %% next_offset cannot move past data that is not durable in S3.
     {S0, _} = init_core(),
     {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
-    {S2, _Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
+    {S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
         Ref, checksum_mismatch, S1
     ),
-    %% The in-flight queue should be empty (gap accepted).
-    ?assertEqual(0, manifest_next_offset(S2)).
+    ?assertMatch(
+        [{resubmit_transfer_delayed, Ref, _, _, _, checksum_mismatch}], Effects
+    ),
+    %% The manifest must not have advanced.
+    ?assertEqual(0, manifest_next_offset(S2)),
+    %% A subsequent successful retry of the same fragment applies it.
+    {S3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, S2),
+    ?assertEqual(100, manifest_next_offset(S3)).
 
-fatal_failure_drains_subsequent(_Config) ->
+fatal_failure_does_not_drain_subsequent(_Config) ->
+    %% The previously buggy behavior: dropping a fatally-failed fragment and
+    %% draining the fragments behind it advanced next_offset over a
+    %% non-durable range, leaving a silent hole (issue #206). The failed
+    %% fragment must instead block the queue until it is durable.
     {S0, _} = init_core(#{persist_threshold => 10}),
     {S1, Ref1, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
     {S2, Ref2, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
     %% Complete second.
     {S3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref2, 2002, S2),
     ?assertEqual(0, manifest_next_offset(S3)),
-    %% First fails fatally. Second should now drain.
+    %% First fails fatally. The second must NOT drain: the manifest stays put.
     {S4, _} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref1, enoent, S3),
-    ?assertEqual(200, manifest_next_offset(S4)).
+    ?assertEqual(0, manifest_next_offset(S4)),
+    %% Only once the first fragment's retry succeeds do both drain, contiguously.
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref1, 1001, S4),
+    ?assertEqual(200, manifest_next_offset(S5)).
+
+fatal_failure_retry_then_complete_no_gap(_Config) ->
+    %% End-to-end regression for issue #206: fragment B between A and C fails
+    %% with a non-transient error, then its retry succeeds. The manifest must
+    %% end up contiguous with no missing entry.
+    {S0, _} = init_core(#{persist_threshold => 10}),
+    {S1, RefA, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, RefB, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
+    {S3, RefC, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(200, 300), S2),
+    %% A completes and applies.
+    {S4, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(RefA, 1001, S3),
+    ?assertEqual(100, manifest_next_offset(S4)),
+    %% B fails fatally. Manifest must not advance.
+    {S5, BEffects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
+        RefB, {open_failed, "seg", enoent}, S4
+    ),
+    ?assertMatch([{resubmit_transfer_delayed, RefB, _, _, _, _}], BEffects),
+    ?assertEqual(100, manifest_next_offset(S5)),
+    %% C completes but is buffered behind B; still no advance.
+    {S6, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(RefC, 3003, S5),
+    ?assertEqual(100, manifest_next_offset(S6)),
+    %% B's retry succeeds: B then C drain, contiguous through 300.
+    {S7, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(RefB, 2002, S6),
+    ?assertEqual(300, manifest_next_offset(S7)),
+    %% Three contiguous fragment entries, no hole.
+    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(S7),
+    ?assertEqual(3 * ?ENTRY_B, byte_size(Manifest#manifest.entries)),
+    Offsets = entry_offsets(Manifest#manifest.entries),
+    ?assertEqual([0, 100, 200], Offsets).
 
 await_offset_satisfied_immediately(_Config) ->
     {S0, _} = init_core_with_manifest(#manifest{next_offset = 500}),
@@ -432,9 +478,9 @@ multiple_transfers_during_persist_all_broadcast(_Config) ->
     assert_edits_reproduce_manifest(#manifest{}, FinalManifest, Edits1 ++ Edits2).
 
 fatal_failure_mid_sequence(_Config) ->
-    %% Cut 4 fragments. Complete 1 and 4. Fragment 2 fails fatally.
-    %% Fragment 3 was already completed (buffered). After the fatal failure
-    %% of 2, fragments 3 and 4 should drain.
+    %% Cut 4 fragments. Complete 1, 3 and 4. Fragment 2 fails fatally.
+    %% Fragments 3 and 4 must stay buffered (not drain) because 2 still
+    %% blocks the queue. They only drain once 2's retry succeeds.
     {S0, _} = init_core(#{persist_threshold => 10}),
     {S1, Ref1, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
     {S2, Ref2, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
@@ -447,9 +493,13 @@ fatal_failure_mid_sequence(_Config) ->
     ?assertEqual(100, manifest_next_offset(S6)),
     {S7, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref4, 1004, S6),
     ?assertEqual(100, manifest_next_offset(S7)),
-    %% Fragment 2 fails fatally. 3 and 4 should drain.
-    {S8, _} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref2, enoent, S7),
-    ?assertEqual(400, manifest_next_offset(S8)).
+    %% Fragment 2 fails fatally. 3 and 4 must NOT drain.
+    {S8, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref2, enoent, S7),
+    ?assertMatch([{resubmit_transfer_delayed, Ref2, _, _, _, enoent}], Effects),
+    ?assertEqual(100, manifest_next_offset(S8)),
+    %% Fragment 2's retry succeeds. Now 2, 3 and 4 drain to 400.
+    {S9, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref2, 1002, S8),
+    ?assertEqual(400, manifest_next_offset(S9)).
 
 many_in_flight_reverse_completion(_Config) ->
     %% 10 fragments cut, completed in reverse order. All should apply
@@ -485,19 +535,18 @@ many_in_flight_reverse_completion(_Config) ->
     ),
     ?assertEqual(1000, manifest_next_offset(S3)).
 
-fatal_only_transfer_then_new_cut_restarts_timer(_Config) ->
-    %% Single in-flight transfer fails fatally. Queue becomes empty.
-    %% Next fragment_cut should restart the commit timer.
+fatal_only_transfer_retries_keeps_queue(_Config) ->
+    %% Single in-flight transfer fails fatally. The fragment must stay in the
+    %% queue for retry (not be dropped), so its eventual completion still
+    %% applies to the manifest.
     {S0, _} = init_core(#{persist_threshold => 10}),
     {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
-    {S2, _} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, enoent, S1),
-    %% since_persist is 0 (nothing was applied), queue is empty.
-    %% Next cut should start the timer.
-    {_S3, _Ref2, Effects} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(
-        meta(100, 200), S2
-    ),
-    Timers = [E || {start_persist_timer, _} = E <- Effects],
-    ?assertMatch([{start_persist_timer, _}], Timers).
+    {S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, enoent, S1),
+    ?assertMatch([{resubmit_transfer_delayed, Ref, _, _, _, enoent}], Effects),
+    ?assertEqual(0, manifest_next_offset(S2)),
+    %% The retry of the same fragment eventually succeeds and applies.
+    {S3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, S2),
+    ?assertEqual(100, manifest_next_offset(S3)).
 
 %% ------------------------------------------------------------------
 %% Rebalancing tests
@@ -1077,10 +1126,10 @@ multiple_persist_conflicts_reinitialize(_Config) ->
 %% Edge case tests
 %% ------------------------------------------------------------------
 
-fatal_front_drains_buffered_completions(_Config) ->
+fatal_front_does_not_drain_buffered_completions(_Config) ->
     %% Cut 3 fragments. Complete 2 and 3 (out of order). Then fragment 1
-    %% fails fatally. Fragments 2 and 3 should drain immediately since
-    %% they were already buffered in pending_completions.
+    %% fails fatally. Fragments 2 and 3 must NOT drain: fragment 1 still
+    %% blocks the queue until its retry succeeds.
     {S0, _} = init_core(#{persist_threshold => 10}),
     {S1, Ref1, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
     {S2, Ref2, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
@@ -1089,9 +1138,12 @@ fatal_front_drains_buffered_completions(_Config) ->
     {S4, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref2, 2002, S3),
     {S5, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref3, 3003, S4),
     ?assertEqual(0, manifest_next_offset(S5)),
-    %% Fragment 1 fails fatally. 2 and 3 should drain.
+    %% Fragment 1 fails fatally. 2 and 3 must stay buffered.
     {S6, _} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref1, enoent, S5),
-    ?assertEqual(300, manifest_next_offset(S6)).
+    ?assertEqual(0, manifest_next_offset(S6)),
+    %% Fragment 1's retry succeeds. Now all three drain to 300.
+    {S7, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref1, 1001, S6),
+    ?assertEqual(300, manifest_next_offset(S7)).
 
 await_offset_satisfied_during_cascading_persist(_Config) ->
     %% Waiter at 150 (satisfied by first persist covering 0..200).
@@ -1308,6 +1360,13 @@ cut_and_complete_effects(State0, FirstOffset, NextOffset, Uid) ->
 manifest_next_offset(State) ->
     Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(State),
     Manifest#manifest.next_offset.
+
+%% Extract the leading offset of every entry in a manifest entries binary,
+%% in order. Used to assert that fragments form a contiguous chain.
+entry_offsets(<<>>) ->
+    [];
+entry_offsets(<<Offset:64/unsigned, _:64, _:64, _:8, _:40, _:32, Rest/binary>>) ->
+    [Offset | entry_offsets(Rest)].
 
 %% Core invariant: applying broadcast edits to From must produce To.
 %% This is the correctness guarantee for manifest replication. If this


### PR DESCRIPTION
A non-transient fragment upload failure took the fatal branch of transfer_failed/3, which removed the fragment from the in-flight queue and drained the fragments behind it. drain_completions then advanced the manifest next_offset over those later fragments, past an offset range that was never made durable in S3. The manifest recorded the range as tiered, the local-tier cleanup (which frees segments at or below next_offset) removed the only remaining copy, and the result was a silent, permanent hole in the middle of the stream with consumable data on both sides (#206).

A confirmed fragment must never be abandoned. transfer_failed/3 now keeps the fragment at its place in the queue and retries it: immediately for transient errors, and after a backoff delay (upload_retry_delay_ms, default 1000ms) for non-transient ones. The pipeline stalls at the failed offset until the fragment is durable rather than advancing past it, and the delayed retry logs a warning naming the stalled offset so the stall is observable.

Add a defensive assert_contiguous/2 guard in apply_fragment so a fragment that does not begin exactly where the manifest ends fails loudly instead of silently recording a gap; on restart the reader re-resolves the durable manifest rather than persisting the hole.

Update the core suite: the cases that codified the old drop-and-gap behavior now assert that a fatal failure retries without advancing the manifest, and a new end-to-end case proves a fragment that fails then succeeds yields a contiguous manifest.

*Issue #, if available:* Likely fixes #206.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
