### PR TITLE
Send persisted manifest to replicas, not the live one

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -420,7 +420,17 @@ handle_cast(
             {noreply, State};
         false ->
             MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
-            Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+            %% Sync the *persisted* manifest, not the live one. Seq is
+            %% broadcast_seq, which only advances when a {broadcast, _} effect
+            %% runs; it therefore lags any edit applied to the live manifest but
+            %% not yet broadcast. Pairing the live manifest with the lagging seq
+            %% makes the replica cache an edit it was never told about, and the
+            %% deferred broadcast then re-delivers that edit in-sequence so the
+            %% replica double-applies it (silent, unhealable divergence: no gap
+            %% is ever observed). persisted_manifest/1 is exactly the snapshot
+            %% consistent with broadcast_seq. Do not change this back to
+            %% manifest/1.
+            Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
             rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
             {noreply, State#state{replicas = Replicas#{Node => MonRef}}}
     end;
@@ -439,7 +449,9 @@ handle_cast(
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     } = State
 ) ->
-    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+    %% Persisted manifest, not live: it must be consistent with broadcast_seq
+    %% (Seq). See the register_acceptor handler.
+    Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
     rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
     {noreply, State};
 handle_cast(_Msg, State) ->
@@ -770,7 +782,9 @@ register_replica(
             State;
         false ->
             MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
-            Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+            %% Persisted manifest, not live: it must be consistent with
+            %% broadcast_seq (Seq). See the register_acceptor handler.
+            Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
             rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
             State#state{replicas = Replicas#{Node => MonRef}}
     end.
@@ -960,7 +974,20 @@ execute_effect(
         persist_pending_bytes = 0
     };
 execute_effect({update_range, _FirstOffset, _NextOffset}, #state{cfg = Cfg, core = Core} = State) ->
-    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+    %% Publish the *persisted* manifest, not the live one. This effect is
+    %% emitted by persist_complete, and the cache + range table it updates gate
+    %% local retention (get_range reads next_offset). Persist runs in a spawned
+    %% task, so more completions can advance the live manifest past what is
+    %% durably committed in Khepri while the persist is in flight. Publishing
+    %% the live manifest here would let local retention reclaim segments
+    %% covering offsets that are not yet durable; a crash before the next
+    %% persist then loses those offsets from both tiers (the #206 durability
+    %% hole). persisted_manifest/1 is the manifest that was just committed; its
+    %% first/next offsets equal the _FirstOffset/_NextOffset this effect carries
+    %% by construction (persist_complete sets last_persisted_manifest and emits
+    %% these offsets in the same batch), so the carried offsets are redundant
+    %% and intentionally ignored. Do not change this back to manifest/1.
+    Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
     ok = rabbitmq_stream_s3_manifest_replica:put_manifest(Cfg#cfg.stream, Manifest),
     on_persist_completed(Manifest, State);
 execute_effect(

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -22,7 +22,8 @@ all() ->
         gap_triggers_resync,
         rapid_edits_with_gap_then_resync,
         stale_edit_after_resync_ignored,
-        retention_and_append_in_same_broadcast
+        retention_and_append_in_same_broadcast,
+        sync_live_manifest_then_broadcast_double_applies
     ].
 
 init_per_suite(Config) ->
@@ -359,6 +360,67 @@ retention_and_append_in_same_broadcast(_Config) ->
     ?assertEqual(3 * ?ENTRY_B, byte_size(M#manifest.entries)),
     %% Total size: original 6000 + 4000 (append) - 1000 (retention) = 9000.
     ?assertEqual(9000, M#manifest.total_size).
+
+%% Demonstrates *why* the writer must sync the persisted manifest, not the live
+%% one. There is no deterministic writer-side regression test for the fix
+%% itself: the consistency requirement couples a shell value (broadcast_seq)
+%% with a core value (last_persisted_manifest), and expressing it as a pure test
+%% would require moving the broadcast sequence into the core (a core/shell
+%% contract change deferred to a later commit). This test instead pins the
+%% replica-side consequence so the catastrophe is documented where the
+%% corruption happens.
+%%
+%% The writer's broadcast_seq only advances when a {broadcast, _} effect runs,
+%% so it lags any edit already applied to the live manifest but not yet
+%% broadcast. The buggy writer sent the *live* manifest (which already contains
+%% that edit) tagged with the *lagging* seq. The replica caches an edit it was
+%% never told about, then the deferred broadcast re-delivers the same edit
+%% in-sequence and the replica applies it a second time. No gap is ever observed
+%% so no self-healing resync fires: the divergence is silent and permanent.
+sync_live_manifest_then_broadcast_double_applies(_Config) ->
+    {Manifest0, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000}}
+    ]),
+    %% An append edit for a second fragment at offset 50. This is the edit that
+    %% has been applied to the writer's live manifest but is still queued in
+    %% edits_since_persist, not yet broadcast.
+    Edit = #edit{
+        first_offset = 0,
+        first_timestamp = Manifest0#manifest.first_timestamp,
+        first_last_timestamp = Manifest0#manifest.first_last_timestamp,
+        next_offset = 51,
+        size = 2000,
+        entries = ?ENTRY(50, 500, 600, ?MANIFEST_KIND_FRAGMENT, 2000, 42),
+        pos = byte_size(Manifest0#manifest.entries),
+        len = 0
+    },
+    %% The live manifest the buggy writer holds: persisted manifest + Edit.
+    LiveManifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
+    ?assertEqual(2 * ?ENTRY_B, byte_size(LiveManifest#manifest.entries)),
+    ?assertEqual(3000, LiveManifest#manifest.total_size),
+
+    %% Correct (fixed) writer: sync the *persisted* manifest at seq 0, then the
+    %% broadcast delivers Edit at seq 1. The replica converges on LiveManifest.
+    Good = <<"stream-c1-good">>,
+    ok = rabbitmq_stream_s3_manifest_replica:sync(Good, 0, 1, Manifest0),
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Good, [Edit], 1, 1),
+    ?assertEqual(LiveManifest, rabbitmq_stream_s3_manifest_replica:get_manifest(Good)),
+
+    %% Buggy writer: sync the *live* manifest (already contains Edit) at the
+    %% lagging seq 0, then the deferred broadcast delivers Edit again at seq 1.
+    Bad = <<"stream-c1-bad">>,
+    ok = rabbitmq_stream_s3_manifest_replica:sync(Bad, 0, 1, LiveManifest),
+    %% In-sequence (1 = 0 + 1), so no gap is detected and Edit is applied a
+    %% second time onto a manifest that already reflects it.
+    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Bad, [Edit], 1, 1),
+    Corrupt = rabbitmq_stream_s3_manifest_replica:get_manifest(Bad),
+
+    %% The double-apply corrupts the replica. The offset-50 fragment is
+    %% duplicated in the ordered entries array (a consumer binary-searching it
+    %% gets wrong/duplicate results) and total_size is double-counted.
+    ?assertEqual(3 * ?ENTRY_B, byte_size(Corrupt#manifest.entries)),
+    ?assertEqual(5000, Corrupt#manifest.total_size),
+    ?assertNotEqual(LiveManifest, Corrupt).
 
 fake_writer(TestPid) ->
     receive


### PR DESCRIPTION
The remote replica reader maintains two manifests: the live in-memory manifest (edits applied immediately on completion) and last_persisted_manifest (consistent with the last durable persist and the last broadcast). The shell reached for the live manifest at sites that require the persisted snapshot.

register_acceptor, resync and register_replica synced the live manifest tagged with broadcast_seq. broadcast_seq only advances when a {broadcast, _} effect runs, so it lags any edit already applied to the live manifest but not yet broadcast. A replica registering in that window cached an edit it was never told about; the deferred broadcast then re-delivered the same edit in-sequence and the replica applied it twice. No gap was observed, so no self-healing resync fired and the divergence was silent and permanent.

The {update_range, _, _} effect handler discarded the just-persisted offsets the effect carries and re-read the live manifest for put_manifest / on_persist_completed. Because persist runs asynchronously, the cache and range table could advance past what is durable in Khepri, letting local retention reclaim segments covering not-yet-durable offsets (the #206 durability hole).

Both sites now use persisted_manifest/1.

Test: manifest_replica_SUITE characterizes the double-apply on the replica side (where the corruption happens). No deterministic writer-side regression test is added: the consistency requirement couples a shell value (broadcast_seq) with a core value (last_persisted_manifest), and expressing it as a pure test needs broadcast_seq moved into the core, deferred to a later change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
