### PR TITLE
Add a helper to ensure stream IDs are converted to binary correctly

### DIFF
--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -72,6 +72,7 @@ efficiently using the `rabbitmq_stream_s3_array` module.
 -export([
     uid/0,
     format_uid/1,
+    ensure_stream_id/1,
     offset_filename/2,
     ref_key/2,
     manifest_key/2,
@@ -91,6 +92,24 @@ efficiently using the `rabbitmq_stream_s3_array` module.
 uid() ->
     <<Uid:32/unsigned>> = crypto:strong_rand_bytes(4),
     Uid.
+
+-doc """
+Converts an `osiris:name()` (binary or string) to a `stream_id()` binary.
+
+In practice, stream names are always binaries by the time they reach this
+plugin (see `rabbit_stream_queue:stream_name/1` which produces a base64url
+binary). This function provides defense-in-depth: if a list were to arrive,
+it handles Unicode correctly rather than silently truncating codepoints > 255
+as `iolist_to_binary/1` would.
+""".
+-spec ensure_stream_id(osiris:name()) -> stream_id().
+ensure_stream_id(Name) when is_binary(Name) ->
+    Name;
+ensure_stream_id(Name) when is_list(Name) ->
+    case unicode:characters_to_binary(Name) of
+        Bin when is_binary(Bin) -> Bin;
+        _ -> error({invalid_stream_name, Name})
+    end.
 
 -doc "Formats a UID as human-readable text".
 -spec format_uid(uid()) -> <<_:64>>.
@@ -227,5 +246,26 @@ fragment_key_offset_test() ->
     ?assertEqual(0, fragment_key_offset(fragment_key(StreamId, 0, 16#deadbeef))),
     ?assertEqual(1234, fragment_key_offset(fragment_key(StreamId, 1234, 16#deadbeef))),
     ok.
+
+ensure_stream_id_binary_passthrough_test() ->
+    %% Binary stream IDs (the normal case) pass through unchanged.
+    ?assertEqual(<<"my-stream">>, ensure_stream_id(<<"my-stream">>)).
+
+ensure_stream_id_ascii_list_test() ->
+    %% ASCII list (Latin-1 subset) converts correctly.
+    ?assertEqual(<<"hello">>, ensure_stream_id("hello")).
+
+ensure_stream_id_unicode_list_test() ->
+    %% Non-ASCII Unicode list: snowman (U+2603).
+    %% This would be silently corrupted by iolist_to_binary/1.
+    ?assertEqual(<<"☃"/utf8>>, ensure_stream_id([16#2603])),
+    %% Pirate flag is a grapheme cluster: U+1F3F4 U+200D U+2620 U+FE0F
+    PirateFlag = [16#1F3F4, 16#200D, 16#2620, 16#FE0F],
+    Expected = unicode:characters_to_binary(PirateFlag),
+    ?assertEqual(Expected, ensure_stream_id(PirateFlag)).
+
+ensure_stream_id_invalid_test() ->
+    %% A list that is not a valid Unicode character list raises.
+    ?assertError({invalid_stream_name, _}, ensure_stream_id([16#D800])).
 
 -endif.

--- a/src/rabbitmq_stream_s3.erl
+++ b/src/rabbitmq_stream_s3.erl
@@ -99,8 +99,8 @@ Converts an `osiris:name()` (binary or string) to a `stream_id()` binary.
 In practice, stream names are always binaries by the time they reach this
 plugin (see `rabbit_stream_queue:stream_name/1` which produces a base64url
 binary). This function provides defense-in-depth: if a list were to arrive,
-it handles Unicode correctly rather than silently truncating codepoints > 255
-as `iolist_to_binary/1` would.
+it handles Unicode correctly rather than crashing with `badarg` on any
+codepoint > 255 as `iolist_to_binary/1` would.
 """.
 -spec ensure_stream_id(osiris:name()) -> stream_id().
 ensure_stream_id(Name) when is_binary(Name) ->

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -34,7 +34,7 @@ Both: appends the local retention function.
 """.
 -spec on_init(writer | acceptor, pid(), osiris_log:config()) -> osiris_log:config().
 on_init(writer, Pid, #{name := Name, dir := Dir, shared := Shared, counter := Counter} = Config) ->
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     RemoteConfig = maps:get(remote_config, Config, #{}),
     Reference = maps:get(reference, Config, undefined),
     Epoch = maps:get(epoch, Config, 0),
@@ -80,7 +80,7 @@ on_init(writer, Pid, #{name := Name, dir := Dir, shared := Shared, counter := Co
     end,
     append_retention(StreamId, Config);
 on_init(acceptor, _Pid, #{name := Name, leader_pid := LeaderPid, counter := Counter} = Config) ->
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     WriterNode = node(LeaderPid),
     gen_server:cast(
         {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
@@ -91,7 +91,7 @@ on_init(acceptor, _Pid, #{name := Name, leader_pid := LeaderPid, counter := Coun
     rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),
     append_retention(StreamId, Config);
 on_init(acceptor, _Pid, #{name := Name, counter := Counter} = Config) ->
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     Shared = maps:get(shared, Config),
     Dir = maps:get(dir, Config),
     rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),
@@ -105,7 +105,7 @@ reader of the new user spec (if one exists locally).
 """.
 -spec on_retention_updated([osiris:retention_spec()], map()) -> [osiris:retention_spec()].
 on_retention_updated(Retention, #{name := Name}) ->
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
         undefined -> ok;
         Pid -> gen_server:cast(Pid, {retention_updated, Retention})
@@ -121,7 +121,7 @@ management UI reports only the local segment window as the message count.
 """.
 -spec on_retention_evaluated(counters:counters_ref(), map()) -> ok.
 on_retention_evaluated(Cnt, #{name := Name}) ->
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     case rabbitmq_stream_s3_manifest_replica:get_range(StreamId) of
         {RemoteFirst, _} ->
             LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
@@ -182,7 +182,7 @@ discover_child(_) ->
 attach_writer(Pid) ->
     #{name := Name, dir := Dir, shared := Shared, reference := Reference} =
         osiris_util:get_reader_context(Pid),
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     %% Seshat registers writer counters under {osiris_writer, Reference}.
     Counter = osiris_counters:fetch({osiris_writer, Reference}),
     #{epoch := Epoch} = osiris_counters:overview({osiris_writer, Reference}),
@@ -218,7 +218,7 @@ attach_writer(Pid) ->
 attach_replica(Pid) ->
     #{name := Name, dir := Dir, shared := Shared, reference := Reference} =
         osiris_util:get_reader_context(Pid),
-    StreamId = iolist_to_binary(Name),
+    StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     %% Seshat registers replica counters under {osiris_replica, Reference}.
     Counter = osiris_counters:fetch({osiris_replica, Reference}),
     rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -744,7 +744,7 @@ resolve_stream_id(VHost, QueueName) ->
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q} ->
             #{name := StreamId} = amqqueue:get_type_state(Q),
-            {ok, iolist_to_binary(StreamId)};
+            {ok, rabbitmq_stream_s3:ensure_stream_id(StreamId)};
         {error, not_found} ->
             {error, {not_found, QueueName}}
     end.


### PR DESCRIPTION
*Issue #, if available:* fixes https://github.com/amazon-mq/rabbitmq-stream-s3/issues/188.

There's an existing doc investigation describing how stream IDs are safe but nothing about Unicode & graphemes. Ulitmately the server ends up limiting down stream IDs to

```
[A-Za-z0-9_-=]
```

So the Unicode changes in this PR are unreachable. But we really ought to have defense-in-depth against any future changes that expand that character class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
