### PR TITLE
Guard the post-reset GC sweep against a deposed writer

### DIFF
--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -28,6 +28,10 @@ writer cannot make progress anymore.
 
 -define(PATH(StreamId), ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId])).
 -define(STREAM_QUEUE_DELETION_TRIGGER_ID, rabbitmq_stream_s3_db_sq_deletion).
+%% Bounds a consistent read so it cannot block indefinitely waiting for a quorum
+%% that will not form (for example on a minority partition); timing out there
+%% surfaces as an error, which a fail-closed caller treats as "skip".
+-define(CONSISTENT_READ_TIMEOUT_MS, 30_000).
 
 -doc """
 Version number of a manifest object.
@@ -46,7 +50,7 @@ Zero indicates that the manifest has not been created yet.
 
 -export([setup/0]).
 
--export([get/1, list/0, count/0, put/5, queue_path/1]).
+-export([get/1, get_consistent/1, list/0, count/0, put/5, queue_path/1]).
 
 -define(C_SPROC_TRIGGERS, 1).
 -define(C_GETS, 2).
@@ -114,12 +118,29 @@ handle_queue_deletion(#{path := ?PATH(StreamId)}) ->
     %% be a node of a replica either.
     ok = rabbitmq_stream_s3_reaper:delete_stream(StreamId).
 
--doc "Gets the latest-known manifest root UID and revision.".
+-doc "Gets the latest-known manifest root UID and revision with a low-latency local read.".
 -spec get(stream_id()) -> {ok, entry()} | {error, not_found | any()}.
 get(StreamId) ->
+    do_get(StreamId, #{}).
+
+-doc """
+Gets the latest-known manifest root UID and revision with a strongly consistent,
+quorum-requiring read.
+
+Unlike get/1, a low-latency local read that can return stale state, this fails
+when the node cannot reach a quorum (for example on a minority partition).
+Callers that must fail closed when this node is not the committed authority rely
+on that. Bounded by a timeout so it cannot block indefinitely on a quorum that
+will not form.
+""".
+-spec get_consistent(stream_id()) -> {ok, entry()} | {error, not_found | any()}.
+get_consistent(StreamId) ->
+    do_get(StreamId, #{favor => consistency, timeout => ?CONSISTENT_READ_TIMEOUT_MS}).
+
+do_get(StreamId, Options) ->
     counters:add(counter(), ?C_GETS, 1),
     Path = ?PATH(StreamId),
-    case rabbit_khepri:adv_get(Path) of
+    case rabbit_khepri:adv_get(Path, Options) of
         {ok, #{Path := #{data := {Uid, Epoch}, payload_version := Revision}}} ->
             {ok, #{uid => Uid, epoch => Epoch, revision => Revision}};
         {error, ?khepri_error(node_not_found, _Props)} ->

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -26,7 +26,7 @@ signal without Khepri restructuring).
 -export([run/0, run/1, run_stream/2, run_stream/3]).
 
 -type mode() :: dry_run | delete.
--type config() :: #{mode => mode()}.
+-type config() :: #{mode => mode(), writer_epoch => non_neg_integer()}.
 -type reason() :: below_first_offset | stale_epoch.
 -type finding() :: #{stream_id := stream_id(), key := rabbitmq_stream_s3:key(), reason := reason()}.
 
@@ -58,7 +58,7 @@ orphaned fragments without a full cross-stream sweep.
 -spec run_stream(stream_id(), config()) -> {ok, [finding()]}.
 run_stream(StreamId, Config) when is_binary(StreamId), is_map(Config) ->
     Mode = maps:get(mode, Config, dry_run),
-    case build_stream_lookup(StreamId) of
+    case build_stream_lookup(StreamId, Config) of
         {ok, Lookup} ->
             Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
             Fun = make_handler(Mode),
@@ -118,25 +118,60 @@ build_lookup(Streams) ->
         Streams
     ).
 
-build_stream_lookup(StreamId) ->
-    case rabbitmq_stream_s3_db:get(StreamId) of
-        {ok, #{epoch := Epoch}} ->
-            %% Read first_offset from the manifest record directly rather than
-            %% via get_range/1, which reports `empty` whenever the entries array
-            %% is empty. A manifest reset (the caller of run_stream/2) installs
-            %% exactly such an empty manifest with first_offset at the local
-            %% floor, and that floor is precisely what the orphaned fragments
-            %% sit below. Using get_range/1 here would skip the stream and
-            %% reclaim nothing.
-            case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                #manifest{first_offset = FirstOffset} ->
-                    {ok, #{StreamId => #{epoch => Epoch, first_offset => FirstOffset}}};
-                undefined ->
+build_stream_lookup(StreamId, Config) ->
+    %% Read the committed epoch with a strongly consistent (quorum-requiring)
+    %% read, not the default low-latency local read. The sweep deletes data
+    %% objects below a floor taken from the local just-reset manifest, which sits
+    %% above the committed floor. A deposed writer that read stale local state
+    %% would delete a successor's live fragments in that gap. A consistent read
+    %% makes a deposed minority writer, which cannot reach a quorum, fail closed
+    %% and skip. When the caller supplies its own writer epoch (the reset path),
+    %% additionally require the committed epoch to equal it, so a deposed writer
+    %% that can still reach a quorum also skips.
+    case rabbitmq_stream_s3_db:get_consistent(StreamId) of
+        {ok, #{epoch := CommittedEpoch}} ->
+            case epoch_permits_sweep(CommittedEpoch, Config) of
+                true ->
+                    %% Read first_offset from the manifest record directly rather
+                    %% than via get_range/1, which reports `empty` whenever the
+                    %% entries array is empty. A manifest reset (the caller of
+                    %% run_stream/2) installs exactly such an empty manifest with
+                    %% first_offset at the local floor, and that floor is precisely
+                    %% what the orphaned fragments sit below. Using get_range/1
+                    %% here would skip the stream and reclaim nothing.
+                    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+                        #manifest{first_offset = FirstOffset} ->
+                            {ok, #{
+                                StreamId => #{epoch => CommittedEpoch, first_offset => FirstOffset}
+                            }};
+                        undefined ->
+                            skip
+                    end;
+                false ->
+                    ?LOG_INFO(
+                        "GC for stream ~ts skipped: writer epoch ~p is behind the "
+                        "committed epoch ~p, this writer has been deposed",
+                        [StreamId, maps:get(writer_epoch, Config, undefined), CommittedEpoch]
+                    ),
                     skip
             end;
-        {error, _} ->
+        {error, Reason} ->
+            ?LOG_INFO(
+                "GC for stream ~ts skipped: could not read committed metadata "
+                "with quorum (~p); not sweeping",
+                [StreamId, Reason]
+            ),
             skip
     end.
+
+%% On the reset path the caller pins its writer epoch, and the sweep is permitted
+%% only when the committed epoch exactly equals it, confirming this writer is the
+%% current committed one and has not been superseded. On the operator CLI path no
+%% writer epoch is pinned, and the consistent read alone is the guard.
+epoch_permits_sweep(CommittedEpoch, #{writer_epoch := WriterEpoch}) ->
+    CommittedEpoch =:= WriterEpoch;
+epoch_permits_sweep(_CommittedEpoch, _Config) ->
+    true.
 
 list_and_classify(_Prefix, done, _Lookup, _Fun, Acc) ->
     lists:reverse(Acc);
@@ -254,6 +289,26 @@ parse_key_group_test() ->
 parse_key_kilo_group_test() ->
     Key = <<"rabbitmq/stream/s/metadata/00000000000000001000.aabbccdd.kgroup">>,
     ?assertEqual({data, <<"s">>, 1000}, parse_key(Key)).
+
+%% The operator CLI path supplies no writer epoch, so the consistent read is the
+%% only guard and the sweep is permitted.
+epoch_permits_sweep_no_writer_epoch_test() ->
+    ?assert(epoch_permits_sweep(7, #{mode => delete})).
+
+%% The reset path pins the writer epoch. The sweep proceeds only when the
+%% committed epoch matches, i.e. this writer is still the committed authority.
+epoch_permits_sweep_matching_epoch_test() ->
+    ?assert(epoch_permits_sweep(7, #{mode => delete, writer_epoch => 7})).
+
+%% A successor has committed a higher epoch: this writer is deposed, skip.
+epoch_permits_sweep_deposed_writer_test() ->
+    ?assertNot(epoch_permits_sweep(8, #{mode => delete, writer_epoch => 7})).
+
+%% A writer that has not yet committed at its own epoch (committed epoch is the
+%% predecessor's) also skips, since below its raised floor could be the
+%% predecessor's committed data.
+epoch_permits_sweep_uncommitted_writer_test() ->
+    ?assertNot(epoch_permits_sweep(6, #{mode => delete, writer_epoch => 7})).
 
 parse_key_mega_group_test() ->
     Key = <<"rabbitmq/stream/s/metadata/00000000000000005000.aabbccdd.mgroup">>,

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -775,10 +775,14 @@ register_replica(
             State#state{replicas = Replicas#{Node => MonRef}}
     end.
 
-gc_stream_async(StreamId) ->
+gc_stream_async(StreamId, WriterEpoch) ->
     spawn(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
-        rabbitmq_stream_s3_gc:run_stream(StreamId, #{mode => delete})
+        %% Pass this writer's epoch so the sweep skips when a consistent read of
+        %% the committed epoch shows this writer has been deposed. Runs in the
+        %% spawned task, not the reader, so the quorum-requiring read cannot stall
+        %% the reader on a partition.
+        rabbitmq_stream_s3_gc:run_stream(StreamId, #{mode => delete, writer_epoch => WriterEpoch})
     end),
     ok.
 
@@ -1278,7 +1282,8 @@ start_reading0(
         cfg = #cfg{
             writer_pid = WriterPid,
             fragment_target_size = TargetSize,
-            stream = StreamId
+            stream = StreamId,
+            epoch = Epoch
         },
         core = Core
     } = State
@@ -1313,7 +1318,7 @@ start_reading0(
                 FreshManifest, State1#state.config
             ),
             ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
-            gc_stream_async(StreamId),
+            gc_stream_async(StreamId, Epoch),
             start_reading(State1#state{core = Core1});
         {error, Reason} ->
             ?LOG_WARNING(


### PR DESCRIPTION
The orphaned-fragment reclamation added after a local-log-ahead reset deletes remote data objects below a floor read from the local just-reset manifest, which sits above the committed floor, and classifies data objects by offset with no epoch gate. A deposed writer on the minority side of a partition keeps running, arms the reset via local retention, and would sweep-delete a successor's live committed fragments in that gap. The lookup read it relied on, `db:get`, is a low-latency local read that succeeds with stale state on a minority rather than failing, so it did not protect against this.

Make the sweep fail closed for a deposed writer:

- add `db:get_consistent/1`, a strongly consistent quorum-requiring read bounded by a timeout, keeping Khepri's read options inside the `db` module; the stream-scoped GC lookup uses it and skips on any error, so a minority writer that cannot reach a quorum does not sweep
- the reset threads the writer's own epoch into the sweep, and the sweep proceeds only when the committed epoch equals it, so a deposed writer that can still reach a quorum also skips. The operator CLI path pins no epoch and relies on the consistent read alone
- the consistent read runs in the spawned GC task, not the reader, so a partition cannot stall the reader

Connects #230

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
