### PR TITLE
Periodically reconcile orphaned writers and replicas

### DIFF
--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -31,6 +31,8 @@ lives here. Callers use these functions instead of calling
     membership_reconciliation_trigger_interval/0,
     membership_reconciliation_target_group_size/0,
     membership_reconciliation_auto_remove/0,
+    reconciliation_enabled/0,
+    reconciliation_interval/0,
     task_retry_delay_max_ms/0,
     task_retry_delay_constant/0,
     task_retry_delay_exponent/0,
@@ -142,6 +144,19 @@ membership_reconciliation_target_group_size() ->
 membership_reconciliation_auto_remove() ->
     application:get_env(?APP, membership_reconciliation_auto_remove, false).
 
+%% Periodic reconciliation of the plugin's attachment to local osiris
+%% processes: a replica reader bound to each live writer, and a registered
+%% manifest_replica context for each live replica. Recovers a stream left
+%% un-tiered by a writer-restart race, a parked reader, or a manifest_replica
+%% restart that lost its in-memory contexts and cache.
+-spec reconciliation_enabled() -> boolean().
+reconciliation_enabled() ->
+    application:get_env(?APP, reconciliation_enabled, true).
+
+-spec reconciliation_interval() -> non_neg_integer().
+reconciliation_interval() ->
+    application:get_env(?APP, reconciliation_interval, 60_000).
+
 -spec task_retry_delay_max_ms() -> non_neg_integer().
 task_retry_delay_max_ms() ->
     application:get_env(?APP, task_retry_delay_max_ms, 5_000).
@@ -240,6 +255,8 @@ defaults_test_() ->
         ?_assertEqual(10_000, membership_reconciliation_trigger_interval()),
         ?_assertEqual(undefined, membership_reconciliation_target_group_size()),
         ?_assertEqual(false, membership_reconciliation_auto_remove()),
+        ?_assertEqual(true, reconciliation_enabled()),
+        ?_assertEqual(60_000, reconciliation_interval()),
         ?_assertEqual(5_000, task_retry_delay_max_ms()),
         ?_assertEqual(10, task_retry_delay_constant()),
         ?_assertEqual(2, task_retry_delay_exponent()),

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -150,14 +150,21 @@ discover() ->
 Periodic reconciliation of the plugin's attachment to local osiris processes,
 driven by `rabbitmq_stream_s3_reconciler`.
 
-Re-runs the discover-style attach for a writer with no replica reader — left
-un-tiered by the writer-restart `already_started` race, a parked reader, or a
-reader that never started. Writers already attached are skipped, so a
-steady-state tick neither restarts readers nor re-runs retention updates.
+For each local osiris writer:
+- if it has no replica reader (the writer-restart `already_started` race, a
+  parked reader, or one that never started), attach one, and
+- otherwise poke its reader to re-sync any replica node that dropped out of its
+  broadcast set — a replica drops out when its `manifest_replica` restarted and
+  the monitored DOWN removed it, leaving the replica's manifest cache empty. The
+  re-sync goes through the writer's own replication state, so no queue-record or
+  coordinator lookup is involved.
 
-(The replica side — re-registering a `manifest_replica` context lost on a cache
-restart — is reconciled the same way and is a planned extension; it is omitted
-here until its cross-node re-seed can be exercised end to end.)
+For each local osiris replica:
+- if its `manifest_replica` context is missing (dropped when the per-node cache
+  singleton restarted), re-register it so tiering-aware local retention resumes.
+
+Streams the plugin is already attached to are skipped, so a steady-state tick
+neither restarts readers, re-runs retention updates, nor re-registers contexts.
 """.
 -spec reconcile() -> ok.
 reconcile() ->
@@ -181,7 +188,9 @@ reconcile_child({_Id, Pid, worker, [osiris_writer]}) when is_pid(Pid) ->
                 %% A reader is attached. If it is bound to a stale writer it is
                 %% already stopping (it monitors that writer's DOWN), so the next
                 %% tick sees no reader and attaches; do not disturb it here.
-                ok;
+                %% Otherwise poke it to re-sync any replica that fell out of its
+                %% broadcast set after the replica's manifest_replica restarted.
+                gen_server:cast(ReaderPid, reconcile_replicas);
             undefined ->
                 ?LOG_INFO(
                     "Reconciliation: writer ~p for stream ~ts has no replica "
@@ -199,12 +208,48 @@ reconcile_child({_Id, Pid, worker, [osiris_writer]}) when is_pid(Pid) ->
                 #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
             )
     end;
+reconcile_child({_Id, Pid, worker, [osiris_replica]}) when is_pid(Pid) ->
+    try
+        StreamId = stream_id_of(Pid),
+        case rabbitmq_stream_s3_manifest_replica:is_context_registered(StreamId) of
+            true ->
+                ok;
+            false ->
+                ?LOG_INFO(
+                    "Reconciliation: replica ~p for stream ~ts has no manifest "
+                    "context; re-registering",
+                    [Pid, StreamId],
+                    #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+                ),
+                register_replica_context(Pid, StreamId)
+        end
+    catch
+        Class:Reason ->
+            ?LOG_WARNING(
+                "Reconciliation could not re-register replica ~p: ~ts:~p",
+                [Pid, Class, Reason],
+                #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+            )
+    end;
 reconcile_child(_) ->
     ok.
 
 stream_id_of(Pid) ->
     #{name := Name} = osiris_util:get_reader_context(Pid),
     rabbitmq_stream_s3:ensure_stream_id(Name).
+
+%% Re-register a discovered replica's context with the per-node manifest_replica
+%% so tiering-aware local retention resumes. Unlike attach_replica/1 this neither
+%% registers with the writer (the writer re-syncs the cache itself via
+%% reconcile_replicas) nor re-injects the retention fun (already on the live
+%% replica), and so needs no leader-node/queue-record lookup.
+register_replica_context(Pid, StreamId) ->
+    #{dir := Dir, shared := Shared, reference := Reference} =
+        osiris_util:get_reader_context(Pid),
+    Counter = osiris_counters:fetch({osiris_replica, Reference}),
+    rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        StreamId, Dir, Shared, Counter
+    ).
 
 append_retention(StreamId, Config) ->
     Fun = {'fun', local_retention_fun(StreamId)},

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -21,7 +21,8 @@ retention is updated.
     on_retention_updated/2,
     on_retention_evaluated/2,
     local_retention_fun/1,
-    discover/0
+    discover/0,
+    reconcile/0
 ]).
 
 -doc """
@@ -145,9 +146,65 @@ discover() ->
         end,
     lists:foreach(fun discover_child/1, Children).
 
+-doc """
+Periodic reconciliation of the plugin's attachment to local osiris processes,
+driven by `rabbitmq_stream_s3_reconciler`.
+
+Re-runs the discover-style attach for a writer with no replica reader — left
+un-tiered by the writer-restart `already_started` race, a parked reader, or a
+reader that never started. Writers already attached are skipped, so a
+steady-state tick neither restarts readers nor re-runs retention updates.
+
+(The replica side — re-registering a `manifest_replica` context lost on a cache
+restart — is reconciled the same way and is a planned extension; it is omitted
+here until its cross-node re-seed can be exercised end to end.)
+""".
+-spec reconcile() -> ok.
+reconcile() ->
+    Children =
+        try
+            supervisor:which_children(osiris_server_sup)
+        catch
+            exit:{noproc, _} -> []
+        end,
+    lists:foreach(fun reconcile_child/1, Children).
+
 %% ------------------------------------------------------------------
 %% Internal
 %% ------------------------------------------------------------------
+
+reconcile_child({_Id, Pid, worker, [osiris_writer]}) when is_pid(Pid) ->
+    try
+        StreamId = stream_id_of(Pid),
+        case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
+            ReaderPid when is_pid(ReaderPid) ->
+                %% A reader is attached. If it is bound to a stale writer it is
+                %% already stopping (it monitors that writer's DOWN), so the next
+                %% tick sees no reader and attaches; do not disturb it here.
+                ok;
+            undefined ->
+                ?LOG_INFO(
+                    "Reconciliation: writer ~p for stream ~ts has no replica "
+                    "reader; attaching",
+                    [Pid, StreamId],
+                    #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+                ),
+                attach_writer(Pid)
+        end
+    catch
+        Class:Reason ->
+            ?LOG_WARNING(
+                "Reconciliation could not attach tiering to writer ~p: ~ts:~p",
+                [Pid, Class, Reason],
+                #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+            )
+    end;
+reconcile_child(_) ->
+    ok.
+
+stream_id_of(Pid) ->
+    #{name := Name} = osiris_util:get_reader_context(Pid),
+    rabbitmq_stream_s3:ensure_stream_id(Name).
 
 append_retention(StreamId, Config) ->
     Fun = {'fun', local_retention_fun(StreamId)},

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -67,7 +67,8 @@ No heartbeat or reconnection mechanism is needed because:
     apply_edits/5,
     sync/4,
     sync/5,
-    register_replica_context/4
+    register_replica_context/4,
+    is_context_registered/1
 ]).
 -export([
     init/1,
@@ -166,6 +167,11 @@ Called from the acceptor hook when a replica starts.
 register_replica_context(StreamId, Dir, Shared, Counter) ->
     gen_server:call(?MODULE, {register_replica_context, StreamId, Dir, Shared, Counter}).
 
+-doc "Whether a replica context is registered for the stream on this node.".
+-spec is_context_registered(stream_id()) -> boolean().
+is_context_registered(StreamId) ->
+    gen_server:call(?MODULE, {is_context_registered, StreamId}).
+
 %% ------------------------------------------------------------------
 %% gen_server callbacks
 %% ------------------------------------------------------------------
@@ -228,6 +234,8 @@ handle_call(
 ) ->
     Ctx = #replica_ctx{dir = Dir, shared = Shared, counter = Counter},
     {reply, ok, State#state{contexts = Ctxs#{StreamId => Ctx}}};
+handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = State) ->
+    {reply, maps:is_key(StreamId, Ctxs), State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 

--- a/src/rabbitmq_stream_s3_reconciler.erl
+++ b/src/rabbitmq_stream_s3_reconciler.erl
@@ -1,0 +1,92 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_reconciler).
+-moduledoc """
+Periodically reconciles the plugin's attachment to local osiris processes.
+
+The plugin attaches to osiris event-driven: a writer's `on_init` hook starts its
+replica reader, and an acceptor's `on_init` hook registers its `manifest_replica`
+context. Those events can be missed or undone:
+
+- A writer that crashes and is respawned at the same epoch can leave its new
+  incarnation with no replica reader, because the old reader was still
+  registered when the new writer's `on_init` ran (the `{StreamId, node()}`
+  registry name does not distinguish writer incarnations). The old reader then
+  stops on its writer's `DOWN`, leaving the live writer un-tiered with nothing
+  to start a reader.
+- A reader that exhausts its per-stream restart budget parks with no reader.
+- A `manifest_replica` restart drops every per-stream context and the manifest
+  cache on the node, and nothing re-registers them.
+
+This server runs `rabbitmq_stream_s3_hooks:reconcile/0` on a timer to re-attach
+anything left detached. It is the "reconciliation" the per-stream supervisors'
+parking behaviour assumes exists. Steady-state ticks skip already-attached
+streams, so they neither restart readers nor re-run retention updates.
+""".
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+-include("include/logging.hrl").
+
+-record(?MODULE, {timer :: reference() | undefined}).
+
+-define(SERVER, ?MODULE).
+-define(RECONCILE, reconcile).
+
+-export([start_link/0]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
+    case rabbitmq_stream_s3_config:reconciliation_enabled() of
+        true ->
+            {ok, #?MODULE{timer = schedule()}};
+        false ->
+            ?LOG_INFO("Tiered storage reconciliation is disabled."),
+            ignore
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(?RECONCILE, #?MODULE{} = State) ->
+    %% A reconciliation error must never kill the timer loop: catch everything
+    %% and reschedule regardless.
+    try
+        rabbitmq_stream_s3_hooks:reconcile()
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Tiered storage reconciliation tick failed: ~ts:~p~n~p",
+                [Class, Reason, Stack]
+            )
+    end,
+    {noreply, State#?MODULE{timer = schedule()}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%----------------------------------------------------------------------------
+
+schedule() ->
+    erlang:send_after(rabbitmq_stream_s3_config:reconciliation_interval(), self(), ?RECONCILE).

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -484,6 +484,22 @@ handle_cast(
     Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
     sync_manifest(StreamId, Epoch, Manifest, Node),
     {noreply, State};
+handle_cast(reconcile_replicas, #state{cfg = #cfg{writer_pid = WriterPid}} = State) ->
+    %% Re-sync any replica node the writer currently has that this reader is no
+    %% longer broadcasting to - a replica drops out of the map when its
+    %% manifest_replica restarts (the monitored DOWN removes it), losing its
+    %% manifest cache. Driven periodically by the reconciler. register_replicas/2
+    %% skips nodes already registered, so this is a no-op once every replica is
+    %% synced. Going through the writer's replication state avoids any
+    %% queue-record or coordinator lookup.
+    case is_process_alive(WriterPid) of
+        true ->
+            RepState = osiris_writer:query_replication_state(WriterPid),
+            ReplicaNodes = maps:keys(RepState) -- [node()],
+            {noreply, register_replicas(ReplicaNodes, State)};
+        false ->
+            {noreply, State}
+    end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -86,6 +86,16 @@ init([]) ->
         type => worker,
         start => {rabbitmq_stream_s3_membership_reconciliation, start_link, []}
     },
+    %% Re-attaches readers/contexts to local osiris processes the plugin has
+    %% become detached from (writer-restart race, parked reader, manifest_replica
+    %% restart). Started last so its dependencies (the registry, the replica
+    %% reader factory, the manifest cache) are already up; its first tick is one
+    %% interval away regardless.
+    Reconciler = #{
+        id => rabbitmq_stream_s3_reconciler,
+        type => worker,
+        start => {rabbitmq_stream_s3_reconciler, start_link, []}
+    },
     Procs = [
         CredentialServer,
         ManifestCache,
@@ -94,7 +104,8 @@ init([]) ->
         UploadPool,
         GeneralPool,
         Governor,
-        ReplicaReaderSup
+        ReplicaReaderSup,
+        Reconciler
     ],
     {ok, {SupFlags, Procs}}.
 

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -98,7 +98,8 @@ groups() ->
         ]},
         {with_replica, [], [
             replication_happy_path,
-            replication_survives_reader_restart
+            replication_survives_reader_restart,
+            reconcile_recovers_replica_after_cache_restart
         ]}
     ].
 
@@ -1221,3 +1222,50 @@ replication_survives_reader_restart(Config) ->
     [osiris:write(Writer, undefined, I, Record) || I <- lists:seq(11, 30)],
     ok = await_offset(StreamId, N1 + 5),
     ?awaitMatch({_, N2} when N2 > N1, get_range(Config, ReplicaNode), 3000).
+
+reconcile_recovers_replica_after_cache_restart(Config) ->
+    %% The per-node manifest_replica singleton holds the replica's per-stream
+    %% context and manifest cache in memory. A crash-restart drops both and
+    %% nothing re-registers them, so tiering-aware local retention stalls (N5)
+    %% and cross-tier reads skip the remote tier (c6). Reconciliation must
+    %% re-register the context (replica side) and re-sync the cache through the
+    %% writer (writer side).
+    StreamId = ?config(stream_id, Config),
+    ReplicaNode = ?config(replica_node, Config),
+    Cache = rabbitmq_stream_s3_manifest_replica,
+
+    {Writer, _ReplicaPids} = start_cluster(
+        Config, [ReplicaNode], #{max_segment_size_bytes => 500}, #{fragment_target_size => 1000}
+    ),
+    Record = binary:copy(<<"R">>, 300),
+    [osiris:write(Writer, undefined, I, Record) || I <- lists:seq(1, 10)],
+    ok = await_offset(StreamId, 5),
+    %% Replica context + cache are populated.
+    ?awaitMatch(true, erpc:call(ReplicaNode, Cache, is_context_registered, [StreamId]), 2000),
+    ?awaitMatch({_, N} when N > 0, get_range(Config, ReplicaNode), 2000),
+
+    %% Restart the replica's manifest_replica: context + owned-ETS cache lost.
+    OldPid = erpc:call(ReplicaNode, erlang, whereis, [Cache]),
+    true = erpc:call(ReplicaNode, erlang, exit, [OldPid, kill]),
+    ?awaitMatch(
+        P when is_pid(P) andalso P =/= OldPid,
+        erpc:call(ReplicaNode, erlang, whereis, [Cache]),
+        2000
+    ),
+    ?assertEqual(false, erpc:call(ReplicaNode, Cache, is_context_registered, [StreamId])),
+
+    %% Replica-side reconcile re-registers the context (N5).
+    ok = erpc:call(ReplicaNode, rabbitmq_stream_s3_hooks, reconcile, []),
+    ?assertEqual(true, erpc:call(ReplicaNode, Cache, is_context_registered, [StreamId])),
+
+    %% Writer-side reconcile re-syncs the replica through the writer, re-seeding
+    %% its cache (c6). Re-run reconcile each poll: the writer must first process
+    %% the replica's manifest_replica DOWN that frees it for re-sync.
+    ?awaitMatch(
+        {_, M} when M > 0,
+        begin
+            ok = rabbitmq_stream_s3_hooks:reconcile(),
+            get_range(Config, ReplicaNode)
+        end,
+        5000
+    ).

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -76,6 +76,7 @@ groups() ->
             seed_log_uploads_deterministic,
             local_ahead_discards_manifest,
             remote_tier_ahead_discards_manifest,
+            reconcile_reattaches_orphaned_writer,
             stream_deletion_cleans_remote_tier,
             stream_deletion_during_active_upload,
             persist_not_found_stops_reader,
@@ -649,6 +650,33 @@ remote_tier_ahead_discards_manifest(Config) ->
         rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId),
         5000
     ).
+
+reconcile_reattaches_orphaned_writer(Config) ->
+    %% The writer-restart race (and a parked reader) leaves a live writer with no
+    %% replica reader and nothing to start one. Periodic reconciliation must
+    %% re-attach a reader, and must not disturb an already-attached one.
+    StreamId = ?config(stream_id, Config),
+    _Writer = start_writer(Config, #{}),
+    Pid1 = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ?assert(is_pid(Pid1)),
+
+    %% Orphan the writer: stop its reader while the writer stays alive.
+    ok = rabbitmq_stream_s3_replica_reader_sup:stop_child(Pid1),
+    ?awaitMatch(
+        undefined,
+        rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+        1000
+    ),
+
+    %% Reconciliation re-attaches a fresh reader to the still-live writer.
+    ok = rabbitmq_stream_s3_hooks:reconcile(),
+    Pid2 = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ?assert(is_pid(Pid2)),
+    ?assertNotEqual(Pid1, Pid2),
+
+    %% Idempotent: a second tick leaves the healthy reader untouched.
+    ok = rabbitmq_stream_s3_hooks:reconcile(),
+    ?assertEqual(Pid2, rabbitmq_stream_s3_registry:whereis_name({StreamId, node()})).
 
 stream_deletion_cleans_remote_tier(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
The lifecycle of replica and replica reader processes is not strongly coupled to the osiris_writer and osiris_replica processes. Instead of trying to hande race conditions directly (which I'm not sure we actually _can_ do), we can periodically check that the associated process in this plugin is running. If it is not yet, we can start and attach it to the writer/replica process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
