### PR TITLE
Add a fault-injection API backend for testing

### DIFF
--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -67,7 +67,8 @@ groups() ->
             read_detects_crc_corruption,
             offset_spec_at_tier_boundary,
             remote_reader_restart_self_heals,
-            become_local_stops_remote_reader
+            become_local_stops_remote_reader,
+            read_retries_transient_remote_error
         ]},
         {with_replica, [], [
             read_from_replica_node
@@ -114,6 +115,11 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(_TestCase, Config) ->
     WriterCfg = ?config(writer_cfg, Config),
     catch osiris_writer:stop(WriterCfg),
+    %% Restore the default API backend if a test swapped in the fault backend.
+    application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fs
+    ),
+    catch rabbitmq_stream_s3_api_fault:reset(),
     Config.
 
 %% ------------------------------------------------------------------
@@ -134,6 +140,33 @@ read_from_remote_first(Config) ->
     {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
     ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
 
+    Records = read_all(Reader0),
+    assert_sequential(Records, N).
+
+read_retries_transient_remote_error(Config) ->
+    %% A transient S3 error on a remote fragment GET must be retried, not
+    %% surfaced to the consumer: the read still delivers the full stream. The
+    %% fault backend injects one slow_down on the next fragment GET.
+    StreamId = ?config(stream_id, Config),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
+    ),
+    ok = rabbitmq_stream_s3_api_fault:setup(),
+
+    Writer = start_writer(Config, #{fragment_target_size => 1000}),
+    N = 200,
+    write_sequential(Writer, N, 5),
+    ReaderCfg = reader_config(Writer, Config),
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch([S] when S > 0, list_segment_offsets(Config), 1000),
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+
+    %% The next remote fragment GET returns a transient error; the reader must
+    %% retry and still deliver the full stream.
+    ok = rabbitmq_stream_s3_api_fault:fail_next(get_range_async, StreamId, slow_down),
+
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
     Records = read_all(Reader0),
     assert_sequential(Records, N).
 

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -68,7 +68,8 @@ groups() ->
             offset_spec_at_tier_boundary,
             remote_reader_restart_self_heals,
             become_local_stops_remote_reader,
-            read_retries_transient_remote_error
+            read_retries_transient_remote_error,
+            read_tolerates_slow_remote
         ]},
         {with_replica, [], [
             read_from_replica_node
@@ -164,6 +165,31 @@ read_retries_transient_remote_error(Config) ->
     %% The next remote fragment GET returns a transient error; the reader must
     %% retry and still deliver the full stream.
     ok = rabbitmq_stream_s3_api_fault:fail_next(get_range_async, StreamId, slow_down),
+
+    {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
+    ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),
+    Records = read_all(Reader0),
+    assert_sequential(Records, N).
+
+read_tolerates_slow_remote(Config) ->
+    %% A slow remote tier (latency on every fragment GET) must still deliver the
+    %% full, correct stream.
+    StreamId = ?config(stream_id, Config),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
+    ),
+    ok = rabbitmq_stream_s3_api_fault:setup(),
+
+    Writer = start_writer(Config, #{fragment_target_size => 1000}),
+    N = 100,
+    write_sequential(Writer, N, 5),
+    ReaderCfg = reader_config(Writer, Config),
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch([S] when S > 0, list_segment_offsets(Config), 1000),
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+
+    %% Inject latency on every remote fragment GET.
+    ok = rabbitmq_stream_s3_api_fault:delay(get_range_async, StreamId, 20),
 
     {ok, Reader0} = rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg),
     ?assertEqual(remote, rabbitmq_stream_s3_log_reader:mode(Reader0)),

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -69,7 +69,8 @@ groups() ->
             remote_reader_restart_self_heals,
             become_local_stops_remote_reader,
             read_retries_transient_remote_error,
-            read_tolerates_slow_remote
+            read_tolerates_slow_remote,
+            read_group_fetch_error_is_surfaced
         ]},
         {with_replica, [], [
             read_from_replica_node
@@ -383,6 +384,45 @@ read_through_group(Config) ->
 
     Records = read_all(Reader0),
     assert_sequential(Records, NextOffset).
+
+read_group_fetch_error_is_surfaced(Config) ->
+    %% Resolving a numeric offset that descends into a group whose object cannot
+    %% be fetched (a retention deferred-deletion 404, or a transient S3 error)
+    %% must surface a clean error, not crash the consumer's reader. The `first`
+    %% spec goes via the fragment iterator (already tolerant); the numeric and
+    %% timestamp specs go via find_fragment, which this guards. The fault backend
+    %% 404s the group object on fetch.
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
+    ),
+    ok = rabbitmq_stream_s3_api_fault:setup(),
+
+    %% 5 fragments, rebalance threshold 4: the oldest 4 are factored into a group
+    %% at offset 0, so resolving offset 0 must descend into it.
+    #{next_offset := NextOffset} = seed_log(Config, [
+        {segment, [{chunk, #{records => 10, size => 600}}]},
+        {segment, [{chunk, #{records => 10, size => 600}}]},
+        {segment, [{chunk, #{records => 10, size => 600}}]},
+        {segment, [{chunk, #{records => 10, size => 600}}]},
+        {segment, [{chunk, #{records => 10, size => 600}}]}
+    ]),
+    Writer = start_writer(
+        Config, #{}, #{fragment_target_size => 500, rebalance_threshold => 4}
+    ),
+    flush_writer(Writer),
+    await_offset(Config, NextOffset),
+    ReaderCfg = reader_config(Writer, Config),
+    #{shared := Shared} = ReaderCfg,
+    ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+
+    %% The group object 404s on fetch (consumer reads use `get` only for group
+    %% objects; index uses get_range, data uses get_range_async).
+    ok = rabbitmq_stream_s3_api_fault:fail_next(get, <<"group">>, not_found),
+
+    ?assertMatch(
+        {error, {group_fetch_failed, not_found}},
+        rabbitmq_stream_s3_log_reader:init_offset_reader(0, ReaderCfg)
+    ).
 
 read_detects_crc_corruption(Config) ->
     %% When verify_crc_on_read is enabled, reading a corrupted fragment

--- a/test/rabbitmq_stream_s3_api_fault.erl
+++ b/test/rabbitmq_stream_s3_api_fault.erl
@@ -16,6 +16,8 @@ specific operation. The control surface (minimal for now):
   trimmed-segment upload failure of issue #225 without a timing race.
 - `fail_next(Op, KeyPattern, Reason)` makes the next matching call to `Op`
   return `{error, Reason}` (e.g. `slow_down`, `not_found`, `timeout`).
+- `delay(Op, KeyPattern, Ms)` sleeps before every matching call to `Op`,
+  simulating slow S3 (cleared by `reset/0`).
 
 Operation is one of: get, get_range, get_range_async, put, stream_put. Key
 matching is a binary substring (`binary:match/2`). When the control table is
@@ -49,7 +51,8 @@ passthrough to the FS backend.
     block_once/2,
     await_blocked/2,
     release/2,
-    fail_next/3
+    fail_next/3,
+    delay/3
 ]).
 
 -define(TBL, ?MODULE).
@@ -101,6 +104,12 @@ fail_next(Op, KeyPat, Reason) ->
     true = ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, 1}),
     ok.
 
+%% Sleep Ms before every matching call to Op (persists until reset/0).
+-spec delay(atom(), binary(), non_neg_integer()) -> ok.
+delay(Op, KeyPat, Ms) ->
+    true = ets:insert(?TBL, {{delay, Op}, KeyPat, Ms}),
+    ok.
+
 %%----------------------------------------------------------------------------
 %% Behaviour callbacks
 %%----------------------------------------------------------------------------
@@ -111,6 +120,7 @@ get_range(Key, RangeSpec, Opts) ->
     with_faults(get_range, Key, fun() -> ?FS:get_range(Key, RangeSpec, Opts) end).
 
 get_range_async(Key, RangeSpec, Opts) ->
+    maybe_delay(get_range_async, Key),
     maybe_block(get_range_async, Key),
     case maybe_fail(get_range_async, Key) of
         {error, Reason} ->
@@ -144,10 +154,24 @@ cancel_async(Req, State) -> ?FS:cancel_async(Req, State).
 %%----------------------------------------------------------------------------
 
 with_faults(Op, Key, Delegate) ->
+    maybe_delay(Op, Key),
     maybe_block(Op, Key),
     case maybe_fail(Op, Key) of
         {error, _} = Err -> Err;
         ok -> Delegate()
+    end.
+
+maybe_delay(Op, Key) ->
+    try ets:lookup(?TBL, {delay, Op}) of
+        [{_, KeyPat, Ms}] ->
+            case matches(KeyPat, Key) of
+                true -> timer:sleep(Ms);
+                false -> ok
+            end;
+        _ ->
+            ok
+    catch
+        error:badarg -> ok
     end.
 
 maybe_block(Op, Key) ->

--- a/test/rabbitmq_stream_s3_api_fault.erl
+++ b/test/rabbitmq_stream_s3_api_fault.erl
@@ -1,0 +1,186 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_api_fault).
+-moduledoc """
+A fault-injecting S3 API backend for tests.
+
+Wraps `rabbitmq_stream_s3_api_fs`, delegating every operation by default, and
+consults a control table first so a test can deterministically block or fail a
+specific operation. The control surface (minimal for now):
+
+- `block_once(Op, KeyPattern)` parks the next matching call to `Op` until the
+  test releases it. This lets a test freeze the pipeline at a precise point -
+  e.g. hold a fragment upload at `stream_put` (before it reads the local
+  segment), trim that segment via retention, then release to reproduce the
+  trimmed-segment upload failure of issue #225 without a timing race.
+- `fail_next(Op, KeyPattern, Reason)` makes the next matching call to `Op`
+  return `{error, Reason}` (e.g. `slow_down`, `not_found`, `timeout`).
+
+Operation is one of: get, get_range, get_range_async, put, stream_put. Key
+matching is a binary substring (`binary:match/2`). When the control table is
+absent (the backend is not configured for a test) every call is a pure
+passthrough to the FS backend.
+""".
+
+-behaviour(rabbitmq_stream_s3_api).
+
+%% rabbitmq_stream_s3_api behaviour
+-export([
+    get/2,
+    get_range/3,
+    get_range_async/3,
+    put/3,
+    stream_put/3,
+    stream_data/2,
+    stream_finish/2,
+    stream_abort/1,
+    delete/2,
+    list/3,
+    match_async/3,
+    handle_async/3,
+    cancel_async/2
+]).
+
+%% Test control surface
+-export([
+    setup/0,
+    reset/0,
+    block_once/2,
+    await_blocked/2,
+    release/2,
+    fail_next/3
+]).
+
+-define(TBL, ?MODULE).
+-define(FS, rabbitmq_stream_s3_api_fs).
+
+%%----------------------------------------------------------------------------
+%% Test control
+%%----------------------------------------------------------------------------
+
+-spec setup() -> ok.
+setup() ->
+    case ets:info(?TBL) of
+        undefined -> _ = ets:new(?TBL, [named_table, public, set]);
+        _ -> reset()
+    end,
+    ok.
+
+-spec reset() -> ok.
+reset() ->
+    catch ets:delete_all_objects(?TBL),
+    ok.
+
+%% Arm a one-shot block: the next call to Op whose key matches KeyPat parks
+%% until released. Returns a Ref to await/release on.
+-spec block_once(atom(), binary()) -> reference().
+block_once(Op, KeyPat) ->
+    Ref = make_ref(),
+    true = ets:insert(?TBL, {{block, Op}, KeyPat, self(), Ref}),
+    Ref.
+
+%% Block until the armed block is hit; returns the blocked (task) pid.
+-spec await_blocked(reference(), timeout()) -> pid().
+await_blocked(Ref, Timeout) ->
+    receive
+        {fault_blocked, Ref, TaskPid} -> TaskPid
+    after Timeout ->
+        error({fault_block_not_hit, Ref})
+    end.
+
+%% Release a blocked task so it proceeds to delegate to the FS backend.
+-spec release(pid(), reference()) -> ok.
+release(TaskPid, Ref) ->
+    TaskPid ! {fault_release, Ref},
+    ok.
+
+%% Arm a one-shot failure for the next matching call to Op.
+-spec fail_next(atom(), binary(), term()) -> ok.
+fail_next(Op, KeyPat, Reason) ->
+    true = ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, 1}),
+    ok.
+
+%%----------------------------------------------------------------------------
+%% Behaviour callbacks
+%%----------------------------------------------------------------------------
+
+get(Key, Opts) -> with_faults(get, Key, fun() -> ?FS:get(Key, Opts) end).
+
+get_range(Key, RangeSpec, Opts) ->
+    with_faults(get_range, Key, fun() -> ?FS:get_range(Key, RangeSpec, Opts) end).
+
+get_range_async(Key, RangeSpec, Opts) ->
+    with_faults(get_range_async, Key, fun() -> ?FS:get_range_async(Key, RangeSpec, Opts) end).
+
+put(Key, Data, Opts) -> with_faults(put, Key, fun() -> ?FS:put(Key, Data, Opts) end).
+
+stream_put(Key, ContentLength, Opts) ->
+    with_faults(stream_put, Key, fun() -> ?FS:stream_put(Key, ContentLength, Opts) end).
+
+%% Pure delegation: faults are injected at the operation boundaries above.
+stream_data(State, Data) -> ?FS:stream_data(State, Data).
+stream_finish(State, Crc) -> ?FS:stream_finish(State, Crc).
+stream_abort(State) -> ?FS:stream_abort(State).
+delete(Keys, Opts) -> ?FS:delete(Keys, Opts).
+list(Prefix, Continuation, Opts) -> ?FS:list(Prefix, Continuation, Opts).
+match_async(Msg, Reqs, Cancelled) -> ?FS:match_async(Msg, Reqs, Cancelled).
+handle_async(Msg, Req, State) -> ?FS:handle_async(Msg, Req, State).
+cancel_async(Req, State) -> ?FS:cancel_async(Req, State).
+
+%%----------------------------------------------------------------------------
+%% Internal
+%%----------------------------------------------------------------------------
+
+with_faults(Op, Key, Delegate) ->
+    maybe_block(Op, Key),
+    case maybe_fail(Op, Key) of
+        {error, _} = Err -> Err;
+        ok -> Delegate()
+    end.
+
+maybe_block(Op, Key) ->
+    case lookup({block, Op}) of
+        {ok, {KeyPat, TestPid, Ref}} ->
+            case matches(KeyPat, Key) of
+                true ->
+                    %% One-shot: remove before parking so only this call blocks.
+                    ets:delete(?TBL, {block, Op}),
+                    TestPid ! {fault_blocked, Ref, self()},
+                    receive
+                        {fault_release, Ref} -> ok
+                    end;
+                false ->
+                    ok
+            end;
+        none ->
+            ok
+    end.
+
+maybe_fail(Op, Key) ->
+    case lookup({fail, Op}) of
+        {ok, {KeyPat, Reason, N}} ->
+            case matches(KeyPat, Key) of
+                true ->
+                    case N =< 1 of
+                        true -> ets:delete(?TBL, {fail, Op});
+                        false -> ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, N - 1})
+                    end,
+                    {error, Reason};
+                false ->
+                    ok
+            end;
+        none ->
+            ok
+    end.
+
+lookup(K) ->
+    try ets:lookup(?TBL, K) of
+        [{_, A, B, C}] -> {ok, {A, B, C}};
+        [] -> none
+    catch
+        error:badarg -> none
+    end.
+
+matches(KeyPat, Key) ->
+    binary:match(Key, KeyPat) =/= nomatch.

--- a/test/rabbitmq_stream_s3_api_fault.erl
+++ b/test/rabbitmq_stream_s3_api_fault.erl
@@ -111,7 +111,18 @@ get_range(Key, RangeSpec, Opts) ->
     with_faults(get_range, Key, fun() -> ?FS:get_range(Key, RangeSpec, Opts) end).
 
 get_range_async(Key, RangeSpec, Opts) ->
-    with_faults(get_range_async, Key, fun() -> ?FS:get_range_async(Key, RangeSpec, Opts) end).
+    maybe_block(get_range_async, Key),
+    case maybe_fail(get_range_async, Key) of
+        {error, Reason} ->
+            %% Deliver the error on the async channel, mirroring how the FS
+            %% backend reports a result, so the reader's retry path engages (a
+            %% synchronous {error, _} return is a different, rarer path).
+            Req = make_ref(),
+            self() ! {'$async', Req, {done, {error, Reason}}},
+            {ok, Req, undefined};
+        ok ->
+            ?FS:get_range_async(Key, RangeSpec, Opts)
+    end.
 
 put(Key, Data, Opts) -> with_faults(put, Key, fun() -> ?FS:put(Key, Data, Opts) end).
 

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
             large_record_cuts_immediately,
             seed_log_uploads_deterministic,
             local_ahead_discards_manifest,
+            upload_path_recovers_from_trimmed_segment,
             remote_tier_ahead_discards_manifest,
             reconcile_reattaches_orphaned_writer,
             reconcile_reseeds_writer_cache_after_restart,
@@ -146,6 +147,12 @@ end_per_testcase(_TestCase, Config) ->
     %% Stop the writer if still running (cascades to replica reader).
     WriterCfg = ?config(writer_cfg, Config),
     catch osiris_writer:stop(WriterCfg),
+    %% Restore the default API backend in case a test swapped in the fault
+    %% backend, and drop any armed fault rules.
+    application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fs
+    ),
+    catch rabbitmq_stream_s3_api_fault:reset(),
     %% Clean up any per-test app env overrides.
     application:unset_env(rabbitmq_stream_s3, fragment_target_size),
     application:unset_env(rabbitmq_stream_s3, persist_threshold),
@@ -616,6 +623,68 @@ local_ahead_discards_manifest(Config) ->
     NewFragments = list_fragment_offsets(Config),
     ?assert(length(NewFragments) > 0),
     ?assert(hd(NewFragments) >= FirstLocal).
+
+upload_path_recovers_from_trimmed_segment(Config) ->
+    %% Issue #225, mid-stream path: while a fragment upload is in flight, user
+    %% retention trims the local segment backing it, so the upload can never
+    %% succeed. The reader must recover (reset to the local floor and resume),
+    %% not stall the manifest forever. The fault backend holds the upload at
+    %% stream_put - before it reads the segment - so the trim is deterministic.
+    StreamId = ?config(stream_id, Config),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
+    ),
+    ok = rabbitmq_stream_s3_api_fault:setup(),
+    %% Keep the transfer deadline well clear of the block window so recovery
+    %% fires via the upload's enoent, not the deadline path.
+    ok = application:set_env(rabbitmq_stream_s3, transfer_deadline_ms, 60_000),
+
+    Writer = start_writer(
+        Config,
+        #{max_segment_size_bytes => 2000, retention => [{max_bytes, 20000}]},
+        #{fragment_target_size => 1000}
+    ),
+    #{shared := Shared} = gen_batch_server:call(Writer, get_reader_context),
+    Record = binary:copy(<<"x">>, 500),
+    Write = fun(N) ->
+        lists:foreach(fun(_) -> ok = osiris_writer:write(Writer, Record) end, lists:seq(1, N)),
+        flush_writer(Writer)
+    end,
+
+    %% Batch A (under max_bytes): fully drain it so the baseline manifest
+    %% next_offset is known and the next upload starts exactly there.
+    Write(20),
+    ok = await_offset(Config, 20),
+    {_, NextA} = get_range(Config),
+
+    %% Arm a one-shot block on the next fragment upload (the one at NextA), then
+    %% write so its upload parks at stream_put (before it reads the segment).
+    Ref = rabbitmq_stream_s3_api_fault:block_once(stream_put, StreamId),
+    Write(5),
+    TaskPid = rabbitmq_stream_s3_api_fault:await_blocked(Ref, 10_000),
+
+    %% Write a lot more: user retention (max_bytes) trims the un-tiered backlog,
+    %% including the segment backing the blocked upload (the oldest, at NextA),
+    %% lifting the local floor above the stalled manifest next_offset.
+    Write(80),
+    ?awaitMatch(F when F > NextA, osiris_log_shared:first_chunk_id(Shared), 10_000),
+
+    %% Release the blocked upload: it now reads a trimmed segment, fails enoent,
+    %% and the reader recovers by resetting to the local floor instead of
+    %% stalling the manifest at NextA forever.
+    ok = rabbitmq_stream_s3_api_fault:release(TaskPid, Ref),
+
+    %% Keep writing so the reset reader is driven by osiris offset notifications
+    %% to drain and re-upload (in #225 writes are continuous). No permanent
+    %% stall: the manifest leaves NextA and advances past it.
+    ?awaitMatch(
+        {_, N} when N > NextA,
+        begin
+            Write(5),
+            get_range(Config)
+        end,
+        30_000
+    ).
 
 remote_tier_ahead_discards_manifest(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
*Issue #, if available:* connects https://github.com/amazon-mq/rabbitmq-stream-s3/issues/36

*Description of changes:* The existing FS backend is too quick and consistent to reproduce recently found timing or failure-based issues. This change adds a failure backend which wraps the FS backend with additional fault-injection which can be used to create reliable high-level (i.e. non-purely-functional) tests which stress shell properties.

Each commit has more details on the relevant change and test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
