### PR TITLE
Advance stream_span by bytes read, not by the requested size

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1696,9 +1696,23 @@ stream_span(Stream0, Crc0, Fd, Pos, Remaining) ->
     ReadSize = min(Remaining, ?READ_BUFFER_SIZE),
     case file:pread(Fd, Pos, ReadSize) of
         {ok, Data} ->
-            Stream1 = rabbitmq_stream_s3_api:stream_data(Stream0, Data),
-            Crc1 = erlang:crc32(Crc0, Data),
-            stream_span(Stream1, Crc1, Fd, Pos + ReadSize, Remaining - ReadSize);
+            %% file:pread/3 on a raw file may return fewer bytes than requested:
+            %% a short read is permitted in raw mode. Advance Pos and Remaining
+            %% by the number of bytes actually read, never by ReadSize.
+            %% Advancing by ReadSize on a short read would skip the unread bytes,
+            %% so the streamed body would be shorter than the Content-Length
+            %% declared to stream_put/3 and S3 would reject the PUT (the
+            %% upload fails and retries rather than committing a corrupt object).
+            case byte_size(Data) of
+                0 ->
+                    %% A zero-byte read that is not eof would spin forever;
+                    %% treat it as an unexpected truncation.
+                    {error, {unexpected_eof, Pos, ReadSize}};
+                Got ->
+                    Stream1 = rabbitmq_stream_s3_api:stream_data(Stream0, Data),
+                    Crc1 = erlang:crc32(Crc0, Data),
+                    stream_span(Stream1, Crc1, Fd, Pos + Got, Remaining - Got)
+            end;
         eof ->
             {error, {unexpected_eof, Pos, ReadSize}};
         {error, _} = Err ->


### PR DESCRIPTION
stream_span/5 streams a segment byte range into a fragment PUT in ?READ_BUFFER_SIZE chunks. It advanced Pos and Remaining by the requested ReadSize while streaming and CRCing only the bytes file:pread/3 returned. file:pread/3 on a raw file may return fewer bytes than requested - a short read is permitted in raw mode - so on a short read the loop skipped the unread bytes. The streamed body would then be shorter than the Content-Length declared to stream_put/3, so S3 rejects the PUT: the upload fails and retries rather than committing a corrupt object, so durability holds, but a filesystem that returns short raw reads would stall the stream's uploads.

Advance Pos and Remaining by byte_size(Data) so a short read simply leads to another read for the remainder. A zero-byte non-eof read is treated as an unexpected truncation rather than spinning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
