### PR TITLE
Raise content-verification max-length-bytes default to 8 GB

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -49,7 +49,11 @@ cleanup: package
 
 CONTENT_VERIFY_DURATION ?= 300
 CONTENT_VERIFY_PRODUCERS ?= 1
-CONTENT_VERIFY_MAX_LENGTH_BYTES ?= 500000000
+# This must exceed the peak un-uploaded backlog: when the publisher outruns the
+# S3 upload, local retention trims un-uploaded segments once the backlog crosses
+# this bound, which discards confirmed-but-not-yet-uploaded data and makes the
+# replay phase report spurious gaps. See issue #233.
+CONTENT_VERIFY_MAX_LENGTH_BYTES ?= 8000000000
 CONTENT_VERIFY_REPLAY_CONSUMERS ?= 4
 
 content-verification: package


### PR DESCRIPTION
## Summary

`make content-verification` ran with `--max-length-bytes 500000000` (500 MB), a single unthrottled producer, and 256-byte messages. Under that configuration the producer outruns S3 upload, so the un-uploaded backlog grows. Once the backlog crosses 500 MB, local retention (osiris `eval_max_bytes`, applied to the survivors of the plugin's local retention function) trims un-uploaded segments before they reach S3. That discards confirmed-but-not-yet-uploaded data and triggers the upload-stall recovery reset (#225), so the replay phase reports gaps for confirmed sequences that were never delivered.

This is not a disk problem: the volume stayed around 13.5 GiB free throughout the run. The data loss came entirely from the 500 MB bound trimming un-uploaded data, which is exactly the small max_bytes regime described in #233.

## Change

Raise the `CONTENT_VERIFY_MAX_LENGTH_BYTES` default from 500 MB to 8 GB, comfortably above the observed peak backlog (~1.5 GiB at the 500 MB bound) and well below the test volume, so the target verifies content integrity rather than exercising the upload-stall recovery path. A comment explains why the bound must exceed peak upload lag and links #233.

## Caveat

This relies on S3 upload keeping pace with ingest on average (which it did in the failing run; the disk stayed flat). A test that deliberately stresses a small bound under sustained overload will still lose confirmed data until publisher backpressure based on upload lag exists. That is tracked in #233.

## Related

- #233 No publisher backpressure when sustained ingest outruns S3 upload throughput
- #225 upload-stall recovery
