### PR TITLE
replica reader: Extract a pure state machine for async task I/O

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -632,95 +632,16 @@ handle_info({group_upload_result, Gen, Result}, #state{tasks = Tasks0} = State0)
         {group_result, Gen, Result}, Tasks0
     ),
     apply_group_decisions(Decisions, State0#state{tasks = Tasks});
-handle_info(
-    {retention_result, Token, unchanged},
-    #state{retention_token = Token, core = Core0, retention_mon = Mon, retention_timer = TRef} =
-        State0
-) ->
-    %% Evaluation ran and found nothing to remove: not a failure, not counted.
-    demonitor(Mon, [flush]),
-    _ = cancel_timer(TRef),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(unchanged, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core,
-            retention_mon = undefined,
-            retention_pid = undefined,
-            retention_timer = undefined,
-            retention_token = undefined
-        })};
-handle_info(
-    {retention_result, Token, {failed, Reason}},
-    #state{retention_token = Token, core = Core0, retention_mon = Mon, retention_timer = TRef} =
-        State0
-) ->
-    %% The async retention task caught a crash and reported it as a failure
-    %% (distinct from unchanged, which means it ran and found nothing). The
-    %% task already logged the crash with a stack trace; record the failure
-    %% as a metric so it is visible separately from no-op evaluations.
-    demonitor(Mon, [flush]),
-    _ = cancel_timer(TRef),
-    inc(State0, ?C_REMOTE_TIER_RETENTION_FAILURES, 1),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(Reason, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core,
-            retention_mon = undefined,
-            retention_pid = undefined,
-            retention_timer = undefined,
-            retention_token = undefined
-        })};
-handle_info(
-    {retention_result, Token, {Edit, Refs}},
-    #state{
-        retention_token = Token,
-        core = Core0,
-        retention_mon = Mon,
-        retention_timer = TRef,
-        cfg = #cfg{stream = StreamId}
-    } =
-        State0
-) ->
-    demonitor(Mon, [flush]),
-    _ = cancel_timer(TRef),
-    State = on_remote_retention(Edit, Refs, StreamId, Core0, State0#state{
-        retention_mon = undefined,
-        retention_pid = undefined,
-        retention_timer = undefined,
-        retention_token = undefined
-    }),
-    {noreply, State};
-handle_info(
-    {retention_result, _StaleToken, _Result},
-    #state{cfg = #cfg{stream = StreamId}} = State
-) ->
-    %% A result from a retention task we are no longer tracking - typically one
-    %% the retention timeout already killed, whose message was queued before the
-    %% kill. Its token does not match the current (or absent) task, so ignore it
-    %% rather than apply a stale truncation edit or demonitor a cleared monitor.
-    ?LOG_DEBUG("~ts ignoring stale retention result", [StreamId]),
-    {noreply, State};
-handle_info(
-    retention_timeout,
-    #state{retention_mon = Mon, retention_pid = Pid, core = Core0, cfg = #cfg{stream = StreamId}} =
-        State0
-) when Mon =/= undefined ->
-    ?LOG_WARNING("~ts retention evaluation task timed out, killing", [StreamId]),
-    exit(Pid, kill),
-    demonitor(Mon, [flush]),
-    inc(State0, ?C_REMOTE_TIER_RETENTION_FAILURES, 1),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(timeout, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core,
-            retention_mon = undefined,
-            retention_pid = undefined,
-            retention_timer = undefined,
-            retention_token = undefined
-        })};
-handle_info(retention_timeout, State) ->
-    %% Stale timeout after normal completion; ignore.
-    {noreply, State};
+handle_info({retention_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {retention_result, Gen, Result}, Tasks0
+    ),
+    apply_retention_decisions(Decisions, State0#state{tasks = Tasks});
+handle_info({retention_timeout, Gen}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {retention_timeout, Gen}, Tasks0
+    ),
+    apply_retention_timeout_decisions(Decisions, State0#state{tasks = Tasks});
 handle_info(persist_timer, #state{core = Core0} = State0) ->
     Now = erlang:system_time(millisecond),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:tick(Now, Core0),
@@ -744,23 +665,6 @@ handle_info({persist_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
         {persist_result, Gen, Result}, Tasks0
     ),
     apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
-handle_info(
-    {'DOWN', Mon, process, _, Reason},
-    #state{retention_mon = Mon, retention_timer = TRef, core = Core0, cfg = #cfg{stream = StreamId}} =
-        State0
-) ->
-    ?LOG_WARNING("~ts retention evaluation task crashed: ~p", [StreamId, Reason]),
-    _ = cancel_timer(TRef),
-    inc(State0, ?C_REMOTE_TIER_RETENTION_FAILURES, 1),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(Reason, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core,
-            retention_mon = undefined,
-            retention_pid = undefined,
-            retention_timer = undefined,
-            retention_token = undefined
-        })};
 handle_info({'DOWN', Mon, process, _Pid, Reason}, State) ->
     %% A monitored async task crashed. Its 'DOWN' carries the monitor ref, which
     %% identifies the family (and, via the model's slot, its generation): a crash
@@ -1311,7 +1215,8 @@ maybe_spawn_group_retention(
     State
 ) when Kind =/= ?MANIFEST_KIND_FRAGMENT ->
     Self = self(),
-    Token = make_ref(),
+    #state{tasks = Tasks0, task_io = Io} = State,
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
     GetGroupFun = rabbitmq_stream_s3_manifest:get_cached_group_fun(StreamId),
     {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
@@ -1327,17 +1232,16 @@ maybe_spawn_group_retention(
                     ),
                     {failed, {Class, Reason}}
             end,
-        Self ! {retention_result, Token, Result}
+        Self ! {retention_result, Gen, Result}
     end),
     Core = rabbitmq_stream_s3_replica_reader_core:retention_started(State#state.core),
     Timeout = rabbitmq_stream_s3_config:retention_task_timeout(),
-    TRef = erlang:send_after(Timeout, Self, retention_timeout),
+    TRef = erlang:send_after(Timeout, Self, {retention_timeout, Gen}),
+    {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(spawn_retention, Tasks0),
     State#state{
         core = Core,
-        retention_mon = MonRef,
-        retention_pid = Pid,
-        retention_timer = TRef,
-        retention_token = Token
+        tasks = Tasks,
+        task_io = Io#{retention => #{mon => MonRef, pid => Pid, timer => TRef}}
     };
 maybe_spawn_group_retention(_Manifest, _Retention, _Now, _StreamId, State) ->
     State.
@@ -2260,6 +2164,19 @@ clear_task_io(Family, #state{task_io = Io} = State) ->
             State
     end.
 
+%% Tear down one single-in-flight task that is still running (a timeout): kill
+%% its process, demonitor (flush its 'DOWN'), and cancel its timer.
+-spec discard_task_io(persist | group | retention, #state{}) -> #state{}.
+discard_task_io(Family, #state{task_io = Io} = State) ->
+    case maps:take(Family, Io) of
+        {Handle, Io1} ->
+            kill_task(maps:get(mon, Handle), maps:get(pid, Handle, undefined)),
+            _ = cancel_timer(maps:get(timer, Handle, undefined)),
+            State#state{task_io = Io1};
+        error ->
+            State
+    end.
+
 %% On recovery: tear down every single-in-flight task - demonitor (flush its
 %% 'DOWN'), cancel its timer, and kill its process if the pid was retained.
 -spec kill_task_io(#state{}) -> #state{}.
@@ -2316,6 +2233,49 @@ apply_group_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}} =
     ?LOG_DEBUG("~ts ignoring stale group upload result", [StreamId]),
     {noreply, State}.
 
+%% Carry out the retention task model's decision for a retention *result*. The
+%% task has finished, so its monitor is demonitored and its timeout timer
+%% cancelled (clear_task_io); a timeout is handled separately below because it
+%% must kill a still-running task. unchanged is a no-op evaluation and is not
+%% counted as a failure.
+apply_retention_decisions(
+    [{deliver, retention_complete, {Edit, Refs}}], #state{cfg = #cfg{stream = StreamId}} = State0
+) ->
+    State1 = clear_task_io(retention, State0),
+    {noreply, on_remote_retention(Edit, Refs, StreamId, State1#state.core, State1)};
+apply_retention_decisions([{deliver, retention_failed, unchanged}], State0) ->
+    State1 = clear_task_io(retention, State0),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(
+        unchanged, State1#state.core
+    ),
+    {noreply, execute_effects(Effects, State1#state{core = Core})};
+apply_retention_decisions([{deliver, retention_failed, Reason}], State0) ->
+    State1 = clear_task_io(retention, State0),
+    inc(State1, ?C_REMOTE_TIER_RETENTION_FAILURES, 1),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(
+        Reason, State1#state.core
+    ),
+    {noreply, execute_effects(Effects, State1#state{core = Core})};
+apply_retention_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}} = State) ->
+    ?LOG_DEBUG("~ts ignoring stale retention result", [StreamId]),
+    {noreply, State}.
+
+%% Carry out the model's decision for a retention *timeout*. The task is still
+%% running, so it is killed (discard_task_io) rather than merely demonitored.
+apply_retention_timeout_decisions(
+    [{deliver, retention_failed, timeout}], #state{cfg = #cfg{stream = StreamId}} = State0
+) ->
+    ?LOG_WARNING("~ts retention evaluation task timed out, killing", [StreamId]),
+    State1 = discard_task_io(retention, State0),
+    inc(State1, ?C_REMOTE_TIER_RETENTION_FAILURES, 1),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:retention_failed(
+        timeout, State1#state.core
+    ),
+    {noreply, execute_effects(Effects, State1#state{core = Core})};
+apply_retention_timeout_decisions([{drop, _Reason}], State) ->
+    %% Stale timeout after normal completion or a recovery; ignore.
+    {noreply, State}.
+
 %% Translate a monitored task's crash into a failure result for the live task.
 apply_task_crash(persist, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_WARNING("~ts commit task crashed: ~p", [StreamId, Reason]),
@@ -2330,7 +2290,16 @@ apply_task_crash(group, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = Strea
     {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
         {group_result, Gen, {error, Reason}}, Tasks0
     ),
-    apply_group_decisions(Decisions, State0#state{tasks = Tasks}).
+    apply_group_decisions(Decisions, State0#state{tasks = Tasks});
+apply_task_crash(retention, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
+    ?LOG_WARNING("~ts retention evaluation task crashed: ~p", [StreamId, Reason]),
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
+    %% A crash is reported as a failure (mirrors the {failed, _} result), so it is
+    %% counted as a retention failure by apply_retention_decisions.
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {retention_result, Gen, {failed, Reason}}, Tasks0
+    ),
+    apply_retention_decisions(Decisions, State0#state{tasks = Tasks}).
 
 on_manifest_resolved(#manifest{next_offset = 0}, State) ->
     inc(State, ?C_MANIFESTS_RESOLVED_EMPTY, 1),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -234,59 +234,14 @@ returned by the functional core module.
     replicas = #{} :: #{node() => reference()},
     %% User-configured retention specs for remote tier evaluation.
     retention = [] :: [osiris:retention_spec()],
-    %% Commit timer reference.
+    %% Periodic commit-tick timer reference. Drives the core's persist
+    %% scheduling; distinct from the async persist task (which lives in the task
+    %% model and task_io).
     persist_timer :: reference() | undefined,
-    %% Monitor ref and PID for the in-flight commit task.
-    persist_mon :: reference() | undefined,
-    persist_pid :: pid() | undefined,
     %% Per-stream seshat counter ref. The id used to register this counter
     %% in the rabbitmq_stream_s3 seshat group, used for cleanup on terminate.
     metrics :: counters:counters_ref() | undefined,
     metrics_id :: term() | undefined,
-    %% Map from in-flight transfer ref to its byte size. Tracked in the
-    %% shell so we can attribute bytes_transferred and decrement
-    %% transfers_in_flight when the result message arrives.
-    transfer_sizes = #{} :: #{reference() => non_neg_integer()},
-    %% Per in-flight transfer, a deadline timer that fires if the governor
-    %% never reports a result. A submitted transfer can fail to report back if
-    %% the governor crashes while the submission sits in its pending queue
-    %% (only when a finite rate limit is configured), if the spawned task is
-    %% killed externally (e.g. by the OOM killer) before it replies, or if the
-    %% result message is otherwise lost. In every case the in-flight queue head
-    %% never drains and the stream's uploads stall silently and permanently. On
-    %% expiry the transfer is resubmitted under the same reference through the
-    %% core's retry path (see the {transfer_deadline, ...} handler). The map
-    %% value is {TimerRef, Token}: the Token disambiguates a live deadline from
-    %% a stale timer message that fired into the mailbox in the narrow window
-    %% before its timer was cancelled.
-    transfer_deadlines = #{} :: #{reference() => {reference(), reference()}},
-    %% Bytes uploaded but not yet covered by a started persist. Moves to
-    %% persisting_bytes when the next start_persist effect fires.
-    persist_pending_bytes = 0 :: non_neg_integer(),
-    %% Bytes covered by the currently-in-flight persist. Snapshotted from
-    %% persist_pending_bytes at start_persist; cleared on persist_result.
-    %% bytes_in_persist gauge = persist_pending_bytes + persisting_bytes.
-    persisting_bytes = 0 :: non_neg_integer(),
-    %% Monitor ref for the in-flight group upload task.
-    group_mon :: reference() | undefined,
-    %% Monitor ref for the in-flight retention evaluation task.
-    retention_mon :: reference() | undefined,
-    %% PID of the in-flight retention evaluation task.
-    retention_pid :: pid() | undefined,
-    %% Timer ref for the retention task timeout.
-    retention_timer :: reference() | undefined,
-    %% Correlation token for the in-flight retention task. Each spawned task
-    %% gets a fresh make_ref/0 and tags its result with it; only a
-    %% {retention_result, Token, _} whose Token matches the current task is
-    %% applied. A result from a task we stopped tracking (e.g. one the retention
-    %% timeout already killed, whose message was queued before the kill) carries
-    %% a stale token and is ignored rather than mis-applied onto a manifest it
-    %% no longer matches.
-    retention_token :: reference() | undefined,
-    %% Kind of the group upload currently in flight. Cleared when the
-    %% group_upload_result message arrives. Only one rebalance is in
-    %% flight at a time so a single slot suffices.
-    pending_group_kind :: rabbitmq_stream_s3:kind() | undefined,
     %% Keys queued for deletion after the next successful persist.
     %% Retention computes which objects to delete but we defer the actual
     %% S3 DELETE until the manifest persist that records their removal
@@ -533,100 +488,24 @@ handle_info({osiris_offset, _Ref, _Offset}, State0) ->
     {noreply, State};
 handle_info(retry_resolve, State0) ->
     {noreply, resolve_and_start(State0)};
-handle_info({transfer_result, Ref, _Result}, State0) when
-    not is_map_key(Ref, State0#state.transfer_sizes)
-->
-    %% Stale result from a transfer submitted before a manifest recovery reset
-    %% the in-flight queue (see handle_local_log_ahead/3). The fragment is no
-    %% longer tracked by the shell or the core, so feeding it to the core would
-    %% crash get_meta or, for a success, append a non-contiguous orphan that
-    %% trips assert_contiguous. Drop it.
-    {noreply, State0};
-handle_info({transfer_result, Ref, {ok, Uid}}, #state{core = Core0} = State0) ->
-    State1 = on_transfer_result(Ref, ok, State0),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, Uid, Core0),
-    State2 = State1#state{core = Core},
-    State3 = execute_effects(Effects, State2),
-    {noreply, State3};
-handle_info({transfer_result, Ref, {error, Reason}}, #state{core = Core0} = State0) ->
-    State1 = on_transfer_result(Ref, {error, Reason}, State0),
-    case local_log_ahead(State1) of
-        {true, LocalFirst, NextOffset} ->
-            %% Local retention trimmed past the manifest's next_offset, so the
-            %% segment backing the stalled fragment is permanently gone and no
-            %% retry can ever make it durable. Without this the core would keep
-            %% the fragment at the head of the in-flight queue and retry it
-            %% forever (issue #225), wedging the manifest and making the bulk of
-            %% the stream inaccessible. Recover the same way start_reading0/1
-            %% does at reader init: discard the remote manifest and restart from
-            %% the local log's first offset, accepting the lost range.
-            {noreply, handle_local_log_ahead(LocalFirst, NextOffset, Reason, State1)};
-        false ->
-            {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
-                Ref, Reason, Core0
-            ),
-            {noreply, execute_effects(Effects, State1#state{core = Core})}
-    end;
-handle_info({transfer_deadline, Ref, Token}, #state{core = Core0} = State0) ->
-    case maps:find(Ref, State0#state.transfer_deadlines) of
-        {ok, {_TimerRef, Token}} ->
-            %% The deadline elapsed with no result for this transfer. Treat it
-            %% exactly as a lost result: account the abandoned submission off
-            %% the pipeline gauges and drop its bookkeeping (as a real error
-            %% result would via on_transfer_result/3), then drive the core's
-            %% retry path to re-upload under the same Ref. If a late original
-            %% result and the resubmit both eventually complete, the second is
-            %% discarded by the stale-Ref clause above once the first has been
-            %% accounted for; the losing upload's object is left for orphan GC.
-            ?LOG_WARNING(
-                "~ts no result for an in-flight fragment transfer within the "
-                "transfer deadline. The governor may have lost the submission "
-                "(crash with a queued item), the upload task may have been "
-                "killed before replying, or the result message was lost. "
-                "Resubmitting to keep the upload pipeline live.",
-                [(State0#state.cfg)#cfg.stream]
-            ),
-            State1 = on_transfer_result(Ref, {error, transfer_deadline}, State0),
-            case local_log_ahead(State1) of
-                {true, LocalFirst, NextOffset} ->
-                    %% Local retention trimmed past next_offset while this
-                    %% transfer was stalled, so no resubmit can ever make the
-                    %% range durable. Recover the same way a permanent upload
-                    %% failure does (see the {error, Reason} clause).
-                    {noreply,
-                        handle_local_log_ahead(
-                            LocalFirst, NextOffset, transfer_deadline, State1
-                        )};
-                false ->
-                    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
-                        Ref, transfer_deadline, Core0
-                    ),
-                    {noreply, execute_effects(Effects, State1#state{core = Core})}
-            end;
-        _ ->
-            %% Stale timer message: the result already arrived (the timer was
-            %% cancelled but had already fired into the mailbox), or a manifest
-            %% recovery reset the in-flight bookkeeping, or this Ref now tracks
-            %% a newer deadline with a different token. Ignore it.
-            {noreply, State0}
-    end;
-handle_info({retry_transfer, Ref, Dir, Meta}, #state{cfg = #cfg{stream = StreamId}} = State) ->
-    %% A previously failed fragment upload is being retried after its backoff
-    %% delay. If a reset (local-log-ahead recovery) cleared the in-flight
-    %% transfer tracking after this retry was scheduled, the fragment is no
-    %% longer part of the pipeline; drop the retry rather than re-submitting a
-    %% phantom upload against the discarded core (mirrors the stale
-    %% transfer_result guard above). The timer is fire-and-forget, so this is
-    %% where the stale retry is filtered.
-    case is_map_key(Ref, State#state.transfer_sizes) of
-        true ->
-            %% The in-flight gauges were already restored when the delayed
-            %% resubmit effect was executed, so only re-submit the upload here.
-            submit_upload(Ref, Dir, StreamId, Meta),
-            {noreply, State};
-        false ->
-            {noreply, State}
-    end;
+handle_info({transfer_result, Ref, Result}, #state{tasks = Tasks0} = State0) ->
+    %% Read the transferred byte count before the step removes the transfer; it
+    %% is needed for the cumulative bytes-transferred counter on success.
+    Size = transfer_byte_size(Ref, Tasks0),
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {transfer_result, Ref, Result}, Tasks0
+    ),
+    apply_transfer_decisions(Decisions, Size, State0#state{tasks = Tasks});
+handle_info({transfer_deadline, Ref, Token}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {transfer_deadline, Ref, Token}, Tasks0
+    ),
+    apply_transfer_decisions(Decisions, 0, State0#state{tasks = Tasks});
+handle_info({retry_transfer, Ref, Dir, Meta}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {retry_transfer, Ref}, Tasks0
+    ),
+    apply_retry_decisions(Decisions, Dir, Meta, State0#state{tasks = Tasks});
 handle_info({group_upload_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
     {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
         {group_result, Gen, Result}, Tasks0
@@ -661,10 +540,13 @@ handle_info(
         _ -> {noreply, State}
     end;
 handle_info({persist_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
+    %% Read the bytes this persist covered before the step frees the slot; needed
+    %% for the cumulative bytes-persisted counter on success.
+    PersistedBytes = persisting_snapshot(Tasks0),
     {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
         {persist_result, Gen, Result}, Tasks0
     ),
-    apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
+    apply_persist_decisions(Decisions, PersistedBytes, State0#state{tasks = Tasks});
 handle_info({'DOWN', Mon, process, _Pid, Reason}, State) ->
     %% A monitored async task crashed. Its 'DOWN' carries the monitor ref, which
     %% identifies the family (and, via the model's slot, its generation): a crash
@@ -712,12 +594,12 @@ format_state(#state{
     log = Log,
     assembly = Assembly,
     core = Core,
-    transfer_deadlines = Deadlines
+    transfer_timers = Timers
 }) ->
     #{
         stream => StreamId,
         fragment_target_size => Target,
-        transfer_deadlines_armed => maps:size(Deadlines),
+        transfer_deadlines_armed => maps:size(Timers),
         core =>
             case Core of
                 undefined -> undefined;
@@ -977,9 +859,8 @@ execute_effect({submit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} =
 execute_effect({resubmit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} = State0) ->
     StreamId = Cfg#cfg.stream,
     submit_upload(Ref, Dir, StreamId, Meta),
-    %% on_transfer_result already decremented the gauges and removed Ref
-    %% from transfer_sizes. Restore them so the eventual completion is
-    %% accounted for correctly.
+    %% The failure already removed Ref from the model. Re-add it (a fresh slot
+    %% with a new deadline token) so the eventual completion is accounted for.
     on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect(
     {resubmit_transfer_delayed, Ref, _StreamId, Dir, Meta, Reason}, #state{cfg = Cfg} = State0
@@ -993,8 +874,9 @@ execute_effect(
         [StreamId, maps:get(first_offset, Meta), Reason, Delay]
     ),
     erlang:send_after(Delay, self(), {retry_transfer, Ref, Dir, Meta}),
-    %% on_transfer_result already decremented the gauges. Restore them: the
-    %% fragment is still pending and its bytes are still in the pipeline.
+    %% The failure already removed Ref from the model. Re-add it now (the fragment
+    %% is still pending and its bytes are still in the pipeline); the retry_transfer
+    %% timer above triggers the actual re-upload after the backoff.
     on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect(
     {upload_group, StreamId, Kind, Entries, _Pos, _Len},
@@ -1032,19 +914,15 @@ execute_effect(
         Result = do_commit(StreamId, Manifest, Epoch, Reference, ExpectedRevision),
         Self ! {persist_result, Gen, Result}
     end),
+    %% step(spawn_persist) snapshots the model's pending bytes into the persist
+    %% slot (the bytes this commit will cover) and zeroes pending; bytes_in_persist
+    %% is unchanged. New transfer completions during the persist accumulate in the
+    %% model's pending pool and are covered by the next persist.
     {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(spawn_persist, Tasks0),
-    %% Snapshot the bytes that this persist will cover. New transfer
-    %% completions during the persist accumulate in persist_pending_bytes
-    %% and will be covered by the next persist. The bytes_in_persist
-    %% gauge is unchanged here (its value equals
-    %% persisting_bytes + persist_pending_bytes both before and after).
-    Snapshot = State#state.persist_pending_bytes,
-    State#state{
+    derive_gauges(State#state{
         tasks = Tasks,
-        task_io = Io#{persist => #{mon => MonRef, pid => CommitPid}},
-        persisting_bytes = Snapshot,
-        persist_pending_bytes = 0
-    };
+        task_io = Io#{persist => #{mon => MonRef, pid => CommitPid}}
+    });
 execute_effect({update_range, _FirstOffset, _NextOffset}, #state{cfg = Cfg, core = Core} = State) ->
     %% Publish the *persisted* manifest, not the live one. This effect is
     %% emitted by persist_complete, and the cache + range table it updates gate
@@ -1893,68 +1771,120 @@ submit_upload(Ref, Dir, StreamId, Meta) ->
 %% Token; on expiry the {transfer_deadline, ...} handler only acts if the
 %% Token still matches the one stored for Ref, which rules out acting on a
 %% timer that fired into the mailbox just before it was cancelled.
-arm_transfer_deadline(Ref, #state{transfer_deadlines = Deadlines} = State) ->
+%% Called from execute_effect/2 for {submit_transfer, ...} and the resubmit
+%% effects. The single point at which a transfer becomes outstanding (initial
+%% submit and every resubmit): occupy a slot in the task model with a fresh
+%% deadline token, arm the liveness deadline timer, and re-derive the pipeline
+%% gauges. The model removes the Ref on every path that ends the transfer
+%% (result, deadline, recover), so a resubmit always finds the Ref absent.
+on_transfer_submitted(Ref, Size, #state{tasks = Tasks0, transfer_timers = Timers} = State) ->
     Token = make_ref(),
     Deadline = rabbitmq_stream_s3_config:transfer_deadline_ms(),
     TimerRef = erlang:send_after(Deadline, self(), {transfer_deadline, Ref, Token}),
-    State#state{transfer_deadlines = Deadlines#{Ref => {TimerRef, Token}}}.
+    {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {spawn_transfer, Ref, Size, Token}, Tasks0
+    ),
+    derive_gauges(State#state{tasks = Tasks, transfer_timers = Timers#{Ref => TimerRef}}).
 
-%% Cancel and forget the liveness deadline for a single transfer. cancel_timer
-%% does not remove an already-delivered message, so a stale deadline message
-%% may still arrive; the Token check in the handler discards it.
-cancel_transfer_deadline(Ref, #state{transfer_deadlines = Deadlines} = State) ->
-    case maps:take(Ref, Deadlines) of
-        {{TimerRef, _Token}, Deadlines1} ->
-            _ = erlang:cancel_timer(TimerRef),
-            State#state{transfer_deadlines = Deadlines1};
+%% Cancel and forget the liveness deadline timer for a single transfer.
+%% cancel_timer does not remove an already-delivered message, so a stale deadline
+%% message may still arrive; the model's token check discards it.
+cancel_transfer_timer(Ref, #state{transfer_timers = Timers} = State) ->
+    case maps:take(Ref, Timers) of
+        {TimerRef, Timers1} ->
+            _ = cancel_timer(TimerRef),
+            State#state{transfer_timers = Timers1};
         error ->
             State
     end.
 
-%% Called from execute_effect/2 for {submit_transfer, ...}.
-on_transfer_submitted(Ref, Size, #state{transfer_sizes = Sizes} = State) ->
-    inc_gauge(State, ?C_TRANSFERS_IN_FLIGHT, 1),
-    %% Pipeline stage 2: bytes enter the transfer phase (governor queue
-    %% or in-flight S3 PUT). Decremented in on_transfer_result.
-    inc_gauge(State, ?C_BYTES_IN_TRANSFER, Size),
-    %% Arm the liveness deadline for this transfer. on_transfer_submitted is
-    %% the single point at which a transfer becomes outstanding (initial submit
-    %% and every resubmit), and on_transfer_result is the single point at which
-    %% it stops being outstanding, so the deadline map stays in lockstep with
-    %% transfer_sizes. Ref is always absent here (a resubmit is preceded by
-    %% on_transfer_result, which removes it), so no prior timer is leaked.
-    arm_transfer_deadline(Ref, State#state{transfer_sizes = Sizes#{Ref => Size}}).
-
-%% Called from handle_info on transfer_result. Outcome is `ok' or
-%% `{error, Reason}'.
-on_transfer_result(Ref, Outcome, #state{transfer_sizes = Sizes} = State0) ->
-    case maps:take(Ref, Sizes) of
-        {Size, Sizes1} ->
-            %% The transfer reported back (or a deadline is treating it as
-            %% reported): it is no longer outstanding, so cancel its liveness
-            %% deadline in lockstep with removing it from transfer_sizes.
-            State = cancel_transfer_deadline(Ref, State0#state{transfer_sizes = Sizes1}),
-            dec(State, ?C_TRANSFERS_IN_FLIGHT, 1),
-            dec(State, ?C_BYTES_IN_TRANSFER, Size),
-            case Outcome of
-                ok ->
-                    inc(State, ?C_TRANSFERS_COMPLETED, 1),
-                    inc(State, ?C_BYTES_TRANSFERRED, Size),
-                    %% Stage 3: bytes are now waiting for a manifest
-                    %% persist to confirm them.
-                    inc_gauge(State, ?C_BYTES_IN_PERSIST, Size),
-                    Pending = State#state.persist_pending_bytes + Size,
-                    State#state{
-                        persist_pending_bytes = Pending
-                    };
-                {error, _} ->
-                    inc(State, ?C_TRANSFERS_FAILED, 1),
-                    State
-            end;
-        error ->
-            %% Should not happen but be defensive.
-            State0
+%% Byte size of an outstanding transfer (for the cumulative bytes-transferred
+%% counter), read from the model before the step removes it.
+transfer_byte_size(Ref, Tasks) ->
+    case maps:find(Ref, rabbitmq_stream_s3_replica_reader_tasks:transfers(Tasks)) of
+        {ok, {Size, _Token}} -> Size;
+        error -> 0
     end.
+
+%% Bytes covered by the in-flight persist (for the cumulative bytes-persisted
+%% counter), read from the model before the step frees the slot.
+persisting_snapshot(Tasks) ->
+    case rabbitmq_stream_s3_replica_reader_tasks:persist_slot(Tasks) of
+        {in_flight, _Gen, Bytes} -> Bytes;
+        idle -> 0
+    end.
+
+%% Publish the pipeline gauges from the task model. They are pure functions of
+%% the model's state rather than independently mutated counters, so they cannot
+%% drift from the in-flight tasks.
+derive_gauges(#state{tasks = Tasks} = State) ->
+    set(
+        State,
+        ?C_TRANSFERS_IN_FLIGHT,
+        rabbitmq_stream_s3_replica_reader_tasks:transfers_in_flight(Tasks)
+    ),
+    set(
+        State,
+        ?C_BYTES_IN_TRANSFER,
+        rabbitmq_stream_s3_replica_reader_tasks:bytes_in_transfer(Tasks)
+    ),
+    set(
+        State, ?C_BYTES_IN_PERSIST, rabbitmq_stream_s3_replica_reader_tasks:bytes_in_persist(Tasks)
+    ),
+    State.
+
+%% Carry out the transfer task model's decision. The transferred byte size is
+%% read before the step for the cumulative counter on success.
+apply_transfer_decisions(
+    [{deliver, transfer_complete, {Ref, Uid}}], Size, #state{core = Core0} = State0
+) ->
+    State1 = cancel_transfer_timer(Ref, State0),
+    inc(State1, ?C_TRANSFERS_COMPLETED, 1),
+    inc(State1, ?C_BYTES_TRANSFERRED, Size),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, Uid, Core0),
+    {noreply, derive_gauges(execute_effects(Effects, State1#state{core = Core}))};
+apply_transfer_decisions([{deliver, transfer_failed, {Ref, Reason}}], _Size, State0) ->
+    handle_transfer_failure(Ref, Reason, State0);
+apply_transfer_decisions([{drop, _Reason}], _Size, State) ->
+    {noreply, State}.
+
+%% A transfer failed (an error result, or its liveness deadline elapsed). Account
+%% it off the pipeline and either recover (local retention trimmed past
+%% next_offset, so no retry can make the range durable - issue #225) or drive the
+%% core's retry path.
+handle_transfer_failure(Ref, Reason, #state{core = Core0} = State0) ->
+    maybe_log_transfer_deadline(Reason, State0),
+    State1 = cancel_transfer_timer(Ref, State0),
+    inc(State1, ?C_TRANSFERS_FAILED, 1),
+    case local_log_ahead(State1) of
+        {true, LocalFirst, NextOffset} ->
+            {noreply,
+                derive_gauges(handle_local_log_ahead(LocalFirst, NextOffset, Reason, State1))};
+        false ->
+            {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
+                Ref, Reason, Core0
+            ),
+            {noreply, derive_gauges(execute_effects(Effects, State1#state{core = Core}))}
+    end.
+
+maybe_log_transfer_deadline(transfer_deadline, #state{cfg = #cfg{stream = StreamId}}) ->
+    ?LOG_WARNING(
+        "~ts no result for an in-flight fragment transfer within the transfer "
+        "deadline. The governor may have lost the submission (crash with a queued "
+        "item), the upload task may have been killed before replying, or the "
+        "result message was lost. Resubmitting to keep the upload pipeline live.",
+        [StreamId]
+    );
+maybe_log_transfer_deadline(_Reason, _State) ->
+    ok.
+
+%% Carry out the retry task model's decision: re-submit if the transfer is still
+%% outstanding, drop a retry left over from before a recovery.
+apply_retry_decisions([{resubmit, Ref}], Dir, Meta, #state{cfg = #cfg{stream = StreamId}} = State) ->
+    submit_upload(Ref, Dir, StreamId, Meta),
+    {noreply, State};
+apply_retry_decisions([{drop, _Reason}], _Dir, _Meta, State) ->
+    {noreply, State}.
 
 on_group_upload_completed(Kind, State) ->
     Idx =
@@ -1976,14 +1906,9 @@ on_persist_completed(#manifest{} = Manifest, State) ->
     inc(State, ?C_PERSISTS_COMPLETED, 1),
     inc(State, ?C_ROOTS_CREATED, 1),
     set(State, ?C_LAST_PERSIST_TIMESTAMP_MS, erlang:system_time(millisecond)),
-    %% Pipeline stage 3: the bytes covered by this persist exit the
-    %% pipeline. Decrement the in-persist gauge and bump the cumulative
-    %% persisted-bytes counter. persisting_bytes was snapshotted from
-    %% persist_pending_bytes at start_persist; reset it now that it has
-    %% been credited.
-    PersistedBytes = State#state.persisting_bytes,
-    dec(State, ?C_BYTES_IN_PERSIST, PersistedBytes),
-    inc(State, ?C_BYTES_PERSISTED, PersistedBytes),
+    %% The bytes_in_persist gauge is derived from the task model, which freed the
+    %% persist slot when this persist completed; the cumulative bytes-persisted
+    %% counter is bumped in apply_persist_decisions where the snapshot is known.
     update_manifest_gauges(Manifest, State),
     %% Persist succeeded. Now safe to delete objects that retention removed
     %% from the manifest. The manifest cache is updated, so readers will no
@@ -2001,7 +1926,7 @@ on_persist_completed(#manifest{} = Manifest, State) ->
     %% next retention pass will re-emit the edit and a subsequent persist
     %% will reconcile the manifest.
     flush_deferred_deletions(State),
-    State#state{persisting_bytes = 0, deferred_deletions = []}.
+    State#state{deferred_deletions = []}.
 
 flush_deferred_deletions(#state{deferred_deletions = []}) ->
     ok;
@@ -2034,94 +1959,49 @@ update_manifest_gauges(
     set(State, ?C_REMOTE_MESSAGES, max(0, NextOff - FirstOff)),
     ok.
 
+%% The snapshotted bytes of a failed persist are returned to the model's pending
+%% pool by step/2, so the next persist covers them and bytes_in_persist is
+%% unchanged. These helpers only bump the cumulative failure counters.
 on_persist_failed(conflict, State0) ->
     inc(State0, ?C_PERSISTS_FAILED, 1),
     inc(State0, ?C_PERSIST_CONFLICTS, 1),
-    return_persisting_bytes(State0);
+    State0;
 on_persist_failed(_Reason, State0) ->
     inc(State0, ?C_PERSISTS_FAILED, 1),
-    return_persisting_bytes(State0).
-
-%% A failed persist returns its snapshotted bytes to persist_pending_bytes
-%% so the next persist will cover them. The bytes_in_persist gauge is
-%% unchanged (the bytes are still in stage 3, just back in the pending
-%% bucket rather than the in-flight slot).
-return_persisting_bytes(#state{persisting_bytes = 0} = State) ->
-    State;
-return_persisting_bytes(
-    #state{persisting_bytes = Snapshot, persist_pending_bytes = Pending} = State
-) ->
-    State#state{persisting_bytes = 0, persist_pending_bytes = Pending + Snapshot}.
+    State0.
 
 %% Reset all in-flight bookkeeping for a manifest-recovery restart, returning
 %% the cleared state for the caller to re-resolve via resolve_and_start/1.
 -spec reset_for_recovery(#state{}) -> #state{}.
-reset_for_recovery(#state{transfer_deadlines = Deadlines0, tasks = Tasks0} = State0) ->
-    set(State0, ?C_TRANSFERS_IN_FLIGHT, 0),
+reset_for_recovery(
+    #state{transfer_timers = Timers0, persist_timer = PersistTimer, tasks = Tasks0} = State0
+) ->
     set(State0, ?C_BYTES_IN_ASSEMBLY, 0),
-    set(State0, ?C_BYTES_IN_TRANSFER, 0),
-    set(State0, ?C_BYTES_IN_PERSIST, 0),
-    maps:foreach(fun(_Ref, {TimerRef, _Token}) -> erlang:cancel_timer(TimerRef) end, Deadlines0),
+    %% Cancel the per-transfer liveness deadline timers (a late deadline message
+    %% is dropped by the model after recover clears the transfer map) and the
+    %% persist tick (the core is about to be replaced).
+    maps:foreach(fun(_Ref, TimerRef) -> erlang:cancel_timer(TimerRef) end, Timers0),
+    _ = cancel_timer(PersistTimer),
     State1 = close_log(State0),
-    State2 = cancel_inflight_tasks(State1),
-    State3 = kill_task_io(State2),
-    %% Bump the model's generation and clear its slots: any task spawned before
-    %% this recovery carries the old generation, so its late result is dropped by
-    %% step/2 rather than applied to the freshly resolved manifest.
+    %% Tear down every in-flight async task before recovery replaces the core: a
+    %% task's result is an ordinary message that demonitor's flush does not
+    %% remove, so it can still be queued. The model's recover bumps the generation
+    %% and clears its slots, so any such late result carries the old generation
+    %% and is dropped by step/2 rather than applied to the freshly resolved
+    %% manifest (which would crash the core or splice in a stale edit).
+    State2 = kill_task_io(State1),
     {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(recover, Tasks0),
-    State3#state{
+    derive_gauges(State2#state{
         tasks = Tasks,
         assembly = undefined,
-        transfer_deadlines = #{},
-        transfer_sizes = #{},
-        persist_pending_bytes = 0,
-        persisting_bytes = 0,
+        transfer_timers = #{},
+        persist_timer = undefined,
         deferred_deletions = []
-    }.
-
-%% Tear down every in-flight async task before recovery replaces the core.
-%% A task's result is delivered as an ordinary message, not the monitor
-%% 'DOWN', so demonitor/2's flush does not remove a result that was already
-%% queued before we kill the task. Clearing the correlation fields here makes
-%% the result-handling clauses ignore such a stale result rather than apply it
-%% to the freshly resolved manifest. Without this, a late persist/retention/
-%% group result lands on the new core and either crashes it (a badrecord on
-%% persist_complete, a badmatch on group_upload_complete) or applies a stale
-%% prefix-truncation edit that deletes still-referenced objects and corrupts
-%% the manifest.
--spec cancel_inflight_tasks(#state{}) -> #state{}.
-cancel_inflight_tasks(State0) ->
-    State1 = stop_persist_task(State0),
-    State2 = stop_group_task(State1),
-    stop_retention_task(State2).
-
-stop_persist_task(#state{persist_mon = Mon, persist_pid = Pid, persist_timer = TRef} = State) ->
-    kill_task(Mon, Pid),
-    _ = cancel_timer(TRef),
-    State#state{persist_mon = undefined, persist_pid = undefined, persist_timer = undefined}.
-
-stop_group_task(#state{group_mon = Mon} = State) ->
-    %% The group upload task's pid is not retained, so it cannot be killed; it
-    %% finishes and its result is ignored (its uploaded object, if any, is left
-    %% for orphan garbage collection). Dropping group_mon flushes its 'DOWN'.
-    kill_task(Mon, undefined),
-    State#state{group_mon = undefined, pending_group_kind = undefined}.
-
-stop_retention_task(
-    #state{retention_mon = Mon, retention_pid = Pid, retention_timer = TRef} = State
-) ->
-    kill_task(Mon, Pid),
-    _ = cancel_timer(TRef),
-    State#state{
-        retention_mon = undefined,
-        retention_pid = undefined,
-        retention_timer = undefined,
-        retention_token = undefined
-    }.
+    }).
 
 %% Demonitor (flushing the queued 'DOWN') and kill the task process if its pid
 %% is known. A result message already in the mailbox is intentionally not
-%% removed; the cleared correlation fields make the result handlers drop it.
+%% removed; the model's recovered generation makes the result handlers drop it.
 kill_task(undefined, _Pid) ->
     ok;
 kill_task(Mon, Pid) ->
@@ -2191,22 +2071,26 @@ kill_task_io(#state{task_io = Io} = State) ->
     State#state{task_io = #{}}.
 
 %% Carry out the persist task model's decision: a deliver runs the matching core
-%% call, a drop ignores a stale result.
-apply_persist_decisions([{deliver, persist_complete, Revision}], State0) ->
+%% call, a drop ignores a stale result. PersistedBytes is the byte count the
+%% commit covered, for the cumulative bytes-persisted counter on success.
+apply_persist_decisions([{deliver, persist_complete, Revision}], PersistedBytes, State0) ->
     State1 = clear_task_io(persist, State0),
+    inc(State1, ?C_BYTES_PERSISTED, PersistedBytes),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(
         Revision, State1#state.core
     ),
-    {noreply, execute_effects(Effects, State1#state{core = Core})};
-apply_persist_decisions([{deliver, persist_failed, Reason}], State0) ->
+    {noreply, derive_gauges(execute_effects(Effects, State1#state{core = Core}))};
+apply_persist_decisions([{deliver, persist_failed, Reason}], _PersistedBytes, State0) ->
     State1 = clear_task_io(persist, State0),
     State2 = on_persist_failed(Reason, State1),
     %% persist_failed/2 can return a stop effect, so route through maybe_stop/1.
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(
         Reason, State2#state.core
     ),
-    maybe_stop(execute_effects(Effects, State2#state{core = Core}));
-apply_persist_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}} = State) ->
+    maybe_stop(derive_gauges(execute_effects(Effects, State2#state{core = Core})));
+apply_persist_decisions(
+    [{drop, _Reason}], _PersistedBytes, #state{cfg = #cfg{stream = StreamId}} = State
+) ->
     ?LOG_DEBUG("~ts ignoring stale persist result", [StreamId]),
     {noreply, State}.
 
@@ -2280,10 +2164,11 @@ apply_retention_timeout_decisions([{drop, _Reason}], State) ->
 apply_task_crash(persist, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_WARNING("~ts commit task crashed: ~p", [StreamId, Reason]),
     Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
+    PersistedBytes = persisting_snapshot(Tasks0),
     {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
         {persist_result, Gen, {error, Reason}}, Tasks0
     ),
-    apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
+    apply_persist_decisions(Decisions, PersistedBytes, State0#state{tasks = Tasks});
 apply_task_crash(group, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_WARNING("~ts group upload task crashed: ~p", [StreamId, Reason]),
     Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
@@ -2372,7 +2257,8 @@ evaluate_retention_on_unresolved_manifest_replies_error_test() ->
 %% tracking must be dropped, not re-submitted as a phantom upload (would
 %% otherwise touch the governor against the discarded core).
 retry_transfer_after_reset_is_dropped_test() ->
-    State = #state{transfer_sizes = #{}, cfg = #cfg{stream = <<"s">>}},
+    %% Default task model has an empty transfer map, as after a recovery.
+    State = #state{cfg = #cfg{stream = <<"s">>}},
     Ref = make_ref(),
     Meta = #{first_offset => 0, size => 0},
     ?assertEqual(
@@ -2380,10 +2266,10 @@ retry_transfer_after_reset_is_dropped_test() ->
         handle_info({retry_transfer, Ref, <<"/tmp">>, Meta}, State)
     ).
 
-%% reset_for_recovery must tear down every in-flight async task: clear the
-%% correlation fields (so a late result is ignored rather than applied to the
-%% freshly resolved core) and kill the tasks whose pid is retained.
-cancel_inflight_tasks_clears_all_tasks_test() ->
+%% Recovery must tear down every in-flight async task's I/O handle: clear the
+%% task_io map and kill the tasks whose pid is retained (a late result is dropped
+%% by the recovered model generation rather than applied to the fresh core).
+kill_task_io_tears_down_all_tasks_test() ->
     Idle = fun() ->
         receive
             stop -> ok
@@ -2393,27 +2279,19 @@ cancel_inflight_tasks_clears_all_tasks_test() ->
     RetentionPid = spawn(Idle),
     GroupPid = spawn(Idle),
     State0 = #state{
-        persist_mon = monitor(process, PersistPid),
-        persist_pid = PersistPid,
-        persist_timer = erlang:send_after(60000, self(), persist_timer),
-        group_mon = monitor(process, GroupPid),
-        pending_group_kind = ?MANIFEST_KIND_GROUP,
-        retention_mon = monitor(process, RetentionPid),
-        retention_pid = RetentionPid,
-        retention_timer = erlang:send_after(60000, self(), retention_timeout),
-        retention_token = make_ref()
+        task_io = #{
+            persist => #{mon => monitor(process, PersistPid), pid => PersistPid},
+            group => #{mon => monitor(process, GroupPid)},
+            retention => #{
+                mon => monitor(process, RetentionPid),
+                pid => RetentionPid,
+                timer => erlang:send_after(60000, self(), {retention_timeout, 0})
+            }
+        }
     },
-    State1 = cancel_inflight_tasks(State0),
-    %% Every correlation field is cleared.
-    ?assertEqual(undefined, State1#state.persist_mon),
-    ?assertEqual(undefined, State1#state.persist_pid),
-    ?assertEqual(undefined, State1#state.persist_timer),
-    ?assertEqual(undefined, State1#state.group_mon),
-    ?assertEqual(undefined, State1#state.pending_group_kind),
-    ?assertEqual(undefined, State1#state.retention_mon),
-    ?assertEqual(undefined, State1#state.retention_pid),
-    ?assertEqual(undefined, State1#state.retention_timer),
-    ?assertEqual(undefined, State1#state.retention_token),
+    State1 = kill_task_io(State0),
+    %% All I/O handles are cleared.
+    ?assertEqual(#{}, State1#state.task_io),
     %% Tasks whose pid is retained (persist, retention) are killed; the group
     %% task whose pid is not retained is left to finish on its own.
     ?assert(wait_dead(PersistPid, 100)),
@@ -2519,7 +2397,8 @@ local_log_ahead_false_when_local_behind_test() ->
 %% the core, which would otherwise crash get_meta on the unknown reference or
 %% append a non-contiguous orphan. The state is returned unchanged.
 stale_transfer_result_dropped_test() ->
-    State = #state{transfer_sizes = #{}},
+    %% Default task model has an empty transfer map.
+    State = #state{},
     Ref = make_ref(),
     ?assertEqual({noreply, State}, handle_info({transfer_result, Ref, {ok, 1}}, State)),
     ?assertEqual(

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -217,6 +217,19 @@ returned by the functional core module.
     assembly :: rabbitmq_stream_s3_fragment_assembly:state() | undefined,
     %% Functional core state.
     core :: rabbitmq_stream_s3_replica_reader_core:state() | undefined,
+    %% Pure model of the async-task lifecycle (persist, group, retention,
+    %% transfer). Owns the correlation decisions (deliver vs drop a result) and
+    %% the pipeline gauges; see rabbitmq_stream_s3_replica_reader_tasks. The
+    %% generation it carries is the join key with task_io below.
+    tasks = rabbitmq_stream_s3_replica_reader_tasks:init() ::
+        rabbitmq_stream_s3_replica_reader_tasks:tasks(),
+    %% Runtime I/O handles for the in-flight tasks the model decides about: the
+    %% monitor refs, pids and timer refs the shell needs to demonitor/kill/cancel.
+    %% Single-in-flight families are keyed by family atom; transfer deadline
+    %% timers are keyed by the transfer Ref. The model says which family/Ref to
+    %% tear down; these are the handles to do it with.
+    task_io = #{} :: #{persist | group | retention => #{atom() => term()}},
+    transfer_timers = #{} :: #{reference() => reference()},
     %% Nodes registered for manifest broadcast.
     replicas = #{} :: #{node() => reference()},
     %% User-configured retention specs for remote tier evaluation.
@@ -747,59 +760,11 @@ handle_info(
         MonRef -> {noreply, State#state{replicas = maps:remove(Node, Replicas)}};
         _ -> {noreply, State}
     end;
-handle_info(
-    {persist_result, {ok, Revision}}, #state{core = Core0, persist_mon = Mon} = State0
-) when Mon =/= undefined ->
-    demonitor(Mon, [flush]),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(Revision, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core, persist_mon = undefined, persist_pid = undefined
-        })};
-handle_info(
-    {persist_result, {error, {conflict, _Entry}}}, #state{core = Core0, persist_mon = Mon} = State0
-) when Mon =/= undefined ->
-    demonitor(Mon, [flush]),
-    State1 = on_persist_failed(conflict, State0),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(conflict, Core0),
-    {noreply,
-        execute_effects(Effects, State1#state{
-            core = Core, persist_mon = undefined, persist_pid = undefined
-        })};
-handle_info(
-    {persist_result, {error, Reason}}, #state{core = Core0, persist_mon = Mon} = State0
-) when Mon =/= undefined ->
-    demonitor(Mon, [flush]),
-    State1 = on_persist_failed(Reason, State0),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(Reason, Core0),
-    maybe_stop(
-        execute_effects(Effects, State1#state{
-            core = Core, persist_mon = undefined, persist_pid = undefined
-        })
-    );
-handle_info({persist_result, _Result}, #state{cfg = #cfg{stream = StreamId}} = State) ->
-    %% A result from a persist task we are no longer tracking - recovery
-    %% (reset_for_recovery) cleared persist_mon and killed the task, but its
-    %% result was an ordinary message already queued before the kill. Ignore it
-    %% rather than apply persist_complete/persist_failed to the freshly resolved
-    %% core (which has no in-flight persist, so persist_complete would crash).
-    ?LOG_DEBUG("~ts ignoring stale persist result", [StreamId]),
-    {noreply, State};
-handle_info(
-    {'DOWN', Mon, process, _, Reason},
-    #state{persist_mon = Mon, core = Core0, cfg = #cfg{stream = StreamId}} = State0
-) ->
-    ?LOG_WARNING("~ts commit task crashed: ~p", [StreamId, Reason]),
-    State1 = on_persist_failed(Reason, State0),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(Reason, Core0),
-    %% Route through maybe_stop/1 like the {persist_result, {error, _}} handler:
-    %% persist_failed/2 can return a stop effect, and a crashed persist task
-    %% must honour it rather than leaving the reader marked stopping but alive.
-    maybe_stop(
-        execute_effects(Effects, State1#state{
-            core = Core, persist_mon = undefined, persist_pid = undefined
-        })
-    );
+handle_info({persist_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {persist_result, Gen, Result}, Tasks0
+    ),
+    apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
 handle_info(
     {'DOWN', Mon, process, _, Reason},
     #state{group_mon = Mon, core = Core0, cfg = #cfg{stream = StreamId}} = State0
@@ -827,6 +792,16 @@ handle_info(
             retention_timer = undefined,
             retention_token = undefined
         })};
+handle_info({'DOWN', Mon, process, _Pid, Reason}, State) ->
+    %% A monitored async task crashed. Its 'DOWN' carries the monitor ref, which
+    %% identifies the family (and, via the model's slot, its generation): a crash
+    %% is delivered to the task model as a failure of the live task, exactly as an
+    %% error result would be. A 'DOWN' whose monitor matches no tracked task (a
+    %% task already torn down by recovery, flushed) falls through to a no-op.
+    case task_family_for_mon(Mon, State) of
+        {ok, Family} -> apply_task_crash(Family, Reason, State);
+        error -> {noreply, State}
+    end;
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -834,20 +809,19 @@ terminate(
     _Reason,
     #state{
         cfg = #cfg{stream = StreamId},
-        persist_mon = Mon,
-        persist_pid = CommitPid,
+        task_io = Io,
         metrics_id = MetricsId
     } = State
 ) ->
     %% Kill any in-flight commit task to prevent orphaned Khepri writes.
     %% An orphaned write advances the revision, causing conflicts for the
     %% next incarnation of this replica reader.
-    case CommitPid of
-        undefined ->
-            ok;
-        _ ->
+    case Io of
+        #{persist := #{mon := Mon, pid := CommitPid}} ->
             demonitor(Mon, [flush]),
-            exit(CommitPid, kill)
+            exit(CommitPid, kill);
+        _ ->
+            ok
     end,
     %% Close the open data reader so its segment file descriptors are released
     %% promptly rather than at process teardown.
@@ -1171,14 +1145,19 @@ execute_effect(
     State0#state{group_mon = MonRef, pending_group_kind = Kind};
 execute_effect(
     {start_persist, Manifest, Epoch, Reference, ExpectedRevision, _Edits},
-    #state{cfg = #cfg{stream = StreamId}} = State
+    #state{cfg = #cfg{stream = StreamId}, tasks = Tasks0, task_io = Io} = State
 ) ->
     Self = self(),
+    %% The result is tagged with the generation the task was spawned in so a
+    %% result that outlives a recovery is correlated to the right incarnation by
+    %% the task model rather than by the monitor field alone.
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
     {CommitPid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result = do_commit(StreamId, Manifest, Epoch, Reference, ExpectedRevision),
-        Self ! {persist_result, Result}
+        Self ! {persist_result, Gen, Result}
     end),
+    {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(spawn_persist, Tasks0),
     %% Snapshot the bytes that this persist will cover. New transfer
     %% completions during the persist accumulate in persist_pending_bytes
     %% and will be covered by the next persist. The bytes_in_persist
@@ -1186,8 +1165,8 @@ execute_effect(
     %% persisting_bytes + persist_pending_bytes both before and after).
     Snapshot = State#state.persist_pending_bytes,
     State#state{
-        persist_mon = MonRef,
-        persist_pid = CommitPid,
+        tasks = Tasks,
+        task_io = Io#{persist => #{mon => MonRef, pid => CommitPid}},
         persisting_bytes = Snapshot,
         persist_pending_bytes = 0
     };
@@ -2202,7 +2181,7 @@ return_persisting_bytes(
 %% Reset all in-flight bookkeeping for a manifest-recovery restart, returning
 %% the cleared state for the caller to re-resolve via resolve_and_start/1.
 -spec reset_for_recovery(#state{}) -> #state{}.
-reset_for_recovery(#state{transfer_deadlines = Deadlines0} = State0) ->
+reset_for_recovery(#state{transfer_deadlines = Deadlines0, tasks = Tasks0} = State0) ->
     set(State0, ?C_TRANSFERS_IN_FLIGHT, 0),
     set(State0, ?C_BYTES_IN_ASSEMBLY, 0),
     set(State0, ?C_BYTES_IN_TRANSFER, 0),
@@ -2210,7 +2189,13 @@ reset_for_recovery(#state{transfer_deadlines = Deadlines0} = State0) ->
     maps:foreach(fun(_Ref, {TimerRef, _Token}) -> erlang:cancel_timer(TimerRef) end, Deadlines0),
     State1 = close_log(State0),
     State2 = cancel_inflight_tasks(State1),
-    State2#state{
+    State3 = kill_task_io(State2),
+    %% Bump the model's generation and clear its slots: any task spawned before
+    %% this recovery carries the old generation, so its late result is dropped by
+    %% step/2 rather than applied to the freshly resolved manifest.
+    {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step(recover, Tasks0),
+    State3#state{
+        tasks = Tasks,
         assembly = undefined,
         transfer_deadlines = #{},
         transfer_sizes = #{},
@@ -2271,6 +2256,80 @@ kill_task(Mon, Pid) ->
         _ -> exit(Pid, kill)
     end,
     ok.
+
+%%----------------------------------------------------------------------------
+%% Task-model I/O. The task model (#state.tasks) decides which family's result
+%% to deliver or drop; these helpers carry out the matching I/O on the runtime
+%% handles in #state.task_io, which the model itself cannot hold.
+%%----------------------------------------------------------------------------
+
+%% Find which single-in-flight family a 'DOWN' monitor ref belongs to.
+-spec task_family_for_mon(reference(), #state{}) -> {ok, persist | group | retention} | error.
+task_family_for_mon(Mon, #state{task_io = Io}) ->
+    maps:fold(
+        fun
+            (Family, #{mon := M}, _Acc) when M =:= Mon -> {ok, Family};
+            (_Family, _Handle, Acc) -> Acc
+        end,
+        error,
+        Io
+    ).
+
+%% On normal completion of a single-in-flight task: demonitor (flushing the
+%% queued 'DOWN') and cancel its timeout timer if any. The task has finished, so
+%% its pid is not killed.
+-spec clear_task_io(persist | group | retention, #state{}) -> #state{}.
+clear_task_io(Family, #state{task_io = Io} = State) ->
+    case maps:take(Family, Io) of
+        {Handle, Io1} ->
+            _ = demonitor(maps:get(mon, Handle), [flush]),
+            _ = cancel_timer(maps:get(timer, Handle, undefined)),
+            State#state{task_io = Io1};
+        error ->
+            State
+    end.
+
+%% On recovery: tear down every single-in-flight task - demonitor (flush its
+%% 'DOWN'), cancel its timer, and kill its process if the pid was retained.
+-spec kill_task_io(#state{}) -> #state{}.
+kill_task_io(#state{task_io = Io} = State) ->
+    maps:foreach(
+        fun(_Family, Handle) ->
+            kill_task(maps:get(mon, Handle), maps:get(pid, Handle, undefined)),
+            _ = cancel_timer(maps:get(timer, Handle, undefined))
+        end,
+        Io
+    ),
+    State#state{task_io = #{}}.
+
+%% Carry out the persist task model's decision: a deliver runs the matching core
+%% call, a drop ignores a stale result.
+apply_persist_decisions([{deliver, persist_complete, Revision}], State0) ->
+    State1 = clear_task_io(persist, State0),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(
+        Revision, State1#state.core
+    ),
+    {noreply, execute_effects(Effects, State1#state{core = Core})};
+apply_persist_decisions([{deliver, persist_failed, Reason}], State0) ->
+    State1 = clear_task_io(persist, State0),
+    State2 = on_persist_failed(Reason, State1),
+    %% persist_failed/2 can return a stop effect, so route through maybe_stop/1.
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_failed(
+        Reason, State2#state.core
+    ),
+    maybe_stop(execute_effects(Effects, State2#state{core = Core}));
+apply_persist_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}} = State) ->
+    ?LOG_DEBUG("~ts ignoring stale persist result", [StreamId]),
+    {noreply, State}.
+
+%% Translate a monitored task's crash into a failure result for the live task.
+apply_task_crash(persist, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
+    ?LOG_WARNING("~ts commit task crashed: ~p", [StreamId, Reason]),
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {persist_result, Gen, {error, Reason}}, Tasks0
+    ),
+    apply_persist_decisions(Decisions, State0#state{tasks = Tasks}).
 
 on_manifest_resolved(#manifest{next_offset = 0}, State) ->
     inc(State, ?C_MANIFESTS_RESOLVED_EMPTY, 1),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -627,32 +627,11 @@ handle_info({retry_transfer, Ref, Dir, Meta}, #state{cfg = #cfg{stream = StreamI
         false ->
             {noreply, State}
     end;
-handle_info(
-    {group_upload_result, {ok, Uid}}, #state{core = Core0, group_mon = Mon} = State0
-) when Mon =/= undefined ->
-    demonitor(Mon, [flush]),
-    State1 = on_group_upload_completed(State0),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(Uid, Core0),
-    {noreply, execute_effects(Effects, State1#state{core = Core, group_mon = undefined})};
-handle_info(
-    {group_upload_result, {error, Reason}},
-    #state{core = Core0, group_mon = Mon, cfg = #cfg{stream = StreamId}} = State0
-) when Mon =/= undefined ->
-    demonitor(Mon, [flush]),
-    ?LOG_WARNING("~ts group upload failed: ~p", [StreamId, Reason]),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_failed(Reason, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core, group_mon = undefined, pending_group_kind = undefined
-        })};
-handle_info({group_upload_result, _Result}, #state{cfg = #cfg{stream = StreamId}} = State) ->
-    %% A result from a group upload task we are no longer tracking - recovery
-    %% cleared group_mon. The result is an ordinary message that demonitor/flush
-    %% does not remove, so it can still be queued; ignore it rather than apply
-    %% group_upload_complete to the freshly resolved core (which has no pending
-    %% rebalance, so the core would crash on a badmatch).
-    ?LOG_DEBUG("~ts ignoring stale group upload result", [StreamId]),
-    {noreply, State};
+handle_info({group_upload_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {group_result, Gen, Result}, Tasks0
+    ),
+    apply_group_decisions(Decisions, State0#state{tasks = Tasks});
 handle_info(
     {retention_result, Token, unchanged},
     #state{retention_token = Token, core = Core0, retention_mon = Mon, retention_timer = TRef} =
@@ -765,16 +744,6 @@ handle_info({persist_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
         {persist_result, Gen, Result}, Tasks0
     ),
     apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
-handle_info(
-    {'DOWN', Mon, process, _, Reason},
-    #state{group_mon = Mon, core = Core0, cfg = #cfg{stream = StreamId}} = State0
-) ->
-    ?LOG_WARNING("~ts group upload task crashed: ~p", [StreamId, Reason]),
-    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_failed(Reason, Core0),
-    {noreply,
-        execute_effects(Effects, State0#state{
-            core = Core, group_mon = undefined, pending_group_kind = undefined
-        })};
 handle_info(
     {'DOWN', Mon, process, _, Reason},
     #state{retention_mon = Mon, retention_timer = TRef, core = Core0, cfg = #cfg{stream = StreamId}} =
@@ -1125,9 +1094,10 @@ execute_effect(
     on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect(
     {upload_group, StreamId, Kind, Entries, _Pos, _Len},
-    State0
+    #state{tasks = Tasks0, task_io = Io} = State0
 ) ->
     Self = self(),
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
     {_Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result =
@@ -1140,9 +1110,10 @@ execute_effect(
                     ),
                     {error, {crashed, Reason}}
             end,
-        Self ! {group_upload_result, Result}
+        Self ! {group_upload_result, Gen, Result}
     end),
-    State0#state{group_mon = MonRef, pending_group_kind = Kind};
+    {Tasks, []} = rabbitmq_stream_s3_replica_reader_tasks:step({spawn_group, Kind}, Tasks0),
+    State0#state{tasks = Tasks, task_io = Io#{group => #{mon => MonRef}}};
 execute_effect(
     {start_persist, Manifest, Epoch, Reference, ExpectedRevision, _Edits},
     #state{cfg = #cfg{stream = StreamId}, tasks = Tasks0, task_io = Io} = State
@@ -2081,7 +2052,7 @@ on_transfer_result(Ref, Outcome, #state{transfer_sizes = Sizes} = State0) ->
             State0
     end.
 
-on_group_upload_completed(#state{pending_group_kind = Kind} = State) ->
+on_group_upload_completed(Kind, State) ->
     Idx =
         case Kind of
             ?MANIFEST_KIND_GROUP -> ?C_GROUPS_CREATED;
@@ -2093,7 +2064,7 @@ on_group_upload_completed(#state{pending_group_kind = Kind} = State) ->
         undefined -> ok;
         _ -> inc(State, Idx, 1)
     end,
-    State#state{pending_group_kind = undefined}.
+    State.
 
 %% Called from execute_effect/2 for {update_range, ...}, which the core
 %% only emits after a successful manifest persist.
@@ -2322,6 +2293,29 @@ apply_persist_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}}
     ?LOG_DEBUG("~ts ignoring stale persist result", [StreamId]),
     {noreply, State}.
 
+%% Carry out the group-upload task model's decision. The kind is carried in the
+%% completion so the per-kind "created" metric is attributed without re-reading
+%% the slot the model just freed.
+apply_group_decisions([{deliver, group_complete, {Kind, Uid}}], State0) ->
+    State1 = clear_task_io(group, State0),
+    State2 = on_group_upload_completed(Kind, State1),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_complete(
+        Uid, State2#state.core
+    ),
+    {noreply, execute_effects(Effects, State2#state{core = Core})};
+apply_group_decisions(
+    [{deliver, group_failed, Reason}], #state{cfg = #cfg{stream = StreamId}} = State0
+) ->
+    State1 = clear_task_io(group, State0),
+    ?LOG_WARNING("~ts group upload failed: ~p", [StreamId, Reason]),
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:group_upload_failed(
+        Reason, State1#state.core
+    ),
+    {noreply, execute_effects(Effects, State1#state{core = Core})};
+apply_group_decisions([{drop, _Reason}], #state{cfg = #cfg{stream = StreamId}} = State) ->
+    ?LOG_DEBUG("~ts ignoring stale group upload result", [StreamId]),
+    {noreply, State}.
+
 %% Translate a monitored task's crash into a failure result for the live task.
 apply_task_crash(persist, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_WARNING("~ts commit task crashed: ~p", [StreamId, Reason]),
@@ -2329,7 +2323,14 @@ apply_task_crash(persist, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = Str
     {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
         {persist_result, Gen, {error, Reason}}, Tasks0
     ),
-    apply_persist_decisions(Decisions, State0#state{tasks = Tasks}).
+    apply_persist_decisions(Decisions, State0#state{tasks = Tasks});
+apply_task_crash(group, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = StreamId}} = State0) ->
+    ?LOG_WARNING("~ts group upload task crashed: ~p", [StreamId, Reason]),
+    Gen = rabbitmq_stream_s3_replica_reader_tasks:generation(Tasks0),
+    {Tasks, Decisions} = rabbitmq_stream_s3_replica_reader_tasks:step(
+        {group_result, Gen, {error, Reason}}, Tasks0
+    ),
+    apply_group_decisions(Decisions, State0#state{tasks = Tasks}).
 
 on_manifest_resolved(#manifest{next_offset = 0}, State) ->
     inc(State, ?C_MANIFESTS_RESOLVED_EMPTY, 1),

--- a/src/rabbitmq_stream_s3_replica_reader_tasks.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_tasks.erl
@@ -1,0 +1,204 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_replica_reader_tasks).
+-moduledoc """
+A pure, total state machine for the replica reader's async-task lifecycle.
+
+The replica reader spawns four families of async tasks - persist (manifest
+commit), group upload, remote retention evaluation, and fragment transfer - and
+reacts to their results, timeouts and crashes. Historically this logic lived
+inline across the gen_server's `handle_info` clauses, each family correlating
+results to the live task with its own ad-hoc scheme (a monitor field, a
+make_ref/0 token, map membership). Every recovery-seam bug we have fixed was a
+missing or mis-coordinated case in that implicit, untyped machine.
+
+This module makes that machine explicit, pure and total so its correctness is a
+property we can falsify rather than a set of guards we hand-verify. The
+gen_server's role shrinks to translating real messages into `event/0`s, running
+`step/2`, and carrying out the returned `decision/0`s as I/O.
+
+## Staleness by construction
+
+The three single-in-flight families (persist, group, retention) each occupy a
+`slot/1`: `idle | {in_flight, Generation, Data}`. The slot carries the
+`generation/0` it was spawned in. A result tagged with a generation is applied
+only when it matches the slot it claims to complete:
+
+```
+step({persist_result, G, R}, #tasks{persist = {in_flight, G, _}} = T) -> deliver;
+step({persist_result, _G, _R}, T)                                     -> drop.
+```
+
+That single pattern subsumes two separate guards the previous design had to
+coordinate by hand:
+
+- a result that races its own timeout is dropped, because the timeout already
+  set the slot to `idle` and `idle` does not match `{in_flight, G, _}`;
+- a result from before a recovery is dropped, because `recover` bumped the
+  generation and any new task in the slot carries the new one, so the stale
+  result's generation does not match.
+
+Transfers are different on purpose: many run at once, each identified by a
+unique caller-minted `Ref` held in a map. A `Ref` is per-task identity that
+needs no generation - `recover` clears the map, so a stale `Ref` is simply
+absent. This is why transfers are not generation-tagged.
+""".
+
+-export([
+    init/0,
+    generation/1,
+    persist_slot/1,
+    group_slot/1,
+    retention_slot/1,
+    transfers/1,
+    step/2
+]).
+
+-export_type([tasks/0, event/0, decision/0, generation/0]).
+
+-type generation() :: non_neg_integer().
+
+%% A slot for a family that has at most one task in flight at a time. It carries
+%% the generation the task was spawned in, so a result claiming to complete it
+%% is matched on both occupancy (idle vs in_flight) and identity (generation) by
+%% one pattern.
+-type slot(Data) :: idle | {in_flight, generation(), Data}.
+
+-record(tasks, {
+    %% The current incarnation. Bumped by recover/0; tasks spawned afterwards
+    %% carry the new generation, so a result from before the recovery cannot
+    %% match the slot a new task now occupies.
+    generation = 0 :: generation(),
+    %% Data is the byte count this persist will cover (carried for the gauges in
+    %% the eventual wiring; opaque here).
+    persist = idle :: slot(non_neg_integer()),
+    %% Data is the group kind being uploaded.
+    group = idle :: slot(term()),
+    %% No per-task data is needed to correlate a retention result.
+    retention = idle :: slot(undefined),
+    %% Transfers are keyed by a unique caller-minted Ref rather than a slot,
+    %% because many run concurrently. Data is the transfer's byte size.
+    transfers = #{} :: #{term() => non_neg_integer()}
+}).
+
+-opaque tasks() :: #tasks{}.
+
+%% Inputs to the machine. Spawn events record that the shell has started a task;
+%% the shell stamps the spawned task's result with generation/1 at that moment.
+%% Result/timeout events arrive later carrying the generation (or Ref) the task
+%% captured at spawn.
+-type event() ::
+    {spawn_persist, Bytes :: non_neg_integer()}
+    | {spawn_group, Kind :: term()}
+    | spawn_retention
+    | {spawn_transfer, Ref :: term(), Size :: non_neg_integer()}
+    | {persist_result, generation(), Result :: term()}
+    | {group_result, generation(), Result :: term()}
+    | {retention_result, generation(), Result :: term()}
+    | {retention_timeout, generation()}
+    | {transfer_result, Ref :: term(), Result :: term()}
+    | recover.
+
+%% Outputs of the machine: deliver a completion to the pure core, or drop a
+%% stale message. The shell turns a `deliver` into the matching core call.
+-type completion() ::
+    persist_complete
+    | persist_failed
+    | group_complete
+    | group_failed
+    | retention_complete
+    | retention_failed
+    | transfer_complete
+    | transfer_failed.
+
+-type decision() ::
+    {deliver, completion(), Payload :: term()}
+    | {drop, Reason :: atom()}.
+
+%%----------------------------------------------------------------------------
+%% Accessors (the wiring layer and the property observer read state through
+%% these rather than the record, keeping the representation private).
+%%----------------------------------------------------------------------------
+
+-spec init() -> tasks().
+init() -> #tasks{}.
+
+-spec generation(tasks()) -> generation().
+generation(#tasks{generation = G}) -> G.
+
+-spec persist_slot(tasks()) -> slot(non_neg_integer()).
+persist_slot(#tasks{persist = S}) -> S.
+
+-spec group_slot(tasks()) -> slot(term()).
+group_slot(#tasks{group = S}) -> S.
+
+-spec retention_slot(tasks()) -> slot(undefined).
+retention_slot(#tasks{retention = S}) -> S.
+
+-spec transfers(tasks()) -> #{term() => non_neg_integer()}.
+transfers(#tasks{transfers = T}) -> T.
+
+%%----------------------------------------------------------------------------
+%% The state machine.
+%%----------------------------------------------------------------------------
+
+-spec step(event(), tasks()) -> {tasks(), [decision()]}.
+
+%% --- spawns: record the new task at the current generation ---
+step({spawn_persist, Bytes}, #tasks{generation = G} = T) ->
+    {T#tasks{persist = {in_flight, G, Bytes}}, []};
+step({spawn_group, Kind}, #tasks{generation = G} = T) ->
+    {T#tasks{group = {in_flight, G, Kind}}, []};
+step(spawn_retention, #tasks{generation = G} = T) ->
+    {T#tasks{retention = {in_flight, G, undefined}}, []};
+step({spawn_transfer, Ref, Size}, #tasks{transfers = Tr} = T) ->
+    {T#tasks{transfers = Tr#{Ref => Size}}, []};
+%% --- persist result: apply only to the matching in-flight persist ---
+step({persist_result, G, Result}, #tasks{persist = {in_flight, G, _Bytes}} = T) ->
+    {T#tasks{persist = idle}, [classify_persist(Result)]};
+step({persist_result, _G, _Result}, T) ->
+    {T, [{drop, stale_persist_result}]};
+%% --- group result ---
+step({group_result, G, Result}, #tasks{group = {in_flight, G, _Kind}} = T) ->
+    {T#tasks{group = idle}, [classify_group(Result)]};
+step({group_result, _G, _Result}, T) ->
+    {T, [{drop, stale_group_result}]};
+%% --- retention result ---
+step({retention_result, G, Result}, #tasks{retention = {in_flight, G, _}} = T) ->
+    {T#tasks{retention = idle}, [classify_retention(Result)]};
+step({retention_result, _G, _Result}, T) ->
+    {T, [{drop, stale_retention_result}]};
+%% --- retention timeout: fail only the matching in-flight task ---
+step({retention_timeout, G}, #tasks{retention = {in_flight, G, _}} = T) ->
+    {T#tasks{retention = idle}, [{deliver, retention_failed, timeout}]};
+step({retention_timeout, _G}, T) ->
+    {T, [{drop, stale_retention_timeout}]};
+%% --- transfer result: keyed by Ref membership, not a slot ---
+step({transfer_result, Ref, Result}, #tasks{transfers = Tr} = T) when is_map_key(Ref, Tr) ->
+    {T#tasks{transfers = maps:remove(Ref, Tr)}, [classify_transfer(Ref, Result)]};
+step({transfer_result, _Ref, _Result}, T) ->
+    {T, [{drop, unknown_transfer_result}]};
+%% --- recover: bump the generation and abandon every in-flight task ---
+step(recover, #tasks{generation = G}) ->
+    {#tasks{generation = G + 1}, []}.
+
+%%----------------------------------------------------------------------------
+%% Result classification. Mirrors the completion the pure core expects for each
+%% raw async result; the shell turns a `deliver` into the corresponding core
+%% call.
+%%----------------------------------------------------------------------------
+
+classify_persist({ok, Revision}) -> {deliver, persist_complete, Revision};
+classify_persist({error, {conflict, _}}) -> {deliver, persist_failed, conflict};
+classify_persist({error, Reason}) -> {deliver, persist_failed, Reason}.
+
+classify_group({ok, Uid}) -> {deliver, group_complete, Uid};
+classify_group({error, Reason}) -> {deliver, group_failed, Reason}.
+
+classify_retention(unchanged) -> {deliver, retention_failed, unchanged};
+classify_retention({failed, Reason}) -> {deliver, retention_failed, Reason};
+classify_retention({Edit, Refs}) -> {deliver, retention_complete, {Edit, Refs}}.
+
+classify_transfer(Ref, {ok, Uid}) -> {deliver, transfer_complete, {Ref, Uid}};
+classify_transfer(Ref, {error, Reason}) -> {deliver, transfer_failed, {Ref, Reason}}.

--- a/src/rabbitmq_stream_s3_replica_reader_tasks.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_tasks.erl
@@ -43,6 +43,36 @@ Transfers are different on purpose: many run at once, each identified by a
 unique caller-minted `Ref` held in a map. A `Ref` is per-task identity that
 needs no generation - `recover` clears the map, so a stale `Ref` is simply
 absent. This is why transfers are not generation-tagged.
+
+## Task crashes are failure results
+
+A persist/group/retention task is monitored; its crash arrives as a `'DOWN'`
+message. The gen_server's `'DOWN'` handler for each family does exactly what its
+error-result handler does (the same core failure call, the same slot teardown,
+the same metric). `demonitor(_, [flush])` on the result path removes the queued
+`'DOWN'`, so a result and a crash are mutually exclusive; a `'DOWN'` from before
+a recovery is flushed by `reset_for_recovery`. A crash is therefore just "a
+failure of the live task", already modelled by a failure `*_result` at the
+slot's generation: the slot's occupancy gives the same mutual exclusion that
+`demonitor`/flush gives in the shell. The model has one failure transition per
+family rather than two delivery channels for the same outcome.
+
+## Derived gauges
+
+The pipeline gauges are pure functions of this state, not independently mutated
+counters (the historical source of gauge drift on task-kill and restart paths):
+
+- `transfers_in_flight/1 = map_size(transfers)`
+- `bytes_in_transfer/1   = sum of the outstanding transfer sizes`
+- `bytes_in_persist/1    = persist_pending_bytes + the in-flight persist snapshot`
+
+`bytes_in_persist` tracks bytes that have been transferred to S3 but are not yet
+durable in a committed manifest. A transfer success moves its bytes into
+`persist_pending_bytes`; `spawn_persist` snapshots the pending bytes into the
+persist slot (the bytes this commit will cover) and zeroes pending; a successful
+persist drops the snapshot; a failed persist returns the snapshot to pending so
+the next persist covers them. The gauge is therefore conserved across
+`spawn_persist` and persist failure, and decreases only on persist success.
 """.
 
 -export([
@@ -52,6 +82,10 @@ absent. This is why transfers are not generation-tagged.
     group_slot/1,
     retention_slot/1,
     transfers/1,
+    persist_pending_bytes/1,
+    transfers_in_flight/1,
+    bytes_in_transfer/1,
+    bytes_in_persist/1,
     step/2
 ]).
 
@@ -70,38 +104,49 @@ absent. This is why transfers are not generation-tagged.
     %% carry the new generation, so a result from before the recovery cannot
     %% match the slot a new task now occupies.
     generation = 0 :: generation(),
-    %% Data is the byte count this persist will cover (carried for the gauges in
-    %% the eventual wiring; opaque here).
+    %% Data is the snapshot of persist_pending_bytes taken at spawn_persist:
+    %% the bytes this commit will make durable. Returned to persist_pending_bytes
+    %% on failure, dropped on success.
     persist = idle :: slot(non_neg_integer()),
     %% Data is the group kind being uploaded.
     group = idle :: slot(term()),
     %% No per-task data is needed to correlate a retention result.
     retention = idle :: slot(undefined),
     %% Transfers are keyed by a unique caller-minted Ref rather than a slot,
-    %% because many run concurrently. Data is the transfer's byte size.
-    transfers = #{} :: #{term() => non_neg_integer()}
+    %% because many run concurrently. Data is {Size, DeadlineToken}: the byte
+    %% size (for the gauges) and the token of the currently-armed liveness
+    %% deadline. The token is re-minted on every (re)submit so a fired-but-queued
+    %% deadline message for a previous arming of the same Ref is rejected.
+    transfers = #{} :: #{term() => {non_neg_integer(), term()}},
+    %% Bytes transferred to S3 but not yet snapshotted into an in-flight persist.
+    %% Accumulated by transfer successes, drained into the persist slot at
+    %% spawn_persist, replenished from the slot when a persist fails.
+    persist_pending_bytes = 0 :: non_neg_integer()
 }).
 
 -opaque tasks() :: #tasks{}.
 
 %% Inputs to the machine. Spawn events record that the shell has started a task;
 %% the shell stamps the spawned task's result with generation/1 at that moment.
-%% Result/timeout events arrive later carrying the generation (or Ref) the task
-%% captured at spawn.
+%% Result/timeout events arrive later carrying the generation (or Ref/Token) the
+%% task captured at spawn.
 -type event() ::
-    {spawn_persist, Bytes :: non_neg_integer()}
+    spawn_persist
     | {spawn_group, Kind :: term()}
     | spawn_retention
-    | {spawn_transfer, Ref :: term(), Size :: non_neg_integer()}
+    | {spawn_transfer, Ref :: term(), Size :: non_neg_integer(), Token :: term()}
     | {persist_result, generation(), Result :: term()}
     | {group_result, generation(), Result :: term()}
     | {retention_result, generation(), Result :: term()}
     | {retention_timeout, generation()}
     | {transfer_result, Ref :: term(), Result :: term()}
+    | {transfer_deadline, Ref :: term(), Token :: term()}
+    | {retry_transfer, Ref :: term()}
     | recover.
 
-%% Outputs of the machine: deliver a completion to the pure core, or drop a
-%% stale message. The shell turns a `deliver` into the matching core call.
+%% Outputs of the machine: deliver a completion to the pure core, re-submit a
+%% transfer upload, or drop a stale message. The shell turns a `deliver` into
+%% the matching core call and a `resubmit` into the upload I/O.
 -type completion() ::
     persist_complete
     | persist_failed
@@ -114,11 +159,13 @@ absent. This is why transfers are not generation-tagged.
 
 -type decision() ::
     {deliver, completion(), Payload :: term()}
+    | {resubmit, Ref :: term()}
     | {drop, Reason :: atom()}.
 
 %%----------------------------------------------------------------------------
 %% Accessors (the wiring layer and the property observer read state through
-%% these rather than the record, keeping the representation private).
+%% these rather than the record, keeping the representation private). The gauge
+%% accessors derive their values rather than reading a stored counter.
 %%----------------------------------------------------------------------------
 
 -spec init() -> tasks().
@@ -136,8 +183,25 @@ group_slot(#tasks{group = S}) -> S.
 -spec retention_slot(tasks()) -> slot(undefined).
 retention_slot(#tasks{retention = S}) -> S.
 
--spec transfers(tasks()) -> #{term() => non_neg_integer()}.
+-spec transfers(tasks()) -> #{term() => {non_neg_integer(), term()}}.
 transfers(#tasks{transfers = T}) -> T.
+
+-spec persist_pending_bytes(tasks()) -> non_neg_integer().
+persist_pending_bytes(#tasks{persist_pending_bytes = B}) -> B.
+
+-spec transfers_in_flight(tasks()) -> non_neg_integer().
+transfers_in_flight(#tasks{transfers = T}) -> map_size(T).
+
+-spec bytes_in_transfer(tasks()) -> non_neg_integer().
+bytes_in_transfer(#tasks{transfers = T}) ->
+    maps:fold(fun(_Ref, {Size, _Token}, Acc) -> Acc + Size end, 0, T).
+
+-spec bytes_in_persist(tasks()) -> non_neg_integer().
+bytes_in_persist(#tasks{persist = Persist, persist_pending_bytes = Pending}) ->
+    Pending + persisting_bytes(Persist).
+
+persisting_bytes({in_flight, _G, Bytes}) -> Bytes;
+persisting_bytes(idle) -> 0.
 
 %%----------------------------------------------------------------------------
 %% The state machine.
@@ -146,22 +210,31 @@ transfers(#tasks{transfers = T}) -> T.
 -spec step(event(), tasks()) -> {tasks(), [decision()]}.
 
 %% --- spawns: record the new task at the current generation ---
-step({spawn_persist, Bytes}, #tasks{generation = G} = T) ->
-    {T#tasks{persist = {in_flight, G, Bytes}}, []};
+%% spawn_persist snapshots the pending bytes (the bytes this commit will cover)
+%% into the slot and zeroes pending; bytes_in_persist is unchanged.
+step(spawn_persist, #tasks{generation = G, persist_pending_bytes = Pending} = T) ->
+    {T#tasks{persist = {in_flight, G, Pending}, persist_pending_bytes = 0}, []};
 step({spawn_group, Kind}, #tasks{generation = G} = T) ->
     {T#tasks{group = {in_flight, G, Kind}}, []};
 step(spawn_retention, #tasks{generation = G} = T) ->
     {T#tasks{retention = {in_flight, G, undefined}}, []};
-step({spawn_transfer, Ref, Size}, #tasks{transfers = Tr} = T) ->
-    {T#tasks{transfers = Tr#{Ref => Size}}, []};
+step({spawn_transfer, Ref, Size, Token}, #tasks{transfers = Tr} = T) ->
+    {T#tasks{transfers = Tr#{Ref => {Size, Token}}}, []};
 %% --- persist result: apply only to the matching in-flight persist ---
-step({persist_result, G, Result}, #tasks{persist = {in_flight, G, _Bytes}} = T) ->
+%% On success the snapshot is dropped; on failure it returns to pending so the
+%% next persist covers those bytes (bytes_in_persist unchanged on failure).
+step({persist_result, G, {ok, _} = Result}, #tasks{persist = {in_flight, G, _Bytes}} = T) ->
     {T#tasks{persist = idle}, [classify_persist(Result)]};
+step(
+    {persist_result, G, Result},
+    #tasks{persist = {in_flight, G, Bytes}, persist_pending_bytes = Pending} = T
+) ->
+    {T#tasks{persist = idle, persist_pending_bytes = Pending + Bytes}, [classify_persist(Result)]};
 step({persist_result, _G, _Result}, T) ->
     {T, [{drop, stale_persist_result}]};
 %% --- group result ---
-step({group_result, G, Result}, #tasks{group = {in_flight, G, _Kind}} = T) ->
-    {T#tasks{group = idle}, [classify_group(Result)]};
+step({group_result, G, Result}, #tasks{group = {in_flight, G, Kind}} = T) ->
+    {T#tasks{group = idle}, [classify_group(Kind, Result)]};
 step({group_result, _G, _Result}, T) ->
     {T, [{drop, stale_group_result}]};
 %% --- retention result ---
@@ -176,9 +249,34 @@ step({retention_timeout, _G}, T) ->
     {T, [{drop, stale_retention_timeout}]};
 %% --- transfer result: keyed by Ref membership, not a slot ---
 step({transfer_result, Ref, Result}, #tasks{transfers = Tr} = T) when is_map_key(Ref, Tr) ->
-    {T#tasks{transfers = maps:remove(Ref, Tr)}, [classify_transfer(Ref, Result)]};
+    {Size, _Token} = maps:get(Ref, Tr),
+    {Tasks, Decision} = classify_transfer(Ref, Size, Result, T),
+    {Tasks#tasks{transfers = maps:remove(Ref, Tr)}, [Decision]};
 step({transfer_result, _Ref, _Result}, T) ->
     {T, [{drop, unknown_transfer_result}]};
+%% --- transfer deadline: fail the transfer only if this token is still armed ---
+%% A fired-but-queued deadline for a previous arming of the same Ref carries an
+%% old token and is dropped; the live arming carries the current token.
+step({transfer_deadline, Ref, Token}, #tasks{transfers = Tr} = T) when
+    is_map_key(Ref, Tr)
+->
+    case maps:get(Ref, Tr) of
+        {_Size, Token} ->
+            {T#tasks{transfers = maps:remove(Ref, Tr)}, [
+                {deliver, transfer_failed, {Ref, transfer_deadline}}
+            ]};
+        _ ->
+            {T, [{drop, stale_transfer_deadline}]}
+    end;
+step({transfer_deadline, _Ref, _Token}, T) ->
+    {T, [{drop, stale_transfer_deadline}]};
+%% --- retry transfer: re-upload only if the transfer is still outstanding ---
+%% A retry scheduled before a recovery cleared the in-flight queue finds its Ref
+%% absent and is dropped, rather than re-submitting a phantom upload.
+step({retry_transfer, Ref}, #tasks{transfers = Tr} = T) when is_map_key(Ref, Tr) ->
+    {T, [{resubmit, Ref}]};
+step({retry_transfer, _Ref}, T) ->
+    {T, [{drop, stale_retry_transfer}]};
 %% --- recover: bump the generation and abandon every in-flight task ---
 step(recover, #tasks{generation = G}) ->
     {#tasks{generation = G + 1}, []}.
@@ -193,12 +291,20 @@ classify_persist({ok, Revision}) -> {deliver, persist_complete, Revision};
 classify_persist({error, {conflict, _}}) -> {deliver, persist_failed, conflict};
 classify_persist({error, Reason}) -> {deliver, persist_failed, Reason}.
 
-classify_group({ok, Uid}) -> {deliver, group_complete, Uid};
-classify_group({error, Reason}) -> {deliver, group_failed, Reason}.
+%% The group kind is carried in the deliver so the shell can attribute the
+%% per-kind "created" metric without re-reading the slot it just freed.
+classify_group(Kind, {ok, Uid}) -> {deliver, group_complete, {Kind, Uid}};
+classify_group(_Kind, {error, Reason}) -> {deliver, group_failed, Reason}.
 
 classify_retention(unchanged) -> {deliver, retention_failed, unchanged};
 classify_retention({failed, Reason}) -> {deliver, retention_failed, Reason};
 classify_retention({Edit, Refs}) -> {deliver, retention_complete, {Edit, Refs}}.
 
-classify_transfer(Ref, {ok, Uid}) -> {deliver, transfer_complete, {Ref, Uid}};
-classify_transfer(Ref, {error, Reason}) -> {deliver, transfer_failed, {Ref, Reason}}.
+%% A transfer success credits its bytes to persist_pending_bytes (stage 3 of the
+%% pipeline): they are durable in S3 and now await a manifest persist. A failure
+%% leaves the byte accounting unchanged (the bytes already left bytes_in_transfer
+%% when the Ref was removed by the caller) and drives the core's retry path.
+classify_transfer(Ref, Size, {ok, Uid}, #tasks{persist_pending_bytes = Pending} = T) ->
+    {T#tasks{persist_pending_bytes = Pending + Size}, {deliver, transfer_complete, {Ref, Uid}}};
+classify_transfer(Ref, _Size, {error, Reason}, T) ->
+    {T, {deliver, transfer_failed, {Ref, Reason}}}.

--- a/test/replica_reader_tasks_SUITE.erl
+++ b/test/replica_reader_tasks_SUITE.erl
@@ -1,0 +1,288 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(replica_reader_tasks_SUITE).
+-moduledoc """
+Property and falsification tests for the pure async-task-lifecycle model
+`rabbitmq_stream_s3_replica_reader_tasks`.
+
+The point of this suite is not to confirm the model is green. It is to show the
+harness is strong enough to *falsify* the recovery-seam bug class: an async
+result from a task that is no longer the live one must never be delivered to the
+core. The soundness oracle (`is_legitimate/3`) re-derives, from the pre-state and
+the event alone, whether a delivery is valid - independently of how `step/2`
+decides. A `step` that delivers a stale result disagrees with the oracle and is
+caught.
+
+To prove the oracle has discriminating power, two faithful reproductions of the
+historical correlation schemes this model replaces (`step_buggy_genonly/2`,
+`step_buggy_slotonly/2`) are run through the same property: the property must
+find a counterexample for each. The generation-only variant is the exact
+timeout-race that was previously found by hand; the slot-only variant is the
+original cross-recovery mis-attribution.
+""".
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, rabbitmq_stream_s3_replica_reader_tasks).
+
+all() ->
+    [
+        correct_step_is_sound,
+        correct_step_preserves_structural_invariants,
+        property_catches_timeout_race,
+        property_catches_cross_recovery_mis_attribution,
+        timeout_race_is_deterministically_caught,
+        cross_recovery_is_deterministically_caught
+    ].
+
+%% =========================================================================
+%% Property cases
+%% =========================================================================
+
+%% The real step never delivers a stale result, for any interleaving.
+correct_step_is_sound(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_sound(fun ?M:step/2) end, [], 5000
+    ).
+
+%% The real step keeps the structural invariants (generation monotonic and only
+%% bumped by recover; recover abandons every in-flight task).
+correct_step_preserves_structural_invariants(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_structural(fun ?M:step/2) end, [], 5000
+    ).
+
+%% Falsification: the generation-only correlation (B's pre-fix retention logic)
+%% must be caught - this is the timeout-race rediscovered automatically.
+property_catches_timeout_race(_Config) ->
+    CE = proper:counterexample(
+        prop_sound(fun step_buggy_genonly/2), [{numtests, 5000}, quiet]
+    ),
+    ct:pal("generation-only counterexample: ~p", [CE]),
+    ?assertNotEqual(true, CE).
+
+%% Falsification: the slot-only correlation (the original pre-generation logic)
+%% must be caught - this is the cross-recovery mis-attribution.
+property_catches_cross_recovery_mis_attribution(_Config) ->
+    CE = proper:counterexample(
+        prop_sound(fun step_buggy_slotonly/2), [{numtests, 5000}, quiet]
+    ),
+    ct:pal("slot-only counterexample: ~p", [CE]),
+    ?assertNotEqual(true, CE).
+
+%% =========================================================================
+%% Deterministic pins for the two historical bugs
+%% =========================================================================
+
+%% A retention result that arrives after its own timeout (slot freed, generation
+%% unchanged): the correct step drops it; the generation-only step delivers it on
+%% an idle slot, which the oracle flags.
+timeout_race_is_deterministically_caught(_Config) ->
+    Seq = [spawn_retention, {retention_timeout, 0}, {retention_result, 0, unchanged}],
+    ?assert(replay_sound(fun ?M:step/2, Seq)),
+    ?assertNot(replay_sound(fun step_buggy_genonly/2, Seq)).
+
+%% A persist result from before a recovery, arriving while a new persist occupies
+%% the slot at the next generation: the correct step drops it; the slot-only step
+%% delivers it to the new task, which the oracle flags.
+cross_recovery_is_deterministically_caught(_Config) ->
+    Seq = [
+        {spawn_persist, 10},
+        recover,
+        {spawn_persist, 20},
+        {persist_result, 0, {ok, 99}}
+    ],
+    ?assert(replay_sound(fun ?M:step/2, Seq)),
+    ?assertNot(replay_sound(fun step_buggy_slotonly/2, Seq)).
+
+%% =========================================================================
+%% Properties
+%% =========================================================================
+
+prop_sound(StepFun) ->
+    ?FORALL(Events, events(), replay_sound(StepFun, Events)).
+
+prop_structural(StepFun) ->
+    ?FORALL(Events, events(), replay_structural(StepFun, Events)).
+
+%% Fold StepFun over the events; every decision at every step must be legitimate
+%% with respect to the state *before* that step.
+replay_sound(StepFun, Events) ->
+    {_Final, Ok} = lists:foldl(
+        fun
+            (Ev, {S, true}) ->
+                {S2, Decisions} = StepFun(Ev, S),
+                {S2, lists:all(fun(D) -> is_legitimate(S, Ev, D) end, Decisions)};
+            (_Ev, {S, false}) ->
+                {S, false}
+        end,
+        {?M:init(), true},
+        Events
+    ),
+    Ok.
+
+replay_structural(StepFun, Events) ->
+    {_Final, Ok} = lists:foldl(
+        fun
+            (Ev, {S, true}) ->
+                {S2, _Decisions} = StepFun(Ev, S),
+                {S2, structural_ok(S, Ev, S2)};
+            (_Ev, {S, false}) ->
+                {S, false}
+        end,
+        {?M:init(), true},
+        Events
+    ),
+    Ok.
+
+%% =========================================================================
+%% Faithful reproductions of the historical correlation schemes this model
+%% replaces, expressed through the model's public API. The property must find a
+%% counterexample for each; that is the evidence the harness is strong enough.
+%% =========================================================================
+
+%% Generation-only retention correlation (B's pre-fix logic, before the
+%% retention_mon guard was restored): a result whose generation matches the
+%% current one is delivered without checking the slot is still occupied. A result
+%% that raced its own timeout - slot already idle, generation unchanged - is
+%% wrongly delivered. The state transition is delegated to the real step; only
+%% the (buggy) decision is overridden.
+step_buggy_genonly({retention_result, G, Result} = Ev, S) ->
+    case ?M:generation(S) =:= G of
+        true ->
+            {S2, _} = ?M:step(Ev, S),
+            {S2, [classify_retention(Result)]};
+        false ->
+            ?M:step(Ev, S)
+    end;
+step_buggy_genonly(Ev, S) ->
+    ?M:step(Ev, S).
+
+%% Monitor-field-only correlation (the original pre-generation logic): a result
+%% is delivered to whatever task occupies the slot, ignoring which incarnation it
+%% belongs to. After a recover plus a re-spawn, a result from the old task is
+%% wrongly delivered to the new one.
+step_buggy_slotonly({persist_result, _G, Result} = Ev, S) ->
+    case ?M:persist_slot(S) of
+        {in_flight, _SlotG, _} ->
+            {S2, _} = ?M:step(Ev, S),
+            {S2, [classify_persist(Result)]};
+        idle ->
+            ?M:step(Ev, S)
+    end;
+step_buggy_slotonly(Ev, S) ->
+    ?M:step(Ev, S).
+
+%% Local mirrors of the model's private classifiers, for the buggy variants.
+classify_retention(unchanged) -> {deliver, retention_failed, unchanged};
+classify_retention({failed, Reason}) -> {deliver, retention_failed, Reason};
+classify_retention({_Edit, _Refs}) -> {deliver, retention_complete, edit}.
+
+classify_persist({ok, Revision}) -> {deliver, persist_complete, Revision};
+classify_persist({error, {conflict, _}}) -> {deliver, persist_failed, conflict};
+classify_persist({error, Reason}) -> {deliver, persist_failed, Reason}.
+
+%% =========================================================================
+%% Soundness oracle: independent of step/2, decides whether a decision is valid
+%% given only the pre-state and the event.
+%% =========================================================================
+
+is_legitimate(_S, _Event, {drop, _Reason}) ->
+    true;
+is_legitimate(S, {persist_result, G, _}, {deliver, C, _}) when
+    C =:= persist_complete; C =:= persist_failed
+->
+    matches_slot(?M:persist_slot(S), G);
+is_legitimate(S, {group_result, G, _}, {deliver, C, _}) when
+    C =:= group_complete; C =:= group_failed
+->
+    matches_slot(?M:group_slot(S), G);
+is_legitimate(S, {retention_result, G, _}, {deliver, C, _}) when
+    C =:= retention_complete; C =:= retention_failed
+->
+    matches_slot(?M:retention_slot(S), G);
+is_legitimate(S, {retention_timeout, G}, {deliver, retention_failed, timeout}) ->
+    matches_slot(?M:retention_slot(S), G);
+is_legitimate(S, {transfer_result, Ref, _}, {deliver, C, _}) when
+    C =:= transfer_complete; C =:= transfer_failed
+->
+    is_map_key(Ref, ?M:transfers(S));
+%% Any other deliver (wrong completion for the event, or a deliver with no
+%% matching live task) is illegitimate.
+is_legitimate(_S, _Event, {deliver, _, _}) ->
+    false.
+
+matches_slot({in_flight, G, _Data}, G) -> true;
+matches_slot(_Slot, _G) -> false.
+
+%% =========================================================================
+%% Structural invariants over a single transition.
+%% =========================================================================
+
+structural_ok(Pre, Event, Post) ->
+    generation_monotonic(Pre, Event, Post) andalso recover_abandons_all(Event, Post).
+
+generation_monotonic(Pre, Event, Post) ->
+    GPre = ?M:generation(Pre),
+    GPost = ?M:generation(Post),
+    case Event of
+        recover -> GPost =:= GPre + 1;
+        _ -> GPost =:= GPre
+    end.
+
+recover_abandons_all(recover, Post) ->
+    ?M:persist_slot(Post) =:= idle andalso
+        ?M:group_slot(Post) =:= idle andalso
+        ?M:retention_slot(Post) =:= idle andalso
+        map_size(?M:transfers(Post)) =:= 0;
+recover_abandons_all(_Event, _Post) ->
+    true.
+
+%% =========================================================================
+%% Generators
+%% =========================================================================
+
+%% Generations and refs are drawn from small pools so that result/timeout events
+%% frequently reference a task that is no longer (or was never) the live one -
+%% the stale interleavings are where the bug class lives.
+events() ->
+    list(event()).
+
+event() ->
+    oneof([
+        {spawn_persist, range(1, 1000)},
+        {spawn_group, group_kind()},
+        spawn_retention,
+        {spawn_transfer, ref_id(), range(1, 1000)},
+        {persist_result, gen(), persist_result_value()},
+        {group_result, gen(), group_result_value()},
+        {retention_result, gen(), retention_result_value()},
+        {retention_timeout, gen()},
+        {transfer_result, ref_id(), transfer_result_value()},
+        recover
+    ]).
+
+gen() -> range(0, 3).
+
+ref_id() -> oneof([r1, r2, r3, r4]).
+
+group_kind() -> oneof([group, kilo_group, mega_group]).
+
+persist_result_value() ->
+    oneof([{ok, range(1, 1000)}, {error, {conflict, entry}}, {error, slow_down}]).
+
+group_result_value() ->
+    oneof([{ok, <<"uid">>}, {error, slow_down}]).
+
+%% The {Edit, Refs} shape is modelled as a 2-tuple whose first element is not one
+%% of the reserved atoms.
+retention_result_value() ->
+    oneof([unchanged, {failed, boom}, {an_edit, []}]).
+
+transfer_result_value() ->
+    oneof([{ok, <<"uid">>}, {error, slow_down}]).

--- a/test/replica_reader_tasks_SUITE.erl
+++ b/test/replica_reader_tasks_SUITE.erl
@@ -7,19 +7,35 @@ Property and falsification tests for the pure async-task-lifecycle model
 `rabbitmq_stream_s3_replica_reader_tasks`.
 
 The point of this suite is not to confirm the model is green. It is to show the
-harness is strong enough to *falsify* the recovery-seam bug class: an async
-result from a task that is no longer the live one must never be delivered to the
-core. The soundness oracle (`is_legitimate/3`) re-derives, from the pre-state and
-the event alone, whether a delivery is valid - independently of how `step/2`
-decides. A `step` that delivers a stale result disagrees with the oracle and is
-caught.
+harness is strong enough to *falsify* the two bug classes the model is meant to
+make impossible:
 
-To prove the oracle has discriminating power, two faithful reproductions of the
-historical correlation schemes this model replaces (`step_buggy_genonly/2`,
-`step_buggy_slotonly/2`) are run through the same property: the property must
-find a counterexample for each. The generation-only variant is the exact
-timeout-race that was previously found by hand; the slot-only variant is the
-original cross-recovery mis-attribution.
+1. The recovery-seam staleness class: an async result from a task that is no
+   longer the live one must never be delivered to the core. The soundness oracle
+   (`is_legitimate/3`) re-derives, from the pre-state and the event alone,
+   whether a delivery is valid - independently of how `step/2` decides. A `step`
+   that delivers a stale result disagrees with the oracle and is caught.
+
+2. The gauge-drift class: the pipeline gauges (transfers-in-flight, bytes in
+   transfer, bytes in persist) are *derived* from task state rather than
+   maintained as independently-mutated counters. The conservation oracle
+   (`gauge_delta_ok/3`) re-derives, from the pre-state and the event, the only
+   gauge movements the transition is allowed to make. A byte mis-accounting (for
+   example a failed persist that drops its bytes instead of returning them to the
+   pending pool) disagrees with the oracle and is caught.
+
+To prove each oracle has discriminating power we run a deliberately wrong variant
+through it and require a counterexample:
+
+- `step_buggy_genonly/2` (generation-only retention correlation) and
+  `step_buggy_slotonly/2` (monitor-field-only persist correlation) are faithful
+  reproductions of the historical schemes this model replaces; the soundness
+  property finds a counterexample for each. The generation-only variant is the
+  exact timeout-race that was previously found by hand; the slot-only variant is
+  the original cross-recovery mis-attribution.
+- `indep_buggy/2` maintains the transfers-in-flight gauge as a separate counter
+  (the historical design) with one missing decrement on the deadline path; the
+  gauge property finds the drift the derived gauge structurally cannot have.
 """.
 
 -compile([export_all, nowarn_export_all]).
@@ -37,11 +53,18 @@ all() ->
         property_catches_timeout_race,
         property_catches_cross_recovery_mis_attribution,
         timeout_race_is_deterministically_caught,
-        cross_recovery_is_deterministically_caught
+        cross_recovery_is_deterministically_caught,
+        gauges_are_nonnegative,
+        recover_zeroes_all_gauges,
+        gauges_are_conserved,
+        persist_byte_oracle_rejects_lost_bytes,
+        derived_gauge_matches_disciplined_counter,
+        property_catches_gauge_drift,
+        gauge_drift_is_deterministically_caught
     ].
 
 %% =========================================================================
-%% Property cases
+%% Soundness property cases
 %% =========================================================================
 
 %% The real step never delivers a stale result, for any interleaving.
@@ -51,7 +74,8 @@ correct_step_is_sound(_Config) ->
     ).
 
 %% The real step keeps the structural invariants (generation monotonic and only
-%% bumped by recover; recover abandons every in-flight task).
+%% bumped by recover; recover abandons every in-flight task and zeroes the
+%% gauges).
 correct_step_preserves_structural_invariants(_Config) ->
     rabbit_ct_proper_helpers:run_proper(
         fun() -> prop_structural(fun ?M:step/2) end, [], 5000
@@ -76,7 +100,45 @@ property_catches_cross_recovery_mis_attribution(_Config) ->
     ?assertNotEqual(true, CE).
 
 %% =========================================================================
-%% Deterministic pins for the two historical bugs
+%% Gauge property cases
+%% =========================================================================
+
+%% The derived gauges are never negative, for any interleaving.
+gauges_are_nonnegative(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_gauges_nonnegative() end, [], 5000
+    ).
+
+%% recover resets every gauge (and the pending-bytes pool) to zero.
+recover_zeroes_all_gauges(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_recover_zeroes_gauges() end, [], 5000
+    ).
+
+%% Over reachable operational sequences, each transition moves the gauges only
+%% by the amount the conservation oracle allows.
+gauges_are_conserved(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_gauge_conservation() end, [], 5000
+    ).
+
+%% The derived gauge equals a correctly-disciplined independent counter.
+derived_gauge_matches_disciplined_counter(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_gauge_matches_independent(fun indep_correct/2) end, [], 5000
+    ).
+
+%% Falsification: an independently-maintained counter with one missing decrement
+%% (the historical gauge-drift bug) must be caught.
+property_catches_gauge_drift(_Config) ->
+    CE = proper:counterexample(
+        prop_gauge_matches_independent(fun indep_buggy/2), [{numtests, 5000}, quiet]
+    ),
+    ct:pal("gauge-drift counterexample: ~p", [CE]),
+    ?assertNotEqual(true, CE).
+
+%% =========================================================================
+%% Deterministic pins
 %% =========================================================================
 
 %% A retention result that arrives after its own timeout (slot freed, generation
@@ -92,13 +154,43 @@ timeout_race_is_deterministically_caught(_Config) ->
 %% delivers it to the new task, which the oracle flags.
 cross_recovery_is_deterministically_caught(_Config) ->
     Seq = [
-        {spawn_persist, 10},
+        spawn_persist,
         recover,
-        {spawn_persist, 20},
+        spawn_persist,
         {persist_result, 0, {ok, 99}}
     ],
     ?assert(replay_sound(fun ?M:step/2, Seq)),
     ?assertNot(replay_sound(fun step_buggy_slotonly/2, Seq)).
+
+%% A failed persist must return its snapshotted bytes to the pending pool so the
+%% next persist covers them; bytes_in_persist is unchanged. The conservation
+%% oracle rejects a transition that instead drops the bytes - which is exactly
+%% the post-state a successful persist produces, so we feed the success post-state
+%% under a failure event and require the oracle to flag it.
+persist_byte_oracle_rejects_lost_bytes(_Config) ->
+    Pre = run(fun ?M:step/2, [
+        {spawn_transfer, r1, 7, t1}, {transfer_result, r1, {ok, <<"u">>}}, spawn_persist
+    ]),
+    %% Sanity: the snapshot is non-zero, so dropping vs returning it is
+    %% observable.
+    {in_flight, G, Snap} = ?M:persist_slot(Pre),
+    ?assert(Snap > 0),
+    {PostOk, _} = ?M:step({persist_result, G, {ok, 1}}, Pre),
+    {PostErr, _} = ?M:step({persist_result, G, {error, boom}}, Pre),
+    %% The real transitions satisfy the oracle.
+    ?assert(gauge_delta_ok(Pre, {persist_result, G, {ok, 1}}, PostOk)),
+    ?assert(gauge_delta_ok(Pre, {persist_result, G, {error, boom}}, PostErr)),
+    %% A failure that produced the success post-state (bytes dropped, not
+    %% returned to pending) is rejected.
+    ?assertNot(gauge_delta_ok(Pre, {persist_result, G, {error, boom}}, PostOk)).
+
+%% A transfer that ends via its liveness deadline must drop out of the
+%% transfers-in-flight gauge. The derived gauge does; an independent counter that
+%% forgets to decrement on the deadline path leaks.
+gauge_drift_is_deterministically_caught(_Config) ->
+    Ops = [{spawn_transfer, r1, 5, t1}, {transfer_deadline, r1, t1}],
+    ?assert(gauge_lockstep_ok(fun indep_correct/2, Ops)),
+    ?assertNot(gauge_lockstep_ok(fun indep_buggy/2, Ops)).
 
 %% =========================================================================
 %% Properties
@@ -109,6 +201,26 @@ prop_sound(StepFun) ->
 
 prop_structural(StepFun) ->
     ?FORALL(Events, events(), replay_structural(StepFun, Events)).
+
+prop_gauges_nonnegative() ->
+    ?FORALL(Events, events(), all_states_nonnegative(Events)).
+
+prop_recover_zeroes_gauges() ->
+    ?FORALL(Events, events(), begin
+        S = run(fun ?M:step/2, Events),
+        {S2, _} = ?M:step(recover, S),
+        gauges(S2) =:= {0, 0, 0} andalso ?M:persist_pending_bytes(S2) =:= 0
+    end).
+
+prop_gauge_conservation() ->
+    ?FORALL(Ops, ops(), replay_gauge_conservation(Ops)).
+
+prop_gauge_matches_independent(IndepFun) ->
+    ?FORALL(Ops, ops(), gauge_lockstep_ok(IndepFun, Ops)).
+
+%% =========================================================================
+%% Replay folds
+%% =========================================================================
 
 %% Fold StepFun over the events; every decision at every step must be legitimate
 %% with respect to the state *before* that step.
@@ -139,6 +251,56 @@ replay_structural(StepFun, Events) ->
         Events
     ),
     Ok.
+
+replay_gauge_conservation(Ops) ->
+    {_Final, Ok} = lists:foldl(
+        fun
+            (Ev, {S, true}) ->
+                {S2, _} = ?M:step(Ev, S),
+                {S2, gauge_delta_ok(S, Ev, S2)};
+            (_Ev, {S, false}) ->
+                {S, false}
+        end,
+        {?M:init(), true},
+        Ops
+    ),
+    Ok.
+
+all_states_nonnegative(Events) ->
+    {_Final, Ok} = lists:foldl(
+        fun
+            (Ev, {S, true}) ->
+                {S2, _} = ?M:step(Ev, S),
+                {S2, gauges_nonnegative(S2)};
+            (_Ev, {S, false}) ->
+                {S, false}
+        end,
+        {?M:init(), gauges_nonnegative(?M:init())},
+        Events
+    ),
+    Ok.
+
+%% Fold StepFun over the events, threading the model and the independent counter
+%% in lockstep; the model's derived transfers-in-flight gauge must equal the
+%% independent count after every step.
+gauge_lockstep_ok(IndepFun, Ops) ->
+    {_S, _I, Ok} = lists:foldl(
+        fun
+            (Ev, {S, I, true}) ->
+                {S2, _} = ?M:step(Ev, S),
+                I2 = IndepFun(Ev, I),
+                {S2, I2, ?M:transfers_in_flight(S2) =:= element(1, I2)};
+            (_Ev, Acc = {_, _, false}) ->
+                Acc
+        end,
+        {?M:init(), {0, #{}}, true},
+        Ops
+    ),
+    Ok.
+
+%% Run StepFun over a sequence and return the final state, discarding decisions.
+run(StepFun, Events) ->
+    lists:foldl(fun(Ev, S) -> element(1, StepFun(Ev, S)) end, ?M:init(), Events).
 
 %% =========================================================================
 %% Faithful reproductions of the historical correlation schemes this model
@@ -188,6 +350,43 @@ classify_persist({error, {conflict, _}}) -> {deliver, persist_failed, conflict};
 classify_persist({error, Reason}) -> {deliver, persist_failed, Reason}.
 
 %% =========================================================================
+%% Independent transfers-in-flight counters (the historical design): a count and
+%% the set of refs it believes are outstanding. The correct discipline
+%% decrements on every path that removes a transfer; the buggy one forgets the
+%% deadline path, so its count drifts above the derived gauge.
+%% =========================================================================
+
+indep_correct({spawn_transfer, Ref, _Size, _Token}, {C, Refs}) ->
+    case is_map_key(Ref, Refs) of
+        true -> {C, Refs};
+        false -> {C + 1, Refs#{Ref => true}}
+    end;
+indep_correct({transfer_result, Ref, _}, State) ->
+    indep_remove(Ref, State);
+indep_correct({transfer_deadline, Ref, _}, State) ->
+    indep_remove(Ref, State);
+indep_correct(recover, _State) ->
+    {0, #{}};
+indep_correct(_Ev, State) ->
+    State.
+
+indep_buggy({transfer_deadline, Ref, _}, {C, Refs}) ->
+    %% Removes the ref from the tracked set but forgets to decrement the count -
+    %% the gauge leaks by one per deadline.
+    case is_map_key(Ref, Refs) of
+        true -> {C, maps:remove(Ref, Refs)};
+        false -> {C, Refs}
+    end;
+indep_buggy(Ev, State) ->
+    indep_correct(Ev, State).
+
+indep_remove(Ref, {C, Refs}) ->
+    case is_map_key(Ref, Refs) of
+        true -> {C - 1, maps:remove(Ref, Refs)};
+        false -> {C, Refs}
+    end.
+
+%% =========================================================================
 %% Soundness oracle: independent of step/2, decides whether a decision is valid
 %% given only the pre-state and the event.
 %% =========================================================================
@@ -212,9 +411,18 @@ is_legitimate(S, {transfer_result, Ref, _}, {deliver, C, _}) when
     C =:= transfer_complete; C =:= transfer_failed
 ->
     is_map_key(Ref, ?M:transfers(S));
+is_legitimate(S, {transfer_deadline, Ref, Token}, {deliver, transfer_failed, _}) ->
+    case maps:find(Ref, ?M:transfers(S)) of
+        {ok, {_Size, Token}} -> true;
+        _ -> false
+    end;
+is_legitimate(S, {retry_transfer, Ref}, {resubmit, Ref}) ->
+    is_map_key(Ref, ?M:transfers(S));
 %% Any other deliver (wrong completion for the event, or a deliver with no
-%% matching live task) is illegitimate.
+%% matching live task) or any unexpected resubmit is illegitimate.
 is_legitimate(_S, _Event, {deliver, _, _}) ->
+    false;
+is_legitimate(_S, _Event, {resubmit, _}) ->
     false.
 
 matches_slot({in_flight, G, _Data}, G) -> true;
@@ -239,37 +447,118 @@ recover_abandons_all(recover, Post) ->
     ?M:persist_slot(Post) =:= idle andalso
         ?M:group_slot(Post) =:= idle andalso
         ?M:retention_slot(Post) =:= idle andalso
-        map_size(?M:transfers(Post)) =:= 0;
+        map_size(?M:transfers(Post)) =:= 0 andalso
+        gauges(Post) =:= {0, 0, 0} andalso
+        ?M:persist_pending_bytes(Post) =:= 0;
 recover_abandons_all(_Event, _Post) ->
     true.
+
+%% =========================================================================
+%% Gauge conservation oracle: independent of step/2's internal byte arithmetic,
+%% it re-derives the only gauge movement each transition is allowed to make from
+%% the pre-state observed through the accessors.
+%% =========================================================================
+
+gauge_delta_ok(Pre, Event, Post) ->
+    {TifP, BitP, BipP} = gauges(Pre),
+    {TifQ, BitQ, BipQ} = gauges(Post),
+    Unchanged = {TifQ, BitQ, BipQ} =:= {TifP, BitP, BipP},
+    case Event of
+        recover ->
+            {TifQ, BitQ, BipQ} =:= {0, 0, 0};
+        spawn_persist ->
+            %% The pending pool is snapshotted into the persist slot; the total
+            %% bytes awaiting durability are unchanged, transfers untouched.
+            Unchanged;
+        {spawn_transfer, Ref, Size, _Token} ->
+            Old = transfer_size(Pre, Ref),
+            New =
+                case is_map_key(Ref, ?M:transfers(Pre)) of
+                    true -> 0;
+                    false -> 1
+                end,
+            TifQ =:= TifP + New andalso
+                BitQ =:= BitP - Old + Size andalso
+                BipQ =:= BipP;
+        {persist_result, G, Result} ->
+            case ?M:persist_slot(Pre) of
+                {in_flight, G, Snap} ->
+                    TifQ =:= TifP andalso BitQ =:= BitP andalso
+                        case Result of
+                            {ok, _} -> BipQ =:= BipP - Snap;
+                            _ -> BipQ =:= BipP
+                        end;
+                _ ->
+                    Unchanged
+            end;
+        {transfer_result, Ref, Result} ->
+            case maps:find(Ref, ?M:transfers(Pre)) of
+                {ok, {Size, _Token}} ->
+                    TifQ =:= TifP - 1 andalso BitQ =:= BitP - Size andalso
+                        case Result of
+                            {ok, _} -> BipQ =:= BipP + Size;
+                            _ -> BipQ =:= BipP
+                        end;
+                error ->
+                    Unchanged
+            end;
+        {transfer_deadline, Ref, Token} ->
+            case maps:find(Ref, ?M:transfers(Pre)) of
+                {ok, {Size, Token}} ->
+                    TifQ =:= TifP - 1 andalso BitQ =:= BitP - Size andalso BipQ =:= BipP;
+                _ ->
+                    Unchanged
+            end;
+        _ ->
+            Unchanged
+    end.
+
+gauges(S) ->
+    {?M:transfers_in_flight(S), ?M:bytes_in_transfer(S), ?M:bytes_in_persist(S)}.
+
+gauges_nonnegative(S) ->
+    {Tif, Bit, Bip} = gauges(S),
+    Tif >= 0 andalso Bit >= 0 andalso Bip >= 0 andalso ?M:persist_pending_bytes(S) >= 0.
+
+transfer_size(S, Ref) ->
+    case maps:find(Ref, ?M:transfers(S)) of
+        {ok, {Size, _Token}} -> Size;
+        error -> 0
+    end.
 
 %% =========================================================================
 %% Generators
 %% =========================================================================
 
-%% Generations and refs are drawn from small pools so that result/timeout events
-%% frequently reference a task that is no longer (or was never) the live one -
-%% the stale interleavings are where the bug class lives.
+%% Arbitrary interleavings for the soundness and structural properties.
+%% Generations, refs and tokens are drawn from small pools so that
+%% result/timeout/deadline events frequently reference a task that is no longer
+%% (or was never) the live one - the stale interleavings are where the staleness
+%% bug class lives.
 events() ->
     list(event()).
 
 event() ->
     oneof([
-        {spawn_persist, range(1, 1000)},
+        spawn_persist,
         {spawn_group, group_kind()},
         spawn_retention,
-        {spawn_transfer, ref_id(), range(1, 1000)},
+        {spawn_transfer, ref_id(), range(0, 1000), token()},
         {persist_result, gen(), persist_result_value()},
         {group_result, gen(), group_result_value()},
         {retention_result, gen(), retention_result_value()},
         {retention_timeout, gen()},
         {transfer_result, ref_id(), transfer_result_value()},
+        {transfer_deadline, ref_id(), token()},
+        {retry_transfer, ref_id()},
         recover
     ]).
 
 gen() -> range(0, 3).
 
 ref_id() -> oneof([r1, r2, r3, r4]).
+
+token() -> oneof([t1, t2, t3]).
 
 group_kind() -> oneof([group, kilo_group, mega_group]).
 
@@ -286,3 +575,60 @@ retention_result_value() ->
 
 transfer_result_value() ->
     oneof([{ok, <<"uid">>}, {error, slow_down}]).
+
+%% Reachable operational sequences for the gauge-conservation and
+%% gauge-matching properties: spawns happen only into an idle slot, transfers use
+%% a fresh ref per spawn, and result/timeout/deadline/retry events reference a
+%% task that is actually live. This is the envelope the core's gating keeps the
+%% shell within; the gauges are only meaningful along it. Staleness is exercised
+%% by events() above, not here.
+ops() ->
+    ?SIZED(Size, valid_ops(?M:init(), Size)).
+
+valid_ops(_State, 0) ->
+    [];
+valid_ops(State, Fuel) ->
+    ?LET(
+        Ev,
+        valid_event(State, Fuel),
+        ?LET(Rest, valid_ops(element(1, ?M:step(Ev, State)), Fuel - 1), [Ev | Rest])
+    ).
+
+valid_event(State, Fuel) ->
+    %% Fuel strictly decreases, so {r, Fuel}/{tok, Fuel} are unique per spawn.
+    Ref = {r, Fuel},
+    Tok = {tok, Fuel},
+    Spawns =
+        [{spawn_transfer, Ref, range(0, 1000), Tok}] ++
+            [spawn_persist || ?M:persist_slot(State) =:= idle] ++
+            [{spawn_group, group_kind()} || ?M:group_slot(State) =:= idle] ++
+            [spawn_retention || ?M:retention_slot(State) =:= idle],
+    Persist =
+        case ?M:persist_slot(State) of
+            {in_flight, G, _} -> [{persist_result, G, persist_result_value()}];
+            idle -> []
+        end,
+    Group =
+        case ?M:group_slot(State) of
+            {in_flight, G2, _} -> [{group_result, G2, group_result_value()}];
+            idle -> []
+        end,
+    Retention =
+        case ?M:retention_slot(State) of
+            {in_flight, G3, _} ->
+                [{retention_result, G3, retention_result_value()}, {retention_timeout, G3}];
+            idle ->
+                []
+        end,
+    Transfers =
+        lists:flatmap(
+            fun({R, {_Size, T}}) ->
+                [
+                    {transfer_result, R, transfer_result_value()},
+                    {transfer_deadline, R, T},
+                    {retry_transfer, R}
+                ]
+            end,
+            maps:to_list(?M:transfers(State))
+        ),
+    oneof([recover | Spawns ++ Persist ++ Group ++ Retention ++ Transfers]).


### PR DESCRIPTION
We've been identifying and squashing a lot of bugs, and most of them live in the replica reader shell half of that functional-core/imperative-shell split. This change is a large refactor that moves the async task I/O, which the shell did, into another pure state machine. This makes property based testing possible for the complicated async interleavings.

This state machine is much more formal than the functionality we had directly in the gen_server previously. There are also typing changes to move towards sum-types which make some classes of bugs structurally impossible to represent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
