### PR TITLE
Make remote retention and root rebalance mutually exclusive

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1023,16 +1023,35 @@ update_counter(Cnt, FstOff, NumSegLeft) ->
 maybe_evaluate_remote_retention(_Manifest, [], _StreamId, State) ->
     State;
 maybe_evaluate_remote_retention(Manifest, Retention, StreamId, #state{core = Core0} = State) ->
-    inc(State, ?C_REMOTE_TIER_RETENTION_EVALUATIONS, 1),
-    Now = erlang:system_time(millisecond),
-    %% First try without group download (handles fragments-only case synchronously).
-    case rabbitmq_stream_s3_manifest:evaluate_remote_retention(Manifest, Retention, Now) of
-        unchanged ->
-            %% No leading fragments to remove. If the first entry is a group,
-            %% spawn an async task to download it and evaluate retention within.
-            maybe_spawn_group_retention(Manifest, Retention, Now, StreamId, State);
-        {Edit, Refs} ->
-            on_remote_retention(Edit, Refs, StreamId, Core0, State)
+    case rabbitmq_stream_s3_replica_reader_core:rebalance_in_flight(Core0) of
+        true ->
+            %% A rebalance is rewriting the manifest's leading entries. Remote
+            %% retention rewrites the same prefix, so evaluating it now would
+            %% compute an edit against a manifest the rebalance is about to
+            %% change, and applying it would race the rebalance over that
+            %% prefix (Single mutator). Skip; retention is re-evaluated by the
+            %% next persist_complete once the rebalance has finished. This
+            %% guards the manual CLI trigger; the automatic post-persist path
+            %% is already gated by persist_complete.
+            ?LOG_DEBUG(
+                "~ts skipping remote retention evaluation: rebalance in flight",
+                [StreamId]
+            ),
+            State;
+        false ->
+            inc(State, ?C_REMOTE_TIER_RETENTION_EVALUATIONS, 1),
+            Now = erlang:system_time(millisecond),
+            %% First try without group download (handles the fragments-only
+            %% case synchronously).
+            case rabbitmq_stream_s3_manifest:evaluate_remote_retention(Manifest, Retention, Now) of
+                unchanged ->
+                    %% No leading fragments to remove. If the first entry is a
+                    %% group, spawn an async task to download it and evaluate
+                    %% retention within.
+                    maybe_spawn_group_retention(Manifest, Retention, Now, StreamId, State);
+                {Edit, Refs} ->
+                    on_remote_retention(Edit, Refs, StreamId, Core0, State)
+            end
     end.
 
 %% Handle a retention result (synchronous fragments-only case or async completion).

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -16,6 +16,7 @@ testable without mocks or timing.
     init/2,
     manifest/1,
     persisted_manifest/1,
+    rebalance_in_flight/1,
     format_state/1,
     fragment_cut/2,
     transfer_complete/3,
@@ -144,6 +145,16 @@ manifest(#state{manifest = Manifest}) ->
 -spec persisted_manifest(state()) -> #manifest{}.
 persisted_manifest(#state{last_persisted_manifest = Manifest}) ->
     Manifest.
+
+-doc """
+Whether a root rebalance (factoring leading entries into a group object) is in
+flight. The shell consults this before evaluating remote retention, since both
+rewrite the manifest's leading entries and must not run concurrently (Single
+mutator).
+""".
+-spec rebalance_in_flight(state()) -> boolean().
+rebalance_in_flight(#state{rebalance_in_flight = Flag}) ->
+    Flag.
 
 -spec format_state(state()) -> map().
 format_state(#state{
@@ -437,8 +448,13 @@ retention_complete(Edit, #state{manifest = Manifest0} = State0) ->
         since_persist = State0#state.since_persist + 1,
         edits_since_persist = [Edit | State0#state.edits_since_persist]
     },
-    {State2, PersistEffects} = maybe_start_persist(State1),
-    {State2, PersistEffects}.
+    %% Retention is now clear, so a rebalance deferred while it was in flight
+    %% can proceed. Re-check rebalance before persist (the same order as
+    %% drain_completions and group_upload_complete); the retention edit just
+    %% shrank the root, so this usually finds nothing to do.
+    {State2, RebalanceEffects} = maybe_start_rebalance(State1),
+    {State3, PersistEffects} = maybe_start_persist(State2),
+    {State3, RebalanceEffects ++ PersistEffects}.
 
 -doc """
 A retention evaluation finished without producing an edit: it either failed
@@ -448,8 +464,12 @@ evaluation. Failures are counted by the shell; the core does not distinguish
 them here because both outcomes mean the same thing to the core.
 """.
 -spec retention_failed(term(), state()) -> {state(), [core_effect()]}.
-retention_failed(_Reason, State) ->
-    {State#state{retention_in_flight = false}, []}.
+retention_failed(_Reason, State0) ->
+    %% Retention cleared without changing the manifest. A rebalance may have
+    %% been deferred while it was in flight; re-check it now that the flag is
+    %% clear so an oversized root does not wait for the next drain to compact.
+    %% Persist is left to the subsequent tick or drain, as before.
+    maybe_start_rebalance(State0#state{retention_in_flight = false}).
 
 %% ------------------------------------------------------------------
 %% Internal
@@ -589,6 +609,12 @@ start_persist(
 %% exceed the threshold for any kind, emit an upload_group effect.
 -spec maybe_start_rebalance(state()) -> {state(), [core_effect()]}.
 maybe_start_rebalance(#state{rebalance_in_flight = true} = State) ->
+    {State, []};
+maybe_start_rebalance(#state{retention_in_flight = true} = State) ->
+    %% A remote retention evaluation is in flight. It rewrites the same
+    %% leading entries a rebalance would factor out, so the two must never run
+    %% concurrently (Single mutator). Defer: the rebalance is re-checked when
+    %% retention completes (retention_complete) and on the next drain.
     {State, []};
 maybe_start_rebalance(#state{cfg = Cfg, manifest = Manifest} = State) ->
     case needs_rebalance(Manifest#manifest.entries, Cfg#cfg.rebalance_threshold) of

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -76,6 +76,9 @@ all() ->
         tick_fires_at_exact_interval_boundary,
         retention_and_rebalance_same_persist_cycle,
         persist_complete_defers_retention_during_rebalance,
+        rebalance_deferred_while_retention_in_flight,
+        retention_complete_rechecks_deferred_rebalance,
+        retention_failed_rechecks_deferred_rebalance,
         retention_deletes_all_entries,
         new_fragment_after_empty_manifest
     ].
@@ -1306,6 +1309,96 @@ persist_complete_defers_retention_during_rebalance(_Config) ->
     %% Complete that persist. NOW retention should be emitted.
     {_S7, FinalEffects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S6),
     ?assertMatch([_ | _], [E || {evaluate_retention, _, _} = E <- FinalEffects]).
+
+rebalance_deferred_while_retention_in_flight(_Config) ->
+    %% The mirror of persist_complete_defers_retention_during_rebalance: a
+    %% remote retention evaluation is in flight when a drain reaches the
+    %% rebalance threshold. maybe_start_rebalance must defer, because retention
+    %% and rebalance rewrite the same leading entries (Single mutator). No
+    %% upload_group is emitted and rebalance_in_flight stays false.
+    Threshold = 4,
+    {S0, _} = init_core(#{rebalance_threshold => Threshold, persist_threshold => 100}),
+    %% Apply Threshold - 1 fragments (below the rebalance threshold).
+    S1 = lists:foldl(
+        fun(I, Acc) ->
+            cut_and_complete(Acc, I * 100, (I + 1) * 100, 1000 + I)
+        end,
+        S0,
+        lists:seq(0, Threshold - 2)
+    ),
+    %% A remote retention evaluation is now in flight.
+    S2 = rabbitmq_stream_s3_replica_reader_core:retention_started(S1),
+    %% The Threshold-th completion would reach the rebalance threshold on drain.
+    {S3, Effects} = cut_and_complete_effects(
+        S2, (Threshold - 1) * 100, Threshold * 100, 2000
+    ),
+    ?assertEqual([], [E || {upload_group, _, _, _, _, _} = E <- Effects]),
+    #{rebalance_in_flight := false} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S3).
+
+retention_complete_rechecks_deferred_rebalance(_Config) ->
+    %% A rebalance deferred while retention was in flight must be re-checked
+    %% once the retention edit is applied. Here the root stays oversized after
+    %% retention removes one entry, so the rebalance fires.
+    Threshold = 4,
+    {S0, _} = init_core(#{rebalance_threshold => Threshold, persist_threshold => 100}),
+    %% Retention is in flight from the start, so the drains below defer the
+    %% rebalance rather than starting it.
+    S1 = rabbitmq_stream_s3_replica_reader_core:retention_started(S0),
+    %% Apply Threshold + 1 fragments. Rebalance is deferred the whole time.
+    S2 = lists:foldl(
+        fun(I, Acc) ->
+            cut_and_complete(Acc, I * 100, (I + 1) * 100, 1000 + I)
+        end,
+        S1,
+        lists:seq(0, Threshold)
+    ),
+    #{rebalance_in_flight := false} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S2),
+    %% Retention removes the first entry, leaving Threshold fragments: still
+    %% oversized. retention_complete clears the flag and re-checks rebalance.
+    RetEdit = #edit{
+        first_offset = 100,
+        first_timestamp = 100 * 1000,
+        first_last_timestamp = 199 * 1000,
+        next_offset = undefined,
+        size = -64_000_000,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    {S3, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_complete(RetEdit, S2),
+    ?assertMatch(
+        [{upload_group, <<"stream">>, ?MANIFEST_KIND_GROUP, _, 0, _}],
+        [E || {upload_group, _, _, _, _, _} = E <- Effects]
+    ),
+    #{rebalance_in_flight := true} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S3).
+
+retention_failed_rechecks_deferred_rebalance(_Config) ->
+    %% A retention evaluation that deferred a rebalance fails without changing
+    %% the manifest. The deferred rebalance must still be re-checked so an
+    %% oversized root does not wait for the next drain to compact.
+    Threshold = 4,
+    {S0, _} = init_core(#{rebalance_threshold => Threshold, persist_threshold => 100}),
+    S1 = rabbitmq_stream_s3_replica_reader_core:retention_started(S0),
+    %% Apply Threshold fragments while retention is in flight: rebalance defers.
+    S2 = lists:foldl(
+        fun(I, Acc) ->
+            cut_and_complete(Acc, I * 100, (I + 1) * 100, 1000 + I)
+        end,
+        S1,
+        lists:seq(0, Threshold - 1)
+    ),
+    #{rebalance_in_flight := false} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S2),
+    {S3, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, S2),
+    ?assertMatch(
+        [{upload_group, <<"stream">>, ?MANIFEST_KIND_GROUP, _, 0, _}],
+        [E || {upload_group, _, _, _, _, _} = E <- Effects]
+    ),
+    #{rebalance_in_flight := true} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S3).
 
 retention_deletes_all_entries(_Config) ->
     %% Retention removes all entries. Manifest becomes empty.


### PR DESCRIPTION
Remote retention and a root rebalance both rewrite the manifest's leading entries, so they must never run concurrently (the Single mutator invariant). The code already enforced one direction: persist_complete does not evaluate retention while a rebalance is in flight. The other direction was missing.

maybe_start_persist short-circuits on both rebalance_in_flight and retention_in_flight, but maybe_start_rebalance only checked the former. So an async remote-retention evaluation (the group-download path) could be in flight when a drain reached the rebalance threshold, starting a rebalance alongside it. When the retention edit then landed it rewrote the leading prefix the rebalance was factoring, and group_upload_complete reconstructed its {Kind, Pos, Len} from the now-shifted manifest, crashing in pending_rebalance.

The manual CLI trigger (evaluate_remote_retention) made it worse: it calls maybe_evaluate_remote_retention directly, bypassing the persist_complete gate, so an operator could start retention in the middle of a rebalance.

Close both directions:

- maybe_start_rebalance now defers while retention_in_flight, mirroring maybe_start_persist. An async retention in flight blocks a rebalance from starting, so the two never overlap and a retention edit is always applied to a manifest no rebalance has changed underneath it
- maybe_evaluate_remote_retention skips evaluation while a rebalance is in flight, gating the manual CLI trigger the same way the automatic post-persist path is already gated. Nothing is computed or deleted; retention is re-evaluated by the next persist_complete after the rebalance finishes
- retention_complete and retention_failed re-check rebalance once the flag is clear, so a rebalance deferred while retention was in flight is not stranded until the next drain

Add a rebalance_in_flight/1 accessor for the shell guard, and core tests for the deferral and both re-check paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
