### PR TITLE
Release streaming-PUT resources when the upload fails before finish

### DIFF
--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -26,6 +26,7 @@ file-system operations. Use that in non-unit tests.
     stream_put/3,
     stream_data/2,
     stream_finish/2,
+    stream_abort/1,
     delete/1,
     delete/2,
     list/1,
@@ -70,6 +71,16 @@ file-system operations. Use that in non-unit tests.
     {ok, async_state()} | {error, any()}.
 -callback stream_data(async_state(), iodata()) -> async_state().
 -callback stream_finish(async_state(), non_neg_integer()) -> ok | {error, any()}.
+-doc """
+Abandon an in-progress streaming PUT that will not be finished.
+
+Called when the caller fails between stream_put/3 and a successful
+stream_finish/2 (for example a source read error while streaming the body).
+stream_finish/2 releases the request's resources on its own paths; this
+releases them when finish is never reached. The partially-sent upload does not
+become a committed object, so it leaves at most an orphan for GC.
+""".
+-callback stream_abort(async_state()) -> ok.
 -doc """
 Delete the given key or all of the listed keys from the remote tier.
 
@@ -229,6 +240,13 @@ stream_finish({StartTs, BackendState}, Crc32) ->
     Ms = rabbitmq_stream_s3_util:elapsed_ms(StartTs),
     rabbitmq_stream_s3_histogram:observe({?MODULE, request_duration, write}, Ms),
     Result.
+
+-spec stream_abort(async_state()) -> ok.
+stream_abort({StartTs, BackendState}) ->
+    ok = (backend()):stream_abort(BackendState),
+    Ms = rabbitmq_stream_s3_util:elapsed_ms(StartTs),
+    rabbitmq_stream_s3_histogram:observe({?MODULE, request_duration, write}, Ms),
+    ok.
 
 -doc #{equiv => delete(Keys, #{})}.
 -spec delete(key() | [key()]) -> ok | {error, any()}.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -23,6 +23,7 @@ A wrapper around the AWS S3 HTTP API.
     stream_put/3,
     stream_data/2,
     stream_finish/2,
+    stream_abort/1,
     delete/2,
     list/3,
     match_async/3,
@@ -462,6 +463,17 @@ stream_finish(
 send_chunk(Conn, StreamRef, Chunk) when is_binary(Chunk) ->
     Size = byte_size(Chunk),
     gun:data(Conn, StreamRef, nofin, [integer_to_binary(Size, 16), <<"\r\n">>, Chunk, <<"\r\n">>]).
+
+-spec stream_abort(async_state()) -> ok.
+stream_abort(#{conn := Conn} = State) ->
+    %% The streaming PUT body was only partially sent, so this HTTP/1.1
+    %% connection is mid-request and cannot be reused. Close it (the pool's
+    %% 'DOWN' handler removes it and opens a replacement) and release the
+    %% active-request gauge without checking the connection back in. Mirrors
+    %% the timeout/cancel path; the half-sent PUT never reaches S3 as an
+    %% object, so nothing is left behind except an orphan at most.
+    gun:close(Conn),
+    finish_async_close(State).
 
 -doc "Deletes the given key or list of keys".
 -spec delete(key() | [key()], request_opts()) ->

--- a/src/rabbitmq_stream_s3_api_fs.erl
+++ b/src/rabbitmq_stream_s3_api_fs.erl
@@ -21,6 +21,7 @@ associated file in that folder.
     stream_put/3,
     stream_data/2,
     stream_finish/2,
+    stream_abort/1,
     delete/2,
     list/3,
     match_async/3,
@@ -212,6 +213,15 @@ stream_finish({Fd, Crc}, Crc32) ->
         Crc32 -> ok;
         _ -> {error, {checksum_mismatch, #{expected => Crc32, actual => Crc}}}
     end.
+
+-spec stream_abort(async_state()) -> ok.
+stream_abort({Fd, _Crc}) ->
+    %% Release the open file descriptor that stream_put/3 acquired. The partial
+    %% file is left on disk as an orphan (it is never referenced by a persisted
+    %% manifest), matching the real backend where an aborted PUT writes no
+    %% committed object.
+    _ = file:close(Fd),
+    ok.
 
 -spec get_stream_data(StreamName) ->
     {ok, Manifest, [FragmentFile]} | {error, not_found}

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1621,7 +1621,6 @@ drain(
     {ok, rabbitmq_stream_s3:uid()} | {error, term()}.
 upload_fragment(Dir, StreamId, Meta) ->
     Uid = rabbitmq_stream_s3:uid(),
-    Spans = maps:get(spans, Meta),
     Size = maps:get(size, Meta),
     NumChunks = maps:get(num_chunks, Meta),
     FirstOffset = maps:get(first_offset, Meta),
@@ -1632,15 +1631,57 @@ upload_fragment(Dir, StreamId, Meta) ->
 
     maybe
         {ok, Stream0} ?= rabbitmq_stream_s3_api:stream_put(Key, ContentLength, #{}),
-        Header = <<"OSIF", ?FRAGMENT_VERSION:32/unsigned>>,
-        Stream1 = rabbitmq_stream_s3_api:stream_data(Stream0, Header),
-        Crc0 = erlang:crc32(Header),
-        {ok, Stream2, Crc1} ?= stream_spans(Stream1, Crc0, Dir, Spans),
-        IdxRecords = maps:get(index_records, Meta),
-        Stream3 = rabbitmq_stream_s3_api:stream_data(Stream2, IdxRecords),
-        Crc = erlang:crc32(Crc1, IdxRecords),
+        %% From here Stream0 owns a pooled connection and the active-request
+        %% gauge (acquired by stream_put). stream_finish releases them on its
+        %% own paths, but if streaming the body fails first (e.g. a segment was
+        %% deleted by local retention between the drain and this pread, so the
+        %% open/pread returns an error) stream_finish is never reached and both
+        %% would leak. stream_body/3 aborts the request on any such failure, so
+        %% by the time it returns {ok, ...} the only remaining release is the
+        %% stream_finish below.
+        {ok, Stream3, Crc} ?= stream_body(Stream0, Dir, Meta),
         ok ?= rabbitmq_stream_s3_api:stream_finish(Stream3, Crc),
         {ok, Uid}
+    end.
+
+%% Stream the fragment header, segment-span bodies, and index records into the
+%% open PUT identified by Stream0. Returns the final stream handle and CRC ready
+%% for stream_finish, or {error, _} after aborting the request (releasing the
+%% connection and active-request gauge that stream_put acquired). Every failure
+%% here happens before stream_finish, so aborting is unconditionally correct and
+%% cannot double-release.
+-spec stream_body(
+    rabbitmq_stream_s3_api:async_state(),
+    directory(),
+    rabbitmq_stream_s3_fragment_assembly:fragment_meta()
+) ->
+    {ok, rabbitmq_stream_s3_api:async_state(), non_neg_integer()} | {error, term()}.
+stream_body(Stream0, Dir, Meta) ->
+    Spans = maps:get(spans, Meta),
+    IdxRecords = maps:get(index_records, Meta),
+    Header = <<"OSIF", ?FRAGMENT_VERSION:32/unsigned>>,
+    Result =
+        try
+            Stream1 = rabbitmq_stream_s3_api:stream_data(Stream0, Header),
+            Crc0 = erlang:crc32(Header),
+            case stream_spans(Stream1, Crc0, Dir, Spans) of
+                {ok, Stream2, Crc1} ->
+                    Stream3 = rabbitmq_stream_s3_api:stream_data(Stream2, IdxRecords),
+                    Crc = erlang:crc32(Crc1, IdxRecords),
+                    {ok, Stream3, Crc};
+                {error, _} = Err ->
+                    Err
+            end
+        catch
+            Class:Reason ->
+                {error, {upload_body_crashed, Class, Reason}}
+        end,
+    case Result of
+        {ok, _, _} ->
+            Result;
+        {error, _} = Error ->
+            rabbitmq_stream_s3_api:stream_abort(Stream0),
+            Error
     end.
 
 stream_spans(Stream, Crc, _Dir, []) ->


### PR DESCRIPTION
stream_put/3 acquires resources for a streaming upload: on the S3 backend a pooled HTTP/1.1 connection plus the active-requests gauge, on the FS backend an open file descriptor. Those were released only by stream_finish/2. If the caller failed between stream_put and stream_finish
- the common case being a segment deleted by local retention between the drain and the pread, so stream_spans returns {error, enoent} - finish was never reached and the connection (and gauge), or the fd, leaked. A pooled connection leak is the more serious consequence: repeated occurrences exhaust the upload pool.

Add a stream_abort/1 callback to the API behaviour and both backends. On the S3 backend it closes the mid-request HTTP/1.1 connection (the pool replaces it) and releases the gauge without checking the poisoned connection back in; on the FS backend it closes the fd. upload_fragment now streams the body via stream_body/3, which aborts the request on any failure before stream_finish. That window is entirely pre-finish, so the abort cannot double-release a request that stream_finish already settled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
