### PR TITLE
Retry a transient group fetch instead of becoming local

### DIFF
--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -310,9 +310,15 @@ step(State0, {iterator_refreshed, Iterator}) ->
             },
             {State1, Effects} = start_current_request(State),
             {State1, [{reply, {next_fragment, Offset}} | Effects]};
-        _ ->
+        end_of_manifest ->
             %% Iterator exhausted after refresh. Become local.
-            {State0, [{reply, {become_local, current_fragment_offset(State0)}}]}
+            {State0, [{reply, {become_local, current_fragment_offset(State0)}}]};
+        {error, {group_fetch_failed, _Reason}} ->
+            %% A group object could not be fetched while advancing the
+            %% refreshed iterator. Transient S3 error, not end of manifest:
+            %% retry rather than routing to a local tier that may lack the
+            %% data.
+            retry_group_fetch(State0)
     end.
 
 %% @doc Returns the pending read, if any.
@@ -348,9 +354,6 @@ try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
                 {observe, fragment_transition, State3#state.read_size}
                 | Effects
             ]};
-        {become_local, State1} ->
-            State2 = State1#state{pending = undefined},
-            {State2, [{reply, {become_local, current_fragment_offset(State1)}}]};
         {await, State1} ->
             State2 = adjust_read_size(miss, State1),
             {State3, Effects} = maybe_start_requests(State2),
@@ -363,11 +366,19 @@ try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
                 {ok, NotFoundOffset} ->
                     {State1, [{refresh_iterator, NotFoundOffset}]};
                 end_of_manifest ->
-                    {State1, [{refresh_iterator, current_fragment_offset(State1)}]}
+                    {State1, [{refresh_iterator, current_fragment_offset(State1)}]};
+                group_fetch_failed ->
+                    %% Probing the next entry hit a transient group fetch
+                    %% error. Retry rather than becoming local.
+                    retry_group_fetch(State1)
             end;
         {refresh_iterator, State1} ->
             %% Iterator exhausted. Refresh past current fragment.
-            {State1, [{refresh_iterator, current_fragment_offset(State1)}]}
+            {State1, [{refresh_iterator, current_fragment_offset(State1)}]};
+        {group_fetch_failed, State1} ->
+            %% A group fetch failed transiently while advancing. Retry rather
+            %% than becoming local.
+            retry_group_fetch(State1)
     end.
 
 %% ------------------------------------------------------------------
@@ -430,9 +441,25 @@ try_fragment_transition(
             {await, State};
         end_of_manifest ->
             {refresh_iterator, State};
-        {error, _} ->
-            {become_local, State#state{pending = undefined}}
+        {error, {group_fetch_failed, _Reason}} ->
+            %% A group object referenced by the manifest could not be fetched.
+            %% This is a transient S3 error, not the end of the manifest (a
+            %% group deleted by retention surfaces as `not_found`, which the
+            %% iterator skips). The group is part of the remote tier we are
+            %% reading, so becoming local here would risk serving missing or
+            %% wrong data (Tier overlap). Retry instead.
+            {group_fetch_failed, State}
     end.
+
+%% A group object could not be fetched (a transient S3 error). Keep the pending
+%% read and retry with backoff rather than routing the consumer to the local
+%% tier. The pending-read deadline bounds the loop and surfaces
+%% `{error, timeout}` if S3 stays unavailable.
+retry_group_fetch(
+    #state{cfg = #cfg{max_retry_delay_ms = MaxDelay}, retry_delay = RetryDelay} = State
+) ->
+    NextDelay = min(RetryDelay * 2, MaxDelay),
+    {State#state{retry_delay = NextDelay, requests_in_flight = #{}}, [{set_timer, RetryDelay}]}.
 
 %% ------------------------------------------------------------------
 %% Internal: fragment navigation
@@ -457,7 +484,8 @@ try_fragment_transition(
 next_fragment_offset(#state{iterator = Iterator}) ->
     case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
         {ok, #fragment_ref{offset = Offset}, _} -> {ok, Offset};
-        _ -> end_of_manifest
+        end_of_manifest -> end_of_manifest;
+        {error, {group_fetch_failed, _}} -> group_fetch_failed
     end.
 
 goto_next_fragment(

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -50,7 +50,11 @@ all() ->
         %% pool_busy backoff (separate from the network-error backoff)
         pool_busy_backoff_capped_at_500,
         pool_busy_delay_resets_on_data,
-        pool_busy_backoff_independent_of_network_errors
+        pool_busy_backoff_independent_of_network_errors,
+        %% Transient group fetch errors must retry, not become local (F3)
+        group_fetch_failure_retries_not_become_local,
+        group_fetch_failure_on_refreshed_iterator_retries,
+        group_fetch_failure_backs_off_and_retries
     ].
 
 init_per_suite(Config) ->
@@ -99,6 +103,35 @@ build_manifest(Entries) ->
         next_offset = element(1, lists:last(Entries)) + 100,
         entries = EntriesBin
     }.
+
+%% Build an iterator whose manifest is the given fragment entries followed by a
+%% group entry, and whose group fetch fails transiently. After init advances
+%% past the first fragment the iterator points at the group, so the next call to
+%% `next/1` descends into it and returns `{error, {group_fetch_failed, _}}`.
+mock_iterator_failing_group(FragEntries, {GroupOffset, _, GroupUid}) ->
+    FragBin = lists:foldl(
+        fun({Offset, Size, Uid}, Acc) ->
+            E = ?ENTRY(Offset, 0, 0, ?MANIFEST_KIND_FRAGMENT, Size, Uid),
+            <<Acc/binary, E/binary>>
+        end,
+        <<>>,
+        FragEntries
+    ),
+    GroupEntry = ?ENTRY(GroupOffset, 0, 0, ?MANIFEST_KIND_GROUP, 0, GroupUid),
+    FirstOffset = element(1, hd(FragEntries)),
+    Manifest = #manifest{
+        first_offset = FirstOffset,
+        next_offset = GroupOffset + 100,
+        entries = <<FragBin/binary, GroupEntry/binary>>
+    },
+    %% A transient S3 error (not `not_found`, which would mean the group was
+    %% deleted by retention and is skipped).
+    GetGroupFun = fun(_) -> {error, slow_down} end,
+    Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, FirstOffset, GetGroupFun),
+    case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+        {ok, _, It} -> It;
+        _ -> Iterator0
+    end.
 
 frag_ref(Offset, Size, Uid) ->
     #fragment_ref{offset = Offset, uid = Uid, size = Size}.
@@ -804,3 +837,59 @@ pool_busy_backoff_independent_of_network_errors(_Config) ->
         S3, {request_error, make_ref(), 0, slow_down}
     ),
     ok.
+
+group_fetch_failure_retries_not_become_local(_Config) ->
+    %% Advancing past the current fragment, the next entry is a group object
+    %% whose fetch fails transiently. The core must retry (set_timer), not route
+    %% the consumer to the local tier: the group is part of the remote tier
+    %% being read, so becoming local could serve missing or wrong data (F3,
+    %% Tier overlap).
+    FragRef = frag_ref(0, 100, 42),
+    Iterator = mock_iterator_failing_group([{0, 100, 42}], {100, 0, 99}),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% Fill the current fragment buffer.
+    Data = binary:copy(<<0>>, 100),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% Read past the end → fragment transition → group fetch fails.
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 164, 50, chunk_boundary}
+    ),
+    ?assertMatch([{set_timer, _}], Effects),
+    ?assertEqual([], [E || {reply, {become_local, _}} = E <- Effects]).
+
+group_fetch_failure_on_refreshed_iterator_retries(_Config) ->
+    %% After a refresh, advancing the refreshed iterator hits a transient group
+    %% fetch error. Retry rather than becoming local. Without the fix the
+    %% `{iterator_refreshed, _}` handler collapsed any non-{ok} result to
+    %% become_local.
+    FragRef = frag_ref(0, 100, 42),
+    Iterator = mock_iterator([{0, 100, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    %% A read is pending (the situation in which a refresh is requested).
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {read, 64, 50, chunk_boundary}),
+    %% The shell feeds back a refreshed iterator whose group fetch fails.
+    Refreshed = mock_iterator_failing_group([{0, 100, 42}], {100, 0, 99}),
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {iterator_refreshed, Refreshed}
+    ),
+    ?assertMatch([{set_timer, _}], Effects),
+    ?assertEqual([], [E || {reply, {become_local, _}} = E <- Effects]).
+
+group_fetch_failure_backs_off_and_retries(_Config) ->
+    %% A persistently-failing group fetch backs off exponentially and keeps
+    %% re-attempting the fetch (the retry re-enters the transition and calls the
+    %% iterator again), rather than giving up to local. The read deadline, not a
+    %% local fallback, bounds the loop.
+    FragRef = frag_ref(0, 100, 42),
+    Iterator = mock_iterator_failing_group([{0, 100, 42}], {100, 0, 99}),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+    Data = binary:copy(<<0>>, 100),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    %% First transition: group fetch fails → retry at the minimum delay.
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(S1, {read, 164, 50, chunk_boundary}),
+    [{set_timer, D1}] = [E || {set_timer, _} = E <- E1],
+    %% The retry re-attempts the fetch (still failing) → retry at a larger delay.
+    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(S2, retry),
+    [{set_timer, D2}] = [E || {set_timer, _} = E <- E2],
+    ?assert(D2 > D1),
+    ?assertEqual([], [E || {reply, {become_local, _}} = E <- E2]).


### PR DESCRIPTION
On the remote read path, advancing the fragment iterator can descend into a group object, which is fetched synchronously from S3. The iterator already distinguishes a transient fetch error (`{group_fetch_failed, _}`) from a group deleted by retention (`not_found`, which it skips) and from the genuine end of the manifest (`end_of_manifest`). The core ignored that distinction: three sites collapsed `{error, {group_fetch_failed, _}}` to `become_local` (or to `end_of_manifest`, which then becomes local).

That is a Tier overlap violation. The group is part of the remote tier the consumer is reading, so a transient S3 error must not route the consumer to the local tier, which may have already trimmed that range. The fallback is silent: the consumer reads missing or wrong data with no error.

Route `{group_fetch_failed, _}` to a backoff retry instead, at all three sites:

- the forward fragment transition (`try_fragment_transition`)
- probing the next entry after a 404 (`next_fragment_offset`)
- advancing a refreshed iterator (`step({iterator_refreshed, _})`)

The retry keeps the pending read, so the existing pending-read deadline bounds the loop and surfaces `{error, timeout}` if S3 stays unavailable, rather than an unbounded stall or a silent local fallback. With the group-fetch error no longer producing `become_local` from `try_serve`, that branch becomes dead and is removed; `become_local` now comes only from a genuinely exhausted manifest.

Add core tests for the transition and refreshed-iterator sites and for the backoff-and-re-attempt behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
