### PR TITLE
Harden apply_edit/2 and isolate replica edit failures

### DIFF
--- a/src/rabbitmq_stream_s3_manifest.erl
+++ b/src/rabbitmq_stream_s3_manifest.erl
@@ -90,25 +90,45 @@ apply_edit(
         entries = Entries0
     } = Manifest0
 ) ->
+    Size0 = byte_size(Entries0),
+    %% apply_edit/2 is a trust boundary: on a replica it applies edits that
+    %% arrived over the network, and on the writer it applies edits the core
+    %% built. The branches below are not self-validating, so a malformed or
+    %% stale edit could splice at the wrong position and silently corrupt the
+    %% ordered entries array (the shape behind the #206/replica-divergence
+    %% bugs). Assert the structural invariants up front and fail loudly
+    %% instead: the replica caller (rabbitmq_stream_s3_manifest_replica)
+    %% catches this and forces a full resync rather than serving a corrupt
+    %% manifest, and on the writer it surfaces a bug rather than persisting
+    %% corruption. Entries are fixed-size records, so every offset and length
+    %% into the array must be entry-aligned and within bounds.
+    assert_edit_well_formed(Pos, Len, byte_size(EditEntries), Size0),
     Entries =
-        if
-            %% Pure insertion (append)
-            Pos =:= byte_size(Entries0) andalso Len =:= 0 ->
-                <<Entries0/binary, EditEntries/binary>>;
-            %% No-op (empty)
-            Len =:= 0 andalso EditEntries =:= <<>> ->
+        case {Len, EditEntries} of
+            %% Metadata-only edit (e.g. retention adjusting a group's leading
+            %% offsets): the entries array does not change.
+            {0, <<>>} ->
                 Entries0;
-            %% Pure deletion (truncate)
-            EditEntries =:= <<>> ->
-                %% We only truncate from the beginning. No hole punching.
+            %% Append. The new entries must land exactly at the end. A stale or
+            %% duplicate append (this replica already applied it, so its array
+            %% is longer) has Pos < Size0 and is rejected here - which is what
+            %% turns the silent double-apply corruption into a caught
+            %% inconsistency that triggers a resync.
+            {0, _} ->
+                ?assertEqual(Size0, Pos),
+                <<Entries0/binary, EditEntries/binary>>;
+            %% Pure deletion (truncate). We only truncate from the beginning;
+            %% no hole punching.
+            {_, <<>>} ->
                 ?assertEqual(0, Pos),
-                binary:part(Entries0, Len, byte_size(Entries0) - Len);
-            %% Replacement (for rebalancing)
-            true ->
+                binary:part(Entries0, Len, Size0 - Len);
+            %% Replacement (rebalancing): replace [Pos, Pos + Len) with the new
+            %% sub-array.
+            {_, _} ->
                 <<
                     (binary:part(Entries0, 0, Pos))/binary,
                     EditEntries/binary,
-                    (binary:part(Entries0, Pos + Len, byte_size(Entries0) - Pos - Len))/binary
+                    (binary:part(Entries0, Pos + Len, Size0 - Pos - Len))/binary
                 >>
         end,
     NextOffset =
@@ -118,14 +138,35 @@ apply_edit(
             _ when is_integer(EditNextOffset) ->
                 EditNextOffset
         end,
+    TotalSize = TotalSize0 + Size,
+    %% total_size is non-negative and serialised as a u70. A duplicate or
+    %% mis-applied retention edit (whose size delta is negative) would drive it
+    %% below zero; reject that here rather than let it crash serialisation on
+    %% the writer or poison max-bytes retention / metrics on a replica.
+    ?assert(TotalSize >= 0),
     Manifest0#manifest{
         first_offset = FirstOffset,
         first_timestamp = FirstTs,
         first_last_timestamp = FirstLastTs,
         next_offset = NextOffset,
-        total_size = TotalSize0 + Size,
+        total_size = TotalSize,
         entries = Entries
     }.
+
+%% Structural invariants common to every edit shape: offsets and lengths into
+%% the entries array are non-negative, entry-aligned, and within the array. A
+%% violation means the edit does not match this manifest (a gap, a diverged
+%% replica, or a malformed edit) and is raised so the caller can recover.
+-spec assert_edit_well_formed(
+    non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()
+) -> ok.
+assert_edit_well_formed(Pos, Len, EditLen, Size0) ->
+    ?assert(Pos >= 0 andalso Len >= 0),
+    ?assertEqual(0, Pos rem ?ENTRY_B),
+    ?assertEqual(0, Len rem ?ENTRY_B),
+    ?assertEqual(0, EditLen rem ?ENTRY_B),
+    ?assert(Pos + Len =< Size0),
+    ok.
 
 -doc """
 Returns a function that downloads group objects from S3 and returns their

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -180,17 +180,20 @@ handle_call(
         {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
             case ets:lookup(?TABLE, StreamId) of
                 [{_, Manifest0}] ->
-                    Manifest = lists:foldl(
-                        fun(Edit, Acc) -> rabbitmq_stream_s3_manifest:apply_edit(Edit, Acc) end,
-                        Manifest0,
-                        Edits
-                    ),
-                    write_manifest(StreamId, Manifest),
-                    maybe_evaluate_retention(StreamId, Manifest0, Manifest, State);
+                    case apply_edits_catching(StreamId, Edits, Manifest0) of
+                        {ok, Manifest} ->
+                            write_manifest(StreamId, Manifest),
+                            maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
+                            {reply, ok, State#state{
+                                seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
+                            }};
+                        {error, _} ->
+                            request_resync(StreamId, WriterNode),
+                            {reply, {error, apply_failed}, State}
+                    end;
                 [] ->
-                    ok
-            end,
-            {reply, ok, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}};
+                    {reply, ok, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}}
+            end;
         _ ->
             request_resync(StreamId, WriterNode),
             {reply, {error, gap}, State}
@@ -199,10 +202,14 @@ handle_call({apply_edit, StreamId, Edit}, _From, State) ->
     Reply =
         case ets:lookup(?TABLE, StreamId) of
             [{_, Manifest0}] ->
-                Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
-                write_manifest(StreamId, Manifest),
-                maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
-                ok;
+                case apply_edits_catching(StreamId, [Edit], Manifest0) of
+                    {ok, Manifest} ->
+                        write_manifest(StreamId, Manifest),
+                        maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
+                        ok;
+                    {error, _} = Err ->
+                        Err
+                end;
             [] ->
                 {error, not_found}
         end,
@@ -223,9 +230,16 @@ handle_cast({put_manifest, StreamId, Manifest}, State) ->
 handle_cast({apply_edit, StreamId, Edit}, State) ->
     case ets:lookup(?TABLE, StreamId) of
         [{_, Manifest0}] ->
-            Manifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Manifest0),
-            write_manifest(StreamId, Manifest),
-            maybe_evaluate_retention(StreamId, Manifest0, Manifest, State);
+            case apply_edits_catching(StreamId, [Edit], Manifest0) of
+                {ok, Manifest} ->
+                    write_manifest(StreamId, Manifest),
+                    maybe_evaluate_retention(StreamId, Manifest0, Manifest, State);
+                {error, _} ->
+                    %% No writer node on this path to resync from; keep the last
+                    %% good manifest and leave recovery to the next broadcast
+                    %% gap or sync.
+                    ok
+            end;
         [] ->
             ok
     end,
@@ -239,17 +253,26 @@ handle_cast({apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, #state{seqs 
             %% In sequence: apply edits.
             case ets:lookup(?TABLE, StreamId) of
                 [{_, Manifest0}] ->
-                    Manifest = lists:foldl(
-                        fun(Edit, Acc) -> rabbitmq_stream_s3_manifest:apply_edit(Edit, Acc) end,
-                        Manifest0,
-                        Edits
-                    ),
-                    write_manifest(StreamId, Manifest),
-                    maybe_evaluate_retention(StreamId, Manifest0, Manifest, State);
+                    case apply_edits_catching(StreamId, Edits, Manifest0) of
+                        {ok, Manifest} ->
+                            write_manifest(StreamId, Manifest),
+                            maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
+                            {noreply, State#state{
+                                seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
+                            }};
+                        {error, _} ->
+                            %% The edit is structurally inconsistent with this
+                            %% replica's manifest: it has diverged (or the edit
+                            %% is malformed). Don't apply a corrupt edit or crash
+                            %% the per-node cache shared by every stream - keep
+                            %% the last good manifest, leave the sequence
+                            %% unadvanced, and force a full resync.
+                            request_resync(StreamId, WriterNode),
+                            {noreply, State}
+                    end;
                 [] ->
-                    ok
-            end,
-            {noreply, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}};
+                    {noreply, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}}
+            end;
         _ ->
             %% Gap or epoch mismatch: request re-sync from writer.
             request_resync(StreamId, WriterNode),
@@ -270,6 +293,34 @@ terminate(_Reason, _State) ->
 
 write_manifest(StreamId, Manifest) ->
     ets:insert(?TABLE, {StreamId, Manifest}).
+
+%% Apply a batch of edits, catching any failure from apply_edit/2. apply_edit/2
+%% raises on a structurally inconsistent edit (a gap, a diverged replica, or a
+%% malformed edit). This per-node process owns the manifest cache for every
+%% stream on the node, so an uncaught crash here would destroy all of them;
+%% isolate the failure to the one stream instead and let the caller request a
+%% resync. The original manifest is returned untouched on failure (we never
+%% write a partially-applied or corrupt manifest).
+-spec apply_edits_catching(stream_id(), [#edit{}], #manifest{}) ->
+    {ok, #manifest{}} | {error, term()}.
+apply_edits_catching(StreamId, Edits, Manifest0) ->
+    try
+        {ok,
+            lists:foldl(
+                fun(Edit, Acc) -> rabbitmq_stream_s3_manifest:apply_edit(Edit, Acc) end,
+                Manifest0,
+                Edits
+            )}
+    catch
+        Class:Reason ->
+            ?LOG_WARNING(
+                "Manifest replica for stream ~ts could not apply an edit "
+                "(~ts:~p); keeping the last good manifest and resyncing",
+                [StreamId, Class, Reason],
+                #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+            ),
+            {error, {Class, Reason}}
+    end.
 
 %% A sync is a full manifest reset tagged with the writer's epoch and sequence.
 %% Casts from different writer nodes can be reordered, so a delayed sync from a

--- a/test/manifest_SUITE.erl
+++ b/test/manifest_SUITE.erl
@@ -22,7 +22,15 @@ all() ->
         kilo_group_max_bytes,
         kilo_group_full_consumption,
         mega_group_retention,
-        multi_tier_idempotent
+        multi_tier_idempotent,
+        apply_edit_appends_in_order,
+        apply_edit_truncates_from_front,
+        apply_edit_rejects_stale_append,
+        apply_edit_rejects_gap_append,
+        apply_edit_rejects_unaligned_pos,
+        apply_edit_rejects_out_of_bounds_replace,
+        apply_edit_rejects_nonzero_pos_truncate,
+        apply_edit_rejects_negative_total_size
     ].
 
 init_per_suite(Config) -> Config.
@@ -162,8 +170,132 @@ multi_tier_idempotent(_Config) ->
     ?assert(M2#manifest.first_offset >= M1#manifest.first_offset).
 
 %% ------------------------------------------------------------------
+%% apply_edit/2 trust-boundary hardening
+%% ------------------------------------------------------------------
+%%
+%% apply_edit/2 raises on a structurally inconsistent edit so the replica cache
+%% can catch it and resync rather than silently corrupt its entries array or
+%% crash the per-node cache shared by every stream.
+
+apply_edit_appends_in_order(_Config) ->
+    M0 = mk_manifest([0], 100),
+    Edit = append_edit(1, 100, byte_size(M0#manifest.entries)),
+    M1 = rabbitmq_stream_s3_manifest:apply_edit(Edit, M0),
+    ?assertEqual(2 * ?ENTRY_B, byte_size(M1#manifest.entries)),
+    ?assertEqual(200, M1#manifest.total_size),
+    ?assertEqual(2, M1#manifest.next_offset).
+
+apply_edit_truncates_from_front(_Config) ->
+    M0 = mk_manifest([0, 1], 200),
+    Edit = #edit{
+        first_offset = 1,
+        first_timestamp = 10,
+        first_last_timestamp = 11,
+        next_offset = undefined,
+        size = -100,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    M1 = rabbitmq_stream_s3_manifest:apply_edit(Edit, M0),
+    ?assertEqual(?ENTRY_B, byte_size(M1#manifest.entries)),
+    ?assertEqual(100, M1#manifest.total_size).
+
+%% The double-apply shape: an append whose Pos is short of the array end
+%% because this replica already applied it. Must be rejected, not spliced in.
+apply_edit_rejects_stale_append(_Config) ->
+    M0 = mk_manifest([0, 1], 200),
+    Stale = append_edit(2, 100, ?ENTRY_B),
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Stale, M0)).
+
+%% An append whose Pos is past the array end (this replica missed edits).
+apply_edit_rejects_gap_append(_Config) ->
+    M0 = mk_manifest([0], 100),
+    Ahead = append_edit(1, 100, 3 * ?ENTRY_B),
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Ahead, M0)).
+
+apply_edit_rejects_unaligned_pos(_Config) ->
+    M0 = mk_manifest([0], 100),
+    Edit = (append_edit(1, 100, 0))#edit{pos = 1},
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Edit, M0)).
+
+apply_edit_rejects_out_of_bounds_replace(_Config) ->
+    M0 = mk_manifest([0], 100),
+    Edit = #edit{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 1,
+        next_offset = undefined,
+        size = 0,
+        entries = frag_entry(9),
+        pos = 0,
+        len = 2 * ?ENTRY_B
+    },
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Edit, M0)).
+
+apply_edit_rejects_nonzero_pos_truncate(_Config) ->
+    M0 = mk_manifest([0, 1], 200),
+    Edit = #edit{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 1,
+        next_offset = undefined,
+        size = -100,
+        entries = <<>>,
+        pos = ?ENTRY_B,
+        len = ?ENTRY_B
+    },
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Edit, M0)).
+
+apply_edit_rejects_negative_total_size(_Config) ->
+    M0 = mk_manifest([0], 50),
+    Edit = #edit{
+        first_offset = 1,
+        first_timestamp = 10,
+        first_last_timestamp = 11,
+        next_offset = undefined,
+        size = -100,
+        entries = <<>>,
+        pos = 0,
+        len = ?ENTRY_B
+    },
+    ?assertError(_, rabbitmq_stream_s3_manifest:apply_edit(Edit, M0)).
+
+%% ------------------------------------------------------------------
 %% Helpers
 %% ------------------------------------------------------------------
+
+%% A fragment entry (?ENTRY_B bytes) at the given offset, 100 bytes of data.
+frag_entry(Offset) ->
+    FirstTs = Offset * 10,
+    LastTs = FirstTs + 1,
+    Uid = Offset + 1,
+    ?ENTRY(Offset, FirstTs, LastTs, ?MANIFEST_KIND_FRAGMENT, 100, Uid).
+
+%% A flat manifest of fragment entries at the given offsets.
+mk_manifest(Offsets, TotalSize) ->
+    Entries = iolist_to_binary([frag_entry(O) || O <- Offsets]),
+    #manifest{
+        first_offset = hd(Offsets),
+        first_timestamp = hd(Offsets) * 10,
+        first_last_timestamp = hd(Offsets) * 10 + 1,
+        next_offset = lists:last(Offsets) + 1,
+        total_size = TotalSize,
+        entries = Entries
+    }.
+
+%% An append edit adding one fragment at Offset with Size bytes, landing at Pos.
+append_edit(Offset, Size, Pos) ->
+    #edit{
+        first_offset = 0,
+        first_timestamp = 0,
+        first_last_timestamp = 1,
+        next_offset = Offset + 1,
+        size = Size,
+        entries = frag_entry(Offset),
+        pos = Pos,
+        len = 0
+    }.
 
 %% A manifest whose root is a single group of four fragments F1..F4 at offsets
 %% 0/100/200/300, each 100 bytes, last_ts 1000/2000/3000/4000. build_manifest's

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -376,8 +376,12 @@ retention_and_append_in_same_broadcast(_Config) ->
 %% broadcast. The buggy writer sent the *live* manifest (which already contains
 %% that edit) tagged with the *lagging* seq. The replica caches an edit it was
 %% never told about, then the deferred broadcast re-delivers the same edit
-%% in-sequence and the replica applies it a second time. No gap is ever observed
-%% so no self-healing resync fires: the divergence is silent and permanent.
+%% in-sequence and the replica applies it a second time. No gap is ever
+%% observed, so the sequence guard does not fire. apply_edit/2's
+%% append-position assertion is the backstop: it rejects the duplicate (the
+%% replica's array already contains the edit) and requests a resync, so the
+%% silent permanent divergence this characterized is now caught. The test pins
+%% both the historical shape and that backstop.
 sync_live_manifest_then_broadcast_double_applies(_Config) ->
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}}
@@ -408,20 +412,33 @@ sync_live_manifest_then_broadcast_double_applies(_Config) ->
     ?assertEqual(LiveManifest, rabbitmq_stream_s3_manifest_replica:get_manifest(Good)),
 
     %% Buggy writer: sync the *live* manifest (already contains Edit) at the
-    %% lagging seq 0, then the deferred broadcast delivers Edit again at seq 1.
+    %% lagging seq 0, then the deferred broadcast re-delivers Edit at seq 1.
+    %% The duplicate is in-sequence, so the seq guard does not catch it - but
+    %% apply_edit/2's append-position assertion does: the replica's array
+    %% already contains Edit, so the append no longer lands at the array end.
+    %% The replica rejects the edit, leaves its manifest untouched, and requests
+    %% a resync rather than silently double-applying (the old corruption this
+    %% test used to characterize).
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer(Self) end),
     Bad = <<"stream-c1-bad">>,
+    yes = rabbitmq_stream_s3_registry:register_name({Bad, node()}, WriterPid),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Bad, 0, 1, LiveManifest),
-    %% In-sequence (1 = 0 + 1), so no gap is detected and Edit is applied a
-    %% second time onto a manifest that already reflects it.
-    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Bad, [Edit], 1, 1),
-    Corrupt = rabbitmq_stream_s3_manifest_replica:get_manifest(Bad),
-
-    %% The double-apply corrupts the replica. The offset-50 fragment is
-    %% duplicated in the ordered entries array (a consumer binary-searching it
-    %% gets wrong/duplicate results) and total_size is double-counted.
-    ?assertEqual(3 * ?ENTRY_B, byte_size(Corrupt#manifest.entries)),
-    ?assertEqual(5000, Corrupt#manifest.total_size),
-    ?assertNotEqual(LiveManifest, Corrupt).
+    ?assertEqual(
+        {error, apply_failed},
+        rabbitmq_stream_s3_manifest_replica:apply_edits(Bad, [Edit], 1, 1)
+    ),
+    %% No corruption: the cached manifest is exactly the one that was synced;
+    %% the duplicate fragment was not spliced in or double-counted.
+    ?assertEqual(LiveManifest, rabbitmq_stream_s3_manifest_replica:get_manifest(Bad)),
+    receive
+        {resync_received, Node} -> ?assertEqual(node(), Node)
+    after 1000 -> ct:fail("resync request not received by writer")
+    end,
+    rabbitmq_stream_s3_registry:unregister_name({Bad, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill).
 
 %% Characterization of the manifest-reset propagation bug. Demonstrates *why* a
 %% writer that resets its manifest (local-log-ahead recovery: it discards the
@@ -434,8 +451,11 @@ sync_live_manifest_then_broadcast_double_applies(_Config) ->
 %%
 %% A reset leaves broadcast_seq unchanged, so the writer's next edit arrives
 %% in-sequence relative to the replica's pre-reset seq. If the reset was not
-%% synced, the replica still holds the old manifest and splices the new edit
-%% onto a manifest the writer has already thrown away.
+%% synced, the replica still holds the old manifest. apply_edit/2's
+%% append-position assertion is the backstop: the post-reset edit is built
+%% against the fresh manifest, so it no longer matches the stale array and is
+%% rejected, triggering a resync instead of splicing onto a manifest the writer
+%% has already thrown away.
 manifest_reset_requires_resync(_Config) ->
     {OldManifest, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}},
@@ -458,15 +478,31 @@ manifest_reset_requires_resync(_Config) ->
 
     %% Buggy writer: resets locally but never syncs the replica. The replica
     %% keeps OldManifest at seq 0; the post-reset edit arrives in-sequence at
-    %% seq 1 and is spliced onto the discarded manifest.
+    %% seq 1. The seq guard does not catch it, but apply_edit/2's
+    %% append-position assertion does: the post-reset append is built against
+    %% the fresh (empty) manifest, so Pos no longer matches the stale array.
+    %% The replica rejects the edit, keeps OldManifest, and requests a resync
+    %% (which would then deliver the fresh manifest) rather than splicing onto
+    %% the discarded manifest (the old corruption this test used to
+    %% characterize).
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer(Self) end),
     Bad = <<"stream-reset-bad">>,
+    yes = rabbitmq_stream_s3_registry:register_name({Bad, node()}, WriterPid),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Bad, 0, 1, OldManifest),
-    ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Bad, [PostResetEdit], 1, 1),
-    Corrupt = rabbitmq_stream_s3_manifest_replica:get_manifest(Bad),
-    %% The replica now lists the stale offset-0 and offset-50 fragments (gone
-    %% from both tiers) alongside the new one, out of order: [100, 0, 50].
-    ?assertEqual(3 * ?ENTRY_B, byte_size(Corrupt#manifest.entries)),
-    ?assertEqual(6000, Corrupt#manifest.total_size),
+    ?assertEqual(
+        {error, apply_failed},
+        rabbitmq_stream_s3_manifest_replica:apply_edits(Bad, [PostResetEdit], 1, 1)
+    ),
+    ?assertEqual(OldManifest, rabbitmq_stream_s3_manifest_replica:get_manifest(Bad)),
+    receive
+        {resync_received, RNode} -> ?assertEqual(node(), RNode)
+    after 1000 -> ct:fail("resync request not received by writer")
+    end,
+    rabbitmq_stream_s3_registry:unregister_name({Bad, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill),
 
     %% Fixed writer: propagates the reset with a full sync (at the unchanged
     %% broadcast_seq) before the next edit. The replica drops OldManifest,
@@ -481,7 +517,7 @@ manifest_reset_requires_resync(_Config) ->
     ?assertEqual(100, Converged#manifest.first_offset),
     ?assertEqual(150, Converged#manifest.next_offset),
     ?assertEqual(3000, Converged#manifest.total_size),
-    ?assertNotEqual(Corrupt, Converged).
+    ?assertNotEqual(OldManifest, Converged).
 
 fake_writer(TestPid) ->
     receive


### PR DESCRIPTION
apply_edit/2 is the trust boundary where a replica applies edits that arrived over the network. It was unguarded: a malformed or stale edit either crashed (binary:part badarg, the truncate Pos=0 assertion) or, for the double-apply shape behind the replica-divergence criticals, silently spliced at the wrong position and corrupted the ordered entries array. And because rabbitmq_stream_s3_manifest_replica is a single per-node gen_server owning the ETS cache for every stream on the node, and applied broadcast edits in a foldl with no try/catch, one bad edit for one stream would crash the process and destroy every stream's cached manifest on the node.

Two changes:

1. apply_edit/2 asserts its structural invariants up front (offsets and lengths entry-aligned and within bounds; appends land exactly at the array end; truncation only from the front; total_size stays non-negative) and raises on violation. The append-position assertion in particular catches the diverged-replica shape: a duplicate or post-reset append no longer matches the array end, so it is rejected rather than spliced in.

2. manifest_replica catches apply failures per stream: it keeps the last good manifest (never writes a partial/corrupt one), leaves the sequence unadvanced, and requests a full resync, instead of crashing the shared cache. A structurally inconsistent edit now self-heals one stream rather than taking down the node's whole cache.

Tests: manifest_SUITE gains direct apply_edit cases (well-formed append/ truncate succeed; stale/gap append, unaligned offset, out-of-bounds replace, non-zero-Pos truncate, and negative total_size all raise). The two manifest_replica_SUITE characterization tests for the C1/C3 shapes now assert the replica rejects the bad edit, keeps its manifest intact, and requests a resync, rather than the old silent corruption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
