### PR TITLE
Document the retention-versus-upload durability model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,7 +213,17 @@ The plugin manages two retention domains.
 
 The `{'fun', ...}` retention spec deletes local segments whose data has been fully uploaded to S3. This is what makes local disk a sliding window over the full stream. It runs on both writer and replica nodes, triggered when the manifest's `next_offset` advances.
 
-The user's configured retention (max-bytes, max-age) runs independently alongside the plugin's spec. If user retention deletes segments the plugin has not uploaded, the remote tier has a gap. The replica reader accepts the gap and jumps forward.
+The user's configured retention (max-bytes, max-age) runs independently alongside the plugin's spec. If user retention deletes segments the plugin has not uploaded, the remote tier has a gap. The replica reader accepts the gap and jumps forward, as described next.
+
+### Durability versus the local retention bound
+
+The user's retention bound (`max-length-bytes`, `max-age`) is a hard limit on local resources. Tiering to S3 is asynchronous and best-effort, and the plugin never extends local retention to wait for an upload to become durable. The bound always wins. This is a deliberate prioritisation: if an S3 outage could pin segments locally until they were durable, the local log would grow without bound for the duration of the outage, defeating the very limit the user set and risking a full disk, which turns an object-store availability problem into a broker availability problem. A bounded loss of the un-uploaded tail is preferable to an unbounded local resource leak. This is also continuous with the no-tiering contract, where data simply ages out at the bound: tiering extends effective retention cheaply, it does not promise durability in S3 regardless of upload progress.
+
+The consequence is a durability window. A record reaches S3 only if its fragment is uploaded before local retention trims the segment backing it. The safety margin is the size of the local retention window against upload throughput. If the object store is unavailable, or uploads simply cannot keep up with ingress, for longer than the local window can buffer, the un-uploaded tail is lost from both tiers. An operator who needs to survive an outage of a given length must size the local window to cover it at the expected ingress rate.
+
+When user retention trims past the manifest's `next_offset`, the segment backing the next fragment to upload is gone from both tiers, so no upload retry can ever make that offset durable. The replica reader recovers by discarding the remote manifest and resuming from the local log's first offset, accepting the lost range, rather than stalling on the missing segment forever. This recovery runs when the data reader is opened (at reader init, and after a re-resolution) and on the upload path when a fragment's source segment has been trimmed mid-stream (issue #225). It is observable through the `local_log_ahead_recoveries` counter and a warning naming the discarded range. Because the manifest must stay contiguous, the recovery also discards the small durable prefix below the trimmed range; keeping it would require a manifest with a hole, which the read path and the Coverage invariant forbid. The manifest mutation this performs is the `reset` operation and its safety is stated as the Reset safety invariant in [invariants.md](./invariants.md).
+
+Two alternatives were considered and rejected. Holding segments past the bound until they are durable reintroduces the unbounded local growth the bound exists to prevent. Applying back-pressure to producers when uploads fall behind couples producer availability to object-store availability, which for a streaming workload is usually worse than a bounded gap.
 
 ### Remote retention
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -13,7 +13,9 @@ A manifest `M` describes the remote tier:
 - A fragment `x` carries an offset interval `I(x) = [lo(x), hi(x))`, a byte size `size(x) ≥ 0`, and a timestamp span `[t₀(x), t₁(x)]`. A group's interval is the union of its descendants'.
 - `Frag(M) ⊆ Obj(M)` is the set of fragments, and `Cov(M) = ⋃_{x ∈ Frag(M)} I(x)` is the covered offset set.
 
-States evolve as `M₀, M₁, …` under four operations: append (upload), rebalance, retention, and replication. Unsubscripted symbols denote the current state.
+States evolve as `M₀, M₁, …` under five operations: append (upload), rebalance, retention, replication, and reset (local-log-ahead recovery, see [Recovery](#recovery)). Unsubscripted symbols denote the current state.
+
+`f_local` denotes the first offset of the local log, the floor below which the local log has been trimmed. The local segments cover `[f_local, T)`.
 
 ## Durability
 
@@ -56,6 +58,14 @@ Retention is the only operation that removes data, and it removes only a prefix.
 | Invariant | Statement | Where |
 |---|---|---|
 | Replica prefix | A replica's applied edits are always a prefix `(ε₁, …, ε_j)` of the writer's edit sequence, and its manifest equals `fold(apply, M₀, (ε₁, …, ε_j))`. A sequence gap forces a re-sync rather than an out-of-order apply. Modeled in [`tla/manifest-replication/`](../tla/manifest-replication/). | [manifest.md](./manifest.md) (Manifest edit replication) |
+
+## Recovery
+
+Append, rebalance, and retention keep the remote tier a contiguous extension below the local log. None of them handles the local log being trimmed past the tier: when user retention deletes segments faster than they upload, the local floor `f_local` rises above the seam `n`, and the offsets `[n, f_local)` are durable in neither tier and can never be uploaded. The reset operation recovers from this. The local retention bound is authoritative and is never extended to wait for upload, so reset accepts the loss rather than stalling (see [architecture.md](./architecture.md), Durability versus the local retention bound).
+
+| Invariant | Statement | Where |
+|---|---|---|
+| Reset safety | When `f_local > n`, the writer discards `M` and installs the empty manifest at the floor: `f := n := f_local` and `Frag := ∅`. Coverage and Durability hold vacuously, since `Cov = ∅ = [f, n)`; the step advances `n` over `[n, f_local)` only while emptying coverage, so it never claims durability it lacks. This is the inverse of the #206 hole, which advanced `n` while claiming coverage. `f` and `n` are non-decreasing, and the seam is restored at `f_local`, so Tier overlap holds again with the remote tier empty and the local segments covering `[f_local, T)`. The discarded range `[f, f_local)` is lost by design: it is the un-uploaded tail together with the now-disconnected durable prefix, which cannot be kept without a hole in `M`. | [architecture.md](./architecture.md) (Durability versus the local retention bound) |
 
 ## Read path
 

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1220,6 +1220,16 @@ resolve_and_start(#state{cfg = #cfg{stream = StreamId}} = State0) ->
             State0
     end.
 
+%% Build the empty manifest the local-log-ahead recovery (the `reset` operation)
+%% installs at the local floor. first_offset = next_offset = LocalFirst so an
+%% empty manifest (Frag = empty) carries f = n, as the Coverage and Accounting
+%% invariants require, and so first_offset only moves forward: it feeds the
+%% first_offset counter and GC. See the Reset safety invariant in
+%% docs/invariants.md.
+-spec reset_manifest(osiris:offset(), rabbitmq_stream_s3_db:revision()) -> #manifest{}.
+reset_manifest(LocalFirst, Revision) ->
+    #manifest{first_offset = LocalFirst, next_offset = LocalFirst, revision = Revision}.
+
 -spec parse_manifest_root(binary()) -> #manifest{}.
 parse_manifest_root(?MANIFEST(FirstOffset, NextOffset, FirstTs, FirstLastTs, TotalSize, Entries)) ->
     #manifest{
@@ -1296,9 +1306,7 @@ start_reading0(
             ),
             inc(State1, ?C_LOCAL_LOG_AHEAD_RECOVERIES, 1),
             delete_manifest_objects(StreamId, Manifest),
-            FreshManifest = #manifest{
-                next_offset = LocalFirst, revision = Manifest#manifest.revision
-            },
+            FreshManifest = reset_manifest(LocalFirst, Manifest#manifest.revision),
             {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(
                 FreshManifest, State1#state.config
             ),
@@ -1876,5 +1884,17 @@ stale_transfer_result_dropped_test() ->
 close_log_without_open_log_is_noop_test() ->
     State = #state{log = undefined},
     ?assertEqual(State, close_log(State)).
+
+%% The reset installs an empty manifest carrying f = n = the local floor, so an
+%% empty manifest satisfies Coverage and Accounting and first_offset only moves
+%% forward (Reset safety invariant).
+reset_manifest_carries_floor_as_first_and_next_test() ->
+    LocalFirst = 149324677,
+    M = reset_manifest(LocalFirst, 7),
+    ?assertEqual(LocalFirst, M#manifest.first_offset),
+    ?assertEqual(LocalFirst, M#manifest.next_offset),
+    ?assertEqual(M#manifest.first_offset, M#manifest.next_offset),
+    ?assertEqual(<<>>, M#manifest.entries),
+    ?assertEqual(7, M#manifest.revision).
 
 -endif.


### PR DESCRIPTION
Make explicit a design decision that was only implied by a one-line comment: the user's local retention bound (max-length-bytes, max-age) is a hard limit on local resources, and tiering to S3 never extends local retention to wait for an upload to become durable. The bound always wins. If user retention trims a segment before its fragment is uploaded, that range is lost from both tiers rather than the local log growing without bound during an object-store outage.

architecture.md gains a "Durability versus the local retention bound" section covering the principle, the resulting durability window (a record reaches S3 only if uploaded before its segment is trimmed; size the local window to cover expected outages), the discard-and-resume recovery, and the two rejected alternatives (holding segments past the bound; producer back-pressure).

invariants.md names the manifest reset (local-log-ahead recovery) as a fifth operation alongside append, rebalance, retention, and replication, and adds the Reset safety invariant: discarding the manifest and reinstalling it empty at the local floor preserves Coverage and Durability vacuously (it advances next_offset only while emptying coverage, the inverse of the issue #206 hole), keeps first_offset and next_offset non-decreasing, and restores the local/remote seam.

For the invariant to hold literally, the reset must install f = n = local floor. The recovery left first_offset at its record default of 0, so an empty manifest carried f = 0, n = local floor, violating the Coverage and Accounting rule that an empty manifest has f = n. It was benign only because get_range short-circuits an empty manifest. Extract reset_manifest/2, which sets first_offset = next_offset = the local floor (also fixing the GC moduledoc's "first_offset only moves forward" premise), and cover it with an inline test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
