### PR TITLE
Acquire the upload connection before incrementing request gauges

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -380,11 +380,18 @@ stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) 
                 )
             of
                 {ok, Headers} ->
+                    Pool = ?UPLOAD_POOL,
+                    %% Acquire the connection before touching the request
+                    %% gauges. checkout/2 re-raises on a timeout or pool-down,
+                    %% and C_ACTIVE_REQUESTS is only decremented by finish_async,
+                    %% which runs once we hold a connection and have built State.
+                    %% Incrementing before the checkout leaked the gauge on every
+                    %% failed checkout (a sustained partial outage that drains the
+                    %% pool drove active_requests up with no way back down).
+                    Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
                     Cnt = counter(),
                     counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
                     counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
-                    Pool = ?UPLOAD_POOL,
-                    Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
                     StreamRef = gun:headers(Conn, Method, Path, Headers),
                     State = #{
                         pool => Pool,


### PR DESCRIPTION
The streaming PUT path incremented active_requests and total_requests before checking out a connection. checkout/2 re-raises on a timeout or pool-down, and active_requests is only decremented by finish_async (which runs once a connection is held and State is built), so a failed checkout leaked the gauge. Under a sustained partial outage that drains the pool this drove active_requests steadily upward with no path back down, misleading on-call during the exact stuck-upload incidents the gauge is meant to illuminate.

Move the gauge increments after a successful checkout so they only count requests that actually acquired a connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
