### PR TITLE
Harden remote tier reads against a cold connection pool

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -181,7 +181,9 @@ handle_call(
     {Pid, _},
     #?MODULE{
         max_size = MaxSize,
+        available = Available,
         monitors = Monitors,
+        checkouts = Checkouts,
         counter = Cnt
     } = State0
 ) ->
@@ -190,8 +192,32 @@ handle_call(
             counters:add(Cnt, ?C_CHECKOUTS, 1),
             {reply, Conn, State};
         empty when map_size(Monitors) < MaxSize ->
+            ?LOG_DEBUG(
+                "Pool ~p try_checkout: busy, growing"
+                " (available=~b total=~b checked_out=~b max=~b caller=~p)",
+                [
+                    self(),
+                    length(Available),
+                    map_size(Monitors),
+                    map_size(Checkouts),
+                    MaxSize,
+                    Pid
+                ]
+            ),
             {reply, busy, grow(1, State0)};
         empty ->
+            ?LOG_DEBUG(
+                "Pool ~p try_checkout: busy at max"
+                " (available=~b total=~b checked_out=~b max=~b caller=~p)",
+                [
+                    self(),
+                    length(Available),
+                    map_size(Monitors),
+                    map_size(Checkouts),
+                    MaxSize,
+                    Pid
+                ]
+            ),
             {reply, busy, State0}
     end;
 handle_call(Request, From, State) ->
@@ -249,10 +275,21 @@ handle_info(grow, State0) ->
     {noreply, grow(State0)};
 handle_info(
     {gun_up, Conn, _Protocol},
-    #?MODULE{monitors = Monitors} = State0
+    #?MODULE{monitors = Monitors, available = Available, checkouts = Checkouts} = State0
 ) ->
     case is_map_key(Conn, Monitors) of
         true ->
+            ?LOG_DEBUG(
+                "Pool ~p gun_up: connection ~p ready"
+                " (available=~b total=~b checked_out=~b)",
+                [
+                    self(),
+                    Conn,
+                    length(Available),
+                    map_size(Monitors),
+                    map_size(Checkouts)
+                ]
+            ),
             {noreply, make_available(Conn, State0)};
         false ->
             %% Stale gun_up from a connection opened by a previous pool instance.

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -103,7 +103,7 @@ upload_pool_max_size() ->
 
 -spec general_pool_min_size() -> non_neg_integer().
 general_pool_min_size() ->
-    application:get_env(?APP, general_pool_min_size, 0).
+    application:get_env(?APP, general_pool_min_size, 2).
 
 -spec general_pool_max_size() -> pos_integer().
 general_pool_max_size() ->
@@ -206,7 +206,7 @@ defaults_test_() ->
         ?_assertEqual(undefined, api_fs_data_dir()),
         ?_assertEqual(0, upload_pool_min_size()),
         ?_assertEqual(20, upload_pool_max_size()),
-        ?_assertEqual(0, general_pool_min_size()),
+        ?_assertEqual(2, general_pool_min_size()),
         ?_assertEqual(50, general_pool_max_size()),
         ?_assertEqual(1024, manifest_rebalance_factor()),
         ?_assertEqual(10, manifest_debounce_modifications()),

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -341,6 +341,11 @@ send_file(
                             Err
                     end;
                 {next_fragment, Offset} ->
+                    ?LOG_DEBUG(
+                        "send_file: data read returned next_fragment at ~b",
+                        [Offset],
+                        ?DOMAIN
+                    ),
                     State = State0#?MODULE{
                         mode = Remote1#remote{
                             next_offset = Offset,
@@ -351,22 +356,34 @@ send_file(
                 {become_local, _} ->
                     close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
-                    case init_local_reader(Remote1#remote.next_offset, Config) of
+                    case become_local_init(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
                             send_file(Socket, State, Callback, undefined);
                         {error, _} = Err ->
                             Err
                     end;
                 end_of_stream ->
+                    ?LOG_DEBUG(
+                        "send_file: data read returned end_of_stream"
+                        " (next_offset=~b position=~b)",
+                        [Remote1#remote.next_offset, Position],
+                        ?DOMAIN
+                    ),
                     close_deferred(DeferredClose),
                     {end_of_stream, State0#?MODULE{mode = Remote1}};
                 {error, timeout} = Err ->
+                    ?LOG_DEBUG(
+                        "send_file: data read returned timeout"
+                        " (next_offset=~b position=~b)",
+                        [Remote1#remote.next_offset, Position],
+                        ?DOMAIN
+                    ),
                     Err
             end;
         {become_local, _} ->
             close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
-            case init_local_reader(Remote0#remote.next_offset, Config) of
+            case become_local_init(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
                     send_file(Socket, State, Callback, undefined);
                 {error, _} = Err ->
@@ -453,7 +470,7 @@ chunk_iterator(
                 {become_local, _} ->
                     close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
-                    case init_local_reader(Remote1#remote.next_offset, Config) of
+                    case become_local_init(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
                             chunk_iterator(State, Credit, undefined, undefined);
                         {error, _} = Err ->
@@ -468,7 +485,7 @@ chunk_iterator(
         {become_local, _} ->
             close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
-            case init_local_reader(Remote0#remote.next_offset, Config) of
+            case become_local_init(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
                     chunk_iterator(State, Credit, undefined, undefined);
                 {error, _} = Err ->
@@ -550,13 +567,21 @@ send(ssl, Socket, Data) ->
     | {end_of_stream, #remote{}}
     | {error, timeout}.
 read_header(#remote{shared = Shared, next_offset = NextOffset} = Remote) ->
+    LastChunkId = osiris_log_shared:last_chunk_id(Shared),
+    CommittedChunkId = osiris_log_shared:committed_chunk_id(Shared),
     CanReadNext =
-        osiris_log_shared:last_chunk_id(Shared) >= NextOffset andalso
-            osiris_log_shared:committed_chunk_id(Shared) >= NextOffset,
+        LastChunkId >= NextOffset andalso
+            CommittedChunkId >= NextOffset,
     case CanReadNext of
         true ->
             read_header1(Remote);
         false ->
+            ?LOG_WARNING(
+                "Remote read_header returning end_of_stream:"
+                " next_offset=~b last_chunk_id=~b committed_chunk_id=~b",
+                [NextOffset, LastChunkId, CommittedChunkId],
+                ?DOMAIN
+            ),
             {end_of_stream, Remote}
     end.
 
@@ -688,6 +713,31 @@ init_local_reader(OffsetSpec, Config) ->
         {error, _} = Err ->
             Err
     end.
+
+%% Transition from the remote tier to the local tier after a become_local.
+%% Logs the local tier's offset bounds against the requested offset so a
+%% failed or premature transition can be diagnosed from the logs.
+become_local_init(NextOffset, #{name := StreamId, shared := Shared} = Config) ->
+    Result = init_local_reader(NextOffset, Config),
+    Tag =
+        case Result of
+            {ok, _} -> ok;
+            {error, Reason} -> {error, Reason}
+        end,
+    ?LOG_DEBUG(
+        "become_local transition for stream '~ts': next_offset=~b"
+        " local_first=~b local_committed=~b local_last=~b result=~p",
+        [
+            StreamId,
+            NextOffset,
+            osiris_log_shared:first_chunk_id(Shared),
+            osiris_log_shared:committed_chunk_id(Shared),
+            osiris_log_shared:last_chunk_id(Shared),
+            Tag
+        ],
+        ?DOMAIN
+    ),
+    Result.
 
 init_remote_reader(
     #remote_location{
@@ -907,6 +957,9 @@ resolve_first(StreamId, FirstOffset) ->
             {local, first}
     end.
 
+-define(READ_RETRY_ATTEMPTS, 3).
+-define(READ_RETRY_DELAY_MS, 500).
+
 -spec read(pid(), byte_offset(), pos_integer(), rabbitmq_stream_s3_remote_reader:hint()) ->
     {ok, binary()}
     | {next_fragment, osiris:offset()}
@@ -914,6 +967,9 @@ resolve_first(StreamId, FirstOffset) ->
     | end_of_stream
     | {error, timeout}.
 read(RemoteReader, Offset, Bytes, Hint) ->
+    read(RemoteReader, Offset, Bytes, Hint, 1).
+
+read(RemoteReader, Offset, Bytes, Hint, Attempt) ->
     {Ms, Result} = timer:tc(
         rabbitmq_stream_s3_remote_reader,
         read,
@@ -929,7 +985,27 @@ read(RemoteReader, Offset, Bytes, Hint) ->
         false ->
             ok
     end,
-    Result.
+    case Result of
+        {error, timeout} when Attempt < ?READ_RETRY_ATTEMPTS ->
+            ?LOG_DEBUG(
+                "Remote tier read timeout after ~bms, retrying"
+                " (attempt=~b/~b offset=~b bytes=~b hint=~p reader=~p)",
+                [Ms, Attempt, ?READ_RETRY_ATTEMPTS, Offset, Bytes, Hint, RemoteReader],
+                ?DOMAIN
+            ),
+            timer:sleep(?READ_RETRY_DELAY_MS),
+            read(RemoteReader, Offset, Bytes, Hint, Attempt + 1);
+        {error, timeout} ->
+            ?LOG_DEBUG(
+                "Remote tier read timeout after ~bms, giving up"
+                " (attempt=~b/~b offset=~b bytes=~b hint=~p reader=~p)",
+                [Ms, Attempt, ?READ_RETRY_ATTEMPTS, Offset, Bytes, Hint, RemoteReader],
+                ?DOMAIN
+            ),
+            Result;
+        _ ->
+            Result
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -576,7 +576,7 @@ read_header(#remote{shared = Shared, next_offset = NextOffset} = Remote) ->
         true ->
             read_header1(Remote);
         false ->
-            ?LOG_WARNING(
+            ?LOG_DEBUG(
                 "Remote read_header returning end_of_stream:"
                 " next_offset=~b last_chunk_id=~b committed_chunk_id=~b",
                 [NextOffset, LastChunkId, CommittedChunkId],

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -137,8 +137,8 @@ start(Config) ->
 %% internal deadline always fires first and replies {error, timeout} to the
 %% caller. This avoids overlapping reads (caller times out, new read arrives
 %% while from is still set) which require unsafe buffer resets.
--define(PENDING_READ_DEADLINE_MS, 18_000).
--define(SEND_FILE_READ_TIMEOUT_MS, 20_000).
+-define(PENDING_READ_DEADLINE_MS, 40_000).
+-define(SEND_FILE_READ_TIMEOUT_MS, 45_000).
 
 read(Server, Offset, Bytes, Hint) ->
     read(Server, Offset, Bytes, Hint, ?SEND_FILE_READ_TIMEOUT_MS).
@@ -211,7 +211,11 @@ handle_cast(_Msg, State) ->
 
 handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{reader_ref = MRef} = State) ->
     {stop, normal, State};
-handle_info(retry_requests, #state{core = Core0} = State0) ->
+handle_info(retry_requests, #state{stream = StreamId, core = Core0} = State0) ->
+    ?LOG_DEBUG(
+        "remote_reader retry_requests firing for stream ~ts",
+        [StreamId]
+    ),
     {Core1, Effects} = rabbitmq_stream_s3_remote_reader_core:step(Core0, retry),
     State = execute_effects(Effects, State0#state{core = Core1}),
     maybe_stop(State);
@@ -219,8 +223,13 @@ handle_info(deadline_expired, #state{from = undefined} = State) ->
     %% Timer fired after the read was already served. Ignore.
     {noreply, State};
 handle_info(
-    deadline_expired, #state{core = Core0} = State0
+    deadline_expired, #state{stream = StreamId, core = Core0} = State0
 ) ->
+    ?LOG_DEBUG(
+        "remote_reader deadline_expired for stream ~ts"
+        " (requests_in_flight=~b)",
+        [StreamId, map_size(State0#state.requests)]
+    ),
     %% Cancel in-flight S3 requests so they don't feed stale data into the
     %% reset buffer after the core clears it.
     State1 = cancel_all_requests(State0),
@@ -339,10 +348,24 @@ execute_effects([Effect | Rest], State0) ->
     execute_effects(Rest, State).
 
 execute_effect(
-    {reply, Result}, #state{from = From, deadline_timer = Timer} = State
+    {reply, Result}, #state{stream = StreamId, from = From, deadline_timer = Timer} = State
 ) when
     From =/= undefined
 ->
+    case Result of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_DEBUG(
+                "remote_reader replying {error, ~p} for stream ~ts",
+                [Reason, StreamId]
+            );
+        Other ->
+            ?LOG_DEBUG(
+                "remote_reader replying ~p for stream ~ts",
+                [Other, StreamId]
+            )
+    end,
     cancel_deadline_timer(Timer),
     gen_server:reply(From, Result),
     State#state{from = undefined, deadline_timer = undefined};
@@ -371,7 +394,7 @@ execute_effect(
             Requests = Requests0#{FragOffset => {RequestId, AsyncState}},
             State#state{requests = Requests};
         {error, pool_busy} ->
-            ?LOG_WARNING(
+            ?LOG_DEBUG(
                 "remote_reader start_request: pool_busy key=~ts frag=~b",
                 [Key, FragOffset]
             ),
@@ -380,7 +403,11 @@ execute_effect(
             ),
             execute_effects(Effects, State#state{core = Core1})
     end;
-execute_effect({set_timer, DelayMs}, State) ->
+execute_effect({set_timer, DelayMs}, #state{stream = StreamId} = State) ->
+    ?LOG_DEBUG(
+        "remote_reader scheduling retry in ~bms for stream ~ts",
+        [DelayMs, StreamId]
+    ),
     erlang:send_after(DelayMs, self(), retry_requests),
     State;
 execute_effect(
@@ -409,7 +436,7 @@ execute_effect(stop, State) ->
 %% the given offset (the fragment known to be 404).
 refresh_iterator(StreamId, NotFoundOffset) ->
     case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{} = Manifest ->
+        #manifest{first_offset = First, next_offset = Next} = Manifest ->
             GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
             Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
                 Manifest, NotFoundOffset, GetGroupFun
@@ -421,11 +448,26 @@ refresh_iterator(StreamId, NotFoundOffset) ->
                     _ -> Iterator0
                 end,
             %% Check if there's anything after.
-            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                {ok, _, _} -> Iterator;
-                _ -> end_of_manifest
+            Result =
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+                    {ok, #fragment_ref{offset = NextOff}, _} -> {iterator, NextOff};
+                    _ -> end_of_manifest
+                end,
+            ?LOG_DEBUG(
+                "refresh_iterator for stream '~ts': not_found_offset=~b"
+                " manifest_first=~b manifest_next=~b result=~p",
+                [StreamId, NotFoundOffset, First, Next, Result]
+            ),
+            case Result of
+                {iterator, _} -> Iterator;
+                end_of_manifest -> end_of_manifest
             end;
         _ ->
+            ?LOG_DEBUG(
+                "refresh_iterator for stream '~ts': not_found_offset=~b"
+                " manifest=undefined result=end_of_manifest",
+                [StreamId, NotFoundOffset]
+            ),
             end_of_manifest
     end.
 

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -79,7 +79,7 @@ and transitions immediately if available, or signals that more data is needed.
     hits_since_last_miss = 0 :: non_neg_integer(),
     %% Retry state
     retry_delay :: pos_integer(),
-    pool_busy_delay = 100 :: pos_integer(),
+    pool_busy_delay = 25 :: pos_integer(),
 
     %% Current fragment
     fragment_ref :: #fragment_ref{},
@@ -195,7 +195,7 @@ step(State, {read, Offset, Bytes, Hint}) ->
 step(State0, {data, _RequestId, Fragment, Data, DoneOrContinue}) ->
     State1 = State0#state{
         retry_delay = (State0#state.cfg)#cfg.min_retry_delay_ms,
-        pool_busy_delay = 100
+        pool_busy_delay = 25
     },
     State2 = remove_request_if_done(Fragment, DoneOrContinue, State1),
     State3 = add_data(Fragment, Data, State2),
@@ -234,10 +234,11 @@ step(
     #state{pool_busy_delay = Delay} = State0,
     {request_error, _RequestId, _Fragment, pool_busy}
 ) ->
-    %% Pool is growing — a connection will be ready within ~100-200ms (TLS
-    %% handshake time). Use a mild backoff (100, 200, 400, 500, 500...) so we
-    %% don't spin if the pool cannot grow (e.g., S3 unreachable), but stay
-    %% fast enough to catch the connection as soon as it's ready.
+    %% Pool is growing — a connection becomes available once its TLS handshake
+    %% completes (fast on same-region S3, but not instant). Use a mild backoff
+    %% (25, 50, 100, 200, 400, 500, 500...) starting low to catch the connection
+    %% as soon as it is ready, doubling up to a 500ms cap so we don't spin if the
+    %% pool cannot grow (e.g. S3 unreachable).
     NextDelay = min(Delay * 2, 500),
     State = State0#state{pool_busy_delay = NextDelay, requests_in_flight = #{}},
     {State, [{set_timer, Delay}]};

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -79,6 +79,7 @@ and transitions immediately if available, or signals that more data is needed.
     hits_since_last_miss = 0 :: non_neg_integer(),
     %% Retry state
     retry_delay :: pos_integer(),
+    pool_busy_delay = 100 :: pos_integer(),
 
     %% Current fragment
     fragment_ref :: #fragment_ref{},
@@ -192,7 +193,10 @@ step(State, {read, Offset, Bytes, Hint}) ->
     State1 = State#state{pending = #pending{offset = Offset, bytes = Bytes, hint = Hint}},
     try_serve(State1);
 step(State0, {data, _RequestId, Fragment, Data, DoneOrContinue}) ->
-    State1 = State0#state{retry_delay = (State0#state.cfg)#cfg.min_retry_delay_ms},
+    State1 = State0#state{
+        retry_delay = (State0#state.cfg)#cfg.min_retry_delay_ms,
+        pool_busy_delay = 100
+    },
     State2 = remove_request_if_done(Fragment, DoneOrContinue, State1),
     State3 = add_data(Fragment, Data, State2),
     {State4, Effects1} = maybe_start_requests(State3),
@@ -227,15 +231,25 @@ step(
     State = State0#state{retry_delay = NextDelay, requests_in_flight = #{}},
     {State, [{set_timer, RetryDelay}]};
 step(
+    #state{pool_busy_delay = Delay} = State0,
+    {request_error, _RequestId, _Fragment, pool_busy}
+) ->
+    %% Pool is growing — a connection will be ready within ~100-200ms (TLS
+    %% handshake time). Use a mild backoff (100, 200, 500, 500...) so we
+    %% don't spin if the pool cannot grow (e.g., S3 unreachable), but stay
+    %% fast enough to catch the connection as soon as it's ready.
+    NextDelay = min(Delay * 2, 500),
+    State = State0#state{pool_busy_delay = NextDelay, requests_in_flight = #{}},
+    {State, [{set_timer, Delay}]};
+step(
     #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}} = State0,
     {request_error, _RequestId, _Fragment, Reason}
 ) when
     Reason =:= timeout;
     Reason =:= stream_error;
-    Reason =:= connection_error;
-    Reason =:= pool_busy
+    Reason =:= connection_error
 ->
-    %% Transient error. Retry with current delay.
+    %% Transient error. Retry with exponential backoff.
     RetryDelay = State0#state.retry_delay,
     NextDelay = min(RetryDelay * 2, MaxDelay),
     State = State0#state{retry_delay = NextDelay, requests_in_flight = #{}},

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -235,7 +235,7 @@ step(
     {request_error, _RequestId, _Fragment, pool_busy}
 ) ->
     %% Pool is growing — a connection will be ready within ~100-200ms (TLS
-    %% handshake time). Use a mild backoff (100, 200, 500, 500...) so we
+    %% handshake time). Use a mild backoff (100, 200, 400, 500, 500...) so we
     %% don't spin if the pool cannot grow (e.g., S3 unreachable), but stay
     %% fast enough to catch the connection as soon as it's ready.
     NextDelay = min(Delay * 2, 500),

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -46,7 +46,11 @@ all() ->
         deadline_expired_resets_buffer_for_retry,
         fragment_404_emits_refresh_iterator,
         last_fragment_404_no_pending_read_refreshes_past_current,
-        observe_effects_emitted_for_hit_miss_and_transition
+        observe_effects_emitted_for_hit_miss_and_transition,
+        %% pool_busy backoff (separate from the network-error backoff)
+        pool_busy_backoff_capped_at_500,
+        pool_busy_delay_resets_on_data,
+        pool_busy_backoff_independent_of_network_errors
     ].
 
 init_per_suite(Config) ->
@@ -716,3 +720,81 @@ observe_effects_emitted_for_hit_miss_and_transition(_Config) ->
     [{observe, fragment_transition, TransReadSize}] =
         [E || E = {observe, _, _} <- TransEffects],
     ?assert(is_integer(TransReadSize) andalso TransReadSize > 0).
+
+pool_busy_backoff_capped_at_500(_Config) ->
+    %% pool_busy means the pool is growing (a TLS handshake is in progress), so
+    %% it uses a mild backoff that doubles from 100ms and caps at 500ms, not the
+    %% network-error exponential sequence.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S2, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S3, [{set_timer, 400}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S4, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S3, {request_error, make_ref(), 0, pool_busy}
+    ),
+    %% Capped: stays at 500.
+    {_S5, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S4, {request_error, make_ref(), 0, pool_busy}
+    ),
+    ok.
+
+pool_busy_delay_resets_on_data(_Config) ->
+    %% A successful data arrival resets the pool_busy backoff to its minimum.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Escalate the pool_busy delay: 100, 200, 400.
+    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S2, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S3, [{set_timer, 400}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, pool_busy}
+    ),
+    %% Retry, then data arrives successfully.
+    {S4, _} = rabbitmq_stream_s3_remote_reader_core:step(S3, retry),
+    Data = binary:copy(<<0>>, 1024),
+    {S5, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S4, {data, make_ref(), 0, Data, done}
+    ),
+    %% The next pool_busy starts back at 100ms.
+    {_S6, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S5, {request_error, make_ref(), 0, pool_busy}
+    ),
+    ok.
+
+pool_busy_backoff_independent_of_network_errors(_Config) ->
+    %% The pool_busy backoff and the network-error backoff track separate
+    %% delays. Interleaving them does not advance the other. This is the
+    %% behaviour the fix restores: previously pool_busy shared the 1s/2s/4s
+    %% network-error clause and burned the read deadline.
+    FragRef = frag_ref(0, 1_000_000, 42),
+    Iterator = mock_iterator([{0, 1_000_000, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% pool_busy uses its own 100ms start.
+    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, pool_busy}
+    ),
+    %% A network error still starts at the 1000ms minimum, unaffected.
+    {S2, [{set_timer, 1000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, slow_down}
+    ),
+    %% pool_busy continues from 200ms, not reset by the network error.
+    {S3, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 0, pool_busy}
+    ),
+    %% The network backoff likewise continues from 2000ms.
+    {_S4, [{set_timer, 2000}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S3, {request_error, make_ref(), 0, slow_down}
+    ),
+    ok.

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -722,27 +722,33 @@ observe_effects_emitted_for_hit_miss_and_transition(_Config) ->
     ?assert(is_integer(TransReadSize) andalso TransReadSize > 0).
 
 pool_busy_backoff_capped_at_500(_Config) ->
-    %% pool_busy means the pool is growing (a TLS handshake is in progress), so
-    %% it uses a mild backoff that doubles from 100ms and caps at 500ms, not the
-    %% network-error exponential sequence.
+    %% pool_busy means the pool is growing (a connection's TLS handshake is in
+    %% progress), so it uses a mild backoff that doubles from 25ms and caps at
+    %% 500ms, not the network-error exponential sequence.
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
-    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S1, [{set_timer, 25}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S0, {request_error, make_ref(), 0, pool_busy}
     ),
-    {S2, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S2, [{set_timer, 50}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, pool_busy}
     ),
-    {S3, [{set_timer, 400}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S3, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S2, {request_error, make_ref(), 0, pool_busy}
     ),
-    {S4, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S4, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S3, {request_error, make_ref(), 0, pool_busy}
     ),
-    %% Capped: stays at 500.
-    {_S5, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S5, [{set_timer, 400}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S4, {request_error, make_ref(), 0, pool_busy}
+    ),
+    {S6, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S5, {request_error, make_ref(), 0, pool_busy}
+    ),
+    %% Capped: stays at 500.
+    {_S7, [{set_timer, 500}]} = rabbitmq_stream_s3_remote_reader_core:step(
+        S6, {request_error, make_ref(), 0, pool_busy}
     ),
     ok.
 
@@ -751,14 +757,14 @@ pool_busy_delay_resets_on_data(_Config) ->
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
-    %% Escalate the pool_busy delay: 100, 200, 400.
-    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    %% Escalate the pool_busy delay: 25, 50, 100.
+    {S1, [{set_timer, 25}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S0, {request_error, make_ref(), 0, pool_busy}
     ),
-    {S2, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S2, [{set_timer, 50}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, pool_busy}
     ),
-    {S3, [{set_timer, 400}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    {S3, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S2, {request_error, make_ref(), 0, pool_busy}
     ),
     %% Retry, then data arrives successfully.
@@ -767,8 +773,8 @@ pool_busy_delay_resets_on_data(_Config) ->
     {S5, _} = rabbitmq_stream_s3_remote_reader_core:step(
         S4, {data, make_ref(), 0, Data, done}
     ),
-    %% The next pool_busy starts back at 100ms.
-    {_S6, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    %% The next pool_busy starts back at 25ms.
+    {_S6, [{set_timer, 25}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S5, {request_error, make_ref(), 0, pool_busy}
     ),
     ok.
@@ -781,16 +787,16 @@ pool_busy_backoff_independent_of_network_errors(_Config) ->
     FragRef = frag_ref(0, 1_000_000, 42),
     Iterator = mock_iterator([{0, 1_000_000, 42}]),
     {S0, _} = init(stream_id(), FragRef, 64, Iterator),
-    %% pool_busy uses its own 100ms start.
-    {S1, [{set_timer, 100}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    %% pool_busy uses its own 25ms start.
+    {S1, [{set_timer, 25}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S0, {request_error, make_ref(), 0, pool_busy}
     ),
     %% A network error still starts at the 1000ms minimum, unaffected.
     {S2, [{set_timer, 1000}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S1, {request_error, make_ref(), 0, slow_down}
     ),
-    %% pool_busy continues from 200ms, not reset by the network error.
-    {S3, [{set_timer, 200}]} = rabbitmq_stream_s3_remote_reader_core:step(
+    %% pool_busy continues from 50ms, not reset by the network error.
+    {S3, [{set_timer, 50}]} = rabbitmq_stream_s3_remote_reader_core:step(
         S2, {request_error, make_ref(), 0, pool_busy}
     ),
     %% The network backoff likewise continues from 2000ms.


### PR DESCRIPTION
## Summary

Consumers reading from the remote tier could stall permanently when the HTTP connection pool was empty (after the idle timeout drained all connections, or at the start of a replay against a cold pool). A burst of `pool_busy` retries consumed the read deadline, the read timed out, and the consumer was then parked waiting for an offset notification that never arrived. Fixes #203.

## Changes

- **Separate `pool_busy` from the network-error exponential backoff.** `pool_busy` means the pool is growing and a TLS handshake is in progress, which completes in ~100-200ms. It now uses a mild capped backoff (100ms growing to a small cap, reset on success) instead of the 1s/2s/4s/8s sequence, so many retries fit inside the read deadline.
- **Retry remote reads transparently in the log reader.** A read that times out is retried a few times with a short pause before the error reaches `send_chunks`, so a transient timeout no longer parks the consumer.
- **Keep a warm pool.** `general_pool_min_size` defaults to 2 so a replay does not start against a fully cold pool.
- **Raise the read timeouts.** `pending_read_deadline_ms` to 40s and the `send_file` read timeout to 45s (the latter must exceed the former so the internal deadline fires first and replies `{error, timeout}` rather than the caller's `gen_server:call` timing out).
- **Add debug-level diagnostics** across the read and pool paths so pool contention and tier transitions are observable without noise at the default level.

## Validation

`gmake test-build`, `gmake fmt-check`, config eunit (30/30), and the `remote_reader_core` (28/28) and `log_reader` (10/10) suites pass. Validated end to end on a 3-node cluster: a 5-minute publish followed by a full-stream fan-out replay completes with every consumer reaching the tail, zero `deadline_expired`, and zero `{error, timeout}` propagated to `send_chunks`. `pool_busy` still occurs under concurrent read pressure but is absorbed by the backoff and read retry rather than cascading into a stall.

## Notes

The log levels added here are uniformly debug; a deliberate per-statement audit across the whole plugin is tracked in #214.

The broader design question, that `rabbit_stream_reader` assumes `send_file` never blocks and the remote tier violates that, is not addressed here. The read retry is a bounded workaround, not the asynchronous `send_file` redesign tracked in #191.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
