### PR TITLE
Reclaim orphaned fragments via GC after a manifest reset

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -504,6 +504,13 @@ rabbitmq-streams stream_s3_gc --formatter json
 rabbitmq-streams stream_s3_gc --mode delete
 ```
 
+Pass a stream name to restrict GC to a single stream, which lists only that stream's S3 prefix instead of sweeping every stream:
+
+```bash
+rabbitmq-streams stream_s3_gc my-stream --vhost /
+rabbitmq-streams stream_s3_gc my-stream --mode delete
+```
+
 See [Garbage collection](#garbage-collection) below for the mechanism and safety guarantees.
 
 ### Inspect a replica reader

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3GcCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3GcCommand.erl
@@ -29,17 +29,24 @@ help_section() ->
 
 validate([], _Opts) ->
     ok;
+validate([_Stream], _Opts) ->
+    ok;
 validate(_, _Opts) ->
     {validation_failure, too_many_args}.
 
 merge_defaults(Args, Opts) ->
-    {Args, maps:merge(#{mode => <<"dry_run">>}, Opts)}.
+    {Args, maps:merge(#{mode => <<"dry_run">>, vhost => <<"/">>}, Opts)}.
 
 usage() ->
-    <<"stream_s3_gc [--mode <dry_run|delete>]">>.
+    <<"stream_s3_gc [<stream>] [--vhost <vhost>] [--mode <dry_run|delete>]">>.
 
 usage_additional() ->
     [
+        [
+            <<"<stream>">>,
+            <<"Restrict GC to a single stream. When omitted, every stream is swept.">>
+        ],
+        [<<"--vhost <vhost>">>, <<"The virtual host of the stream.">>],
         [
             <<"--mode <mode>">>,
             <<"dry_run (default) to report only, delete to remove dangling objects.">>
@@ -54,11 +61,27 @@ run([], #{node := NodeName, mode := ModeBin, timeout := Timeout}) ->
         run,
         [#{mode => Mode}],
         Timeout
+    );
+run([Stream], #{node := NodeName, vhost := VHost, mode := ModeBin, timeout := Timeout}) ->
+    Mode = parse_mode(ModeBin),
+    rabbit_misc:rpc_call(
+        NodeName,
+        rabbitmq_stream_s3_gc,
+        run_stream,
+        [VHost, Stream, #{mode => Mode}],
+        Timeout
     ).
 
 banner([], #{mode := Mode}) ->
     erlang:iolist_to_binary(
         io_lib:format("Running tiered storage GC (mode=~ts) ...", [Mode])
+    );
+banner([Stream], #{mode := Mode, vhost := VHost}) ->
+    erlang:iolist_to_binary(
+        io_lib:format(
+            "Running tiered storage GC for stream ~ts in vhost ~ts (mode=~ts) ...",
+            [Stream, VHost, Mode]
+        )
     ).
 
 output({ok, Findings}, #{formatter := <<"json">>}) ->
@@ -67,6 +90,8 @@ output({ok, Findings}, _Opts) ->
     Lines = [format_finding(F) || F <- Findings],
     Summary = io_lib:format("~b dangling object(s) found.", [length(Findings)]),
     {ok, erlang:iolist_to_binary(lists:join($\n, Lines ++ [Summary]))};
+output({error, {not_found, _}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(), <<"Stream not found.">>};
 output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -174,9 +174,17 @@ fragment_key(StreamId, Offset, Uid) when
 stream_data_key(StreamId, Filename) when is_binary(StreamId) andalso is_binary(Filename) ->
     <<"rabbitmq/stream/", StreamId/binary, "/data/", Filename/binary>>.
 
+-doc """
+Returns the S3 key prefix under which all of a stream's objects live.
+
+Includes the trailing slash so the prefix ends on a path boundary. This is
+required for correctness: stream IDs derive from user-controlled vhost and
+queue names, so one stream ID can be a textual prefix of another. Without the
+delimiter, a LIST on this prefix could match a sibling stream's objects.
+""".
 -spec stream_prefix(stream_id()) -> key().
 stream_prefix(StreamId) when is_binary(StreamId) ->
-    <<"rabbitmq/stream/", StreamId/binary>>.
+    <<"rabbitmq/stream/", StreamId/binary, "/">>.
 
 -doc "Extracts the first offset from a segment filename".
 -spec segment_file_offset(file:filename_all()) -> osiris:offset().

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -23,7 +23,7 @@ signal without Khepri restructuring).
 -include("include/logging.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([run/0, run/1, run_stream/2]).
+-export([run/0, run/1, run_stream/2, run_stream/3]).
 
 -type mode() :: dry_run | delete.
 -type config() :: #{mode => mode()}.
@@ -70,6 +70,22 @@ run_stream(StreamId, Config) when is_binary(StreamId), is_map(Config) ->
             {ok, Findings};
         skip ->
             {ok, []}
+    end.
+
+-doc """
+Run garbage collection scoped to a single stream identified by its vhost and
+queue name. Resolves the stream id, then delegates to `run_stream/2`.
+""".
+-spec run_stream(rabbit_types:vhost(), binary(), config()) ->
+    {ok, [finding()]} | {error, {not_found, binary()}}.
+run_stream(VHost, QueueName, Config) when
+    is_binary(VHost), is_binary(QueueName), is_map(Config)
+->
+    case rabbitmq_stream_s3_replica_reader:resolve_stream_id(VHost, QueueName) of
+        {ok, StreamId} ->
+            run_stream(StreamId, Config);
+        {error, _} = Err ->
+            Err
     end.
 
 make_handler(dry_run) ->

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -23,7 +23,7 @@ signal without Khepri restructuring).
 -include("include/logging.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([run/0, run/1]).
+-export([run/0, run/1, run_stream/2]).
 
 -type mode() :: dry_run | delete.
 -type config() :: #{mode => mode()}.
@@ -48,6 +48,29 @@ run(Config) when is_map(Config) ->
     Findings = list_and_classify(<<"rabbitmq/stream/">>, start, Lookup, Fun, []),
     ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
     {ok, Findings}.
+
+-doc """
+Run garbage collection scoped to a single stream. Only lists objects under the
+stream's S3 prefix and classifies them against the stream's current epoch and
+first_offset. Used by the replica reader after a manifest reset to reclaim
+orphaned fragments without a full cross-stream sweep.
+""".
+-spec run_stream(stream_id(), config()) -> {ok, [finding()]}.
+run_stream(StreamId, Config) when is_binary(StreamId), is_map(Config) ->
+    Mode = maps:get(mode, Config, dry_run),
+    case build_stream_lookup(StreamId) of
+        {ok, Lookup} ->
+            Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
+            Fun = make_handler(Mode),
+            Findings = list_and_classify(Prefix, start, Lookup, Fun, []),
+            ?LOG_INFO(
+                "GC ~ts for stream ~ts complete: ~b dangling object(s)",
+                [Mode, StreamId, length(Findings)]
+            ),
+            {ok, Findings};
+        skip ->
+            {ok, []}
+    end.
 
 make_handler(dry_run) ->
     fun(Finding, Acc) ->
@@ -78,6 +101,26 @@ build_lookup(Streams) ->
         #{},
         Streams
     ).
+
+build_stream_lookup(StreamId) ->
+    case rabbitmq_stream_s3_db:get(StreamId) of
+        {ok, #{epoch := Epoch}} ->
+            %% Read first_offset from the manifest record directly rather than
+            %% via get_range/1, which reports `empty` whenever the entries array
+            %% is empty. A manifest reset (the caller of run_stream/2) installs
+            %% exactly such an empty manifest with first_offset at the local
+            %% floor, and that floor is precisely what the orphaned fragments
+            %% sit below. Using get_range/1 here would skip the stream and
+            %% reclaim nothing.
+            case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+                #manifest{first_offset = FirstOffset} ->
+                    {ok, #{StreamId => #{epoch => Epoch, first_offset => FirstOffset}}};
+                undefined ->
+                    skip
+            end;
+        {error, _} ->
+            skip
+    end.
 
 list_and_classify(_Prefix, done, _Lookup, _Fun, Acc) ->
     lists:reverse(Acc);

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -21,6 +21,7 @@ returned by the functional core module.
 -export([evaluate_local_retention/1, evaluate_local_retention/2]).
 -export([evaluate_remote_retention/1, evaluate_remote_retention/2]).
 -export([force_fragment_cut/1, force_fragment_cut/2]).
+-export([resolve_stream_id/2]).
 -export([identity_formatter/1]).
 -export([counter_fields/0, init_counters/0]).
 -export([
@@ -728,11 +729,22 @@ call(StreamId, Msg) ->
     end.
 
 call(VHost, QueueName, Msg) ->
+    case resolve_stream_id(VHost, QueueName) of
+        {ok, StreamId} ->
+            call(StreamId, Msg);
+        {error, _} = Err ->
+            Err
+    end.
+
+-doc "Resolve a vhost and queue name to the internal stream id.".
+-spec resolve_stream_id(rabbit_types:vhost(), binary()) ->
+    {ok, stream_id()} | {error, {not_found, binary()}}.
+resolve_stream_id(VHost, QueueName) ->
     QName = rabbit_misc:r(VHost, queue, QueueName),
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q} ->
             #{name := StreamId} = amqqueue:get_type_state(Q),
-            call(iolist_to_binary(StreamId), Msg);
+            {ok, iolist_to_binary(StreamId)};
         {error, not_found} ->
             {error, {not_found, QueueName}}
     end.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -763,19 +763,10 @@ register_replica(
             State#state{replicas = Replicas#{Node => MonRef}}
     end.
 
-delete_manifest_objects(StreamId, Manifest) ->
+gc_stream_async(StreamId) ->
     spawn(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
-        GetGroupFun = fun(GroupRef) ->
-            Key = rabbitmq_stream_s3:group_key(StreamId, GroupRef),
-            case rabbitmq_stream_s3_api:get(Key) of
-                {ok, Data} -> {ok, Data};
-                {error, _} = Err -> Err
-            end
-        end,
-        Refs = rabbitmq_stream_s3_fragment_iterator:all_refs(Manifest, GetGroupFun),
-        Keys = [rabbitmq_stream_s3:ref_key(StreamId, Ref) || Ref <- Refs],
-        rabbitmq_stream_s3_reaper:delete_objects(StreamId, Keys)
+        rabbitmq_stream_s3_gc:run_stream(StreamId, #{mode => delete})
     end),
     ok.
 
@@ -1305,12 +1296,12 @@ start_reading0(
                 [StreamId, LocalFirst, StartOffset]
             ),
             inc(State1, ?C_LOCAL_LOG_AHEAD_RECOVERIES, 1),
-            delete_manifest_objects(StreamId, Manifest),
             FreshManifest = reset_manifest(LocalFirst, Manifest#manifest.revision),
             {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(
                 FreshManifest, State1#state.config
             ),
             ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
+            gc_stream_async(StreamId),
             start_reading(State1#state{core = Core1});
         {error, Reason} ->
             ?LOG_WARNING(


### PR DESCRIPTION
Fixes #230.

## Problem

When local retention trims a segment before its fragment is uploaded, the replica reader discards the remote manifest and restarts from the local log first offset (the #225 recovery, on `main` via #228). Fragments already uploaded below the new floor are left in S3 as orphans.

The reset previously called `delete_manifest_objects/2`, which only removed objects referenced by the in-memory manifest being discarded (`all_refs`). Under sustained recovery that manifest has usually already collapsed to a near-empty root by reset time, so fragments uploaded and applied between resets are never enumerated and leak. In the prompting run this left 187 fragments (~12 GiB) in S3.

## Fix

Route reclamation through the garbage collector instead of the manifest-walk, per the direction in #230: GC's epoch and `first_offset` checks are the safe signal, especially on a deposed writer.

- Add `rabbitmq_stream_s3_gc:run_stream/2`: lists only the stream's own S3 prefix and deletes any data object below the manifest `first_offset`, reusing the collector's existing `below_first_offset` / `stale_epoch` classification
- The replica reader spawns it in `delete` mode **after** installing the reset manifest, so the collector observes the new (advanced) floor
- `build_stream_lookup/1` reads `first_offset` from the manifest record directly rather than via `get_range/1`. The reset installs an *empty* manifest, and `get_range/1` reports `empty` whenever the entries array is empty — which would skip the stream and reclaim nothing in exactly the case this targets

## Correctness hardening: `stream_prefix/1`

`stream_prefix/1` now includes the trailing slash. Stream IDs derive from user-controlled vhost and queue names, so one stream ID can be a textual prefix of another; without the delimiter a LIST on the prefix could match a sibling stream's objects. This also hardens the reaper's stream-deletion listing, which already used `stream_prefix/1` without the delimiter.

Stream IDs cannot contain a slash (they are `base64uri`-encoded, and `/` is not in the allowed set), so no double-slash case arises.

## Safety

GC only deletes objects strictly below `first_offset`, which is monotonic (a stale read can only be lower, never higher), so deletion is always conservative. A repeated reset re-runs GC; double-deletes of an already-removed S3 key are no-ops. The lookup degrades to a no-op (`skip`) if Khepri or the manifest replica is unavailable.

## Validation

- 96 eunit tests pass
- `replica_reader_SUITE`: 26 ok, 0 failed — `local_ahead_discards_manifest` is the direct end-to-end test for this path (drives a real discard, the reset installs an empty manifest, and GC reclaims the old fragments through Khepri + the manifest replica)
- `broker_SUITE`: 6 ok, 0 failed — exercises the `stream_prefix/1` change via the reaper's `stream_deletion_cleans_remote_tier` and the listing helpers
- Clean compile, no warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.