### PR TITLE
Harden remote tier reader lifecycle on become_local and crash

### DIFF
--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -43,6 +43,7 @@ tier.
 -define(C_RESOLVE_LOCAL, 10).
 -define(C_RESOLVE_DURATION_MS, 11).
 -define(C_RESOLVE, 12).
+-define(C_REMOTE_READER_RESTART, 13).
 -define(COUNTERS, [
     {remote_init, ?C_REMOTE_INIT, counter, "Readers initialized in remote mode"},
     {local_init, ?C_LOCAL_INIT, counter, "Readers initialized in local mode"},
@@ -65,9 +66,16 @@ tier.
     {resolve_local, ?C_RESOLVE_LOCAL, counter, "Offset specs resolved to local tier"},
     {resolve_duration_ms, ?C_RESOLVE_DURATION_MS, counter,
         "Total milliseconds spent resolving offset specs"},
-    {resolve, ?C_RESOLVE, counter, "Number of offset spec resolutions"}
+    {resolve, ?C_RESOLVE, counter, "Number of offset spec resolutions"},
+    {remote_reader_restart, ?C_REMOTE_READER_RESTART, counter,
+        "Remote tier readers restarted after an unexpected exit"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
+
+%% Bounded restart attempts when the remote reader exits unexpectedly within a
+%% single send_file/chunk_iterator pass, to avoid spinning on a poison chunk
+%% that crashes every fresh reader.
+-define(REMOTE_REINIT_ATTEMPTS, 3).
 
 -export([init_counters/0]).
 
@@ -108,7 +116,7 @@ tier.
 ]).
 
 %% Debugging, testing.
--export([mode/1]).
+-export([mode/1, remote_pid/1]).
 
 -ifdef(TEST).
 -export([find_fragment/3, find_index_position/2, resolve_remote_location/2]).
@@ -307,7 +315,31 @@ close_deferred(Local) -> osiris_log:close(Local).
 send_file(Socket, State, Callback) ->
     send_file(Socket, State, Callback, undefined).
 
-send_file(
+send_file(Socket, State, Callback, DeferredClose) ->
+    send_file(Socket, State, Callback, DeferredClose, ?REMOTE_REINIT_ATTEMPTS).
+
+send_file(Socket, State, Callback, DeferredClose, Attempt) ->
+    case send_file0(Socket, State, Callback, DeferredClose) of
+        {remote_reader_down, NextOffset} ->
+            close_deferred(DeferredClose),
+            restart_remote_send_file(Socket, State, Callback, NextOffset, Attempt);
+        Other ->
+            Other
+    end.
+
+restart_remote_send_file(_Socket, _State, _Callback, _NextOffset, Attempt) when
+    Attempt =< 0
+->
+    {error, remote_reader_unavailable};
+restart_remote_send_file(Socket, #?MODULE{config = Config}, Callback, NextOffset, Attempt) ->
+    case reinit_remote(NextOffset, Config) of
+        {ok, NewState} ->
+            send_file(Socket, NewState, Callback, undefined, Attempt - 1);
+        {error, _} = Err ->
+            Err
+    end.
+
+send_file0(
     Socket,
     #?MODULE{config = Config, mode = #remote{} = Remote0, verify_crc = VerifyCrc} = State0,
     Callback,
@@ -362,12 +394,15 @@ send_file(
                 {become_local, _} ->
                     close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
+                    rabbitmq_stream_s3_remote_reader:stop(Remote1#remote.pid),
                     case become_local_init(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
                             send_file(Socket, State, Callback, undefined);
                         {error, _} = Err ->
                             Err
                     end;
+                {error, {remote_reader_down, _}} ->
+                    {remote_reader_down, Remote1#remote.next_offset};
                 end_of_stream ->
                     ?LOG_DEBUG(
                         "send_file: data read returned end_of_stream"
@@ -389,6 +424,7 @@ send_file(
         {become_local, _} ->
             close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
+            rabbitmq_stream_s3_remote_reader:stop(Remote0#remote.pid),
             case become_local_init(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
                     send_file(Socket, State, Callback, undefined);
@@ -398,10 +434,12 @@ send_file(
         {end_of_stream, Remote} ->
             close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Remote}};
+        {error, {remote_reader_down, _}} ->
+            {remote_reader_down, Remote0#remote.next_offset};
         {error, timeout} = Err ->
             Err
     end;
-send_file(Socket, #?MODULE{mode = Local0} = State0, Callback, DeferredClose) ->
+send_file0(Socket, #?MODULE{mode = Local0} = State0, Callback, DeferredClose) ->
     case osiris_log:send_file(Socket, Local0, Callback) of
         {ok, Local} ->
             close_deferred(DeferredClose),
@@ -432,7 +470,29 @@ send_file(Socket, #?MODULE{mode = Local0} = State0, Callback, DeferredClose) ->
 chunk_iterator(State, Credit, PrevIter) ->
     chunk_iterator(State, Credit, PrevIter, undefined).
 
-chunk_iterator(
+chunk_iterator(State, Credit, PrevIter, DeferredClose) ->
+    chunk_iterator(State, Credit, PrevIter, DeferredClose, ?REMOTE_REINIT_ATTEMPTS).
+
+chunk_iterator(State, Credit, PrevIter, DeferredClose, Attempt) ->
+    case chunk_iterator0(State, Credit, PrevIter, DeferredClose) of
+        {remote_reader_down, NextOffset} ->
+            close_deferred(DeferredClose),
+            restart_remote_chunk_iterator(State, Credit, NextOffset, Attempt);
+        Other ->
+            Other
+    end.
+
+restart_remote_chunk_iterator(_State, _Credit, _NextOffset, Attempt) when Attempt =< 0 ->
+    {error, remote_reader_unavailable};
+restart_remote_chunk_iterator(#?MODULE{config = Config}, Credit, NextOffset, Attempt) ->
+    case reinit_remote(NextOffset, Config) of
+        {ok, NewState} ->
+            chunk_iterator(NewState, Credit, undefined, undefined, Attempt - 1);
+        {error, _} = Err ->
+            Err
+    end.
+
+chunk_iterator0(
     #?MODULE{config = Config, mode = #remote{} = Remote0, verify_crc = VerifyCrc} = State0,
     Credit,
     _PrevIter,
@@ -476,12 +536,15 @@ chunk_iterator(
                 {become_local, _} ->
                     close_deferred(DeferredClose),
                     counters:add(counter(), ?C_REMOTE_CLOSE, 1),
+                    rabbitmq_stream_s3_remote_reader:stop(Remote1#remote.pid),
                     case become_local_init(Remote1#remote.next_offset, Config) of
                         {ok, State} ->
                             chunk_iterator(State, Credit, undefined, undefined);
                         {error, _} = Err ->
                             Err
                     end;
+                {error, {remote_reader_down, _}} ->
+                    {remote_reader_down, Remote1#remote.next_offset};
                 end_of_stream ->
                     close_deferred(DeferredClose),
                     {end_of_stream, State0#?MODULE{mode = Remote1}};
@@ -491,6 +554,7 @@ chunk_iterator(
         {become_local, _} ->
             close_deferred(DeferredClose),
             counters:add(counter(), ?C_REMOTE_CLOSE, 1),
+            rabbitmq_stream_s3_remote_reader:stop(Remote0#remote.pid),
             case become_local_init(Remote0#remote.next_offset, Config) of
                 {ok, State} ->
                     chunk_iterator(State, Credit, undefined, undefined);
@@ -500,10 +564,12 @@ chunk_iterator(
         {end_of_stream, Remote} ->
             close_deferred(DeferredClose),
             {end_of_stream, State0#?MODULE{mode = Remote}};
+        {error, {remote_reader_down, _}} ->
+            {remote_reader_down, Remote0#remote.next_offset};
         {error, timeout} = Err ->
             Err
     end;
-chunk_iterator(#?MODULE{mode = Local0} = State0, Credit, PrevIter, DeferredClose) ->
+chunk_iterator0(#?MODULE{mode = Local0} = State0, Credit, PrevIter, DeferredClose) ->
     case osiris_log:chunk_iterator(Local0, Credit, PrevIter) of
         {ok, Header, Iter, Local} ->
             close_deferred(DeferredClose),
@@ -555,6 +621,10 @@ iterator_next(Local) ->
 mode(#?MODULE{mode = #remote{}}) -> remote;
 mode(#?MODULE{}) -> local.
 
+-spec remote_pid(#?MODULE{}) -> pid() | undefined.
+remote_pid(#?MODULE{mode = #remote{pid = Pid}}) -> Pid;
+remote_pid(#?MODULE{}) -> undefined.
+
 send(tcp, Socket, Data) ->
     gen_tcp:send(Socket, Data);
 send(ssl, Socket, Data) ->
@@ -571,7 +641,8 @@ send(ssl, Socket, Data) ->
     {ok, osiris_log:header_map(), #remote{}}
     | {become_local, osiris:offset()}
     | {end_of_stream, #remote{}}
-    | {error, timeout}.
+    | {error, timeout}
+    | {error, {remote_reader_down, term()}}.
 read_header(#remote{shared = Shared, next_offset = NextOffset} = Remote) ->
     LastChunkId = osiris_log_shared:last_chunk_id(Shared),
     CommittedChunkId = osiris_log_shared:committed_chunk_id(Shared),
@@ -610,6 +681,8 @@ read_header1(
             {become_local, Offset};
         end_of_stream ->
             {end_of_stream, Remote0};
+        {error, {remote_reader_down, _}} = Err ->
+            Err;
         {error, timeout} = Err ->
             Err
     end.
@@ -801,6 +874,19 @@ maybe_become_remote(Offset, #?MODULE{config = Config, mode = Local}) ->
         _ ->
             false
     end.
+
+%% The remote reader exited unexpectedly (a crash or an already-dead pid). Re-
+%% resolve the current offset and start a fresh reader so the subscription
+%% self-heals instead of wedging on the dead pid. The offset may now resolve to
+%% the local tier, in which case a local reader is returned.
+reinit_remote(NextOffset, Config) ->
+    counters:add(counter(), ?C_REMOTE_READER_RESTART, 1),
+    ?LOG_WARNING(
+        "Remote tier reader exited unexpectedly; restarting at offset ~b",
+        [NextOffset],
+        ?DOMAIN
+    ),
+    init_offset_reader(NextOffset, Config).
 
 -spec find_position(
     {offset, osiris:offset()} | {timestamp, osiris:timestamp()},
@@ -1015,7 +1101,8 @@ resolve_first(StreamId, FirstOffset) ->
     | {next_fragment, osiris:offset()}
     | {become_local, osiris:offset()}
     | end_of_stream
-    | {error, timeout}.
+    | {error, timeout}
+    | {error, {remote_reader_down, term()}}.
 read(RemoteReader, Offset, Bytes, Hint) ->
     read(RemoteReader, Offset, Bytes, Hint, 1).
 

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -90,6 +90,7 @@ synchronous feedback is generated.
 %% API
 -export([
     start/1,
+    stop/1,
     read/4,
     read/5,
     init_counters/0,
@@ -133,6 +134,12 @@ read_size_prometheus_format() ->
 start(Config) ->
     gen_server:start(?MODULE, Config, []).
 
+%% Asynchronous, fire-and-forget stop. The reader also monitors its consumer
+%% and stops on its own when the consumer exits; this reclaims it eagerly on a
+%% become_local transition so it does not linger for the consumer's lifetime.
+stop(Pid) ->
+    gen_server:cast(Pid, stop).
+
 %% The gen_server:call timeout must exceed PENDING_READ_DEADLINE_MS so the
 %% internal deadline always fires first and replies {error, timeout} to the
 %% caller. This avoids overlapping reads (caller times out, new read arrives
@@ -149,7 +156,14 @@ read(Server, Offset, Bytes, Hint, Timeout) ->
         try
             gen_server:call(Server, #read{offset = Offset, bytes = Bytes, hint = Hint}, Timeout)
         catch
-            exit:{timeout, _} -> {error, timeout}
+            exit:{timeout, _} ->
+                {error, timeout};
+            exit:Reason ->
+                %% The reader gen_server crashed or is already gone (noproc).
+                %% Surface a clean error so the caller can restart it, instead
+                %% of the exit propagating into and crashing the consumer
+                %% connection (which may serve many other subscriptions).
+                {error, {remote_reader_down, Reason}}
         end,
     Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
     counters:add(counter(), ?C_READ_DURATION_MS, Duration),
@@ -206,6 +220,8 @@ handle_call(
 handle_call(Request, From, State) ->
     {stop, {unknown_call, From, Request}, State}.
 
+handle_cast(stop, State) ->
+    {stop, normal, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -65,7 +65,9 @@ groups() ->
             local_to_remote_transition,
             read_through_group,
             read_detects_crc_corruption,
-            offset_spec_at_tier_boundary
+            offset_spec_at_tier_boundary,
+            remote_reader_restart_self_heals,
+            become_local_stops_remote_reader
         ]},
         {with_replica, [], [
             read_from_replica_node
@@ -409,6 +411,80 @@ offset_spec_at_tier_boundary(Config) ->
     ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader2)),
     rabbitmq_stream_s3_log_reader:close(Reader2).
 
+remote_reader_restart_self_heals(Config) ->
+    %% When the remote reader gen_server exits unexpectedly, the read must not
+    %% crash the consumer. The log reader surfaces a clean error, restarts a
+    %% fresh remote reader and the subscription self-heals.
+    Writer = start_writer(Config, #{fragment_target_size => 1000}),
+    N = 200,
+    write_sequential(Writer, N, 5),
+
+    ReaderCfg = reader_config(Writer, Config),
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch([S] when S > 0, list_segment_offsets(Config), 1000),
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+
+    %% Kill the remote reader out from under the consumer.
+    Pid = rabbitmq_stream_s3_log_reader:remote_pid(Reader0),
+    ?assert(is_process_alive(Pid)),
+    exit(Pid, kill),
+    ?awaitMatch(false, is_process_alive(Pid), 1000),
+
+    %% The next read restarts a fresh reader (a new live pid) instead of
+    %% crashing on the dead one.
+    {ok, _Header, Iter, Reader1} =
+        rabbitmq_stream_s3_log_reader:chunk_iterator(Reader0, 1, undefined),
+    NewPid = rabbitmq_stream_s3_log_reader:remote_pid(Reader1),
+    ?assertNotEqual(Pid, NewPid),
+    ?assert(is_process_alive(NewPid)),
+
+    %% The full stream reads back correctly across the restart.
+    FirstChunk = drain_iter(Iter, 0, []),
+    Rest = read_all(Reader1),
+    assert_sequential(FirstChunk ++ Rest, N).
+
+become_local_stops_remote_reader(Config) ->
+    %% A reader that transitions from the remote tier back to the local tier
+    %% (become_local) must stop the remote reader gen_server rather than
+    %% leaving it orphaned for the consumer's lifetime.
+    %%
+    %% Build a remote tier that stops short of the local tail: upload a first
+    %% batch and let retention evict its early segments, then halt uploads and
+    %% append a local-only tail. A reader starting below the local floor opens
+    %% on the remote tier and must become_local when it reaches the tail.
+    WriterCfg0 = ?config(writer_cfg, Config),
+    WriterCfg = maps:merge(WriterCfg0, #{log_hooks => undefined}),
+    {ok, Writer} = osiris_writer:start(WriterCfg),
+    flush_writer(Writer),
+
+    %% Batch A: uploaded and partly evicted by retention.
+    write_sequential(Writer, 200, 5),
+    ReaderPid = start_replica_reader(Writer, Config, #{fragment_target_size => 500}),
+    await_offset(Config, 200),
+    ReaderCfg = reader_config(Writer, Config),
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 2000),
+
+    %% Halt uploads, then append a tail that stays local-only.
+    ok = rabbitmq_stream_s3_replica_reader_sup:stop_child(ReaderPid),
+    write_sequential(Writer, 50, 5),
+    flush_writer(Writer),
+
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+    RemotePid = rabbitmq_stream_s3_log_reader:remote_pid(Reader0),
+    ?assert(is_process_alive(RemotePid)),
+
+    %% Read forward until the reader crosses into the local tier.
+    ReaderFinal = read_until_local(Reader0),
+    ?assertEqual(local, rabbitmq_stream_s3_log_reader:mode(ReaderFinal)),
+
+    %% The orphaned remote reader must have been stopped.
+    ?awaitMatch(false, is_process_alive(RemotePid), 1000).
+
 read_from_replica_node(Config) ->
     StreamId = ?config(stream_id, Config),
     ReplicaNode = ?config(replica_node, Config),
@@ -451,6 +527,19 @@ read_from_replica_node(Config) ->
 %% ------------------------------------------------------------------
 %% Internal helpers
 %% ------------------------------------------------------------------
+
+read_until_local(Reader) ->
+    case rabbitmq_stream_s3_log_reader:mode(Reader) of
+        local ->
+            Reader;
+        remote ->
+            case rabbitmq_stream_s3_log_reader:chunk_iterator(Reader, 1, undefined) of
+                {ok, _Header, _Iter, Reader1} ->
+                    read_until_local(Reader1);
+                {end_of_stream, Reader1} ->
+                    Reader1
+            end
+    end.
 
 corrupt_first_fragment(Config) ->
     RemoteDir = ?config(remote_dir, Config),


### PR DESCRIPTION
The consumer-side remote reader is an unsupervised gen_server that is unlinked from and monitors its consumer. Two lifecycle gaps remained.

become_local left the remote reader orphaned: on a remote->local transition the reader switched its mode to a fresh local reader but never stopped the remote reader gen_server, which then lingered (holding its buffers) until the consumer process exited. Add a fire-and-forget stop and call it from every become_local branch.

A remote reader crash crashed the whole consumer connection: read/5 only caught exit:{timeout, _}, so a reader crash or an already-dead pid re-raised the gen_server:call exit into the consumer process. For the stream protocol that process serves many multiplexed subscriptions, so one stream's transient remote-read failure tore down the entire connection. Catch all exits and surface a clean {error, {remote_reader_down, _}}, which the read paths convert into a bounded restart: re-resolve the current offset and start a fresh reader (or a local reader if the data is now local). This matches the tolerant {error, _} contract the stream protocol already has for send_file/chunk_iterator, so a failure now degrades a single subscription instead of the connection, and self-heals on the next read.

Restarts are bounded per send_file/chunk_iterator pass to avoid spinning on a poison chunk that crashes every fresh reader.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
