### PR TITLE
Make remote group retention idempotent across cycles

### DIFF
--- a/src/rabbitmq_stream_s3_manifest.erl
+++ b/src/rabbitmq_stream_s3_manifest.erl
@@ -344,7 +344,17 @@ maybe_eval_group_retention(#manifest{entries = Entries} = Manifest, Specs, Now, 
     end.
 
 %% Evaluate retention on fragment entries within a group.
-eval_group_entries(Manifest, GroupEntries, GroupRef, Specs, Now) ->
+%%
+%% A group object is immutable, so after an earlier cycle partially consumed
+%% this group it still lists the children those cycles already removed. Skip
+%% that already-consumed prefix (children below the manifest's first_offset)
+%% before evaluating. Otherwise retention re-counts and re-deletes them and
+%% double-subtracts their sizes from total_size on every subsequent cycle,
+%% which drifts total_size below the true durable size (silently disabling
+%% max_bytes retention) or negative (crashing the persist under max_age), and
+%% regresses first_offset below the real data floor.
+eval_group_entries(Manifest, GroupEntries0, GroupRef, Specs, Now) ->
+    GroupEntries = drop_consumed_children(GroupEntries0, Manifest#manifest.first_offset),
     NumToRemove = eval_group_retention_specs(
         GroupEntries, Manifest#manifest.total_size, Specs, Now
     ),
@@ -357,6 +367,22 @@ eval_group_entries(Manifest, GroupEntries, GroupRef, Specs, Now) ->
                 Manifest, GroupEntries, GroupRef, NumToRemove, NumGroupEntries
             )
     end.
+
+%% Drop the leading group children whose offset is below first_offset: an
+%% earlier retention cycle already removed them, but they remain in the
+%% immutable group object.
+drop_consumed_children(GroupEntries, FirstOffset) ->
+    Skip = consumed_prefix_bytes(GroupEntries, FirstOffset, 0),
+    binary:part(GroupEntries, Skip, byte_size(GroupEntries) - Skip).
+
+consumed_prefix_bytes(
+    <<Offset:64/unsigned, _FTs:64/signed, _LTs:64/signed, _K:8, _Sz:40, _Uid:32, Rest/binary>>,
+    FirstOffset,
+    Acc
+) when Offset < FirstOffset ->
+    consumed_prefix_bytes(Rest, FirstOffset, Acc + ?ENTRY_B);
+consumed_prefix_bytes(_Entries, _FirstOffset, Acc) ->
+    Acc.
 
 eval_group_retention_specs(GroupEntries, ManifestTotalSize, Specs, Now) ->
     lists:foldl(

--- a/test/manifest_SUITE.erl
+++ b/test/manifest_SUITE.erl
@@ -1,0 +1,122 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(manifest_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include("include/rabbitmq_stream_s3.hrl").
+
+%% Each test fragment covers 100 offsets and is 100 bytes of segment data.
+-define(SZ, 100).
+
+all() ->
+    [
+        partial_group_consumption_basic,
+        partial_group_max_bytes_does_not_regress_first_offset,
+        partial_group_max_age_no_negative_total_size,
+        partial_then_full_consumption_removes_group
+    ].
+
+init_per_suite(Config) -> Config.
+end_per_suite(Config) -> Config.
+
+%% ------------------------------------------------------------------
+%% Tests
+%% ------------------------------------------------------------------
+
+%% A single partial consumption behaves as expected: the oldest two children
+%% are removed, total_size and first_offset advance to the first survivor.
+%% This pins the first-cycle behavior the idempotency fix must not change.
+partial_group_consumption_basic(_Config) ->
+    {Manifest0, GetGroup} = grouped_manifest(),
+    {Refs, M1} = run_cycle(Manifest0, [{max_bytes, 250}], 5000, GetGroup),
+    ?assertEqual([0, 100], fragment_offsets(Refs)),
+    ?assertEqual(200, M1#manifest.total_size),
+    ?assertEqual(200, M1#manifest.first_offset),
+    %% The group entry stays in the root (partial consumption).
+    ?assertEqual(?ENTRY_B, byte_size(M1#manifest.entries)).
+
+%% Regression for the primary finding: a second retention cycle against a
+%% partially-consumed group must not re-process the already-removed prefix.
+%% The immutable group object still lists F1/F2, so without the fix the second
+%% cycle re-removes F1 and regresses first_offset below the real data floor.
+partial_group_max_bytes_does_not_regress_first_offset(_Config) ->
+    {Manifest0, GetGroup} = grouped_manifest(),
+    %% Cycle 1: remove F1, F2. first_offset -> 200 (F3), total_size -> 200.
+    {_Refs1, M1} = run_cycle(Manifest0, [{max_bytes, 250}], 5000, GetGroup),
+    ?assertEqual(200, M1#manifest.first_offset),
+    %% Cycle 2: a tighter cap removes only F3; first_offset advances to 300.
+    {Refs2, M2} = run_cycle(M1, [{max_bytes, 150}], 6000, GetGroup),
+    ?assertEqual([200], fragment_offsets(Refs2)),
+    ?assertEqual(300, M2#manifest.first_offset),
+    ?assertEqual(100, M2#manifest.total_size),
+    %% first_offset must never regress below the previous cycle's floor.
+    ?assert(M2#manifest.first_offset >= M1#manifest.first_offset).
+
+%% Regression: re-processing an already-removed prefix double-subtracts its
+%% size and would drive total_size negative (which crashes the persist when it
+%% is serialized as an unsigned field). After the fix the second cycle sizes
+%% only the surviving children.
+partial_group_max_age_no_negative_total_size(_Config) ->
+    {Manifest0, GetGroup} = grouped_manifest(),
+    %% Cycle 1: max_bytes removes F1, F2. total_size -> 200, first_offset -> 200.
+    {_Refs1, M1} = run_cycle(Manifest0, [{max_bytes, 250}], 5000, GetGroup),
+    ?assertEqual(200, M1#manifest.total_size),
+    %% Cycle 2: max_age expires F1, F2, F3 (last_ts 1000/2000/3000) but not F4
+    %% (4000). Cutoff = Now - MaxAge = 9000 - 5500 = 3500.
+    {Refs2, M2} = run_cycle(M1, [{max_age, 5500}], 9000, GetGroup),
+    %% Only F3 is newly removable; F1/F2 are already gone.
+    ?assertEqual([200], fragment_offsets(Refs2)),
+    ?assertEqual(100, M2#manifest.total_size),
+    ?assert(M2#manifest.total_size >= 0).
+
+%% A partial consumption followed by a cycle that consumes the rest must fully
+%% remove the group (entry + object) and account only for the survivors, not
+%% re-list the already-removed prefix.
+partial_then_full_consumption_removes_group(_Config) ->
+    {Manifest0, GetGroup} = grouped_manifest(),
+    {_Refs1, M1} = run_cycle(Manifest0, [{max_bytes, 250}], 5000, GetGroup),
+    %% Cycle 2: a tiny cap consumes the remaining survivors F3, F4 entirely.
+    {Refs2, M2} = run_cycle(M1, [{max_bytes, 50}], 6000, GetGroup),
+    %% The group entry is gone from the root and total_size reaches zero.
+    ?assertEqual(<<>>, M2#manifest.entries),
+    ?assertEqual(0, M2#manifest.total_size),
+    %% Only the survivors and the group object are deleted; F1/F2 are not
+    %% re-deleted.
+    ?assertEqual([200, 300], fragment_offsets(Refs2)),
+    ?assertEqual(1, length(group_refs(Refs2))).
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+%% A manifest whose root is a single group of four fragments F1..F4 at offsets
+%% 0/100/200/300, each 100 bytes, last_ts 1000/2000/3000/4000. build_manifest's
+%% GetGroupFun always returns the full, immutable child list regardless of
+%% edits applied to the root -- exactly how the real S3 group object behaves.
+grouped_manifest() ->
+    rabbitmq_stream_s3_test_helpers:build_manifest([
+        {group, [
+            {fragment, #{offset => 0, size => ?SZ, last_ts => 1000, uid => 1}},
+            {fragment, #{offset => 100, size => ?SZ, last_ts => 2000, uid => 2}},
+            {fragment, #{offset => 200, size => ?SZ, last_ts => 3000, uid => 3}},
+            {fragment, #{offset => 300, size => ?SZ, last_ts => 4000, uid => 4}}
+        ]}
+    ]).
+
+run_cycle(Manifest, Specs, Now, GetGroup) ->
+    case rabbitmq_stream_s3_manifest:evaluate_remote_retention(Manifest, Specs, Now, GetGroup) of
+        unchanged ->
+            {[], Manifest};
+        {Edit, Refs} ->
+            {Refs, rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest)}
+    end.
+
+fragment_offsets(Refs) ->
+    [O || #fragment_ref{offset = O} <- Refs].
+
+group_refs(Refs) ->
+    [R || #group_ref{} = R <- Refs].

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -26,6 +26,7 @@ all() ->
         truncate_edit_advances_first_offset,
         truncate_edit_shrinks_total_size,
         sequence_of_edits_maintains_invariants,
+        retention_cycles_preserve_accounting,
         %% Fragment assembly properties
         assembly_size_is_sum_of_chunks,
         assembly_offsets_are_bounded,
@@ -160,6 +161,130 @@ prop_sequence_of_edits_maintains_invariants() ->
                 Final#manifest.next_offset >= Final#manifest.first_offset
         end
     ).
+
+%% =========================================================================
+%% Manifest retention properties
+%% =========================================================================
+
+retention_cycles_preserve_accounting(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun prop_retention_cycles_preserve_accounting/0, [], 500
+    ).
+
+%% Property: across any sequence of remote-retention cycles (max_bytes and
+%% max_age, in any order) against a manifest containing a group, the accounting
+%% stays consistent with an independent model of which fragments survive:
+%%   - no fragment is deleted twice (idempotent across cycles);
+%%   - deletions are always an oldest-contiguous prefix (never a middle hole);
+%%   - total_size equals the sum of surviving fragment sizes (never drifts or
+%%     goes negative);
+%%   - first_offset equals the oldest survivor and never regresses;
+%%   - next_offset is unchanged by retention.
+%% A group object is immutable, so re-reading it must not re-process already
+%% removed children -- the regression this guards (see manifest_SUITE).
+prop_retention_cycles_preserve_accounting() ->
+    ?FORALL(
+        {TreeSpec, Frags, Schedule},
+        gen_ret_scenario(),
+        begin
+            {M0, GetGroup} = rabbitmq_stream_s3_test_helpers:build_manifest(TreeSpec),
+            check_ret_cycles(Schedule, M0, GetGroup, Frags, M0#manifest.first_offset)
+        end
+    ).
+
+%% Fold the schedule, applying each retention cycle and checking the invariants
+%% against the live-fragment model (a list of {Offset, Size, LastTs}).
+check_ret_cycles([], _M, _GetGroup, _Live, _PrevFirst) ->
+    true;
+check_ret_cycles([{Specs, Now} | Rest], M, GetGroup, Live, PrevFirst) ->
+    case rabbitmq_stream_s3_manifest:evaluate_remote_retention(M, Specs, Now, GetGroup) of
+        unchanged ->
+            check_ret_cycles(Rest, M, GetGroup, Live, PrevFirst);
+        {Edit, Refs} ->
+            DelOffs = [O || #fragment_ref{offset = O} <- Refs],
+            LiveOffs = [O || {O, _, _} <- Live],
+            M1 = rabbitmq_stream_s3_manifest:apply_edit(Edit, M),
+            Live1 = [F || {O, _, _} = F <- Live, not lists:member(O, DelOffs)],
+            SurvOffs = [O || {O, _, _} <- Live1],
+            ExpSize = lists:sum([S || {_, S, _} <- Live1]),
+            Checks = [
+                %% No fragment deleted twice, this cycle or in a prior one.
+                lists:all(fun(O) -> lists:member(O, LiveOffs) end, DelOffs),
+                length(DelOffs) =:= length(lists:usort(DelOffs)),
+                %% Deletions are an oldest-contiguous prefix.
+                is_oldest_prefix(DelOffs, SurvOffs),
+                %% total_size tracks the surviving fragments exactly.
+                M1#manifest.total_size =:= ExpSize,
+                M1#manifest.total_size >= 0,
+                %% first_offset is the oldest survivor and never regresses.
+                first_offset_ok(M1, SurvOffs),
+                M1#manifest.first_offset >= PrevFirst,
+                %% Retention never moves next_offset.
+                M1#manifest.next_offset =:= M#manifest.next_offset
+            ],
+            case lists:all(fun(B) -> B end, Checks) of
+                true ->
+                    check_ret_cycles(Rest, M1, GetGroup, Live1, M1#manifest.first_offset);
+                false ->
+                    false
+            end
+    end.
+
+is_oldest_prefix([], _SurvOffs) -> true;
+is_oldest_prefix(_DelOffs, []) -> true;
+is_oldest_prefix(DelOffs, SurvOffs) -> lists:max(DelOffs) < lists:min(SurvOffs).
+
+first_offset_ok(M, []) -> M#manifest.first_offset =:= M#manifest.next_offset;
+first_offset_ok(M, SurvOffs) -> M#manifest.first_offset =:= lists:min(SurvOffs).
+
+%% Generate a manifest with a leading group of G fragments followed by R
+%% trailing root fragments (offsets 0,100,..., last_ts strictly increasing),
+%% plus a schedule of retention cycles to apply. The leading group is what
+%% exercises partial-then-further group consumption across cycles.
+gen_ret_scenario() ->
+    ?LET(
+        {G, R},
+        {integer(3, 6), integer(1, 3)},
+        ?LET(
+            Sizes,
+            vector(G + R, integer(50, 500)),
+            begin
+                N = G + R,
+                Frags = [
+                    {I * 100, lists:nth(I + 1, Sizes), (I + 1) * 1000}
+                 || I <- lists:seq(0, N - 1)
+                ],
+                GroupFrags = lists:sublist(Frags, G),
+                RootFrags = lists:nthtail(G, Frags),
+                TreeSpec =
+                    [{group, [frag_spec(F) || F <- GroupFrags]}] ++
+                        [frag_spec(F) || F <- RootFrags],
+                Total = lists:sum(Sizes),
+                MaxTs = N * 1000,
+                ?LET(
+                    Schedule,
+                    gen_ret_schedule(Total, MaxTs),
+                    {TreeSpec, Frags, Schedule}
+                )
+            end
+        )
+    ).
+
+frag_spec({Off, Size, LastTs}) ->
+    {fragment, #{
+        offset => Off, size => Size, first_ts => LastTs, last_ts => LastTs, uid => Off + 1
+    }}.
+
+gen_ret_schedule(Total, MaxTs) ->
+    ?LET(K, integer(2, 6), vector(K, gen_ret_step(Total, MaxTs))).
+
+%% A step is either a max_bytes target (any size, applied at Now = 0) or a
+%% max_age cutoff expressed as Now with a zero max-age (cutoff = Now).
+gen_ret_step(Total, MaxTs) ->
+    frequency([
+        {1, ?LET(T, integer(0, Total), {[{max_bytes, T}], 0})},
+        {1, ?LET(Now, integer(0, MaxTs + 2000), {[{max_age, 0}], Now})}
+    ]).
 
 %% =========================================================================
 %% Replica reader core: rebalancing


### PR DESCRIPTION
A group object is immutable: once fragments are factored into a group and uploaded, the object always lists all of its original children. When remote retention partially consumes a group, build_group_retention_result leaves the root group entry and the group object untouched (it only advances first_offset and total_size), so the already-removed children remain in the object.

On the next retention cycle eval_group_entries re-downloaded the full group and counted from the first child again, with no reference to first_offset. It therefore re-processed the already-removed leading children every cycle, which:

  * double-subtracted their sizes from total_size, drifting it below the true durable size (silently disabling max_bytes retention) or negative (which crashes the persist, since total_size is serialized as an unsigned field);
  * regressed first_offset below the real data floor, pointing it at children whose objects had already been deleted.

eval_group_entries now drops the already-consumed prefix (children whose offset is below the manifest's first_offset) before evaluating, so each cycle sizes, deletes and advances over only the surviving children. First-cycle behavior is unchanged because first_offset equals the group's first child offset until a partial consumption advances it.

Add manifest_SUITE covering multi-cycle group retention (previously uncovered): the basic partial case, idempotent max_bytes that does not regress first_offset, max_age that no longer drives total_size negative, and a partial followed by a full consumption that removes the group entry. The three multi-cycle cases fail without the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
