### PR TITLE
Recover when the remote tier is ahead of the local log

### DIFF
--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -59,15 +59,15 @@ For the concepts behind these scenarios, see [concepts.md](./concepts.md). For t
 **Detection.** Logs on the writer node when the replica reader starts:
 
 ```
-~ts local log ahead of manifest (local_first=N, manifest_next=M).
-Discarding remote manifest and restarting.
+~ts remote tier ahead of local log (manifest_next=M, local_first=N).
+Discarding remote manifest and restarting from the local log.
 ```
 
-`rabbitmq_stream_s3_local_log_ahead_recoveries` increments. The manifest's `rabbitmq_stream_s3_manifest_next_offset` resets to the local log's first offset.
+`rabbitmq_stream_s3_remote_tier_ahead_recoveries` increments. The manifest's `rabbitmq_stream_s3_manifest_next_offset` resets to the local log's first offset. (This is the inverse of the "Segment deleted before upload" case below, which fires `rabbitmq_stream_s3_local_log_ahead_recoveries`: there the local log's first offset is *ahead of* the manifest; here the manifest's next offset is *beyond* the local log's last offset.)
 
 **Mitigation.** None. The replica reader handles this automatically on startup.
 
-**Resolution.** The replica reader discards the remote manifest, deletes the stale fragment objects in the background (via the reaper), and resumes normal operation from the local log's first offset. The local log is always authoritative.
+**Resolution.** The replica reader discards the remote manifest, deletes the stale fragment objects in the background (via the reaper), and resumes normal operation from the local log's first offset. The local log is always authoritative. One sub-case is intentionally left to the ordinary resolution retry rather than triggering a reset: a *completely empty* local log paired with a non-empty manifest, which is more often a transient writer-recovery state than a genuine timeline divergence, and resetting then would prematurely discard recoverable remote data.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -202,6 +202,7 @@ These metrics decompose disk-resident bytes by their position in the upload pipe
 | `rabbitmq_stream_s3_manifests_resolved_empty`          | counter | Times a genuinely empty manifest was resolved on startup          |
 | `rabbitmq_stream_s3_manifest_resolution_failures`      | counter | Resolutions that hit a transient store or object error and were retried instead of resolving empty |
 | `rabbitmq_stream_s3_local_log_ahead_recoveries`        | counter | Times the replica reader discarded the remote manifest because the local log was ahead (e.g. retention deleted un-uploaded data) |
+| `rabbitmq_stream_s3_remote_tier_ahead_recoveries`      | counter | Times the replica reader discarded the remote manifest because the remote tier was ahead of the local log (manifest next_offset beyond the local log after a leader election or data-directory loss) |
 
 #### Retention
 

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -97,19 +97,20 @@ returned by the functional core module.
 -define(C_BYTES_PERSISTED, 21).
 -define(C_REMOTE_TIER_RETENTION_FAILURES, 22).
 -define(C_MANIFEST_RESOLUTION_FAILURES, 23).
+-define(C_REMOTE_TIER_AHEAD_RECOVERIES, 24).
 %% Counters above; gauges below. The macro ?NODE_COUNTERS filters by
 %% type, and seshat requires counter indexes to be 1..N sequential. Add
 %% new counters before this divider and renumber the gauges that follow.
--define(C_TRANSFERS_IN_FLIGHT, 24).
--define(C_LAST_PERSIST_TIMESTAMP_MS, 25).
--define(C_MANIFEST_FIRST_OFFSET, 26).
--define(C_MANIFEST_NEXT_OFFSET, 27).
--define(C_MANIFEST_FIRST_TIMESTAMP_MS, 28).
--define(C_REMOTE_BYTES, 29).
--define(C_REMOTE_MESSAGES, 30).
--define(C_BYTES_IN_ASSEMBLY, 31).
--define(C_BYTES_IN_TRANSFER, 32).
--define(C_BYTES_IN_PERSIST, 33).
+-define(C_TRANSFERS_IN_FLIGHT, 25).
+-define(C_LAST_PERSIST_TIMESTAMP_MS, 26).
+-define(C_MANIFEST_FIRST_OFFSET, 27).
+-define(C_MANIFEST_NEXT_OFFSET, 28).
+-define(C_MANIFEST_FIRST_TIMESTAMP_MS, 29).
+-define(C_REMOTE_BYTES, 30).
+-define(C_REMOTE_MESSAGES, 31).
+-define(C_BYTES_IN_ASSEMBLY, 32).
+-define(C_BYTES_IN_TRANSFER, 33).
+-define(C_BYTES_IN_PERSIST, 34).
 
 -define(STREAM_COUNTERS, [
     {transfers_completed, ?C_TRANSFERS_COMPLETED, counter,
@@ -151,6 +152,10 @@ returned by the functional core module.
     {local_log_ahead_recoveries, ?C_LOCAL_LOG_AHEAD_RECOVERIES, counter,
         "Times the replica reader discarded the remote manifest because the local log "
         "was ahead (e.g. local retention deleted un-uploaded data)"},
+    {remote_tier_ahead_recoveries, ?C_REMOTE_TIER_AHEAD_RECOVERIES, counter,
+        "Times the replica reader discarded the remote manifest because the remote tier "
+        "was ahead of the local log (the manifest's next_offset was beyond the local "
+        "log's last offset after a leader election or data-directory loss)"},
     {bytes_drained_total, ?C_BYTES_DRAINED, counter,
         "Cumulative bytes the replica reader has drained from osiris (sum of chunk "
         "byte sizes read via osiris_log:read_header)"},
@@ -1490,8 +1495,7 @@ start_reading0(
         cfg = #cfg{
             writer_pid = WriterPid,
             fragment_target_size = TargetSize,
-            stream = StreamId,
-            epoch = Epoch
+            stream = StreamId
         },
         core = Core
     } = State
@@ -1521,21 +1525,30 @@ start_reading0(
                 [StreamId, LocalFirst, StartOffset]
             ),
             inc(State1, ?C_LOCAL_LOG_AHEAD_RECOVERIES, 1),
-            FreshManifest = reset_manifest(LocalFirst, Manifest#manifest.revision),
-            {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(
-                FreshManifest, State1#state.config
+            restart_at_local_floor(LocalFirst, Manifest, State1);
+        {error, {offset_out_of_range, {LocalFirst, _LastOffset}}} ->
+            %% The manifest's next_offset is beyond the local log's last offset
+            %% (LocalFirst =< StartOffset, so this is not the local-ahead case
+            %% above): a leader election or a power-loss timeline change left the
+            %% local log shorter than the committed manifest. This is the "remote
+            %% tier ahead of local" case in failure-modes.md. Local data is
+            %% authoritative, so discard the remote manifest and restart from the
+            %% local log's first offset. Without this the open at StartOffset
+            %% fails identically on every retry_resolve, wedging tiering forever
+            %% and growing local disk unbounded (local retention only reclaims
+            %% offsets below the pinned next_offset). The empty-local-log shape
+            %% (offset_out_of_range = empty) is intentionally left to the retry
+            %% path below: an empty local log can be a transient writer-recovery
+            %% state, and resetting then would prematurely discard recoverable
+            %% remote data.
+            ?LOG_WARNING(
+                "~ts remote tier ahead of local log "
+                "(manifest_next=~b, local_first=~b). "
+                "Discarding remote manifest and restarting from the local log.",
+                [StreamId, StartOffset, LocalFirst]
             ),
-            ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
-            %% Propagate the reset to replicas. The reset discards the writer's
-            %% manifest and installs a fresh one at the local floor, but leaves
-            %% broadcast_seq unchanged. Replicas still hold the pre-reset
-            %% manifest at their last broadcast seq; without this resync the
-            %% next broadcast would land in-sequence and splice an edit onto a
-            %% manifest the writer has already discarded, corrupting every
-            %% replica (the same silent divergence as an unsynced register).
-            ok = sync_all_replicas(FreshManifest, State1),
-            gc_stream_async(StreamId, Epoch),
-            start_reading(State1#state{core = Core1});
+            inc(State1, ?C_REMOTE_TIER_AHEAD_RECOVERIES, 1),
+            restart_at_local_floor(LocalFirst, Manifest, State1);
         {error, Reason} ->
             ?LOG_WARNING(
                 "Failed to open data reader for stream ~ts: ~p",
@@ -1553,6 +1566,31 @@ start_reading0(
             %% Retry immediately (same pattern as osiris_log:init_offset_reader).
             start_reading((close_log(State1))#state{core = Core, assembly = undefined})
     end.
+
+%% Discard the remote manifest and restart tiering from the local log's first
+%% offset. Shared by both manifest/local divergence directions handled in
+%% start_reading0/1: local-ahead (local retention trimmed the local log past the
+%% manifest) and remote-ahead (the manifest's next_offset is beyond the local
+%% log after a timeline change). In both, local data is authoritative.
+-spec restart_at_local_floor(osiris:offset(), #manifest{}, #state{}) -> #state{}.
+restart_at_local_floor(
+    LocalFirst,
+    #manifest{revision = Revision},
+    #state{cfg = #cfg{stream = StreamId, epoch = Epoch}} = State
+) ->
+    FreshManifest = reset_manifest(LocalFirst, Revision),
+    {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(FreshManifest, State#state.config),
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
+    %% Propagate the reset to replicas. The reset discards the writer's manifest
+    %% and installs a fresh one at the local floor, but leaves broadcast_seq
+    %% unchanged. Replicas still hold the pre-reset manifest at their last
+    %% broadcast seq; without this resync the next broadcast would land
+    %% in-sequence and splice an edit onto a manifest the writer has already
+    %% discarded, corrupting every replica (the same silent divergence as an
+    %% unsynced register).
+    ok = sync_all_replicas(FreshManifest, State),
+    gc_stream_async(StreamId, Epoch),
+    start_reading(State#state{core = Core1}).
 
 %% Whether the live local log has been trimmed past the manifest's next_offset.
 %% When true, the segment backing the stalled head fragment is permanently gone

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
             large_record_cuts_immediately,
             seed_log_uploads_deterministic,
             local_ahead_discards_manifest,
+            remote_tier_ahead_discards_manifest,
             stream_deletion_cleans_remote_tier,
             stream_deletion_during_active_upload,
             persist_not_found_stops_reader,
@@ -611,6 +612,42 @@ local_ahead_discards_manifest(Config) ->
     NewFragments = list_fragment_offsets(Config),
     ?assert(length(NewFragments) > 0),
     ?assert(hd(NewFragments) >= FirstLocal).
+
+remote_tier_ahead_discards_manifest(Config) ->
+    StreamId = ?config(stream_id, Config),
+
+    %% Phase 1: seed a local log, upload, so the manifest reaches next_offset N.
+    #{next_offset := N} = seed_log(Config, [
+        {segment, [{chunk, #{records => 10, size => 600}}]},
+        {segment, [{chunk, #{records => 10, size => 600}}]}
+    ]),
+    Writer = start_writer(Config, #{}, #{fragment_target_size => 500}),
+    flush_writer(Writer),
+    await_offset(Config, N),
+
+    %% Phase 2: stop the reader and forge a manifest whose next_offset is far
+    %% beyond the local log's last offset, as a leader election or a
+    %% data-directory loss would leave it (the remote tier ahead of local).
+    %% Keep the committed revision so the reader trusts this cached manifest on
+    %% resolve.
+    ReaderPid = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ok = rabbitmq_stream_s3_replica_reader_sup:stop_child(ReaderPid),
+    Manifest = rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+    {ok, #{revision := Rev}} = rabbitmq_stream_s3_db:get(StreamId),
+    Ahead = Manifest#manifest{next_offset = N + 1000, revision = Rev},
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, Ahead),
+
+    %% Phase 3: restart the reader. It must discard the remote manifest and
+    %% restart from the local log's first offset, then re-tier the local log
+    %% back up to N - rather than wedging in a 1s retry_resolve loop with
+    %% next_offset pinned at N+1000 (the bug). Recovery resets next_offset below
+    %% the forged value and re-tiering brings it back to exactly N.
+    _ = start_replica_reader(Writer, Config, #{fragment_target_size => 500}),
+    ?awaitMatch(
+        #manifest{next_offset = N},
+        rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
+        5000
+    ).
 
 stream_deletion_cleans_remote_tier(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
start_reading0/1 only handled the local-ahead divergence: an offset_out_of_range whose first available offset is greater than the manifest's next_offset (local retention trimmed data the manifest still expected). The inverse - the manifest's next_offset beyond the local log's last offset, after a leader election or a data-directory loss left a shorter local timeline - fell through to the generic error branch, which reschedules retry_resolve after one second. retry_resolve re-reads the same committed manifest and re-opens the data reader at the same out-of-range offset, so the reader looped every second forever: tiering stopped silently and local disk grew unbounded, because local retention only reclaims offsets below the pinned next_offset. failure-modes.md documents this "remote tier ahead of local" scenario as automatically recovered, but the recovery did not exist.

Handle the remote-ahead offset_out_of_range shape (LocalFirst =< StartOffset) by discarding the remote manifest and restarting from the local log's first offset, the same "local always wins" reset the local-ahead branch performs. The shared reset sequence (reset_manifest, core re-init, put_manifest, replica resync, GC, restart) is extracted into restart_at_local_floor/3 so the two directions cannot drift. A new counter, remote_tier_ahead_recoveries, is distinct from local_log_ahead_recoveries, which counts the opposite direction; failure-modes.md is corrected to reference the right log line and metric.

The empty-local-log shape (offset_out_of_range = empty) is intentionally left to the retry path: an empty local log is more often a transient writer-recovery state than a genuine divergence, and resetting then would prematurely discard recoverable remote data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
