### PR TITLE
Recurse remote retention through nested group objects

### DIFF
--- a/include/rabbitmq_stream_s3.hrl
+++ b/include/rabbitmq_stream_s3.hrl
@@ -106,7 +106,7 @@
 %% * first timestamp (8)
 %% * first last timestamp (8)
 %% * size (9)
-%% = 41 bytes
+%% = 49 bytes
 -define(MANIFEST_HEADER_SIZE, 49).
 
 -define(MANIFEST(FirstOffset, NextOffset, FirstTs, FirstLastTs, TotalSize, Entries), <<

--- a/src/rabbitmq_stream_s3_manifest.erl
+++ b/src/rabbitmq_stream_s3_manifest.erl
@@ -324,152 +324,261 @@ build_retention_result(#manifest{entries = Entries} = Manifest, NumEntries) ->
     },
     {Edit, Refs}.
 
-%% Evaluate retention within the first group entry, if present.
+%% Evaluate retention when the oldest root entry is a group of any kind.
 maybe_eval_group_retention(_Manifest, _Specs, _Now, undefined) ->
     unchanged;
 maybe_eval_group_retention(#manifest{entries = Entries} = Manifest, Specs, Now, GetGroupFun) ->
     case Entries of
-        <<Offset:64/unsigned, _FTs:64/signed, _LTs:64/signed, Kind:8/unsigned, _Size:40/unsigned,
-            Uid:32/unsigned,
-            _Rest/binary>> when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
-            GroupRef = #group_ref{offset = Offset, kind = Kind, uid = Uid},
-            case GetGroupFun(GroupRef) of
-                {ok, GroupEntries} ->
-                    eval_group_entries(Manifest, GroupEntries, GroupRef, Specs, Now);
-                {error, _} ->
-                    unchanged
-            end;
+        <<_:64, _:64/signed, _:64/signed, Kind:8/unsigned, _:40, _:32, _/binary>> when
+            Kind =/= ?MANIFEST_KIND_FRAGMENT
+        ->
+            group_retention_result(Manifest, Specs, Now, GetGroupFun);
         _ ->
             unchanged
     end.
 
-%% Evaluate retention on fragment entries within a group.
+%% Retention over a manifest whose oldest root entry is a group. The manifest
+%% tree may be several levels deep (group, kilo-group, mega-group), so this
+%% recurses to fragment granularity.
 %%
-%% A group object is immutable, so after an earlier cycle partially consumed
-%% this group it still lists the children those cycles already removed. Skip
-%% that already-consumed prefix (children below the manifest's first_offset)
-%% before evaluating. Otherwise retention re-counts and re-deletes them and
-%% double-subtracts their sizes from total_size on every subsequent cycle,
-%% which drifts total_size below the true durable size (silently disabling
-%% max_bytes retention) or negative (crashing the persist under max_age), and
-%% regresses first_offset below the real data floor.
-eval_group_entries(Manifest, GroupEntries0, GroupRef, Specs, Now) ->
-    GroupEntries = drop_consumed_children(GroupEntries0, Manifest#manifest.first_offset),
-    NumToRemove = eval_group_retention_specs(
-        GroupEntries, Manifest#manifest.total_size, Specs, Now
-    ),
-    case NumToRemove of
-        0 ->
+%% The computation is in two phases. First it finds the new first_offset f': the
+%% offset of the oldest fragment that survives the policy, found by descending
+%% the tree. Then it deletes exactly the objects whose offset interval lies in
+%% [f, f') -- the fragments below f' and every group object all of whose
+%% descendants are below f' -- and splices out the leading root entries that are
+%% wholly consumed. Objects below the current first_offset were removed by an
+%% earlier cycle and are skipped, which keeps retention idempotent at every
+%% level. Group objects are immutable and are never rewritten.
+group_retention_result(
+    #manifest{entries = Entries, first_offset = Lo, next_offset = N, total_size = TotalSize},
+    Specs,
+    Now,
+    Get
+) ->
+    try new_first_offset(Lo, N, Entries, Specs, Now, TotalSize, Get) of
+        unchanged ->
             unchanged;
-        _ ->
-            NumGroupEntries = byte_size(GroupEntries) div ?ENTRY_B,
-            build_group_retention_result(
-                Manifest, GroupEntries, GroupRef, NumToRemove, NumGroupEntries
-            )
+        {Hi, NewFirstTs, NewFirstLastTs} ->
+            case collect_deletions(Entries, Lo, Hi, Get) of
+                {[], _, _} ->
+                    unchanged;
+                {Refs, Bytes, _} ->
+                    NumWhole = count_whole_root(Entries, Hi, Get, 0),
+                    Edit = #edit{
+                        first_offset = Hi,
+                        first_timestamp = NewFirstTs,
+                        first_last_timestamp = NewFirstLastTs,
+                        next_offset = undefined,
+                        size = -Bytes,
+                        entries = <<>>,
+                        pos = 0,
+                        len = NumWhole * ?ENTRY_B
+                    },
+                    {Edit, Refs}
+            end
+    catch
+        throw:group_fetch_failed ->
+            unchanged
     end.
 
-%% Drop the leading group children whose offset is below first_offset: an
-%% earlier retention cycle already removed them, but they remain in the
-%% immutable group object.
-drop_consumed_children(GroupEntries, FirstOffset) ->
-    Skip = consumed_prefix_bytes(GroupEntries, FirstOffset, 0),
-    binary:part(GroupEntries, Skip, byte_size(GroupEntries) - Skip).
+%% Fetch a group object's child entries, aborting retention on a fetch error.
+get_children(Get, GroupRef) ->
+    case Get(GroupRef) of
+        {ok, Children} -> Children;
+        {error, _} -> throw(group_fetch_failed)
+    end.
 
-consumed_prefix_bytes(
-    <<Offset:64/unsigned, _FTs:64/signed, _LTs:64/signed, _K:8, _Sz:40, _Uid:32, Rest/binary>>,
-    FirstOffset,
-    Acc
-) when Offset < FirstOffset ->
-    consumed_prefix_bytes(Rest, FirstOffset, Acc + ?ENTRY_B);
-consumed_prefix_bytes(_Entries, _FirstOffset, Acc) ->
-    Acc.
-
-eval_group_retention_specs(GroupEntries, ManifestTotalSize, Specs, Now) ->
-    lists:foldl(
-        fun(Spec, Acc) ->
-            max(Acc, group_entries_to_remove(GroupEntries, ManifestTotalSize, Spec, Now))
+%% The new first_offset: the largest f' any policy in Specs requires, with the
+%% timestamps of the fragment that becomes the new first. Returns unchanged when
+%% no policy removes anything.
+new_first_offset(Lo, N, Entries, Specs, Now, TotalSize, Get) ->
+    Best = lists:foldl(
+        fun(Spec, {BestHi, _, _} = Acc) ->
+            {Hi, _, _} = Cand = spec_boundary(Lo, N, Entries, Spec, Now, TotalSize, Get),
+            case Hi > BestHi of
+                true -> Cand;
+                false -> Acc
+            end
         end,
-        0,
+        {Lo, -1, -1},
         Specs
-    ).
-
-group_entries_to_remove(Entries, ManifestTotalSize, {max_bytes, MaxBytes}, _Now) ->
-    remove_for_max_bytes_in_group(Entries, ManifestTotalSize, MaxBytes, 0);
-group_entries_to_remove(Entries, _ManifestTotalSize, {max_age, MaxAgeMs}, Now) ->
-    Cutoff = Now - MaxAgeMs,
-    remove_for_max_age_in_group(Entries, Cutoff, 0);
-group_entries_to_remove(_, _, _, _) ->
-    0.
-
-%% Like remove_for_max_bytes but allows removing all entries (groups can be
-%% fully consumed).
-remove_for_max_bytes_in_group(_Entries, TotalSize, MaxBytes, N) when TotalSize =< MaxBytes ->
-    N;
-remove_for_max_bytes_in_group(<<>>, _TotalSize, _MaxBytes, N) ->
-    N;
-remove_for_max_bytes_in_group(Entries, TotalSize, MaxBytes, N) ->
-    <<_:64, _:64, _:64, _:8, Size:40, _:32, Rest/binary>> = Entries,
-    remove_for_max_bytes_in_group(Rest, TotalSize - Size, MaxBytes, N + 1).
-
-%% Like remove_for_max_age but doesn't stop at the last entry (groups can be
-%% fully consumed).
-remove_for_max_age_in_group(<<>>, _Cutoff, N) ->
-    N;
-remove_for_max_age_in_group(Entries, Cutoff, N) ->
-    <<_Offset:64, _FirstTs:64/signed, LastTs:64/signed, _Kind:8, _Size:40, _Uid:32, Rest/binary>> =
-        Entries,
-    case LastTs < Cutoff of
-        true -> remove_for_max_age_in_group(Rest, Cutoff, N + 1);
-        false -> N
+    ),
+    case Best of
+        {Lo, _, _} -> unchanged;
+        _ -> Best
     end.
 
-build_group_retention_result(Manifest, GroupEntries, GroupRef, NumToRemove, NumGroupEntries) ->
-    BytesToRemove = NumToRemove * ?ENTRY_B,
-    Removed = binary:part(GroupEntries, 0, BytesToRemove),
-    FragRefs = collect_fragment_refs(Removed, []),
-    SizeDelta = lists:foldl(fun(#fragment_ref{size = S}, Acc) -> Acc - S end, 0, FragRefs),
-    case NumToRemove >= NumGroupEntries of
+%% The new first_offset a single policy requires, as {Offset, FirstTs, LastTs}.
+%% A boundary equal to Lo means the policy removes nothing.
+spec_boundary(Lo, N, Entries, {max_age, MaxAgeMs}, Now, _TotalSize, Get) ->
+    Cutoff = Now - MaxAgeMs,
+    case boundary_age(Entries, Lo, Cutoff, Get) of
+        all -> {N, -1, -1};
+        {_, _, _} = B -> B
+    end;
+spec_boundary(Lo, N, Entries, {max_bytes, MaxBytes}, _Now, TotalSize, Get) ->
+    case TotalSize - MaxBytes of
+        ToRemove when ToRemove > 0 ->
+            case boundary_bytes(Entries, Lo, ToRemove, Get) of
+                {all, _} -> {N, -1, -1};
+                {boundary, Off, FTs, LTs} -> {Off, FTs, LTs}
+            end;
+        _ ->
+            {Lo, -1, -1}
+    end;
+spec_boundary(Lo, _N, _Entries, _Spec, _Now, _TotalSize, _Get) ->
+    {Lo, -1, -1}.
+
+%% The oldest fragment at or after Lo whose last timestamp is at or after the
+%% cutoff -- i.e. the oldest survivor. `all` if every fragment is expired.
+%% Timestamps are monotonic across fragments, so the expired prefix is
+%% contiguous and a group whose last timestamp predates the cutoff is wholly
+%% expired and can be skipped without descending.
+boundary_age(<<>>, _Lo, _Cutoff, _Get) ->
+    all;
+boundary_age(
+    <<Offset:64/unsigned, FTs:64/signed, LTs:64/signed, Kind:8/unsigned, _:40, Uid:32/unsigned,
+        Rest/binary>>,
+    Lo,
+    Cutoff,
+    Get
+) ->
+    case Kind of
+        ?MANIFEST_KIND_FRAGMENT when Offset >= Lo andalso LTs >= Cutoff ->
+            {Offset, FTs, LTs};
+        ?MANIFEST_KIND_FRAGMENT ->
+            boundary_age(Rest, Lo, Cutoff, Get);
+        _ when LTs < Cutoff ->
+            boundary_age(Rest, Lo, Cutoff, Get);
+        _ ->
+            Children = get_children(Get, #group_ref{offset = Offset, kind = Kind, uid = Uid}),
+            case boundary_age(Children, Lo, Cutoff, Get) of
+                all -> boundary_age(Rest, Lo, Cutoff, Get);
+                Found -> Found
+            end
+    end.
+
+%% The fragment at which the oldest ToRemove bytes have been removed (removing
+%% whole fragments oldest-first), as {boundary, Offset, FirstTs, LastTs}, or
+%% {all, RemainingToRemove} if every fragment is removed. Group entries carry no
+%% size, so groups are descended to reach their fragments.
+boundary_bytes(<<>>, _Lo, ToRemove, _Get) ->
+    {all, ToRemove};
+boundary_bytes(
+    <<Offset:64/unsigned, FTs:64/signed, LTs:64/signed, Kind:8/unsigned, Size:40/unsigned,
+        Uid:32/unsigned, Rest/binary>>,
+    Lo,
+    ToRemove,
+    Get
+) ->
+    case Kind of
+        ?MANIFEST_KIND_FRAGMENT when Offset < Lo ->
+            boundary_bytes(Rest, Lo, ToRemove, Get);
+        ?MANIFEST_KIND_FRAGMENT when ToRemove =< 0 ->
+            {boundary, Offset, FTs, LTs};
+        ?MANIFEST_KIND_FRAGMENT ->
+            boundary_bytes(Rest, Lo, ToRemove - Size, Get);
+        _ ->
+            Children = get_children(Get, #group_ref{offset = Offset, kind = Kind, uid = Uid}),
+            case boundary_bytes(Children, Lo, ToRemove, Get) of
+                {boundary, _, _, _} = B -> B;
+                {all, ToRemove1} -> boundary_bytes(Rest, Lo, ToRemove1, Get)
+            end
+    end.
+
+%% Collect the objects to delete -- fragments in [Lo, Hi) and groups all of
+%% whose descendants are below Hi -- with the total fragment bytes removed.
+%% Returns {Refs, Bytes, AllConsumed}; AllConsumed is true when every entry of
+%% this node lies below Hi. Fragments below Lo were deleted by an earlier cycle
+%% and are skipped; a group with no newly-deleted children is likewise already
+%% gone and its object is not re-deleted.
+collect_deletions(<<>>, _Lo, _Hi, _Get) ->
+    {[], 0, true};
+collect_deletions(
+    <<Offset:64/unsigned, _:64/signed, _:64/signed, Kind:8/unsigned, Size:40/unsigned,
+        Uid:32/unsigned, Rest/binary>>,
+    Lo,
+    Hi,
+    Get
+) ->
+    case Offset >= Hi of
         true ->
-            %% Entire group consumed. Remove the group entry from the root.
-            Remaining = binary:part(
-                Manifest#manifest.entries, ?ENTRY_B, byte_size(Manifest#manifest.entries) - ?ENTRY_B
-            ),
-            {NewFirstOffset, NewFirstTs, NewFirstLastTs} =
-                case Remaining of
-                    <<>> ->
-                        {Manifest#manifest.next_offset, -1, -1};
-                    ?ENTRY(Off, FTs, LTs, _, _, _, _) ->
-                        {Off, FTs, LTs}
-                end,
-            Edit = #edit{
-                first_offset = NewFirstOffset,
-                first_timestamp = NewFirstTs,
-                first_last_timestamp = NewFirstLastTs,
-                next_offset = undefined,
-                size = SizeDelta,
-                entries = <<>>,
-                pos = 0,
-                len = ?ENTRY_B
-            },
-            {Edit, [GroupRef | FragRefs]};
+            {[], 0, false};
         false ->
-            %% Partial group consumption. Update root metadata only.
-            %% The group entry stays. Determine new first_offset from the
-            %% first surviving entry in the group.
-            SurvivingStart = binary:part(GroupEntries, BytesToRemove, ?ENTRY_B),
-            <<NewFirstOffset:64/unsigned, NewFirstTs:64/signed, NewFirstLastTs:64/signed, _:8, _:40,
-                _:32>> = SurvivingStart,
-            Edit = #edit{
-                first_offset = NewFirstOffset,
-                first_timestamp = NewFirstTs,
-                first_last_timestamp = NewFirstLastTs,
-                next_offset = undefined,
-                size = SizeDelta,
-                entries = <<>>,
-                pos = 0,
-                len = 0
-            },
-            {Edit, FragRefs}
+            case Kind of
+                ?MANIFEST_KIND_FRAGMENT when Offset >= Lo ->
+                    {RRefs, RBytes, RAll} = collect_deletions(Rest, Lo, Hi, Get),
+                    Ref = #fragment_ref{offset = Offset, uid = Uid, size = Size},
+                    {[Ref | RRefs], Size + RBytes, RAll};
+                ?MANIFEST_KIND_FRAGMENT ->
+                    collect_deletions(Rest, Lo, Hi, Get);
+                _ ->
+                    GroupRef = #group_ref{offset = Offset, kind = Kind, uid = Uid},
+                    Children = get_children(Get, GroupRef),
+                    {CRefs, CBytes, CAll} = collect_deletions(Children, Lo, Hi, Get),
+                    {RRefs, RBytes, RAll} = collect_deletions(Rest, Lo, Hi, Get),
+                    case CAll of
+                        true ->
+                            GroupDel =
+                                case CRefs of
+                                    [] -> [];
+                                    _ -> [GroupRef]
+                                end,
+                            {GroupDel ++ CRefs ++ RRefs, CBytes + RBytes, RAll};
+                        false ->
+                            {CRefs ++ RRefs, CBytes + RBytes, false}
+                    end
+            end
+    end.
+
+%% Number of leading root entries lying wholly below Hi, which are spliced out
+%% of the root array. A group is wholly consumed when it has no descendant at or
+%% beyond Hi.
+count_whole_root(<<>>, _Hi, _Get, N) ->
+    N;
+count_whole_root(
+    <<Offset:64/unsigned, _:64/signed, _:64/signed, Kind:8/unsigned, _:40, Uid:32/unsigned,
+        Rest/binary>>,
+    Hi,
+    Get,
+    N
+) ->
+    case Offset >= Hi of
+        true ->
+            N;
+        false ->
+            case Kind of
+                ?MANIFEST_KIND_FRAGMENT ->
+                    count_whole_root(Rest, Hi, Get, N + 1);
+                _ ->
+                    Children = get_children(Get, #group_ref{offset = Offset, kind = Kind, uid = Uid}),
+                    case has_offset_ge(Children, Hi, Get) of
+                        true -> N;
+                        false -> count_whole_root(Rest, Hi, Get, N + 1)
+                    end
+            end
+    end.
+
+%% Whether any fragment at or beyond Hi exists within these entries.
+has_offset_ge(<<>>, _Hi, _Get) ->
+    false;
+has_offset_ge(
+    <<Offset:64/unsigned, _:64/signed, _:64/signed, Kind:8/unsigned, _:40, Uid:32/unsigned,
+        Rest/binary>>,
+    Hi,
+    Get
+) ->
+    case Offset >= Hi of
+        true ->
+            true;
+        false ->
+            case Kind of
+                ?MANIFEST_KIND_FRAGMENT ->
+                    has_offset_ge(Rest, Hi, Get);
+                _ ->
+                    Children = get_children(Get, #group_ref{offset = Offset, kind = Kind, uid = Uid}),
+                    has_offset_ge(Children, Hi, Get) orelse has_offset_ge(Rest, Hi, Get)
+            end
     end.
 
 collect_fragment_refs(<<>>, Acc) ->

--- a/test/manifest_SUITE.erl
+++ b/test/manifest_SUITE.erl
@@ -17,7 +17,12 @@ all() ->
         partial_group_consumption_basic,
         partial_group_max_bytes_does_not_regress_first_offset,
         partial_group_max_age_no_negative_total_size,
-        partial_then_full_consumption_removes_group
+        partial_then_full_consumption_removes_group,
+        kilo_group_max_age_partial,
+        kilo_group_max_bytes,
+        kilo_group_full_consumption,
+        mega_group_retention,
+        multi_tier_idempotent
     ].
 
 init_per_suite(Config) -> Config.
@@ -89,6 +94,73 @@ partial_then_full_consumption_removes_group(_Config) ->
     ?assertEqual([200, 300], fragment_offsets(Refs2)),
     ?assertEqual(1, length(group_refs(Refs2))).
 
+%% A kilo-group (a group of groups) where max_age expires the first inner group
+%% wholly and the second inner group partially. Retention must descend two
+%% levels: delete the wholly-consumed inner group object plus the expired leaf
+%% fragments, leave the kilo-group entry in place, and advance first_offset to
+%% the oldest survivor.
+kilo_group_max_age_partial(_Config) ->
+    {M0, GetGroup} = kilo_manifest(),
+    %% last_ts are 1000..4000 for the kilo's fragments, 5000 for the trailing
+    %% root fragment. Cutoff = 9000 - 5500 = 3500 expires F0..F2, keeps F3, F4.
+    {Refs, M1} = run_cycle(M0, [{max_age, 5500}], 9000, GetGroup),
+    ?assertEqual([0, 100, 200], fragment_offsets(Refs)),
+    %% Exactly the first inner group object is deleted (it is wholly consumed).
+    ?assertEqual(1, length(group_refs(Refs))),
+    ?assertEqual(300, M1#manifest.first_offset),
+    ?assertEqual(2 * ?SZ, M1#manifest.total_size),
+    %% The kilo-group entry survives, so the two root entries remain.
+    ?assertEqual(2 * ?ENTRY_B, byte_size(M1#manifest.entries)).
+
+%% max_bytes across a kilo-group: the size to remove is computed by descending
+%% to leaves (group entries carry no size).
+kilo_group_max_bytes(_Config) ->
+    {M0, GetGroup} = kilo_manifest(),
+    %% total_size = 500. max_bytes 250 removes the oldest 250 bytes: F0, F1, F2.
+    {Refs, M1} = run_cycle(M0, [{max_bytes, 250}], 1000, GetGroup),
+    ?assertEqual([0, 100, 200], fragment_offsets(Refs)),
+    ?assertEqual(1, length(group_refs(Refs))),
+    ?assertEqual(300, M1#manifest.first_offset),
+    ?assertEqual(2 * ?SZ, M1#manifest.total_size).
+
+%% Expiring everything consumes the whole kilo-group and the trailing root
+%% fragment: both root entries are spliced and every nested object is deleted.
+kilo_group_full_consumption(_Config) ->
+    {M0, GetGroup} = kilo_manifest(),
+    {Refs, M1} = run_cycle(M0, [{max_age, 0}], 99999999, GetGroup),
+    ?assertEqual([0, 100, 200, 300, 400], fragment_offsets(Refs)),
+    %% The kilo-group object and both inner group objects are deleted.
+    ?assertEqual(3, length(group_refs(Refs))),
+    ?assertEqual(<<>>, M1#manifest.entries),
+    ?assertEqual(0, M1#manifest.total_size),
+    ?assertEqual(M0#manifest.next_offset, M1#manifest.first_offset).
+
+%% A three-level tree (mega-group of kilo-groups of groups) is handled to leaf
+%% granularity.
+mega_group_retention(_Config) ->
+    {M0, GetGroup} = mega_manifest(),
+    %% Remove just the oldest fragment by bytes (total 800, keep 700).
+    {Refs, M1} = run_cycle(M0, [{max_bytes, 700}], 1000, GetGroup),
+    ?assertEqual([0], fragment_offsets(Refs)),
+    ?assertEqual(100, M1#manifest.first_offset),
+    ?assertEqual(7 * ?SZ, M1#manifest.total_size).
+
+%% Multi-tier retention is idempotent across cycles: a second pass against the
+%% partially-consumed kilo-group does not re-delete the objects the first pass
+%% removed and keeps total_size and first_offset consistent.
+multi_tier_idempotent(_Config) ->
+    {M0, GetGroup} = kilo_manifest(),
+    {Refs1, M1} = run_cycle(M0, [{max_bytes, 350}], 1000, GetGroup),
+    ?assertEqual([0, 100], fragment_offsets(Refs1)),
+    ?assertEqual(200, M1#manifest.first_offset),
+    ?assertEqual(300, M1#manifest.total_size),
+    %% Second cycle removes only the next fragment; F0/F1 are not revisited.
+    {Refs2, M2} = run_cycle(M1, [{max_bytes, 250}], 1000, GetGroup),
+    ?assertEqual([200], fragment_offsets(Refs2)),
+    ?assertEqual(300, M2#manifest.first_offset),
+    ?assertEqual(200, M2#manifest.total_size),
+    ?assert(M2#manifest.first_offset >= M1#manifest.first_offset).
+
 %% ------------------------------------------------------------------
 %% Helpers
 %% ------------------------------------------------------------------
@@ -104,6 +176,42 @@ grouped_manifest() ->
             {fragment, #{offset => 100, size => ?SZ, last_ts => 2000, uid => 2}},
             {fragment, #{offset => 200, size => ?SZ, last_ts => 3000, uid => 3}},
             {fragment, #{offset => 300, size => ?SZ, last_ts => 4000, uid => 4}}
+        ]}
+    ]).
+
+%% Root = [kilo-group(group[F0,F1], group[F2,F3]), F4]. Fragments at offsets
+%% 0/100/200/300 nested two levels deep under the kilo-group, plus a trailing
+%% root fragment F4 at 400. last_ts 1000..5000, each 100 bytes (total 500).
+kilo_manifest() ->
+    rabbitmq_stream_s3_test_helpers:build_manifest([
+        {kilo_group, [
+            {group, [
+                {fragment, #{offset => 0, size => ?SZ, last_ts => 1000}},
+                {fragment, #{offset => 100, size => ?SZ, last_ts => 2000}}
+            ]},
+            {group, [
+                {fragment, #{offset => 200, size => ?SZ, last_ts => 3000}},
+                {fragment, #{offset => 300, size => ?SZ, last_ts => 4000}}
+            ]}
+        ]},
+        {fragment, #{offset => 400, size => ?SZ, last_ts => 5000}}
+    ]).
+
+%% Root = [mega-group(kilo-group(group[F0,F1], group[F2,F3]),
+%%                     kilo-group(group[F4,F5], group[F6,F7]))]. Eight fragments
+%% at offsets 0..700 nested three levels deep, each 100 bytes (total 800).
+mega_manifest() ->
+    Frag = fun(O) -> {fragment, #{offset => O, size => ?SZ}} end,
+    rabbitmq_stream_s3_test_helpers:build_manifest([
+        {mega_group, [
+            {kilo_group, [
+                {group, [Frag(0), Frag(100)]},
+                {group, [Frag(200), Frag(300)]}
+            ]},
+            {kilo_group, [
+                {group, [Frag(400), Frag(500)]},
+                {group, [Frag(600), Frag(700)]}
+            ]}
         ]}
     ]).
 

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -256,19 +256,34 @@ gen_ret_scenario() ->
                 ],
                 GroupFrags = lists:sublist(Frags, G),
                 RootFrags = lists:nthtail(G, Frags),
-                TreeSpec =
-                    [{group, [frag_spec(F) || F <- GroupFrags]}] ++
-                        [frag_spec(F) || F <- RootFrags],
                 Total = lists:sum(Sizes),
                 MaxTs = N * 1000,
                 ?LET(
-                    Schedule,
-                    gen_ret_schedule(Total, MaxTs),
-                    {TreeSpec, Frags, Schedule}
+                    {Structure, Schedule},
+                    {oneof([flat, kilo]), gen_ret_schedule(Total, MaxTs)},
+                    begin
+                        TreeSpec =
+                            [leading_tree(Structure, GroupFrags)] ++
+                                [frag_spec(F) || F <- RootFrags],
+                        {TreeSpec, Frags, Schedule}
+                    end
                 )
             end
         )
     ).
+
+%% Nest the leading fragments either in one flat group or, to exercise the
+%% recursive multi-tier retention path, in a kilo-group of two-fragment groups.
+leading_tree(flat, Frags) ->
+    {group, [frag_spec(F) || F <- Frags]};
+leading_tree(kilo, Frags) ->
+    {kilo_group, [{group, [frag_spec(F) || F <- Chunk]} || Chunk <- chunks_of(2, Frags)]}.
+
+chunks_of(_N, []) ->
+    [];
+chunks_of(N, Frags) ->
+    {Head, Tail} = lists:split(min(N, length(Frags)), Frags),
+    [Head | chunks_of(N, Tail)].
 
 frag_spec({Off, Size, LastTs}) ->
     {fragment, #{


### PR DESCRIPTION
Remote retention assumed the oldest root entry was a group of fragments. When a stream grew enough to form kilo-groups or mega-groups (groups of groups), the oldest entry could be one of those, and the deletion-ref collection hard-matched fragment entries, so it crashed on the group children it found instead. The crash was caught by the retention task, so retention silently made no progress against a deeply nested prefix and the remote tier grew without bound. Group entries also carry no size, so max_bytes could not measure how much a group represented.

Replace the single-level group evaluation with a recursive one that walks the manifest tree to fragment granularity. It computes the new first_offset f' as a leaf boundary (descending groups, summing leaf sizes for max_bytes and using the contiguity of timestamps for max_age), then deletes exactly the objects whose interval lies in [f, f') -- the fragments below f' and every group object all of whose descendants are below f' -- skipping the prefix below the current first_offset so retention stays idempotent at every level, and splices only the wholly-consumed leading root entries. Group objects remain immutable. A group fetch error aborts the cycle cleanly rather than crashing.

Extend manifest_SUITE with kilo- and mega-group cases (partial, max_bytes, full consumption, and multi-cycle idempotence) and make the prop_SUITE retention property also generate kilo-group trees; the property fails without this change.

Note: review for https://github.com/amazon-mq/rabbitmq-stream-s3/pull/211 caught this indirectly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
