### PR TITLE
Classify the S3 API layer's real error shapes as retriable

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -742,14 +742,35 @@ assert_contiguous(NextOffset, FragmentFirstOffset) ->
     ).
 
 -spec is_retriable(term()) -> boolean().
-is_retriable({http, 500}) -> true;
-is_retriable({http, 503}) -> true;
-is_retriable(timeout) -> true;
+%% Transient conditions worth retrying without operator intervention. These are
+%% the actual error shapes the S3 API layer produces (see
+%% rabbitmq_stream_s3_api_aws): a 500 is reported as `internal_error`, a 503 as
+%% `slow_down`, a dropped or oversaturated connection as `connection_error`, and
+%% any other non-success status as `#{status => _}`. The earlier `{http, 500}`
+%% / `{http, 503}` clauses matched terms that no code ever constructs, so every
+%% real transient fell through to the fatal answer. The transfer paths that
+%% consult this never abandon a confirmed fragment (the fatal branch retries
+%% with a backoff), so a wrong answer only changes retry timing; keep the set to
+%% genuinely transient conditions and let everything else fall through.
+is_retriable(timeout) ->
+    true;
 %% A reader-side transfer deadline: the governor never reported a result for a
 %% submitted transfer (lost message, externally killed task, or a queued
 %% submission dropped by a governor restart). The fragment was never made
-%% durable, so retrying immediately under the same reference is both safe and
+%% durable, so retrying immediately under the same reference is safe and
 %% correct. See rabbitmq_stream_s3_config:transfer_deadline_ms/0 and the
 %% transfer_deadline handler in rabbitmq_stream_s3_replica_reader.
-is_retriable(transfer_deadline) -> true;
-is_retriable(_) -> false.
+is_retriable(transfer_deadline) ->
+    true;
+is_retriable(connection_error) ->
+    true;
+is_retriable(slow_down) ->
+    true;
+is_retriable(internal_error) ->
+    true;
+is_retriable(#{status := Status}) ->
+    %% 408 request timeout, 429 throttling, and any 5xx are server-side
+    %% transients; everything else (e.g. 403, 404) is fatal.
+    Status =:= 408 orelse Status =:= 429 orelse (Status >= 500 andalso Status =< 599);
+is_retriable(_) ->
+    false.

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -34,6 +34,7 @@ all() ->
         persist_failed_not_found_zero_revision_reinitializes,
         persist_failed_transient_retries,
         transfer_failed_retriable_resubmits,
+        transfer_failed_status_map_retriable_resubmits,
         transfer_failed_fatal_retries_no_gap,
         fatal_failure_does_not_drain_subsequent,
         fatal_failure_retry_then_complete_no_gap,
@@ -304,7 +305,19 @@ persist_failed_transient_retries(_Config) ->
 transfer_failed_retriable_resubmits(_Config) ->
     {S0, _} = init_core(),
     {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
-    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, {http, 503}, S1),
+    %% slow_down is the S3 API layer's term for a 503 (the real shape; the old
+    %% {http, 503} term was never constructed by any code).
+    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, slow_down, S1),
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _}], Effects).
+
+transfer_failed_status_map_retriable_resubmits(_Config) ->
+    %% A non-special-cased transient status arrives as #{status => _}; a 5xx
+    %% must be treated as retriable.
+    {S0, _} = init_core(),
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
+        Ref, #{status => 504, headers => []}, S1
+    ),
     ?assertMatch([{resubmit_transfer, Ref, _, _, _}], Effects).
 
 transfer_failed_fatal_retries_no_gap(_Config) ->
@@ -858,9 +871,10 @@ group_upload_failed_retriable_retries(_Config) ->
         S0,
         lists:seq(0, Threshold - 1)
     ),
-    %% Retriable failure re-emits upload_group.
+    %% Retriable failure re-emits upload_group. internal_error is the API
+    %% layer's term for a 500 (the real shape).
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_failed(
-        {http, 503}, S1
+        internal_error, S1
     ),
     UploadGroups = [E || {upload_group, _, _, _, _, _} = E <- Effects],
     ?assertMatch([_], UploadGroups).
@@ -875,9 +889,10 @@ group_upload_failed_fatal_abandons(_Config) ->
         S0,
         lists:seq(0, Threshold - 1)
     ),
-    %% Fatal failure abandons rebalance and allows persist to proceed.
+    %% Fatal failure abandons rebalance and allows persist to proceed. A 403
+    %% arrives as #{status => 403}; it is not in the retriable set.
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_failed(
-        {http, 403}, S1
+        #{status => 403, headers => []}, S1
     ),
     %% No upload_group retry, but persist should fire (threshold met).
     UploadGroups = [E || {upload_group, _, _, _, _, _} = E <- Effects],


### PR DESCRIPTION
is_retriable/1 keyed on {http, 500} and {http, 503} atoms that no code ever constructs. The S3 API layer reports a 500 as `internal_error`, a 503 as `slow_down`, a dropped or oversaturated connection as `connection_error`, and any other non-success status as `#{status => _}`. So every real transient matched the catch-all and was treated as fatal: group rebalance uploads abandoned and waited for the next drain, and fragment transfers took the slow backoff path while logging a misleading non-transient warning on each retry.

Match the actual shapes instead: internal_error, slow_down, connection_error, and #{status := S} for 408/429/5xx, alongside the existing timeout and transfer_deadline. The transfer paths that consult this never abandon a confirmed fragment, so the change only moves genuine transients onto the fast retry path.

Update the retriable/fatal tests to use the real shapes (the old ones asserted behavior for terms that never occur) and add a #{status => 504} case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
