### PR TITLE
Use the manifest revision as the broadcast sequence number

### DIFF
--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -18,6 +18,13 @@ Edits carry a monotonic sequence number and epoch. The replica applies
 edits only if `seq == last_seq + 1` and the epoch matches. On gap or
 epoch mismatch, the replica requests a full re-sync from the writer.
 
+The sequence number is the writer's manifest revision (the stream's Khepri
+`payload_version`), which advances by exactly one per persist in lockstep with
+broadcasts. Because it is durable, a writer-side reader that crashes and is
+restarted at the same epoch resumes the sequence where the previous incarnation
+left off, so its sync is not rejected as stale (a same-epoch restart would
+otherwise restart an in-memory counter at zero and wedge replica sync).
+
 No heartbeat or reconnection mechanism is needed because:
 - Message loss on a live connection is detected when the next edit
   arrives (gap in sequence). The persist interval (default 2s)

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -219,9 +219,6 @@ returned by the functional core module.
     core :: rabbitmq_stream_s3_replica_reader_core:state() | undefined,
     %% Nodes registered for manifest broadcast.
     replicas = #{} :: #{node() => reference()},
-    %% Monotonic sequence number for broadcast edits. Incremented per edit
-    %% batch sent. Replicas use this to detect gaps and request re-sync.
-    broadcast_seq = 0 :: non_neg_integer(),
     %% User-configured retention specs for remote tier evaluation.
     retention = [] :: [osiris:retention_spec()],
     %% Commit timer reference.
@@ -448,7 +445,6 @@ handle_cast(
     #state{
         replicas = Replicas,
         core = Core,
-        broadcast_seq = Seq,
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     } = State
 ) ->
@@ -457,18 +453,16 @@ handle_cast(
             {noreply, State};
         false ->
             MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
-            %% Sync the *persisted* manifest, not the live one. Seq is
-            %% broadcast_seq, which only advances when a {broadcast, _} effect
-            %% runs; it therefore lags any edit applied to the live manifest but
-            %% not yet broadcast. Pairing the live manifest with the lagging seq
-            %% makes the replica cache an edit it was never told about, and the
-            %% deferred broadcast then re-delivers that edit in-sequence so the
-            %% replica double-applies it (silent, unhealable divergence: no gap
-            %% is ever observed). persisted_manifest/1 is exactly the snapshot
-            %% consistent with broadcast_seq. Do not change this back to
-            %% manifest/1.
+            %% Sync the *persisted* manifest, not the live one: sync_manifest/4
+            %% tags the sync with the manifest's revision as the sequence number
+            %% (see the {broadcast, _} effect), and that revision only advances
+            %% when a persist commits. Pairing the live manifest with the
+            %% persisted revision would cache an edit the replica was never told
+            %% about, which the next broadcast then re-delivers in-sequence so
+            %% the replica double-applies it (silent, unhealable divergence: no
+            %% gap is ever observed). Do not change this back to manifest/1.
             Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
-            rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
+            sync_manifest(StreamId, Epoch, Manifest, Node),
             {noreply, State#state{replicas = Replicas#{Node => MonRef}}}
     end;
 handle_cast(
@@ -482,14 +476,13 @@ handle_cast(
     {resync, Node},
     #state{
         core = Core,
-        broadcast_seq = Seq,
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     } = State
 ) ->
-    %% Persisted manifest, not live: it must be consistent with broadcast_seq
-    %% (Seq). See the register_acceptor handler.
+    %% Persisted manifest, not live: its revision is the sequence number the
+    %% replica gap-detects against. See the register_acceptor handler.
     Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
-    rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
+    sync_manifest(StreamId, Epoch, Manifest, Node),
     {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
@@ -902,7 +895,6 @@ register_replica(
     #state{
         replicas = Replicas,
         core = Core,
-        broadcast_seq = Seq,
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     } = State
 ) ->
@@ -911,35 +903,46 @@ register_replica(
             State;
         false ->
             MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
-            %% Persisted manifest, not live: it must be consistent with
-            %% broadcast_seq (Seq). See the register_acceptor handler.
+            %% Persisted manifest, not live: its revision is the sequence number.
+            %% See the register_acceptor handler.
             Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
-            rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node),
+            sync_manifest(StreamId, Epoch, Manifest, Node),
             State#state{replicas = Replicas#{Node => MonRef}}
     end.
 
 %% Force every registered replica to drop its cached manifest and adopt the
-%% given one via a full sync, tagged with the current broadcast_seq. Used after
-%% a manifest reset (local-log-ahead recovery), which discards the writer's
-%% manifest without advancing broadcast_seq: subsequent broadcasts continue at
-%% broadcast_seq + 1 and stay in sequence relative to this sync. Casts to a
-%% given node are FIFO from this process, so each replica observes the sync
-%% before the next apply_edits.
+%% given one via a full sync, tagged with that manifest's revision as the
+%% sequence number. Used after a manifest reset (local-log-ahead and
+%% remote-tier-ahead recovery), which installs a fresh manifest carrying the
+%% discarded manifest's revision: subsequent broadcasts continue at the next
+%% revision and stay in sequence relative to this sync. Casts to a given node
+%% are FIFO from this process, so each replica observes the sync before the
+%% next apply_edits.
 -spec sync_all_replicas(#manifest{}, #state{}) -> ok.
 sync_all_replicas(
     Manifest,
     #state{
         replicas = Replicas,
-        broadcast_seq = Seq,
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     }
 ) ->
     maps:foreach(
         fun(Node, _MonRef) ->
-            rabbitmq_stream_s3_manifest_replica:sync(StreamId, Seq, Epoch, Manifest, Node)
+            sync_manifest(StreamId, Epoch, Manifest, Node)
         end,
         Replicas
     ).
+
+%% Send a full sync of Manifest to a replica node, tagged with the manifest's
+%% revision as the broadcast sequence number. The revision (the stream's Khepri
+%% payload_version) is the single source of the sequence: it advances by exactly
+%% one per persist, the persist's CAS rejects any competing same-epoch write so
+%% consecutive revisions are contiguous, and it is durable so a restarted reader
+%% resumes the sequence where the previous incarnation left off rather than
+%% restarting at zero (which a replica would reject as stale).
+-spec sync_manifest(stream_id(), non_neg_integer(), #manifest{}, node()) -> ok.
+sync_manifest(StreamId, Epoch, #manifest{revision = Revision} = Manifest, Node) ->
+    rabbitmq_stream_s3_manifest_replica:sync(StreamId, Revision, Epoch, Manifest, Node).
 
 gc_stream_async(StreamId, WriterEpoch) ->
     spawn(fun() ->
@@ -1144,16 +1147,25 @@ execute_effect({update_range, _FirstOffset, _NextOffset}, #state{cfg = Cfg, core
     on_persist_completed(Manifest, State);
 execute_effect(
     {broadcast, StreamId, Edits},
-    #state{replicas = Replicas, broadcast_seq = Seq0, cfg = #cfg{epoch = Epoch}} = State
+    #state{replicas = Replicas, core = Core, cfg = #cfg{epoch = Epoch}} = State
 ) ->
-    Seq = Seq0 + 1,
+    %% Tag the broadcast with the persisted manifest's revision as the sequence
+    %% number. This effect is emitted by persist_complete, which has already
+    %% stamped the core's persisted manifest with the new revision (the Khepri
+    %% payload_version), so persisted_manifest/1 carries it here. The revision
+    %% advances by exactly one per persist, and the persist's CAS rejects any
+    %% competing same-epoch write, so consecutive broadcasts are contiguous
+    %% (revision N then N+1) - the replica's gap detection holds without a
+    %% separate counter, and a restarted reader resumes the sequence from the
+    %% durable revision instead of restarting at zero.
+    #manifest{revision = Seq} = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
     maps:foreach(
         fun(Node, _MonRef) ->
             rabbitmq_stream_s3_manifest_replica:apply_edits(StreamId, Edits, Seq, Epoch, Node)
         end,
         Replicas
     ),
-    State#state{broadcast_seq = Seq};
+    State;
 execute_effect(
     {evaluate_retention, _StreamId, _Dir},
     #state{core = Core, retention = Retention, cfg = Cfg} = State
@@ -1581,13 +1593,13 @@ restart_at_local_floor(
     FreshManifest = reset_manifest(LocalFirst, Revision),
     {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(FreshManifest, State#state.config),
     ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
-    %% Propagate the reset to replicas. The reset discards the writer's manifest
-    %% and installs a fresh one at the local floor, but leaves broadcast_seq
-    %% unchanged. Replicas still hold the pre-reset manifest at their last
-    %% broadcast seq; without this resync the next broadcast would land
-    %% in-sequence and splice an edit onto a manifest the writer has already
-    %% discarded, corrupting every replica (the same silent divergence as an
-    %% unsynced register).
+    %% Propagate the reset to replicas. The fresh manifest carries the discarded
+    %% manifest's revision (the broadcast sequence number), so the sync is not
+    %% rejected as stale and subsequent broadcasts continue in sequence. Replicas
+    %% still hold the pre-reset manifest; without this resync the next broadcast
+    %% would land in-sequence and splice an edit onto a manifest the writer has
+    %% already discarded, corrupting every replica (the same silent divergence as
+    %% an unsynced register).
     ok = sync_all_replicas(FreshManifest, State),
     gc_stream_async(StreamId, Epoch),
     start_reading(State#state{core = Core1}).

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -96,7 +96,8 @@ groups() ->
             stale_group_upload_result_is_ignored
         ]},
         {with_replica, [], [
-            replication_happy_path
+            replication_happy_path,
+            replication_survives_reader_restart
         ]}
     ].
 
@@ -1158,3 +1159,37 @@ replication_happy_path(Config) ->
 
     %% Replica has reclaimed uploaded segments (only current segment remains).
     ?awaitMatch([_], list_segment_offsets(Config, ReplicaNode), 1000).
+
+replication_survives_reader_restart(Config) ->
+    %% A writer-side replica reader that crashes is respawned by its supervisor
+    %% at the SAME epoch (the epoch is the writer's, and the writer is
+    %% untouched). The broadcast sequence number is the durable manifest
+    %% revision, so the new incarnation resumes the sequence where the previous
+    %% one left off and the replica keeps accepting its broadcasts. Were the
+    %% sequence an in-memory counter, it would restart at zero, the replica would
+    %% reject every post-restart sync and broadcast as stale, and its manifest
+    %% would freeze - the bug this guards against.
+    StreamId = ?config(stream_id, Config),
+    ReplicaNode = ?config(replica_node, Config),
+
+    {Writer, _ReplicaPids} = start_cluster(
+        Config, [ReplicaNode], #{max_segment_size_bytes => 500}, #{fragment_target_size => 1000}
+    ),
+
+    Record = binary:copy(<<"R">>, 300),
+    [osiris:write(Writer, undefined, I, Record) || I <- lists:seq(1, 10)],
+    ok = await_offset(StreamId, 5),
+    %% Replica caught up to the first batch.
+    ?awaitMatch({_, N} when N > 0, get_range(Config, ReplicaNode), 1000),
+    {_, N1} = get_range(Config, ReplicaNode),
+
+    %% Restart the writer-side replica reader at the same epoch.
+    ReaderPid = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ok = rabbitmq_stream_s3_replica_reader_sup:stop_child(ReaderPid),
+    _ = start_replica_reader(Writer, Config, #{fragment_target_size => 1000}),
+
+    %% Write more; the restarted reader uploads and broadcasts. The replica must
+    %% advance past N1 rather than freezing on stale-rejected broadcasts.
+    [osiris:write(Writer, undefined, I, Record) || I <- lists:seq(11, 30)],
+    ok = await_offset(StreamId, N1 + 5),
+    ?awaitMatch({_, N2} when N2 > N1, get_range(Config, ReplicaNode), 3000).


### PR DESCRIPTION
The replica reader tagged each broadcast and sync with broadcast_seq, an in-memory counter that reset to zero on every reader incarnation. The epoch is the writer's, not the reader's, and the two are only loosely coupled, so a reader that crashed and was respawned by its supervisor came back at the same epoch with broadcast_seq back at zero. Replicas still held the pre-crash sequence at that epoch, so they rejected the new incarnation's sync and every subsequent broadcast as stale (is_stale_sync compares epoch then sequence) until the counter climbed back above the old value - which never happens on an idle stream. The replica then served a frozen manifest and its local retention, gated on next_offset advancing, stalled and let local segments accumulate.

Replace broadcast_seq with the manifest revision (the stream's Khepri payload_version). The revision is the natural sequence number: it advances by exactly one per persist, in lockstep with broadcasts (both happen in persist_complete); the persist's optimistic lock (#if_payload_version) rejects any competing same-epoch write, so consecutive revisions are contiguous without a separate counter; and it is durable, so a restarted reader resumes the sequence from the resolved revision instead of zero. Its sync then carries a sequence at least as high as the replica's recorded value and is accepted, so sync heals immediately - including on first deploy, where replicas still hold old counter-based sequences below the revision.

This removes the dual-counter fragility: broadcast_seq was incremented in the shell without reading the revision it was meant to mirror, so any future path that advanced the revision without a broadcast (or vice versa) would silently desync the two and reintroduce stale rejections. There is now a single source of truth.

The wire format is unchanged: the same apply_edits/5 and sync/5 carry the revision in the sequence slot, and manifest_replica is structurally unchanged (it gap-detects and compares staleness on whatever value occupies that slot). A sync_manifest/4 helper centralises tagging a sync with its manifest's revision across the register, resync, and reset paths.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
