### PR TITLE
Re-arm persist when an async retention evaluation finishes empty

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -481,11 +481,25 @@ them here because both outcomes mean the same thing to the core.
 """.
 -spec retention_failed(term(), state()) -> {state(), [core_effect()]}.
 retention_failed(_Reason, State0) ->
-    %% Retention cleared without changing the manifest. A rebalance may have
-    %% been deferred while it was in flight; re-check it now that the flag is
-    %% clear so an oversized root does not wait for the next drain to compact.
-    %% Persist is left to the subsequent tick or drain, as before.
-    maybe_start_rebalance(State0#state{retention_in_flight = false}).
+    %% Retention cleared without changing the manifest. Mirror the wrap-up of
+    %% retention_complete/2 (minus the edit): re-check a rebalance deferred while
+    %% retention was in flight, then re-evaluate persist and re-arm the persist
+    %% timer.
+    %%
+    %% The timer re-arm is the important part. While retention_in_flight was
+    %% true, both maybe_start_persist and tick/2 were suppressed. A fragment that
+    %% completed during that window armed a one-shot persist timer, but the tick
+    %% that timer eventually drives is a no-op (still in flight) that consumes the
+    %% one-shot without rescheduling. If we do not re-arm here, that pending edit
+    %% is stranded unpersisted until the next publish: on an idle low-throughput
+    %% stream await_offset waiters block and local retention cannot reclaim the
+    %% segments. Every other flag-clearing path already re-arms; this was the one
+    %% exit that did not.
+    State1 = State0#state{retention_in_flight = false},
+    {State2, RebalanceEffects} = maybe_start_rebalance(State1),
+    {State3, PersistEffects} = maybe_start_persist(State2),
+    TimerEffects = rearm_persist_timer_if_pending(PersistEffects, State3),
+    {State3, RebalanceEffects ++ PersistEffects ++ TimerEffects}.
 
 %% ------------------------------------------------------------------
 %% Internal

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -68,6 +68,7 @@ all() ->
         retention_edit_broadcast_on_persist_complete,
         retention_failed_clears_flag,
         pending_prefix_rewrite_reports_blocker,
+        retention_failed_rearms_persist,
         persist_failed_during_rebalance_retries_after,
         recursive_rebalance_three_levels_deep,
         multiple_persist_conflicts_reinitialize,
@@ -1115,18 +1116,48 @@ pending_prefix_rewrite_reports_blocker(_Config) ->
     ?assertEqual(rebalance, rabbitmq_stream_s3_replica_reader_core:pending_prefix_rewrite(S4)).
 
 retention_failed_clears_flag(_Config) ->
-    %% After retention_failed, persist should be unblocked.
+    %% After retention_failed clears the in-flight flag, a time-based tick can
+    %% persist again. Uses a persist_threshold above the pending count so the
+    %% persist is not count-triggered by retention_failed itself (that path is
+    %% covered by retention_failed_rearms_persist); here we pin that the flag is
+    %% cleared so the subsequent tick is no longer suppressed.
+    {S0, _} = init_core(#{persist_threshold => 3}),
+    %% Establish a persisted baseline: three fragments hit the threshold.
+    S1 = cut_and_complete(S0, 0, 100, 1001),
+    S2 = cut_and_complete(S1, 100, 200, 1002),
+    S3 = cut_and_complete(S2, 200, 300, 1003),
+    {S4, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S3),
+    %% Mark retention started, then apply one fragment (since_persist = 1 < 3).
+    S5 = rabbitmq_stream_s3_replica_reader_core:retention_started(S4),
+    S6 = cut_and_complete(S5, 300, 400, 1004),
+    %% Retention fails. The threshold is not met, so no persist starts yet, but
+    %% the flag is cleared so a tick is no longer a no-op.
+    {S7, FailEffects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, S6),
+    ?assertEqual([], [E || {start_persist, _, _, _, _, _} = E <- FailEffects]),
+    %% Tick should trigger persist (since_persist > 0, interval elapsed).
+    Now = erlang:system_time(millisecond) + 10000,
+    {_S8, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S7),
+    Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
+    ?assertMatch([_], Persists).
+
+retention_failed_rearms_persist(_Config) ->
+    %% A fragment that completes while retention is in flight has its persist
+    %% deferred and the one-shot persist timer it would rely on is consumed by a
+    %% no-op tick. retention_failed/2 must itself re-evaluate persist when it
+    %% clears the flag, otherwise the pending fragment is stranded unpersisted
+    %% on an idle stream until the next publish. This pins that retention_failed
+    %% emits the persist directly, without depending on a later tick.
     {S0, _} = init_core(#{persist_threshold => 1}),
     S1 = cut_and_complete(S0, 0, 100, 1001),
     {S2, _} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, S1),
-    %% Mark retention started, then apply a fragment.
+    %% Retention starts, then a fragment completes during the in-flight window.
     S3 = rabbitmq_stream_s3_replica_reader_core:retention_started(S2),
-    S4 = cut_and_complete(S3, 100, 200, 1002),
-    %% Retention fails. Persist should now be possible.
-    {S5, _} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, S4),
-    %% Tick should trigger persist (since_persist > 0, interval elapsed).
-    Now = erlang:system_time(millisecond) + 10000,
-    {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, S5),
+    {S4, DeferEffects} = cut_and_complete_effects(S3, 100, 200, 1002),
+    %% Persist was deferred while retention was in flight.
+    ?assertEqual([], [E || {start_persist, _, _, _, _, _} = E <- DeferEffects]),
+    %% Retention fails. With a pending fragment and threshold=1, persist must
+    %% start now, from retention_failed itself.
+    {_S5, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, S4),
     Persists = [E || {start_persist, _, _, _, _, _} = E <- Effects],
     ?assertMatch([_], Persists).
 


### PR DESCRIPTION
While an async remote-retention evaluation is in flight, both maybe_start_persist and tick/2 are suppressed. A fragment that completes during that window arms a one-shot persist timer, but the tick that timer drives is a no-op (retention still in flight) that consumes the one-shot without rescheduling. retention_failed/2 was the only flag-clearing exit that did not re-arm afterwards: it ran only maybe_start_rebalance. So when a retention evaluation returned "found nothing", timed out, or errored (the common outcome) and the stream then went idle, the uploaded fragment's manifest entry was stranded unpersisted until the next publish or a reader restart. await_offset waiters block on it and local retention cannot reclaim the segment.

Make retention_failed/2 mirror retention_complete/2's wrap-up (minus the edit): re-check a deferred rebalance, re-evaluate persist, and re-arm the persist timer if an edit is still pending.

Tests: add retention_failed_rearms_persist (a fragment deferred during in-flight retention is persisted directly by retention_failed when the threshold is met). Adjust retention_failed_clears_flag to establish a persisted baseline and use a threshold above the pending count, so it still exercises the distinct flag-cleared-then-tick path rather than the now-immediate persist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
