### PR TITLE
Refuse a remote retention evaluation while a prefix rewrite is in flight

### DIFF
--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
@@ -68,6 +68,16 @@ output(ok, _Opts) ->
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         <<"Stream not found or replica reader not running on this node.">>};
+output({error, {in_progress, Blocker}}, _Opts) ->
+    {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_tempfail(),
+        erlang:iolist_to_binary(
+            io_lib:format(
+                "A manifest change (~ts) is already in progress for this stream; "
+                "remote retention evaluation cannot run concurrently. Try again "
+                "once it completes.",
+                [Blocker]
+            )
+        )};
 output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -260,6 +260,14 @@ returned by the functional core module.
     retention_pid :: pid() | undefined,
     %% Timer ref for the retention task timeout.
     retention_timer :: reference() | undefined,
+    %% Correlation token for the in-flight retention task. Each spawned task
+    %% gets a fresh make_ref/0 and tags its result with it; only a
+    %% {retention_result, Token, _} whose Token matches the current task is
+    %% applied. A result from a task we stopped tracking (e.g. one the retention
+    %% timeout already killed, whose message was queued before the kill) carries
+    %% a stale token and is ignored rather than mis-applied onto a manifest it
+    %% no longer matches.
+    retention_token :: reference() | undefined,
     %% Kind of the group upload currently in flight. Cleared when the
     %% group_upload_result message arrives. Only one rebalance is in
     %% flight at a time so a single slot suffices.
@@ -387,9 +395,20 @@ handle_call(
     _From,
     #state{core = Core, retention = Retention, cfg = #cfg{stream = StreamId}} = State
 ) ->
-    Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
-    State1 = maybe_evaluate_remote_retention(Manifest, Retention, StreamId, State),
-    {reply, ok, State1};
+    case rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(Core) of
+        none ->
+            Manifest = rabbitmq_stream_s3_replica_reader_core:manifest(Core),
+            State1 = maybe_evaluate_remote_retention(Manifest, Retention, StreamId, State),
+            {reply, ok, State1};
+        Blocker ->
+            %% A manifest-prefix rewrite (an async retention evaluation or a
+            %% rebalance) is already in flight. Spawning a second evaluation
+            %% would capture the same pre-retention snapshot and recompute the
+            %% identical prefix-truncation edit, which would be applied twice.
+            %% Refuse and name the blocker so the operator can retry once it
+            %% settles.
+            {reply, {error, {in_progress, Blocker}}, State}
+    end;
 handle_call(force_fragment_cut, _From, #state{assembly = undefined} = State) ->
     {reply, {error, no_assembly}, State};
 handle_call(
@@ -578,8 +597,9 @@ handle_info(
             core = Core, group_mon = undefined, pending_group_kind = undefined
         })};
 handle_info(
-    {retention_result, unchanged},
-    #state{core = Core0, retention_mon = Mon, retention_timer = TRef} = State0
+    {retention_result, Token, unchanged},
+    #state{retention_token = Token, core = Core0, retention_mon = Mon, retention_timer = TRef} =
+        State0
 ) ->
     %% Evaluation ran and found nothing to remove: not a failure, not counted.
     demonitor(Mon, [flush]),
@@ -590,11 +610,13 @@ handle_info(
             core = Core,
             retention_mon = undefined,
             retention_pid = undefined,
-            retention_timer = undefined
+            retention_timer = undefined,
+            retention_token = undefined
         })};
 handle_info(
-    {retention_result, {failed, Reason}},
-    #state{core = Core0, retention_mon = Mon, retention_timer = TRef} = State0
+    {retention_result, Token, {failed, Reason}},
+    #state{retention_token = Token, core = Core0, retention_mon = Mon, retention_timer = TRef} =
+        State0
 ) ->
     %% The async retention task caught a crash and reported it as a failure
     %% (distinct from unchanged, which means it ran and found nothing). The
@@ -609,18 +631,38 @@ handle_info(
             core = Core,
             retention_mon = undefined,
             retention_pid = undefined,
-            retention_timer = undefined
+            retention_timer = undefined,
+            retention_token = undefined
         })};
 handle_info(
-    {retention_result, {Edit, Refs}},
-    #state{core = Core0, retention_mon = Mon, retention_timer = TRef, cfg = #cfg{stream = StreamId}} =
+    {retention_result, Token, {Edit, Refs}},
+    #state{
+        retention_token = Token,
+        core = Core0,
+        retention_mon = Mon,
+        retention_timer = TRef,
+        cfg = #cfg{stream = StreamId}
+    } =
         State0
 ) ->
     demonitor(Mon, [flush]),
     _ = cancel_timer(TRef),
     State = on_remote_retention(Edit, Refs, StreamId, Core0, State0#state{
-        retention_mon = undefined, retention_pid = undefined, retention_timer = undefined
+        retention_mon = undefined,
+        retention_pid = undefined,
+        retention_timer = undefined,
+        retention_token = undefined
     }),
+    {noreply, State};
+handle_info(
+    {retention_result, _StaleToken, _Result},
+    #state{cfg = #cfg{stream = StreamId}} = State
+) ->
+    %% A result from a retention task we are no longer tracking - typically one
+    %% the retention timeout already killed, whose message was queued before the
+    %% kill. Its token does not match the current (or absent) task, so ignore it
+    %% rather than apply a stale truncation edit or demonitor a cleared monitor.
+    ?LOG_DEBUG("~ts ignoring stale retention result", [StreamId]),
     {noreply, State};
 handle_info(
     retention_timeout,
@@ -637,7 +679,8 @@ handle_info(
             core = Core,
             retention_mon = undefined,
             retention_pid = undefined,
-            retention_timer = undefined
+            retention_timer = undefined,
+            retention_token = undefined
         })};
 handle_info(retention_timeout, State) ->
     %% Stale timeout after normal completion; ignore.
@@ -725,7 +768,8 @@ handle_info(
             core = Core,
             retention_mon = undefined,
             retention_pid = undefined,
-            retention_timer = undefined
+            retention_timer = undefined,
+            retention_token = undefined
         })};
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -1154,22 +1198,8 @@ update_counter(Cnt, FstOff, NumSegLeft) ->
 maybe_evaluate_remote_retention(_Manifest, [], _StreamId, State) ->
     State;
 maybe_evaluate_remote_retention(Manifest, Retention, StreamId, #state{core = Core0} = State) ->
-    case rabbitmq_stream_s3_replica_reader_core:rebalance_in_flight(Core0) of
-        true ->
-            %% A rebalance is rewriting the manifest's leading entries. Remote
-            %% retention rewrites the same prefix, so evaluating it now would
-            %% compute an edit against a manifest the rebalance is about to
-            %% change, and applying it would race the rebalance over that
-            %% prefix (Single mutator). Skip; retention is re-evaluated by the
-            %% next persist_complete once the rebalance has finished. This
-            %% guards the manual CLI trigger; the automatic post-persist path
-            %% is already gated by persist_complete.
-            ?LOG_DEBUG(
-                "~ts skipping remote retention evaluation: rebalance in flight",
-                [StreamId]
-            ),
-            State;
-        false ->
+    case rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(Core0) of
+        none ->
             inc(State, ?C_REMOTE_TIER_RETENTION_EVALUATIONS, 1),
             Now = erlang:system_time(millisecond),
             %% First try without group download (handles the fragments-only
@@ -1182,7 +1212,26 @@ maybe_evaluate_remote_retention(Manifest, Retention, StreamId, #state{core = Cor
                     maybe_spawn_group_retention(Manifest, Retention, Now, StreamId, State);
                 {Edit, Refs} ->
                     on_remote_retention(Edit, Refs, StreamId, Core0, State)
-            end
+            end;
+        Blocker ->
+            %% A manifest-prefix rewrite is already in flight. Remote retention
+            %% rewrites that same prefix, so evaluating it now would compute an
+            %% edit against a manifest that is about to change (racing the
+            %% in-flight writer: Single mutator). A second remote-retention task
+            %% in particular would capture the same pre-retention snapshot and
+            %% recompute the identical prefix-truncation edit, which would then
+            %% be applied a second time: splicing out live entries and
+            %% double-counting total_size. The corrupt edit is persisted and
+            %% broadcast in-sequence, so every replica applies it with no gap
+            %% detected. Skip; retention is re-evaluated by the next
+            %% persist_complete once the in-flight work finishes. This guards the
+            %% manual CLI and retention_updated triggers; the automatic
+            %% post-persist path is already gated by persist_complete.
+            ?LOG_DEBUG(
+                "~ts skipping remote retention evaluation: ~ts in flight",
+                [StreamId, Blocker]
+            ),
+            State
     end.
 
 %% Handle a retention result (synchronous fragments-only case or async completion).
@@ -1210,6 +1259,7 @@ maybe_spawn_group_retention(
     State
 ) when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
     Self = self(),
+    Token = make_ref(),
     GetGroupFun = rabbitmq_stream_s3_manifest:get_cached_group_fun(StreamId),
     {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
@@ -1225,12 +1275,18 @@ maybe_spawn_group_retention(
                     ),
                     {failed, {Class, Reason}}
             end,
-        Self ! {retention_result, Result}
+        Self ! {retention_result, Token, Result}
     end),
     Core = rabbitmq_stream_s3_replica_reader_core:retention_started(State#state.core),
     Timeout = rabbitmq_stream_s3_config:retention_task_timeout(),
     TRef = erlang:send_after(Timeout, Self, retention_timeout),
-    State#state{core = Core, retention_mon = MonRef, retention_pid = Pid, retention_timer = TRef};
+    State#state{
+        core = Core,
+        retention_mon = MonRef,
+        retention_pid = Pid,
+        retention_timer = TRef,
+        retention_token = Token
+    };
 maybe_spawn_group_retention(_Manifest, _Retention, _Now, _StreamId, State) ->
     State.
 

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -16,7 +16,7 @@ testable without mocks or timing.
     init/2,
     manifest/1,
     persisted_manifest/1,
-    rebalance_in_flight/1,
+    pending_prefix_rewrite/1,
     format_state/1,
     fragment_cut/2,
     transfer_complete/3,
@@ -147,14 +147,20 @@ persisted_manifest(#state{last_persisted_manifest = Manifest}) ->
     Manifest.
 
 -doc """
-Whether a root rebalance (factoring leading entries into a group object) is in
-flight. The shell consults this before evaluating remote retention, since both
-rewrite the manifest's leading entries and must not run concurrently (Single
-mutator).
+Which manifest-prefix rewrite, if any, is in flight: a `rebalance` (factoring
+leading entries into a group object) or a remote `retention` evaluation
+(truncating leading entries). Both rewrite the manifest's leading entries, so a
+remote-retention trigger must stand down while either runs: evaluating against a
+prefix that is about to change races the in-flight writer (Single mutator), and
+a second retention task in particular would capture the same pre-retention
+snapshot, recompute the identical prefix-truncation edit, and apply it twice,
+deleting live entries and double-counting total_size. Returns the specific
+blocker so the caller can report which one is in progress.
 """.
--spec rebalance_in_flight(state()) -> boolean().
-rebalance_in_flight(#state{rebalance_in_flight = Flag}) ->
-    Flag.
+-spec pending_prefix_rewrite(state()) -> none | rebalance | retention.
+pending_prefix_rewrite(#state{rebalance_in_flight = true}) -> rebalance;
+pending_prefix_rewrite(#state{retention_in_flight = true}) -> retention;
+pending_prefix_rewrite(#state{}) -> none.
 
 -spec format_state(state()) -> map().
 format_state(#state{

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -89,7 +89,8 @@ groups() ->
             remote_retention_deletes_within_group,
             remote_retention_deletes_all_fragments,
             old_manifest_roots_deleted,
-            attach_to_stream_with_prior_retention
+            attach_to_stream_with_prior_retention,
+            stale_retention_result_is_ignored
         ]},
         {with_replica, [], [
             replication_happy_path
@@ -1033,6 +1034,25 @@ attach_to_stream_with_prior_retention(Config) ->
     {FirstOffset, NextOffset} = get_range(Config),
     ?assert(FirstOffset > 0),
     ?assertEqual(20, NextOffset).
+
+stale_retention_result_is_ignored(Config) ->
+    %% A retention result whose token does not match the in-flight task (for
+    %% example one the retention timeout already killed, whose message was
+    %% queued before the kill) must be ignored, not routed to the apply path.
+    %% Inject one with a fresh, unknown token and a payload that would crash the
+    %% reader if it reached the edit-apply handler ({not_an_edit, []} would be
+    %% taken as an {Edit, Refs} result), then confirm the reader is unaffected.
+    StreamId = ?config(stream_id, Config),
+    _ = start_writer(Config, #{}),
+    ReaderPid = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ?assert(is_pid(ReaderPid)),
+    ReaderPid ! {retention_result, make_ref(), {not_an_edit, []}},
+    %% A synchronous call doubles as a barrier: it only returns once the info
+    %% message above has been handled. The reader must still be the same live
+    %% process (no crash, no supervised restart).
+    _ = rabbitmq_stream_s3_replica_reader:evaluate_remote_retention(StreamId),
+    ?assert(is_process_alive(ReaderPid)),
+    ?assertEqual(ReaderPid, rabbitmq_stream_s3_registry:whereis_name({StreamId, node()})).
 
 replication_happy_path(Config) ->
     StreamId = ?config(stream_id, Config),

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -67,6 +67,7 @@ all() ->
         retention_defers_persist,
         retention_edit_broadcast_on_persist_complete,
         retention_failed_clears_flag,
+        pending_prefix_rewrite_reports_blocker,
         persist_failed_during_rebalance_retries_after,
         recursive_rebalance_three_levels_deep,
         multiple_persist_conflicts_reinitialize,
@@ -1093,6 +1094,25 @@ retention_edit_broadcast_on_persist_complete(_Config) ->
     ?assertMatch([_], RetEdits),
     %% The invariant must hold.
     assert_edits_reproduce_manifest(From, To, Edits).
+
+pending_prefix_rewrite_reports_blocker(_Config) ->
+    %% pending_prefix_rewrite/1 is the single gate the shell consults before
+    %% evaluating remote retention. It must report none when idle, and name the
+    %% specific in-flight prefix rewrite (retention or rebalance) so the CLI can
+    %% tell the operator which one is blocking.
+    {S0, _} = init_core(#{rebalance_threshold => 4, persist_threshold => 100}),
+    ?assertEqual(none, rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(S0)),
+    %% An async remote-retention evaluation in flight.
+    SRet = rabbitmq_stream_s3_replica_reader_core:retention_started(S0),
+    ?assertEqual(retention, rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(SRet)),
+    %% A rebalance in flight: four fragments reach the rebalance threshold.
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    S4 = cut_and_complete(S3, 300, 400, 1004),
+    #{rebalance_in_flight := true} =
+        rabbitmq_stream_s3_replica_reader_core:format_state(S4),
+    ?assertEqual(rebalance, rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(S4)).
 
 retention_failed_clears_flag(_Config) ->
     %% After retention_failed, persist should be unblocked.


### PR DESCRIPTION
A remote-retention evaluation against a manifest whose root is a group runs as an async task: it downloads the group, computes a prefix-truncation edit (pos=0, len=NumWhole*ENTRY_B, size=-Bytes), and applies it on completion. The trigger paths (the evaluate_remote_retention CLI call and the retention_updated cast) only checked for an in-flight rebalance, never for an in-flight retention task. So a second trigger during the seconds-long group download spawned a second task that captured the same pre-retention snapshot and recomputed the identical edit. Both results were applied: the second spliced out a second run of leading entries (now live, surviving fragments) and double-subtracted total_size. The corrupt edit is persisted and broadcast in-sequence, so every replica applies the same corruption with no gap detected, and the flushed refs delete objects the surviving manifest still references.

Two parts:

- Consolidate the two in-flight checks into a single core accessor, pending_prefix_rewrite/1, that returns which rewrite (rebalance or retention) holds the leading prefix, or none. Both trigger paths now stand down while either is in flight; the CLI replies {error, {in_progress, Blocker}} naming the blocker, surfaced by the command with a try-again message and a tempfail exit code, and the event-driven path skips and re-evaluates on the next persist.

- Correlate each async retention task with a fresh make_ref/0 token. The task tags its result with the token and the result handlers only apply a result whose token matches the current task; a result from a task we stopped tracking (for example one the retention timeout already killed, whose message was queued before the kill) carries a stale token and is ignored rather than applied onto a manifest it no longer matches or crashing on a cleared monitor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
