### PR TITLE
Use double-layer supervision for replica reader process

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,14 +35,30 @@ rabbitmq_stream_s3_sup (one_for_one)
 │     Per-node transfer pacing. Accepts fragment upload submissions from
 │     replica readers, paces them via a token bucket, spawns tasks, and
 │     reports completions back.
-└── rabbitmq_stream_s3_replica_reader_sup (simple_one_for_one, temporary)
-      └── rabbitmq_stream_s3_replica_reader (per-stream)
-            Owns the full upload lifecycle for one stream: drain committed
-            chunks, assemble fragments, submit to governor, apply completions
-            in order, persist manifest, broadcast edits, evaluate retention.
+└── rabbitmq_stream_s3_replica_reader_sup (simple_one_for_one)
+      Factory. Its dynamic children are per-stream supervisors, started
+      `temporary` so the factory never restarts them.
+      └── rabbitmq_stream_s3_stream_sup (one per stream)
+            Per-stream supervisor. Owns its own restart-intensity budget
+            and auto-shuts-down when its reader exits normally.
+            └── rabbitmq_stream_s3_replica_reader (per-stream worker)
+                  Owns the full upload lifecycle for one stream: drain
+                  committed chunks, assemble fragments, submit to governor,
+                  apply completions in order, persist manifest, broadcast
+                  edits, evaluate retention.
 ```
 
 The supervisor init also performs one-time setup: creates the seshat counter group, initializes the API backend, sets the osiris hooks (`log_hooks` and `log_reader`), registers the Khepri deletion trigger, and creates the process registry ETS table.
+
+### Replica reader fault isolation
+
+Replica readers are supervised in two layers so that one stream's failure stays confined to that stream.
+
+The factory (`rabbitmq_stream_s3_replica_reader_sup`) is a `simple_one_for_one` whose dynamic children are per-stream supervisors (`rabbitmq_stream_s3_stream_sup`), each owning exactly one replica reader. The reason for the extra layer is the restart-intensity budget. A supervisor's `intensity`/`period` is a single counter shared by all of its children; if it is exceeded the supervisor terminates every child. With replica readers as direct children of one supervisor, a single reader that crash-loops on bad state (or several unrelated readers crashing in the same window) could exhaust that shared budget and take down every reader on the node. Giving each stream its own supervisor gives each stream its own budget, so a poison stream parks alone.
+
+The worker is `transient` and `significant`, and the per-stream supervisor sets `auto_shutdown => any_significant`. The replica reader stops with reason `normal` when its osiris writer goes down (the reader monitors the writer; writer DOWN is the normal end of a stream's life on this node, e.g. leadership transfer or stream deletion). `transient` means that normal stop is not restarted; `auto_shutdown` then terminates the now-childless per-stream supervisor, so a departed stream does not leave an idle supervisor behind. A genuine crash is an abnormal exit, which is restarted within the per-stream budget; only after that budget is exhausted does the per-stream supervisor exit (`shutdown`) and the stream park.
+
+Because the per-stream supervisors are `temporary`, the factory never restarts them and never spends its own budget on their termination, whether they park or auto-shut-down. A parked stream has a live writer but no reader; re-attaching it is the job of discovery (on plugin start) or membership reconciliation, not the supervisor.
 
 ## Process registry
 

--- a/src/rabbitmq_stream_s3_replica_reader_sup.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_sup.erl
@@ -2,6 +2,20 @@
 %% SPDX-License-Identifier: Apache-2.0
 
 -module(rabbitmq_stream_s3_replica_reader_sup).
+-moduledoc """
+Factory supervisor for per-stream replica readers.
+
+This is the top layer of a two-level structure. Its dynamic children are
+per-stream supervisors (`rabbitmq_stream_s3_stream_sup`), each owning exactly
+one replica reader. See that module for why the extra layer exists.
+
+The per-stream supervisors are `temporary`: the factory never restarts them.
+A stream that exhausts its own restart budget exits with reason `shutdown`
+and parks; a stream whose writer goes away auto-shuts-down normally. In both
+cases the factory neither restarts the child nor spends its own restart
+budget, so one stream's failure cannot cascade to other streams.
+""".
+
 -behaviour(supervisor).
 
 -export([start_link/0, start_child/1, stop_child/1]).
@@ -10,21 +24,104 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
--spec start_child(rabbitmq_stream_s3_replica_reader:config()) -> {ok, pid()} | {error, term()}.
-start_child(Args) ->
-    supervisor:start_child(?MODULE, [Args]).
+-doc """
+Start a per-stream supervisor and its replica reader.
 
+Returns `{ok, ReaderPid}` where `ReaderPid` is the replica reader worker
+itself (not the per-stream supervisor), preserving the contract for callers
+that address the reader by pid. Returns `{error, {already_started, Pid}}`
+when a reader for this stream is already registered, matching the previous
+single-layer behaviour (the reader registers a
+`{via, registry, {StreamId, node()}}` name, so a duplicate start would
+otherwise fail deep inside the per-stream supervisor's init).
+""".
+-spec start_child(rabbitmq_stream_s3_replica_reader:config()) ->
+    {ok, pid()} | {error, term()}.
+start_child(#{stream := StreamId} = Args) ->
+    Name = {StreamId, node()},
+    case rabbitmq_stream_s3_registry:whereis_name(Name) of
+        Pid when is_pid(Pid) ->
+            {error, {already_started, Pid}};
+        undefined ->
+            case supervisor:start_child(?MODULE, [Args]) of
+                {ok, SupPid} ->
+                    {ok, reader_pid(SupPid)};
+                {error, _} = Err ->
+                    %% A concurrent start may have registered the reader
+                    %% between our check and the start attempt. Surface the
+                    %% same already_started result the caller expects rather
+                    %% than the nested per-stream-supervisor start error.
+                    case rabbitmq_stream_s3_registry:whereis_name(Name) of
+                        P when is_pid(P) -> {error, {already_started, P}};
+                        undefined -> Err
+                    end
+            end
+    end.
+
+-doc """
+Stop the per-stream supervisor that owns the given replica reader pid.
+
+Callers pass the reader (worker) pid, typically obtained from the registry.
+This terminates the enclosing per-stream supervisor, which shuts the reader
+down gracefully: the reader traps exits and its `terminate/2` unregisters
+from the registry. The call is synchronous, so the registry entry is cleared
+by the time it returns.
+""".
 -spec stop_child(pid()) -> ok.
-stop_child(Pid) ->
-    supervisor:terminate_child(?MODULE, Pid).
+stop_child(ReaderPid) when is_pid(ReaderPid) ->
+    case stream_sup_of(ReaderPid) of
+        {ok, SupPid} ->
+            _ = supervisor:terminate_child(?MODULE, SupPid),
+            ok;
+        error ->
+            ok
+    end.
 
 init([]) ->
     ChildSpec = #{
-        id => rabbitmq_stream_s3_replica_reader,
-        start => {rabbitmq_stream_s3_replica_reader, start_link, []},
-        restart => transient,
-        shutdown => 5000,
-        type => worker,
-        modules => [rabbitmq_stream_s3_replica_reader]
+        id => rabbitmq_stream_s3_stream_sup,
+        start => {rabbitmq_stream_s3_stream_sup, start_link, []},
+        %% Per-stream supervisors are never restarted by the factory. They
+        %% either park (own budget exhausted) or auto-shut-down (writer
+        %% gone). Restarting here would resurrect a reader with no live
+        %% writer, and would couple one stream's failures to the factory's
+        %% shared budget, which is exactly what this layer avoids.
+        restart => temporary,
+        shutdown => infinity,
+        type => supervisor,
+        modules => [rabbitmq_stream_s3_stream_sup]
     },
+    %% The factory's own intensity/period is largely inert: temporary
+    %% children are never restarted, so per-stream terminations (parking or
+    %% auto-shutdown) do not consume it. It only guards against a per-stream
+    %% supervisor that repeatedly fails to start.
     {ok, {{simple_one_for_one, 3, 10}, [ChildSpec]}}.
+
+%% ------------------------------------------------------------------
+%% Internal
+%% ------------------------------------------------------------------
+
+%% Return the replica reader worker pid inside a per-stream supervisor. The
+%% worker is started synchronously during the per-stream supervisor's init,
+%% so it is present by the time a successful start_child returns.
+reader_pid(SupPid) ->
+    case lists:keyfind(rabbitmq_stream_s3_replica_reader, 1, supervisor:which_children(SupPid)) of
+        {_, Pid, _, _} when is_pid(Pid) -> Pid;
+        _ -> undefined
+    end.
+
+%% Find the per-stream supervisor whose replica reader is ReaderPid. Linear
+%% in the number of streams on the node, but stop_child is a rare,
+%% maintenance/test-time operation (plugin disable tears down the whole tree
+%% instead of stopping children one by one).
+stream_sup_of(ReaderPid) ->
+    SupPids = [P || {_, P, supervisor, _} <- supervisor:which_children(?MODULE), is_pid(P)],
+    find_sup(SupPids, ReaderPid).
+
+find_sup([], _ReaderPid) ->
+    error;
+find_sup([SupPid | Rest], ReaderPid) ->
+    case lists:keyfind(rabbitmq_stream_s3_replica_reader, 1, supervisor:which_children(SupPid)) of
+        {_, ReaderPid, _, _} -> {ok, SupPid};
+        _ -> find_sup(Rest, ReaderPid)
+    end.

--- a/src/rabbitmq_stream_s3_stream_sup.erl
+++ b/src/rabbitmq_stream_s3_stream_sup.erl
@@ -1,0 +1,70 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_stream_sup).
+-moduledoc """
+Per-stream supervisor wrapping a single replica reader.
+
+This is the middle layer of a two-level supervision structure:
+
+```
+rabbitmq_stream_s3_replica_reader_sup   (simple_one_for_one factory)
+└── rabbitmq_stream_s3_stream_sup        (one per stream, this module)
+      └── rabbitmq_stream_s3_replica_reader   (the worker)
+```
+
+The middle layer exists to isolate failures between streams. Each stream
+gets its own restart-intensity budget, so a replica reader that crash-loops
+on bad state exhausts only *this* supervisor's budget and parks *this*
+stream. Sibling streams keep uploading. Without this layer, every replica
+reader on the node would share a single budget under the factory, and one
+poison stream could trip it and take down all readers on the node.
+
+The worker is `transient` and `significant`. The replica reader stops with
+reason `normal` when its osiris writer goes down (leadership transfer or
+stream deletion). `transient` means a normal stop is not restarted, and
+`auto_shutdown => any_significant` means this supervisor then terminates
+itself, so a departed stream does not leave an idle supervisor behind. A
+genuine crash (abnormal exit) is restarted within the per-stream budget;
+only once that budget is exhausted does the stream park, awaiting
+reconciliation.
+""".
+
+-behaviour(supervisor).
+
+-export([start_link/1, init/1]).
+
+-spec start_link(rabbitmq_stream_s3_replica_reader:config()) ->
+    supervisor:startlink_ret().
+start_link(Args) ->
+    supervisor:start_link(?MODULE, Args).
+
+init(Args) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        %% Per-stream restart budget. A reader that deterministically
+        %% crashes on startup gets a few attempts before this supervisor
+        %% gives up and the stream parks. The budget is private to this
+        %% stream, so exhausting it never affects other streams.
+        intensity => 5,
+        period => 10,
+        %% Terminate this supervisor when the (significant) replica reader
+        %% exits normally and is not restarted, i.e. when the writer is
+        %% gone. Without this the supervisor would idle forever with no
+        %% children, leaking one process per stream teardown.
+        auto_shutdown => any_significant
+    },
+    ReplicaReader = #{
+        id => rabbitmq_stream_s3_replica_reader,
+        start => {rabbitmq_stream_s3_replica_reader, start_link, [Args]},
+        %% transient: do not restart on the normal exit the reader performs
+        %% when its writer goes down; do restart genuine crashes.
+        restart => transient,
+        %% significant: a normal (non-restarted) exit triggers the
+        %% auto_shutdown above. Only legal because restart is not permanent.
+        significant => true,
+        shutdown => 5000,
+        type => worker,
+        modules => [rabbitmq_stream_s3_replica_reader]
+    },
+    {ok, {SupFlags, [ReplicaReader]}}.


### PR DESCRIPTION
Replica readers were direct children of a single simple_one_for_one supervisor, sharing one restart-intensity budget across the whole node. That shared budget couples unrelated streams: one reader that crash-loops on bad state, or several readers crashing in the same window, can exhaust the budget and take down every replica reader on the node.

Interpose a per-stream supervisor (rabbitmq_stream_s3_stream_sup) between the factory and the worker:

    rabbitmq_stream_s3_replica_reader_sup   (simple_one_for_one factory)
    └── rabbitmq_stream_s3_stream_sup        (one per stream)
          └── rabbitmq_stream_s3_replica_reader   (the worker)

Each stream now owns its own restart budget, so a poison stream parks alone and its siblings keep uploading.

The per-stream supervisors are temporary, so the factory never restarts them and never spends its own budget on their termination. The worker is transient and significant, and the per-stream supervisor sets auto_shutdown => any_significant: when the reader stops normally (its osiris writer went down on leadership transfer or stream deletion) the now-childless supervisor shuts itself down instead of idling. A genuine crash is restarted within the per-stream budget; only once that budget is exhausted does the stream park, awaiting reconciliation by discovery or membership reconciliation.

start_child still returns the reader worker pid and still reports {error, {already_started, Pid}} for a duplicate stream, preserving the single-layer contract. stop_child maps a reader pid back to its enclosing per-stream supervisor and terminates that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
