### PR TITLE
Add reader-side transfer deadline to recover lost upload results

### DIFF
--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -114,6 +114,28 @@ Discarding remote manifest and restarting.
 
 ---
 
+## Lost transfer result (stalled upload pipeline)
+
+**Trigger.** A fragment transfer is submitted to the governor but no `{transfer_result, ...}` ever comes back. Three ways this happens:
+
+- The governor process crashes while the submission is still in its in-memory `pending` queue. The governor is supervised on its own and restarts with an empty `pending` queue, so the submission is lost. The `pending` queue is only non-empty when a finite `stream_s3.max_transfer_bytes_per_sec` is throttling, so this trigger requires a rate limit. In-flight tasks run in unlinked processes that outlive a governor restart and still deliver their results.
+- The spawned upload task is killed externally (for example by the OOM killer) before it replies. The task's exception handling only converts errors raised inside the upload function; an external kill produces no result.
+- The result message is otherwise lost.
+
+**Impact assessment.** Without recovery, the affected reader's in-flight queue head never drains, so `next_offset` is pinned, await-offset waiters never return, and local retention cannot reclaim the affected segments. The stream's remote tier stops advancing while the local log keeps growing. If local retention then trims past the pinned `next_offset`, the reader takes the local-log-ahead recovery path and the un-uploaded range is lost from both tiers. The failure is otherwise silent.
+
+**Detection.**
+
+- `rabbitmq_stream_s3_transfers_in_flight` stays elevated with no matching `rate(rabbitmq_stream_s3_transfers_completed[5m])`.
+- `transfer_deadlines_armed` in the replica reader's `format_state` shows armed deadlines that do not clear.
+- Logs: `~ts no result for an in-flight fragment transfer within the transfer deadline ... Resubmitting to keep the upload pipeline live.`
+
+**Mitigation.** None required: recovery is automatic.
+
+**Resolution.** Each submitted transfer arms a reader-side deadline (`stream_s3.transfer_deadline_ms`, default four times `segment_upload_timeout`). On expiry the reader resubmits the transfer under the same reference through the normal retry path, recovering from a dropped `pending` item, an externally killed task, or a lost message with one mechanism. The deadline is generous so a healthy but slow upload (including time queued behind the token bucket) is not resubmitted spuriously; a spurious resubmit is harmless because the reference is reused, the first result to arrive is accounted and the duplicate is discarded, and the losing upload's object becomes an orphan that GC reclaims. If local retention has already trimmed past the stalled offset by the time the deadline fires, the reader instead takes the local-log-ahead recovery path (see "Segment deleted before upload").
+
+---
+
 ## Persist conflict (deposed writer races new writer)
 
 **Trigger.** Two replica readers attempt to update the same stream's manifest in Khepri. Possible during partition-induced leader elections.

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -37,6 +37,7 @@ lives here. Callers use these functions instead of calling
     verbose_logging/0,
     segment_upload_timeout/0,
     upload_retry_delay_ms/0,
+    transfer_deadline_ms/0,
     retention_task_timeout/0,
     tick_timeout_milliseconds/0,
     max_transfer_bytes_per_sec/0,
@@ -168,6 +169,29 @@ segment_upload_timeout() ->
 upload_retry_delay_ms() ->
     application:get_env(?APP, upload_retry_delay_ms, 1000).
 
+%% Deadline for a submitted fragment transfer to report a result back to the
+%% replica reader. The reader submits each transfer to the per-node governor
+%% and waits for a `{transfer_result, Ref, _}` message. That message can fail
+%% to arrive: the governor can crash while the submission sits in its pending
+%% queue (only reachable under a finite rate limit), the spawned task can be
+%% killed externally (e.g. by the OOM killer) before it replies, or the
+%% message can otherwise be lost. None of those produce a result, so without a
+%% deadline the in-flight queue head never drains, `next_offset` is pinned, and
+%% the stream's uploads stall silently and permanently. On expiry the reader
+%% resubmits the transfer under the same reference (see the transfer_deadline
+%% handling in rabbitmq_stream_s3_replica_reader).
+%%
+%% The default is a generous multiple of segment_upload_timeout so a healthy
+%% but slow upload (including time spent queued behind the governor's token
+%% bucket) is never resubmitted spuriously. A spurious early resubmit is safe
+%% regardless: the resubmit reuses the same reference, the core accounts the
+%% first result to arrive and drops the duplicate, and the losing upload's S3
+%% object becomes an orphan that GC reclaims. Correctness does not depend on
+%% the value; only efficiency does.
+-spec transfer_deadline_ms() -> non_neg_integer().
+transfer_deadline_ms() ->
+    application:get_env(?APP, transfer_deadline_ms, segment_upload_timeout() * 4).
+
 -spec retention_task_timeout() -> non_neg_integer().
 retention_task_timeout() ->
     application:get_env(?APP, retention_task_timeout, 60_000).
@@ -222,6 +246,7 @@ defaults_test_() ->
         ?_assertEqual(false, verbose_logging()),
         ?_assertEqual(45_000, segment_upload_timeout()),
         ?_assertEqual(1000, upload_retry_delay_ms()),
+        ?_assertEqual(180_000, transfer_deadline_ms()),
         ?_assertEqual(60_000, retention_task_timeout()),
         ?_assertEqual(5000, tick_timeout_milliseconds()),
         ?_assertEqual(false, verify_crc_on_read()),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -232,6 +232,19 @@ returned by the functional core module.
     %% shell so we can attribute bytes_transferred and decrement
     %% transfers_in_flight when the result message arrives.
     transfer_sizes = #{} :: #{reference() => non_neg_integer()},
+    %% Per in-flight transfer, a deadline timer that fires if the governor
+    %% never reports a result. A submitted transfer can fail to report back if
+    %% the governor crashes while the submission sits in its pending queue
+    %% (only when a finite rate limit is configured), if the spawned task is
+    %% killed externally (e.g. by the OOM killer) before it replies, or if the
+    %% result message is otherwise lost. In every case the in-flight queue head
+    %% never drains and the stream's uploads stall silently and permanently. On
+    %% expiry the transfer is resubmitted under the same reference through the
+    %% core's retry path (see the {transfer_deadline, ...} handler). The map
+    %% value is {TimerRef, Token}: the Token disambiguates a live deadline from
+    %% a stale timer message that fired into the mailbox in the narrow window
+    %% before its timer was cancelled.
+    transfer_deadlines = #{} :: #{reference() => {reference(), reference()}},
     %% Bytes uploaded but not yet covered by a started persist. Moves to
     %% persisting_bytes when the next start_persist effect fires.
     persist_pending_bytes = 0 :: non_neg_integer(),
@@ -499,6 +512,49 @@ handle_info({transfer_result, Ref, {error, Reason}}, #state{core = Core0} = Stat
             ),
             {noreply, execute_effects(Effects, State1#state{core = Core})}
     end;
+handle_info({transfer_deadline, Ref, Token}, #state{core = Core0} = State0) ->
+    case maps:find(Ref, State0#state.transfer_deadlines) of
+        {ok, {_TimerRef, Token}} ->
+            %% The deadline elapsed with no result for this transfer. Treat it
+            %% exactly as a lost result: account the abandoned submission off
+            %% the pipeline gauges and drop its bookkeeping (as a real error
+            %% result would via on_transfer_result/3), then drive the core's
+            %% retry path to re-upload under the same Ref. If a late original
+            %% result and the resubmit both eventually complete, the second is
+            %% discarded by the stale-Ref clause above once the first has been
+            %% accounted for; the losing upload's object is left for orphan GC.
+            ?LOG_WARNING(
+                "~ts no result for an in-flight fragment transfer within the "
+                "transfer deadline. The governor may have lost the submission "
+                "(crash with a queued item), the upload task may have been "
+                "killed before replying, or the result message was lost. "
+                "Resubmitting to keep the upload pipeline live.",
+                [(State0#state.cfg)#cfg.stream]
+            ),
+            State1 = on_transfer_result(Ref, {error, transfer_deadline}, State0),
+            case local_log_ahead(State1) of
+                {true, LocalFirst, NextOffset} ->
+                    %% Local retention trimmed past next_offset while this
+                    %% transfer was stalled, so no resubmit can ever make the
+                    %% range durable. Recover the same way a permanent upload
+                    %% failure does (see the {error, Reason} clause).
+                    {noreply,
+                        handle_local_log_ahead(
+                            LocalFirst, NextOffset, transfer_deadline, State1
+                        )};
+                false ->
+                    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
+                        Ref, transfer_deadline, Core0
+                    ),
+                    {noreply, execute_effects(Effects, State1#state{core = Core})}
+            end;
+        _ ->
+            %% Stale timer message: the result already arrived (the timer was
+            %% cancelled but had already fired into the mailbox), or a manifest
+            %% recovery reset the in-flight bookkeeping, or this Ref now tracks
+            %% a newer deadline with a different token. Ignore it.
+            {noreply, State0}
+    end;
 handle_info({retry_transfer, Ref, Dir, Meta}, #state{cfg = #cfg{stream = StreamId}} = State) ->
     %% A previously failed fragment upload is being retried after its backoff
     %% delay. The in-flight gauges were already restored when the delayed
@@ -708,11 +764,13 @@ format_state(#state{
     cfg = #cfg{stream = StreamId, fragment_target_size = Target},
     log = Log,
     assembly = Assembly,
-    core = Core
+    core = Core,
+    transfer_deadlines = Deadlines
 }) ->
     #{
         stream => StreamId,
         fragment_target_size => Target,
+        transfer_deadlines_armed => maps:size(Deadlines),
         core =>
             case Core of
                 undefined -> undefined;
@@ -1044,7 +1102,7 @@ execute_effect(cancel_persist_timer, #state{persist_timer = Ref} = State) ->
     State#state{persist_timer = undefined};
 execute_effect(reinitialize, #state{cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_INFO("~ts reinitializing after commit conflict", [StreamId]),
-    State1 = (close_log(State0))#state{
+    State1 = (close_log(cancel_all_transfer_deadlines(State0)))#state{
         assembly = undefined,
         transfer_sizes = #{},
         persist_pending_bytes = 0,
@@ -1471,7 +1529,7 @@ handle_local_log_ahead(
         "remote tier.",
         [StreamId, NextOffset, Reason, LocalFirst, NextOffset]
     ),
-    resolve_and_start((close_log(State0))#state{
+    resolve_and_start((close_log(cancel_all_transfer_deadlines(State0)))#state{
         assembly = undefined,
         transfer_sizes = #{},
         persist_pending_bytes = 0,
@@ -1734,36 +1792,75 @@ submit_upload(Ref, Dir, StreamId, Meta) ->
     Fun = fun() -> upload_fragment(Dir, StreamId, Meta) end,
     rabbitmq_stream_s3_governor:submit(Fun, Size, Self, Ref).
 
+%% Arm the per-transfer liveness deadline. The timer message carries a fresh
+%% Token; on expiry the {transfer_deadline, ...} handler only acts if the
+%% Token still matches the one stored for Ref, which rules out acting on a
+%% timer that fired into the mailbox just before it was cancelled.
+arm_transfer_deadline(Ref, #state{transfer_deadlines = Deadlines} = State) ->
+    Token = make_ref(),
+    Deadline = rabbitmq_stream_s3_config:transfer_deadline_ms(),
+    TimerRef = erlang:send_after(Deadline, self(), {transfer_deadline, Ref, Token}),
+    State#state{transfer_deadlines = Deadlines#{Ref => {TimerRef, Token}}}.
+
+%% Cancel and forget the liveness deadline for a single transfer. cancel_timer
+%% does not remove an already-delivered message, so a stale deadline message
+%% may still arrive; the Token check in the handler discards it.
+cancel_transfer_deadline(Ref, #state{transfer_deadlines = Deadlines} = State) ->
+    case maps:take(Ref, Deadlines) of
+        {{TimerRef, _Token}, Deadlines1} ->
+            _ = erlang:cancel_timer(TimerRef),
+            State#state{transfer_deadlines = Deadlines1};
+        error ->
+            State
+    end.
+
+%% Cancel every outstanding liveness deadline. Used by the manifest-recovery
+%% reset paths (reinitialize, local-log-ahead) that abandon all in-flight
+%% transfers; the abandoned transfers' late results and any late deadline
+%% messages are dropped by the stale-Ref / Token guards.
+cancel_all_transfer_deadlines(#state{transfer_deadlines = Deadlines} = State) ->
+    maps:foreach(fun(_Ref, {TimerRef, _Token}) -> erlang:cancel_timer(TimerRef) end, Deadlines),
+    State#state{transfer_deadlines = #{}}.
+
 %% Called from execute_effect/2 for {submit_transfer, ...}.
 on_transfer_submitted(Ref, Size, #state{transfer_sizes = Sizes} = State) ->
     inc_gauge(State, ?C_TRANSFERS_IN_FLIGHT, 1),
     %% Pipeline stage 2: bytes enter the transfer phase (governor queue
     %% or in-flight S3 PUT). Decremented in on_transfer_result.
     inc_gauge(State, ?C_BYTES_IN_TRANSFER, Size),
-    State#state{transfer_sizes = Sizes#{Ref => Size}}.
+    %% Arm the liveness deadline for this transfer. on_transfer_submitted is
+    %% the single point at which a transfer becomes outstanding (initial submit
+    %% and every resubmit), and on_transfer_result is the single point at which
+    %% it stops being outstanding, so the deadline map stays in lockstep with
+    %% transfer_sizes. Ref is always absent here (a resubmit is preceded by
+    %% on_transfer_result, which removes it), so no prior timer is leaked.
+    arm_transfer_deadline(Ref, State#state{transfer_sizes = Sizes#{Ref => Size}}).
 
 %% Called from handle_info on transfer_result. Outcome is `ok' or
 %% `{error, Reason}'.
 on_transfer_result(Ref, Outcome, #state{transfer_sizes = Sizes} = State0) ->
     case maps:take(Ref, Sizes) of
         {Size, Sizes1} ->
-            dec(State0, ?C_TRANSFERS_IN_FLIGHT, 1),
-            dec(State0, ?C_BYTES_IN_TRANSFER, Size),
+            %% The transfer reported back (or a deadline is treating it as
+            %% reported): it is no longer outstanding, so cancel its liveness
+            %% deadline in lockstep with removing it from transfer_sizes.
+            State = cancel_transfer_deadline(Ref, State0#state{transfer_sizes = Sizes1}),
+            dec(State, ?C_TRANSFERS_IN_FLIGHT, 1),
+            dec(State, ?C_BYTES_IN_TRANSFER, Size),
             case Outcome of
                 ok ->
-                    inc(State0, ?C_TRANSFERS_COMPLETED, 1),
-                    inc(State0, ?C_BYTES_TRANSFERRED, Size),
+                    inc(State, ?C_TRANSFERS_COMPLETED, 1),
+                    inc(State, ?C_BYTES_TRANSFERRED, Size),
                     %% Stage 3: bytes are now waiting for a manifest
                     %% persist to confirm them.
-                    inc_gauge(State0, ?C_BYTES_IN_PERSIST, Size),
-                    Pending = State0#state.persist_pending_bytes + Size,
-                    State0#state{
-                        transfer_sizes = Sizes1,
+                    inc_gauge(State, ?C_BYTES_IN_PERSIST, Size),
+                    Pending = State#state.persist_pending_bytes + Size,
+                    State#state{
                         persist_pending_bytes = Pending
                     };
                 {error, _} ->
-                    inc(State0, ?C_TRANSFERS_FAILED, 1),
-                    State0#state{transfer_sizes = Sizes1}
+                    inc(State, ?C_TRANSFERS_FAILED, 1),
+                    State
             end;
         error ->
             %% Should not happen but be defensive.

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -739,4 +739,11 @@ assert_contiguous(NextOffset, FragmentFirstOffset) ->
 is_retriable({http, 500}) -> true;
 is_retriable({http, 503}) -> true;
 is_retriable(timeout) -> true;
+%% A reader-side transfer deadline: the governor never reported a result for a
+%% submitted transfer (lost message, externally killed task, or a queued
+%% submission dropped by a governor restart). The fragment was never made
+%% durable, so retrying immediately under the same reference is both safe and
+%% correct. See rabbitmq_stream_s3_config:transfer_deadline_ms/0 and the
+%% transfer_deadline handler in rabbitmq_stream_s3_replica_reader.
+is_retriable(transfer_deadline) -> true;
 is_retriable(_) -> false.

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -71,6 +71,7 @@ groups() ->
             retention_reclaims_uploaded_segments,
             message_count_reflects_remote_tier,
             resumes_after_restart,
+            lost_transfer_result_recovered_by_deadline,
             large_record_cuts_immediately,
             seed_log_uploads_deterministic,
             local_ahead_discards_manifest,
@@ -140,6 +141,7 @@ end_per_testcase(_TestCase, Config) ->
     %% Clean up any per-test app env overrides.
     application:unset_env(rabbitmq_stream_s3, fragment_target_size),
     application:unset_env(rabbitmq_stream_s3, persist_threshold),
+    application:unset_env(rabbitmq_stream_s3, transfer_deadline_ms),
     Config.
 
 %% ------------------------------------------------------------------
@@ -443,6 +445,83 @@ large_record_cuts_immediately(Config) ->
     %% One record, one chunk, one fragment.
     ok = await_offset(StreamId, 1),
     ?assertEqual([0], list_fragment_offsets(Config)).
+
+%% Regression for the governor-transfer-liveness issue: a submitted transfer
+%% whose result never comes back (governor crash dropping a queued submission,
+%% an externally killed upload task, or a lost message) must not pin the
+%% in-flight queue head forever. The reader arms a per-transfer deadline and,
+%% on expiry, resubmits under the same reference so the pipeline stays live.
+%%
+%% The test stands a controllable process in for the governor. It drops the
+%% first submission of each reference (simulating a lost result) and serves the
+%% resubmission normally. Without the reader-side deadline, await_offset would
+%% hang on the dropped first submission.
+lost_transfer_result_recovered_by_deadline(Config) ->
+    StreamId = ?config(stream_id, Config),
+    %% Short deadline so the resubmit happens quickly. Correctness does not
+    %% depend on the value (a spurious early resubmit is safe); this only keeps
+    %% the test fast.
+    application:set_env(rabbitmq_stream_s3, transfer_deadline_ms, 300),
+
+    Self = self(),
+    ok = supervisor:terminate_child(rabbitmq_stream_s3_sup, rabbitmq_stream_s3_governor),
+    Interceptor = spawn(fun() -> governor_interceptor(Self, #{}) end),
+    true = register(rabbitmq_stream_s3_governor, Interceptor),
+
+    try
+        %% One 2000-byte record with a 1000-byte target cuts exactly one
+        %% fragment, hence exactly one transfer reference.
+        Writer = start_writer(Config, #{}, #{fragment_target_size => 1000}),
+        osiris_writer:write(Writer, binary:copy(<<"L">>, 2000)),
+        flush_writer(Writer),
+
+        %% Returns only because the deadline fired and the resubmission was
+        %% served. Generous timeout: 300ms deadline + a fast FS upload.
+        ok = rabbitmq_stream_s3_test_helpers:await_offset(StreamId, 1, 5000),
+        ?assertEqual([0], list_fragment_offsets(Config)),
+
+        %% Confirm the same reference was submitted twice: dropped, then served.
+        receive
+            {interceptor_resubmitted, _Ref} -> ok
+        after 5000 ->
+            ct:fail("governor interceptor never received a resubmission")
+        end
+    after
+        catch unregister(rabbitmq_stream_s3_governor),
+        catch exit(Interceptor, kill),
+        %% Restore the real governor for subsequent tests.
+        {ok, _} = supervisor:restart_child(
+            rabbitmq_stream_s3_sup, rabbitmq_stream_s3_governor
+        )
+    end.
+
+%% Stand-in for the governor process. Speaks the same cast protocol
+%% (gen_server:cast wraps the request in {'$gen_cast', _}). Drops the first
+%% submission of each reference (no reply, simulating a lost transfer_result)
+%% and serves every later submission of a reference it has already seen by
+%% running the upload closure and replying, exactly as the governor does.
+governor_interceptor(Test, Seen) ->
+    receive
+        {'$gen_cast', {submit, Fun, _Size, ReplyTo, Ref}} ->
+            case maps:is_key(Ref, Seen) of
+                false ->
+                    governor_interceptor(Test, Seen#{Ref => dropped});
+                true ->
+                    _ = spawn(fun() ->
+                        Result =
+                            try
+                                Fun()
+                            catch
+                                C:R -> {error, {C, R}}
+                            end,
+                        ReplyTo ! {transfer_result, Ref, Result}
+                    end),
+                    Test ! {interceptor_resubmitted, Ref},
+                    governor_interceptor(Test, Seen)
+            end;
+        _Other ->
+            governor_interceptor(Test, Seen)
+    end.
 
 seed_log_uploads_deterministic(Config) ->
     %% Seed: 2 segments, 3 chunks each, 200 bytes payload per chunk.


### PR DESCRIPTION
A replica reader submits each fragment upload to the per-node governor and waits for a {transfer_result, Ref, _} message with no timeout, no monitor, and no resubmit. If that result never arrives the in-flight queue head never drains: next_offset is pinned, await-offset waiters never return, local retention cannot reclaim the affected segments, and the stream's uploads stall silently and permanently. A stalled upload eventually trips local-log-ahead recovery, which discards the un-uploaded range, so the stall escalates into data loss.

A result can fail to arrive in three ways: the governor crashes while the submission sits in its pending queue (reachable only under a finite rate limit), the spawned task is killed externally (e.g. by the OOM killer) before it replies, or the message is lost. The latter two are configuration-independent.

Fix: arm a per-transfer deadline on the reader side. On expiry the transfer is resubmitted under the same reference through the core's existing resubmit_transfer retry path, closing the whole class with one mechanism. The deadline (transfer_deadline_ms, default 4x segment_upload_timeout) is generous so a slow-but-healthy upload is not resubmitted spuriously; a spurious resubmit is safe because the reference is reused, the first result to arrive is accounted and the duplicate is dropped by the stale-Ref guard, and the losing upload's object is left for orphan GC. The deadline map is kept in lockstep with transfer_sizes and cleared on the reinitialize and local-log-ahead reset paths.

- config: transfer_deadline_ms/0
- core: classify transfer_deadline as retriable (immediate resubmit)
- shell: arm/cancel deadlines, {transfer_deadline, Ref, Token} handler, transfer_deadlines_armed in format_state for stall diagnostics
- test: replica_reader_SUITE:lost_transfer_result_recovered_by_deadline
- docs: failure-modes.md "Lost transfer result" entry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
