### PR TITLE
Add content-verification integration test and fan-out replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,20 @@ Read the relevant documentation before modifying any module:
 
 - `docs/README.md` — overview and reading guide
 - `docs/DEVELOPMENT.md` — building, testing, formatting
+- `docs/GLOSSARY.md` — terminology used throughout the plugin and its docs
 - `docs/concepts.md` — streaming primitives and how the plugin extends them
 - `docs/architecture.md` — how the pieces fit together
 - `docs/conventions.md` — patterns and conventions for writing code here
+
+When working on a specific subsystem, also read its dedicated document first:
+
+- `docs/read-path.md` — the consumer read path, including the remote-to-local tier transition (`become_local`)
+- `docs/upload-path.md` — how local segments are uploaded to the remote tier
+- `docs/manifest.md` — the manifest tree, fragments, and how the remote tier is indexed
+- `docs/failure-modes.md` — known failure modes and how the plugin handles them
+- `docs/investigations/` — write-ups of prior investigations; check here before debugging a hard problem, it may already be documented
+
+The Java end-to-end integration tests live in `test/integration/`; see `test/integration/README.md` before writing or changing a replay test.
 
 ## Building and Testing
 
@@ -49,13 +60,13 @@ If you encounter any of the following, stop and present what you know:
 
 ### Running tests
 
-- Always use `timeout` when running make targets: `timeout 30 make ct-...`
+- Always wrap a make target in `timeout`, sized to the suite (a suite that starts a broker needs minutes, not seconds). The point is to bound a genuine hang, not to kill a slow-but-healthy run.
 - If a test hangs, that is a bug. Do not retry. Investigate.
-- Always use `make test-build`, never `erlc` directly.
+- Always use `gmake test-build`, never `erlc` directly.
 - Tee output to a file so you can grep without re-running:
 
 ```bash
-timeout 120 make ct-replica_reader 2>&1 | tee /tmp/ct-out.txt
+timeout 120 gmake ct-replica_reader 2>&1 | tee /tmp/ct-out.txt
 grep -E 'pass|fail|Error' /tmp/ct-out.txt
 ```
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -40,11 +40,28 @@ MESSAGE_SIZE ?= 1024
 MAX_LENGTH_BYTES ?= 10000000000
 REPLAY_TIMEOUT ?= 3600
 
-.PHONY: cleanup high-throughput multi-offset-consumer stream-deletion
+.PHONY: cleanup content-verification high-throughput multi-offset-consumer stream-deletion
 
 cleanup: package
 	$(JAVA) -jar $(JAR) cleanup \
 		--mgmt-uri $(MGMT_URI) \
+		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
+
+CONTENT_VERIFY_DURATION ?= 300
+CONTENT_VERIFY_PRODUCERS ?= 1
+CONTENT_VERIFY_MAX_LENGTH_BYTES ?= 500000000
+CONTENT_VERIFY_REPLAY_CONSUMERS ?= 4
+
+content-verification: package
+	$(JAVA) -jar $(JAR) content-verification \
+		--uris $(STREAM_URIS) \
+		--mgmt-uri $(MGMT_URI) \
+		--metrics-uris $(METRICS_URIS) \
+		--stream s3-content-verify \
+		--duration $(CONTENT_VERIFY_DURATION) \
+		--producers $(CONTENT_VERIFY_PRODUCERS) \
+		--max-length-bytes $(CONTENT_VERIFY_MAX_LENGTH_BYTES) \
+		--replay-consumers $(CONTENT_VERIFY_REPLAY_CONSUMERS) \
 		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
 
 high-throughput: package

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,60 @@
+# `rabbitmq_stream_s3` integration tests
+
+Java-based integration tests that exercise the S3 tiered-storage plugin against a
+running cluster. Each test is a subcommand; see `Main.java` for the list and
+`TODO.md` for what each one covers and what remains to be built.
+
+Run them through the `Makefile` targets (each target documents its variables) or
+directly via the shaded jar:
+
+```
+java -jar target/stream-s3-integration-test-*.jar <subcommand> --uris ... --mgmt-uri ...
+```
+
+## Consumption patterns (read before writing a replay test)
+
+A RabbitMQ stream is a **replayable log, not a work queue**. This distinction has
+caused real bugs in this suite, so it is worth stating plainly.
+
+In a work queue, each message is delivered to exactly one consumer, so you
+parallelize by dividing the work: N workers each take a disjoint subset, and the
+union is the whole. **Streams do not work this way.** A stream consumer subscribes
+at a start offset and the broker pushes every record from that offset forward to
+the tail. There is no "stop at offset X" and no server-side partitioning of a
+plain stream across cooperating consumers.
+
+Two consequences follow directly:
+
+1. **You cannot hand disjoint offset-slices of one plain stream to N consumers.**
+   Subscribing consumer *i* at `startOffset(i)` does not bound it to its slice — it
+   reads to the tail like every other consumer, so the consumers overlap
+   completely. Filtering messages client-side (`if (offset >= endOffset) return;`)
+   discards records after the fact but does not stop delivery, and it does not make
+   the slices real. Partitioning one logical stream across consumers is exactly
+   what [super streams](https://www.rabbitmq.com/docs/streams#super-streams)
+   provide; each partition is a *separate* stream, not an offset range of one.
+
+2. **Offsets are not message counts.** Deriving a per-consumer message target from
+   offset arithmetic (`sliceSize = offsetRange / consumers`) couples the test to an
+   assumption (1 offset == 1 message) that is incidental, and combining it with
+   client-side slice filtering produces counters that either never reach their
+   target (the test stalls) or trip early off overlapping reads (the test passes
+   for the wrong reason and masks the bug).
+
+### The fan-out pattern these tests model
+
+The real-world pattern a plain stream serves is **independent fan-out**: several
+applications each subscribe and replay the whole log non-destructively — analytics,
+audit, and multiple services all reading the same stream from their own offset.
+
+So a parallel replay test should have **every consumer read the whole stream from
+`first()` to the tail independently**, and verify each consumer's view on its own.
+This is also the stronger test for tiered storage: N consumers each re-reading the
+full S3-resident history multiply the concurrent remote-read pressure on the same
+fragments, and any per-consumer divergence (a gap or duplicate one consumer sees
+and another does not) becomes visible.
+
+`ContentVerificationTest` is the reference implementation of this pattern: each
+consumer replays `first()`..tail, completion is *all* consumers reaching the tail,
+and the pass gate is the *slowest* consumer reaching the threshold so a single
+stuck consumer fails the test rather than being masked by faster ones.

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ConfirmedSequences.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ConfirmedSequences.java
@@ -1,0 +1,80 @@
+package com.amazon.mq.rabbitmq.stream.s3;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/**
+ * A thread-safe, lazily-grown bitset over message sequence numbers recording
+ * which sequences the broker confirmed.
+ *
+ * <p>The producer assigns a sequence to every send but only some are confirmed;
+ * unconfirmed sends leave holes in the sequence space. Replay verification uses
+ * this to distinguish a real gap (a confirmed sequence that was never delivered)
+ * from an expected hole (an unconfirmed sequence).
+ *
+ * <p>Storage is paged and allocated on demand, so memory tracks the sequence
+ * range actually used rather than a preallocated maximum, keeping it bounded
+ * regardless of run length.
+ */
+final class ConfirmedSequences {
+
+  private static final int BITS_PER_WORD = 64;
+  // 2^20 bits per page: 16384 longs == 128 KiB per page.
+  private static final int PAGE_BITS = 1 << 20;
+  private static final int WORDS_PER_PAGE = PAGE_BITS / BITS_PER_WORD;
+
+  private final ConcurrentHashMap<Long, AtomicLongArray> pages = new ConcurrentHashMap<>();
+
+  /** Marks a sequence as confirmed. Thread-safe. */
+  void set(long seq) {
+    if (seq < 0) {
+      return;
+    }
+    long pageIdx = seq / PAGE_BITS;
+    int bitInPage = (int) (seq % PAGE_BITS);
+    int wordIdx = bitInPage / BITS_PER_WORD;
+    long mask = 1L << (bitInPage % BITS_PER_WORD);
+    AtomicLongArray page = pages.computeIfAbsent(pageIdx, k -> new AtomicLongArray(WORDS_PER_PAGE));
+    long prev;
+    long next;
+    do {
+      prev = page.get(wordIdx);
+      next = prev | mask;
+      if (prev == next) {
+        return;
+      }
+    } while (!page.compareAndSet(wordIdx, prev, next));
+  }
+
+  /** Returns whether a sequence was confirmed. */
+  boolean isSet(long seq) {
+    if (seq < 0) {
+      return false;
+    }
+    long pageIdx = seq / PAGE_BITS;
+    AtomicLongArray page = pages.get(pageIdx);
+    if (page == null) {
+      return false;
+    }
+    int bitInPage = (int) (seq % PAGE_BITS);
+    int wordIdx = bitInPage / BITS_PER_WORD;
+    long mask = 1L << (bitInPage % BITS_PER_WORD);
+    return (page.get(wordIdx) & mask) != 0;
+  }
+
+  /**
+   * Counts confirmed sequences in the inclusive range [from, to]. Used to size a
+   * gap: the number of confirmed sequences a consumer skipped over. Gap ranges
+   * are small, so a per-bit scan is adequate.
+   */
+  long countInRange(long from, long to) {
+    long lo = Math.max(0, from);
+    long count = 0;
+    for (long s = lo; s <= to; s++) {
+      if (isSet(s)) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
@@ -1,0 +1,486 @@
+package com.amazon.mq.rabbitmq.stream.s3;
+
+import com.rabbitmq.stream.Consumer;
+import com.rabbitmq.stream.Environment;
+import com.rabbitmq.stream.OffsetSpecification;
+import com.rabbitmq.stream.Producer;
+import com.rabbitmq.stream.StreamException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "content-verification",
+    description =
+        "Publish messages with sequential IDs, then replay the whole stream from "
+            + "'first' independently from every consumer and verify ordering, no "
+            + "duplicates, and no gaps in the confirmed sequences. Catches corruption, "
+            + "reordering, and silent message skips.")
+public class ContentVerificationTest implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContentVerificationTest.class);
+
+  @CommandLine.Mixin private ClusterOptions cluster;
+
+  @CommandLine.Option(
+      names = "--duration",
+      description = "Publishing duration in seconds",
+      defaultValue = "300")
+  private int durationSeconds;
+
+  @CommandLine.Option(
+      names = "--producers",
+      description = "Number of producers (use 1 for strict ordering verification)",
+      defaultValue = "1")
+  private int numProducers;
+
+  @CommandLine.Option(
+      names = "--message-size",
+      description = "Message body size in bytes (minimum 8 for the sequence header)",
+      defaultValue = "256")
+  private int messageSize;
+
+  @CommandLine.Option(
+      names = "--max-length-bytes",
+      description = "Stream max-length-bytes (small to force data into S3 quickly)",
+      defaultValue = "500000000")
+  private long maxLengthBytes;
+
+  @CommandLine.Option(
+      names = "--progress-interval",
+      description = "Seconds between progress reports",
+      defaultValue = "30")
+  private int progressInterval;
+
+  @CommandLine.Option(
+      names = "--replay-timeout",
+      description = "Maximum seconds for the replay phase",
+      defaultValue = "1800")
+  private int replayTimeoutSeconds;
+
+  @CommandLine.Option(
+      names = "--replay-consumers",
+      description = "Number of parallel consumers for the replay phase",
+      defaultValue = "4")
+  private int replayConsumers;
+
+  @Override
+  public void run() {
+    LOG.info(
+        "Starting content-verification test: stream={} duration={}s producers={}"
+            + " msg-size={} max-length-bytes={}",
+        cluster.stream,
+        durationSeconds,
+        numProducers,
+        messageSize,
+        maxLengthBytes);
+
+    if (messageSize < 8) {
+      LOG.error("FAIL: --message-size must be >= 8 (need 8 bytes for sequence number)");
+      System.exit(1);
+    }
+
+    ManagementApi mgmt = new ManagementApi(cluster.mgmtUri);
+    MetricsClient metrics = new MetricsClient(cluster.metricsUris);
+    ClusterHealthMonitor health = new ClusterHealthMonitor(cluster.mgmtUri);
+    S3Monitor s3Monitor = cluster.buildS3Monitor();
+
+    // Records which sequence numbers the broker confirmed, so replay can tell a
+    // real gap from a hole left by an unconfirmed send.
+    ConfirmedSequences confirmed = new ConfirmedSequences();
+
+    long[] result;
+    try (Environment env = cluster.buildEnvironment()) {
+      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, maxLengthBytes);
+      result = publishPhase(env, metrics, health, s3Monitor, confirmed);
+    } catch (Exception e) {
+      LOG.error("FAILED during publish phase", e);
+      System.exit(1);
+      return;
+    }
+    long published = result[0];
+    long maxSequence = result[1];
+    LOG.info("Publish phase complete: confirmed={} maxSequence={}", published, maxSequence);
+
+    if (published == 0) {
+      LOG.error("FAIL: zero messages published");
+      System.exit(1);
+    }
+
+    try (Environment replayEnv = cluster.buildEnvironment()) {
+      replayPhase(replayEnv, maxSequence, confirmed, metrics);
+      LOG.info("SUCCESS: content-verification test passed");
+    } catch (Exception e) {
+      LOG.error("FAILED during replay phase", e);
+      System.exit(1);
+    } finally {
+      if (s3Monitor != null) {
+        s3Monitor.close();
+      }
+    }
+  }
+
+  private long[] publishPhase(
+      Environment env,
+      MetricsClient metrics,
+      ClusterHealthMonitor health,
+      S3Monitor s3Monitor,
+      ConfirmedSequences confirmed)
+      throws InterruptedException {
+    AtomicLong sequence = new AtomicLong(0);
+    AtomicLong totalConfirmed = new AtomicLong(0);
+    CountDownLatch stop = new CountDownLatch(1);
+
+    java.util.List<Thread> publisherThreads = new java.util.ArrayList<>();
+    java.util.List<Producer> producers = new java.util.ArrayList<>();
+
+    for (int i = 0; i < numProducers; i++) {
+      Producer producer = env.producerBuilder().stream(cluster.stream).build();
+      producers.add(producer);
+      int idx = i;
+      Thread t =
+          new Thread(
+              () -> {
+                byte[] padding = new byte[messageSize - 8];
+                try {
+                  while (!stop.await(0, TimeUnit.MILLISECONDS)) {
+                    long seq = sequence.getAndIncrement();
+                    byte[] body = encodeMessage(seq, padding);
+                    producer.send(
+                        producer.messageBuilder().addData(body).build(),
+                        status -> {
+                          if (status.isConfirmed()) {
+                            totalConfirmed.incrementAndGet();
+                            // Record the confirmed sequence so replay can tell a
+                            // real gap from a hole left by an unconfirmed send.
+                            confirmed.set(seq);
+                          }
+                        });
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              },
+              "publisher-" + idx);
+      t.start();
+      publisherThreads.add(t);
+    }
+
+    long startTime = System.currentTimeMillis();
+    long deadline = startTime + Duration.ofSeconds(durationSeconds).toMillis();
+    long nextReport = startTime + Duration.ofSeconds(progressInterval).toMillis();
+
+    LOG.info("Publishing for {}s...", durationSeconds);
+
+    while (System.currentTimeMillis() < deadline) {
+      Thread.sleep(1000);
+      long now = System.currentTimeMillis();
+      if (now >= nextReport) {
+        long elapsed = (now - startTime) / 1000;
+        long confirmedCount = totalConfirmed.get();
+        long sent = sequence.get();
+        double rate = confirmedCount * 1000.0 / (now - startTime);
+        MetricsClient.Snapshot snap = metrics.snapshot();
+        ClusterHealthMonitor.Snapshot healthSnap = health.snapshot();
+
+        String s3Info = "";
+        if (s3Monitor != null) {
+          S3Monitor.Snapshot s3Snap = s3Monitor.snapshot();
+          s3Info = String.format(" s3-objects=%d", s3Snap.objectCount);
+        }
+
+        LOG.info(
+            "Publish [{}s]: sent={} confirmed={} ({} msg/s) s3-sent={} MiB/s{}",
+            elapsed,
+            sent,
+            confirmedCount,
+            String.format("%.0f", rate),
+            String.format("%.1f", snap.sentMiBPerS(progressInterval)),
+            s3Info);
+        LOG.info("  Health: {}", healthSnap.format());
+
+        if (healthSnap.hasAlarm()) {
+          LOG.error("ALARM detected - aborting");
+          System.exit(1);
+        }
+
+        nextReport = now + Duration.ofSeconds(progressInterval).toMillis();
+      }
+    }
+
+    stop.countDown();
+    for (Thread t : publisherThreads) {
+      t.join(5000);
+    }
+
+    // Wait for in-flight confirms to settle before closing producers. The
+    // confirm callback records the sequence in `confirmed`, and closing a
+    // producer does not drain outstanding confirms. Replay distinguishes a real
+    // gap from an unconfirmed hole using `confirmed`, so every confirm that will
+    // arrive must be recorded first. totalConfirmed increments in the same
+    // callback as confirmed.set, so a stable totalConfirmed means the bitset is
+    // complete.
+    long settled = -1;
+    for (int i = 0; i < 20; i++) {
+      long current = totalConfirmed.get();
+      if (current == settled) {
+        break;
+      }
+      settled = current;
+      Thread.sleep(500);
+    }
+
+    for (Producer p : producers) {
+      p.close();
+    }
+
+    return new long[] {totalConfirmed.get(), sequence.get()};
+  }
+
+  private void replayPhase(
+      Environment env, long maxSequence, ConfirmedSequences confirmed, MetricsClient metrics)
+      throws InterruptedException {
+    // Real-world fan-out: every consumer independently replays the whole stream
+    // from 'first' to the tail, the way separate applications each read the same
+    // log non-destructively. Each consumer must observe the identical complete,
+    // ordered, gap-free sequence. Reading the full S3-resident history from N
+    // consumers also multiplies the concurrent remote-read pressure on the same
+    // fragments, which is exactly the path we want to stress.
+    //
+    // The readable message count is whatever the consumers observe, not a number
+    // queried up front: the management message count lags retention and is an
+    // eventually-consistent approximation. Ground truth is what the consumers
+    // actually read, cross-checked for agreement across all of them.
+
+    // The tail at replay start. Publishing has stopped, so this offset is stable
+    // and is the last offset every consumer must reach.
+    com.rabbitmq.stream.StreamStats stats = env.queryStreamStats(cluster.stream);
+    long endOffset = stats.committedOffset();
+
+    LOG.info(
+        "Replay: {} consumers each reading first..{}, timeout={}s",
+        replayConsumers,
+        endOffset,
+        replayTimeoutSeconds);
+
+    AtomicLong outOfOrder = new AtomicLong(0);
+    AtomicLong duplicates = new AtomicLong(0);
+    AtomicLong corruptMessages = new AtomicLong(0);
+    AtomicLong gaps = new AtomicLong(0);
+
+    // Per-consumer counters so each independent replay is verified on its own.
+    AtomicLong[] counts = new AtomicLong[replayConsumers];
+    long[] lastSeq = new long[replayConsumers];
+    boolean[] finished = new boolean[replayConsumers];
+    for (int i = 0; i < replayConsumers; i++) {
+      counts[i] = new AtomicLong(0);
+    }
+    java.util.Arrays.fill(lastSeq, -1);
+
+    // One count-down per consumer; the replay is done when all consumers have
+    // reached the tail.
+    CountDownLatch done = new CountDownLatch(replayConsumers);
+
+    java.util.List<Consumer> consumers = new java.util.ArrayList<>();
+
+    for (int i = 0; i < replayConsumers; i++) {
+      int consumerIdx = i;
+
+      Consumer c = null;
+      for (int attempt = 1; attempt <= 5; attempt++) {
+        try {
+          var builder =
+              env.consumerBuilder().stream(cluster.stream).offset(OffsetSpecification.first());
+          builder.flow().initialCredits(10);
+          c =
+              builder
+                  .messageHandler(
+                      (context, message) -> {
+                        long off = context.offset();
+                        // Ignore anything past the tail captured at replay start.
+                        if (off > endOffset) {
+                          return;
+                        }
+                        counts[consumerIdx].incrementAndGet();
+
+                        byte[] body = message.getBodyAsBinary();
+                        if (body == null || body.length < 8) {
+                          corruptMessages.incrementAndGet();
+                        } else {
+                          long seq = decodeSequence(body);
+                          if (seq < 0 || seq >= maxSequence) {
+                            corruptMessages.incrementAndGet();
+                          } else {
+                            verifySequence(
+                                consumerIdx, seq, lastSeq, confirmed, duplicates, outOfOrder, gaps);
+                          }
+                        }
+
+                        // Reaching the tail offset marks this consumer complete.
+                        if (off >= endOffset && !finished[consumerIdx]) {
+                          finished[consumerIdx] = true;
+                          done.countDown();
+                        }
+                      })
+                  .build();
+          break;
+        } catch (StreamException e) {
+          if (attempt == 5) {
+            throw e;
+          }
+          LOG.warn(
+              "  Consumer {} subscribe attempt {}/5 failed: {} — retrying in 15s",
+              consumerIdx,
+              attempt,
+              e.getMessage());
+          Thread.sleep(15000);
+        }
+      }
+      consumers.add(c);
+      LOG.info("  Consumer {}: reading first..{}", consumerIdx, endOffset);
+    }
+
+    long startTime = System.currentTimeMillis();
+    long nextReport = startTime + Duration.ofSeconds(progressInterval).toMillis();
+
+    while (!done.await(1, TimeUnit.SECONDS)) {
+      long elapsed = System.currentTimeMillis() - startTime;
+      if (elapsed > Duration.ofSeconds(replayTimeoutSeconds).toMillis()) {
+        for (Consumer c : consumers) {
+          c.close();
+        }
+        LOG.error(
+            "REPLAY TIMEOUT: slowest consumer at {} after {}s (not all consumers reached the tail)",
+            ReplayProgress.min(counts),
+            replayTimeoutSeconds);
+        LOG.info("  Per-consumer: {}", ReplayProgress.format(counts));
+        System.exit(1);
+      }
+      long now = System.currentTimeMillis();
+      if (now >= nextReport) {
+        long min = ReplayProgress.min(counts);
+        long sum = ReplayProgress.sum(counts);
+        double rate = sum * 1000.0 / (now - startTime);
+        long elapsedSec = (now - startTime) / 1000;
+        MetricsClient.Snapshot snap = metrics.snapshot();
+        LOG.info(
+            "Replay [{}s]: slowest={} total={} ({} msg/s) s3-recv={} MiB/s"
+                + " corrupt={} dup={} gap={} ooo={}",
+            elapsedSec,
+            min,
+            sum,
+            String.format("%.0f", rate),
+            String.format("%.1f", snap.receivedMiBPerS(progressInterval)),
+            corruptMessages.get(),
+            duplicates.get(),
+            gaps.get(),
+            outOfOrder.get());
+        nextReport = now + Duration.ofSeconds(progressInterval).toMillis();
+      }
+    }
+
+    for (Consumer c : consumers) {
+      c.close();
+    }
+
+    long elapsedSec = (System.currentTimeMillis() - startTime) / 1000;
+    long corrupt = corruptMessages.get();
+    long dups = duplicates.get();
+    long ooo = outOfOrder.get();
+    long gap = gaps.get();
+    long min = ReplayProgress.min(counts);
+    long max = ReplayProgress.max(counts);
+
+    LOG.info("Replay complete: each consumer read {} messages in {}s", min, elapsedSec);
+    LOG.info("  Per-consumer: {}", ReplayProgress.format(counts));
+    LOG.info(
+        "Integrity: corrupt={} duplicates={} gaps={} out-of-order={}", corrupt, dups, gap, ooo);
+
+    // Fan-out consistency: every consumer subscribed at 'first' and read to the
+    // same tail, so they must all observe the same number of messages. The
+    // consumers subscribe in a tight loop with no reads in between, so retention
+    // cannot advance the readable start between them and skew the counts. A
+    // divergence therefore means a consumer saw a different view of the log.
+    if (min != max) {
+      LOG.error(
+          "REPLAY FAILED: consumers disagree on message count (min={} max={})", min, max);
+      System.exit(1);
+    }
+    if (min == 0) {
+      LOG.error("REPLAY FAILED: consumers read zero messages");
+      System.exit(1);
+    }
+    if (corrupt > 0) {
+      LOG.error("CORRUPTION DETECTED: {} messages had invalid sequence numbers", corrupt);
+      System.exit(1);
+    }
+    // gaps counts only confirmed sequences that were skipped, so any gap is a
+    // real missing message rather than a hole left by an unconfirmed send.
+    if (gap > 0) {
+      LOG.error("GAP DETECTED: {} confirmed sequences were never delivered", gap);
+      System.exit(1);
+    }
+    if (dups > 0) {
+      LOG.error("DUPLICATES: {} duplicate sequences detected", dups);
+      System.exit(1);
+    }
+    if (ooo > 0) {
+      LOG.error("ORDERING VIOLATION: {} messages received out of order", ooo);
+      System.exit(1);
+    }
+
+    LOG.info("Replay PASSED: all messages verified");
+  }
+
+  // Verifies a single consumer's view of the sequence: detects duplicates,
+  // gaps, and ordering violations against the previously seen sequence. With a
+  // single producer the confirmed sequences are strictly contiguous; with
+  // multiple producers small interleaving inversions are tolerated. No confirmed
+  // sequence may be missing or repeated within a consumer's full-stream replay.
+  private void verifySequence(
+      int consumerIdx,
+      long seq,
+      long[] lastSeq,
+      ConfirmedSequences confirmed,
+      AtomicLong duplicates,
+      AtomicLong outOfOrder,
+      AtomicLong gaps) {
+    long prev = lastSeq[consumerIdx];
+    if (prev >= 0) {
+      if (seq == prev) {
+        duplicates.incrementAndGet();
+      } else if (seq < prev) {
+        long backwards = prev - seq;
+        if (numProducers == 1 || backwards > 10000) {
+          outOfOrder.incrementAndGet();
+        }
+      } else if (numProducers == 1 && seq > prev + 1) {
+        // Single producer: a forward jump means the consumer skipped over the
+        // sequences in (prev, seq). The producer assigns a sequence to every
+        // send but only confirmed sends reach the stream, so count only the
+        // confirmed sequences in the skipped range as real gaps. Holes left by
+        // unconfirmed sends are expected and ignored.
+        long skipped = confirmed.countInRange(prev + 1, seq - 1);
+        if (skipped > 0) {
+          gaps.addAndGet(skipped);
+        }
+      }
+    }
+    lastSeq[consumerIdx] = seq;
+  }
+
+  private static byte[] encodeMessage(long sequence, byte[] padding) {
+    byte[] body = new byte[8 + padding.length];
+    ByteBuffer.wrap(body).putLong(sequence);
+    return body;
+  }
+
+  private static long decodeSequence(byte[] body) {
+    return ByteBuffer.wrap(body, 0, 8).getLong();
+  }
+}

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
@@ -326,35 +326,34 @@ public class HighThroughputTest implements Runnable {
 
     StreamStats stats = env.queryStreamStats(cluster.stream);
     long committedOffset = stats.committedOffset();
-    // stats.firstOffset() returns the local-tier first offset, which does not
-    // account for messages in the remote tier. Derive the actual first readable
-    // offset from committedOffset and the management API message count.
-    long firstOffset = committedOffset - expectedMessages;
-    if (firstOffset < 0) {
-      firstOffset = 0;
-    }
-    long offsetRange = committedOffset - firstOffset;
-    long sliceSize = offsetRange / replayConsumers;
+    // The tail at replay start. Publishing has stopped, so this offset is stable
+    // and is the last offset every consumer must reach.
+    long endOffset = committedOffset;
 
     LOG.info(
-        "Replay: {} consumers, expecting >= {} messages (95% of {}), timeout={}s, expectS3={},"
-            + " firstOffset={}, committedOffset={}",
+        "Replay: {} consumers each reading first..{}, expecting >= {} messages each"
+            + " (95% of {}), timeout={}s, expectS3={}",
         replayConsumers,
+        endOffset,
         threshold,
         expectedMessages,
         replayTimeoutSeconds,
-        expectS3Reads,
-        firstOffset,
-        committedOffset);
+        expectS3Reads);
 
-    AtomicLong totalConsumed = new AtomicLong(0);
-    CountDownLatch done = new CountDownLatch(1);
+    // Real-world fan-out: every consumer independently replays the whole stream
+    // from 'first' to the tail, the way separate applications each read the same
+    // log non-destructively. See README.md (Consumption patterns). Per-consumer
+    // counters let the slowest consumer gate completion so a single stuck
+    // consumer fails the test rather than being masked by faster ones.
+    AtomicLong[] counts = new AtomicLong[replayConsumers];
+    boolean[] finished = new boolean[replayConsumers];
+    for (int i = 0; i < replayConsumers; i++) {
+      counts[i] = new AtomicLong(0);
+    }
+    CountDownLatch done = new CountDownLatch(replayConsumers);
 
     List<Consumer> consumers = new ArrayList<>();
     for (int i = 0; i < replayConsumers; i++) {
-      long startOffset = firstOffset + i * sliceSize;
-      long endOffset =
-          (i == replayConsumers - 1) ? Long.MAX_VALUE : firstOffset + (i + 1) * sliceSize;
       int consumerIdx = i;
 
       // Retry subscribe to work around issue #191: the rabbit_stream_reader
@@ -365,18 +364,21 @@ public class HighThroughputTest implements Runnable {
       for (int attempt = 1; attempt <= 5; attempt++) {
         try {
           var builder =
-              env.consumerBuilder().stream(cluster.stream)
-                  .offset(OffsetSpecification.offset(startOffset));
+              env.consumerBuilder().stream(cluster.stream).offset(OffsetSpecification.first());
           builder.flow().initialCredits(10);
           c =
               builder
                   .messageHandler(
                       (context, message) -> {
-                        if (context.offset() >= endOffset) {
+                        long off = context.offset();
+                        // Ignore anything past the tail captured at replay start.
+                        if (off > endOffset) {
                           return;
                         }
-                        long count = totalConsumed.incrementAndGet();
-                        if (count >= threshold) {
+                        counts[consumerIdx].incrementAndGet();
+                        // Reaching the tail offset marks this consumer complete.
+                        if (off >= endOffset && !finished[consumerIdx]) {
+                          finished[consumerIdx] = true;
                           done.countDown();
                         }
                       })
@@ -395,11 +397,7 @@ public class HighThroughputTest implements Runnable {
         }
       }
       consumers.add(c);
-      LOG.info(
-          "  Consumer {}: offset {} to {}",
-          consumerIdx,
-          startOffset,
-          endOffset == Long.MAX_VALUE ? "end" : endOffset);
+      LOG.info("  Consumer {}: reading first..{}", consumerIdx, endOffset);
     }
 
     long startTime = System.currentTimeMillis();
@@ -414,24 +412,27 @@ public class HighThroughputTest implements Runnable {
           c.close();
         }
         LOG.error(
-            "REPLAY TIMEOUT: consumed {} of {} expected in {}s",
-            totalConsumed.get(),
+            "REPLAY TIMEOUT: slowest consumer at {} of {} expected in {}s",
+            ReplayProgress.min(counts),
             expectedMessages,
             replayTimeoutSeconds);
+        LOG.info("  Per-consumer: {}", ReplayProgress.format(counts));
         System.exit(1);
       }
       long now = System.currentTimeMillis();
       if (now >= nextReport) {
         reportCount++;
-        long current = totalConsumed.get();
-        double rate = current * 1000.0 / (now - startTime);
+        long min = ReplayProgress.min(counts);
+        long sum = ReplayProgress.sum(counts);
+        double rate = sum * 1000.0 / (now - startTime);
         long elapsedSec = (now - startTime) / 1000;
         MetricsClient.Snapshot snap = metrics.snapshot();
         LOG.info(
-            "Replay [{}s]: {}/{} ({} msg/s) s3-recv={} MiB/s",
+            "Replay [{}s]: slowest={}/{} total={} ({} msg/s) s3-recv={} MiB/s",
             elapsedSec,
-            current,
+            min,
             expectedMessages,
+            sum,
             String.format("%.0f", rate),
             String.format("%.1f", snap.receivedMiBPerS(progressInterval)));
 
@@ -460,18 +461,21 @@ public class HighThroughputTest implements Runnable {
     for (Consumer c : consumers) {
       c.close();
     }
-    long total = totalConsumed.get();
+    long min = ReplayProgress.min(counts);
     long elapsedSec = (System.currentTimeMillis() - startTime) / 1000;
 
     LOG.info(
-        "Replay complete: {} messages in {}s ({}% of {})",
-        total,
+        "Replay complete: slowest consumer {} messages in {}s ({}% of {})",
+        min,
         elapsedSec,
-        expectedMessages > 0 ? total * 100 / expectedMessages : 0,
+        expectedMessages > 0 ? min * 100 / expectedMessages : 0,
         expectedMessages);
+    LOG.info("  Per-consumer: {}", ReplayProgress.format(counts));
 
-    if (total < threshold) {
-      LOG.error("REPLAY FAILED: {} < {} (95% of {})", total, threshold, expectedMessages);
+    // Every consumer must independently reach the threshold.
+    if (min < threshold) {
+      LOG.error(
+          "REPLAY FAILED: slowest consumer {} < {} (95% of {})", min, threshold, expectedMessages);
       System.exit(1);
     }
 

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/Main.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/Main.java
@@ -6,6 +6,7 @@ import picocli.CommandLine;
     name = "stream-s3-test",
     description = "Integration test harness for rabbitmq_stream_s3",
     subcommands = {
+      ContentVerificationTest.class,
       HighThroughputTest.class,
       MultiOffsetConsumerTest.class,
       StreamDeletionTest.class,

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ReplayProgress.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ReplayProgress.java
@@ -1,0 +1,53 @@
+package com.amazon.mq.rabbitmq.stream.s3;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Helpers for tracking independent per-consumer progress during a fan-out
+ * replay, where every consumer reads the whole stream on its own. The slowest
+ * consumer gates completion; the sum is reported for an aggregate throughput
+ * view.
+ */
+final class ReplayProgress {
+
+  private ReplayProgress() {}
+
+  /** The slowest consumer's count. Used to gate completion and pass/fail. */
+  static long min(AtomicLong[] counts) {
+    long min = Long.MAX_VALUE;
+    for (AtomicLong c : counts) {
+      min = Math.min(min, c.get());
+    }
+    return min;
+  }
+
+  /** The fastest consumer's count. Used to check fan-out agreement against min. */
+  static long max(AtomicLong[] counts) {
+    long max = 0;
+    for (AtomicLong c : counts) {
+      max = Math.max(max, c.get());
+    }
+    return max;
+  }
+
+  /** The combined count across all consumers. Used for aggregate throughput. */
+  static long sum(AtomicLong[] counts) {
+    long sum = 0;
+    for (AtomicLong c : counts) {
+      sum += c.get();
+    }
+    return sum;
+  }
+
+  /** A compact per-consumer breakdown, e.g. {@code c0=123 c1=456}. */
+  static String format(AtomicLong[] counts) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < counts.length; i++) {
+      if (i > 0) {
+        sb.append(' ');
+      }
+      sb.append('c').append(i).append('=').append(counts[i].get());
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## Summary

Add a `content-verification` integration test and correct both replay tests to model real-world fan-out consumption.

## Changes

- **`content-verification` test.** Publishes messages with sequential IDs, replays the whole stream from `first` independently from every consumer, and verifies ordering, no duplicates, and no gaps in the confirmed sequences. Catches corruption, reordering, and silent message skips. This is the test that surfaced #206.
- **`ConfirmedSequences`.** A paged bitset recording which sequences the broker confirmed, so a real gap is distinguished from a hole left by an unconfirmed send. A settle-wait before closing producers ensures the bitset is complete before replay reads it.
- **Fan-out correction to both replay tests.** Every consumer now reads the whole stream from `first` to the tail rather than a sliced offset range. A stream is a replayable log, not a work queue, so a plain stream cannot be partitioned across cooperating consumers by offset slice; that is what super streams are for. The previous slicing made `content-verification` stall and let `high-throughput` pass for the wrong reason.
- **`ReplayProgress`.** Shared per-consumer progress helpers extracted from the two tests.
- **Docs.** A `test/integration/README.md` documenting the consumption patterns so the distinction is not re-derived, and the plugin `AGENTS.md` now points at the subsystem docs, the glossary, the investigations directory, and the integration-test README.

## Validation

`mvn compile` is clean. The `content-verification` test passes against current `main` (which includes the #206 durability fix from #210).

## Notes

This branch is test and documentation only; it shares no files with the #203 read-path fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
