### PR TITLE
Serve a small final fragment chunk instead of hanging

### DIFF
--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -395,11 +395,27 @@ try_read(#state{end_pos = EndPos} = State, Offset, Bytes) when
 ->
     %% Not enough data buffered.
     IdxStartPos = ?SEGMENT_HEADER_B + (State#state.fragment_ref)#fragment_ref.size,
-    case EndPos >= IdxStartPos andalso Offset + 64 =< EndPos of
+    case EndPos >= IdxStartPos of
         true ->
-            %% Header over-read: cap at index boundary.
+            %% All chunk data is buffered (the index region, which follows the
+            %% chunk data, has started), so nothing more is coming for a read
+            %% within the chunk-data range: this is the consumer over-reading a
+            %% chunk header at the fragment tail. Cap the read at the index
+            %% boundary and serve the remaining chunk data.
+            %%
+            %% The only read that overshoots EndPos is the header over-read,
+            %% which read_header1/1 always issues at a chunk boundary, so
+            %% IdxStartPos - Offset is the full last chunk (>= CHUNK_HEADER_B +
+            %% FilterSize) and read_header2/2 has enough to parse. A previous
+            %% `Offset + 64 =< EndPos` guard additionally required 64 bytes
+            %% available; a final chunk plus index totalling fewer than 64 bytes
+            %% failed it, so the reader awaited data that would never arrive and
+            %% the consumer hung. (The 64 was also arbitrary: the over-read is
+            %% CHUNK_HEADER_B + MAX_FILTER_SIZE bytes, not 64.)
             try_read(State, Offset, EndPos - Offset);
         false ->
+            %% Chunk data is still streaming in (EndPos has not reached the
+            %% index boundary). Wait for more, unless the fragment 404'd.
             case State of
                 #state{current_not_found = true} ->
                     {not_found_check_range, State};

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -40,6 +40,7 @@ all() ->
         retry_resets_delay_on_success,
         read_larger_than_buffer_awaits,
         header_overread_capped_at_index_boundary,
+        tail_header_overread_below_guard_serves_remaining,
         next_fragment_404_triggers_refresh_iterator,
         prefetch_404_full_recovery,
         deadline_expired_replies_error_timeout,
@@ -573,6 +574,35 @@ header_overread_capped_at_index_boundary(_Config) ->
     ?assertMatch([{reply, {ok, _}}], Replies),
     [{reply, {ok, ResultData}}] = Replies,
     ?assertEqual(108, byte_size(ResultData)).
+
+tail_header_overread_below_guard_serves_remaining(_Config) ->
+    %% Regression: a small final chunk at the fragment tail must still be
+    %% served. The consumer over-reads a chunk header at the last chunk's
+    %% boundary; when the remaining chunk data (plus index) is smaller than the
+    %% over-read size, the read overshoots the buffered end. Because all chunk
+    %% data is buffered (EndPos >= IdxStartPos), the core must cap at the index
+    %% boundary and serve the remaining bytes, not await data that will never
+    %% arrive (which hung the consumer until timeout).
+    %%
+    %% FragSize = 500, SEGMENT_HEADER_B = 8, so IdxStartPos = 508. Fill the full
+    %% chunk-data region (EndPos = 508). Read at offset 460 (a last-chunk
+    %% boundary leaving 48 bytes of chunk data) for a 64-byte header over-read:
+    %% 460 + 64 = 524 > EndPos = 508, so the over-read branch fires. With the
+    %% old `Offset + 64 =< EndPos` guard this awaited (524 > 508); now it serves
+    %% the 48 remaining bytes (508 - 460).
+    FragSize = 500,
+    FragRef = frag_ref(0, FragSize, 42),
+    Iterator = mock_iterator([{0, FragSize, 42}]),
+    {S0, _} = init(stream_id(), FragRef, 8, Iterator),
+    Data = binary:copy(<<0>>, FragSize),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(S0, {data, make_ref(), 0, Data, done}),
+    {_S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 460, 64, chunk_boundary}
+    ),
+    Replies = [E || {reply, _} = E <- Effects],
+    ?assertMatch([{reply, {ok, _}}], Replies),
+    [{reply, {ok, ResultData}}] = Replies,
+    ?assertEqual(48, byte_size(ResultData)).
 
 next_fragment_404_triggers_refresh_iterator(_Config) ->
     %% Prefetch of next fragment returns 404. When the consumer reads past


### PR DESCRIPTION
When the consumer reads a chunk header, log_reader over-reads at the chunk boundary. For the last chunk this over-read extends past the buffered end of the fragment object. try_read handled that by capping the read at the index boundary, but only when EndPos >= IdxStartPos *and* Offset + 64 =< EndPos. When a final chunk plus the index totalled fewer than 64 bytes, the second condition failed and the reader returned {await, State}, waiting for bytes that would never arrive because the fragment was already complete. The consumer hung until it timed out.

Gate the cap on EndPos >= IdxStartPos alone. That condition already means all chunk data is buffered (the index follows the chunk data), so a read within the chunk-data range can always be served and never needs to await. The cap serves min(Bytes, IdxStartPos - Offset), i.e. only chunk-data bytes. The sole read that overshoots EndPos is the header over-read, which is always issued at a chunk boundary, so IdxStartPos - Offset is the full last chunk (>= CHUNK_HEADER_B + FilterSize) and read_header2 has enough to parse: the cap can never truncate a header. The 64 was also arbitrary - the over-read is CHUNK_HEADER_B + MAX_FILTER_SIZE bytes, not 64.

Test: remote_reader_core_SUITE covers a tail read whose remaining chunk data is smaller than the old guard, asserting it is served (capped at the index boundary) rather than awaited.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
