### PR TITLE
log reader: Extract a helper for offset resolution

### DIFF
--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -119,7 +119,7 @@ tier.
 -export([mode/1, remote_pid/1]).
 
 -ifdef(TEST).
--export([find_fragment/3, find_index_position/2, resolve_remote_location/2]).
+-export([find_fragment/3, find_index_position/2, resolve_remote_location/2, resolve_first_lookup/1]).
 -endif.
 
 %%%===================================================================
@@ -1123,20 +1123,52 @@ resolve_first(StreamId, FirstOffset) ->
             Iterator = rabbitmq_stream_s3_fragment_iterator:init(
                 Manifest, FirstOffset, GetGroupFun
             ),
-            case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                {ok, FragRef, Iterator1} ->
-                    {ok, #remote_location{
-                        chunk_id = FragRef#fragment_ref.offset,
-                        position = ?SEGMENT_HEADER_B,
-                        fragment_ref = FragRef,
-                        iterator = Iterator1
-                    }};
-                _ ->
-                    {local, first}
+            Lookup = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
+            case resolve_first_lookup(Lookup) of
+                {remote, Location} ->
+                    {ok, Location};
+                {local, first} ->
+                    {local, first};
+                {retry, Reason} ->
+                    %% A transient group fetch failed while descending to the
+                    %% first fragment. Failing the read setup (rather than
+                    %% falling back to the local tier) makes the consumer retry
+                    %% instead of silently skipping the remote range below the
+                    %% local floor.
+                    {error, Reason}
             end;
         _ ->
             {local, first}
     end.
+
+%% Interpret the first-fragment lookup returned by the fragment iterator. Total
+%% over the three outcomes of `fragment_iterator:next/1`, with no catch-all so a
+%% transient fetch error cannot be silently absorbed into the "empty -> local"
+%% branch: an `ok` serves the read remotely; `end_of_manifest` means the remote
+%% tier is genuinely empty here, so the local tier serves it; a transient
+%% `group_fetch_failed` must fail the read setup so the consumer retries rather
+%% than skipping the remote range below the local floor. The same point fix has
+%% been applied one site at a time (`find_fragment`, `remote_reader_core`); this
+%% was the site left behind. Exercised directly by `read_resolution_SUITE`.
+-spec resolve_first_lookup(
+    {ok, #fragment_ref{}, rabbitmq_stream_s3_fragment_iterator:iterator()}
+    | end_of_manifest
+    | {error, {group_fetch_failed, term()}}
+) ->
+    {remote, #remote_location{}}
+    | {local, first}
+    | {retry, {group_fetch_failed, term()}}.
+resolve_first_lookup({ok, #fragment_ref{offset = Offset} = FragRef, Iterator}) ->
+    {remote, #remote_location{
+        chunk_id = Offset,
+        position = ?SEGMENT_HEADER_B,
+        fragment_ref = FragRef,
+        iterator = Iterator
+    }};
+resolve_first_lookup(end_of_manifest) ->
+    {local, first};
+resolve_first_lookup({error, {group_fetch_failed, _} = Reason}) ->
+    {retry, Reason}.
 
 -define(READ_RETRY_ATTEMPTS, 3).
 -define(READ_RETRY_DELAY_MS, 500).

--- a/test/log_reader_SUITE.erl
+++ b/test/log_reader_SUITE.erl
@@ -386,12 +386,16 @@ read_through_group(Config) ->
     assert_sequential(Records, NextOffset).
 
 read_group_fetch_error_is_surfaced(Config) ->
-    %% Resolving a numeric offset that descends into a group whose object cannot
-    %% be fetched (a retention deferred-deletion 404, or a transient S3 error)
-    %% must surface a clean error, not crash the consumer's reader. The `first`
-    %% spec goes via the fragment iterator (already tolerant); the numeric and
-    %% timestamp specs go via find_fragment, which this guards. The fault backend
-    %% 404s the group object on fetch.
+    %% Resolving a spec that descends into a group hitting a *transient* S3 error
+    %% (here slow_down) must surface a clean error, not silently fall back to a
+    %% local reader (skipping the remote tier) or crash the consumer's reader. The
+    %% numeric spec goes via find_fragment; the `first` spec goes via resolve_first
+    %% and the fragment iterator. Both must surface the error.
+    %%
+    %% A transient error is distinct from not_found: the iterator treats not_found
+    %% as a group deleted by retention and skips past it (covered for find_fragment
+    %% by the eunit find_fragment_group_fetch_error_is_surfaced_test), so a
+    %% transient error is what exercises the resolve_first surfacing fix.
     ok = application:set_env(
         rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
     ),
@@ -414,14 +418,33 @@ read_group_fetch_error_is_surfaced(Config) ->
     ReaderCfg = reader_config(Writer, Config),
     #{shared := Shared} = ReaderCfg,
     ?awaitMatch(F when F > 0, osiris_log_shared:first_chunk_id(Shared), 1000),
+    %% The assertions require the descent to actually fetch a group object, so
+    %% barrier on the rebalance having factored the leading fragments into a
+    %% group entry. first_chunk_id alone (local retention) does not imply the
+    %% manifest has been grouped yet: without this the resolution can find a flat
+    %% fragment, fetch no group, and return {ok, _} instead of the injected error.
+    ?awaitMatch(true, manifest_has_group(Config), 5000),
 
-    %% The group object 404s on fetch (consumer reads use `get` only for group
-    %% objects; index uses get_range, data uses get_range_async).
-    ok = rabbitmq_stream_s3_api_fault:fail_next(get, <<"group">>, not_found),
+    %% Every group object fetch returns a transient error (consumer reads use
+    %% `get` only for group objects; index uses get_range, data uses
+    %% get_range_async). fail_matching (not fail_next) so a background retention
+    %% group fetch cannot consume a one-shot failure before the resolution under
+    %% test reaches the backend.
+    ok = rabbitmq_stream_s3_api_fault:fail_matching(get, <<"group">>, slow_down),
 
+    %% The numeric spec resolves through find_fragment.
     ?assertMatch(
-        {error, {group_fetch_failed, not_found}},
+        {error, {group_fetch_failed, slow_down}},
         rabbitmq_stream_s3_log_reader:init_offset_reader(0, ReaderCfg)
+    ),
+
+    %% The `first` spec resolves through resolve_first, which descends into the
+    %% leading group. A transient fetch error there must surface, not silently
+    %% return a local reader at the local floor (which would skip the entire
+    %% remote tier below it).
+    ?assertMatch(
+        {error, {group_fetch_failed, slow_down}},
+        rabbitmq_stream_s3_log_reader:init_offset_reader(first, ReaderCfg)
     ).
 
 read_detects_crc_corruption(Config) ->
@@ -626,6 +649,22 @@ read_from_replica_node(Config) ->
 %% ------------------------------------------------------------------
 %% Internal helpers
 %% ------------------------------------------------------------------
+
+%% Whether the stream's cached manifest has had any fragments factored into a
+%% group entry (the rebalance has run).
+manifest_has_group(Config) ->
+    StreamId = ?config(stream_id, Config),
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        #manifest{entries = Entries} -> entries_have_group(Entries);
+        _ -> false
+    end.
+
+entries_have_group(?ENTRY(_O, _F, _L, ?MANIFEST_KIND_GROUP, _S, _U, _Rest)) ->
+    true;
+entries_have_group(<<_:?ENTRY_B/binary, Rest/binary>>) ->
+    entries_have_group(Rest);
+entries_have_group(_) ->
+    false.
 
 read_until_local(Reader) ->
     case rabbitmq_stream_s3_log_reader:mode(Reader) of

--- a/test/rabbitmq_stream_s3_api_fault.erl
+++ b/test/rabbitmq_stream_s3_api_fault.erl
@@ -16,6 +16,10 @@ specific operation. The control surface (minimal for now):
   trimmed-segment upload failure of issue #225 without a timing race.
 - `fail_next(Op, KeyPattern, Reason)` makes the next matching call to `Op`
   return `{error, Reason}` (e.g. `slow_down`, `not_found`, `timeout`).
+- `fail_matching(Op, KeyPattern, Reason)` makes *every* matching call to `Op`
+  return `{error, Reason}` until `reset/0`. Unlike `fail_next`, this is immune to
+  a background call (e.g. a retention group fetch) racing in and consuming a
+  one-shot failure before the call under test reaches the backend.
 - `delay(Op, KeyPattern, Ms)` sleeps before every matching call to `Op`,
   simulating slow S3 (cleared by `reset/0`).
 
@@ -52,6 +56,7 @@ passthrough to the FS backend.
     await_blocked/2,
     release/2,
     fail_next/3,
+    fail_matching/3,
     delay/3
 ]).
 
@@ -102,6 +107,13 @@ release(TaskPid, Ref) ->
 -spec fail_next(atom(), binary(), term()) -> ok.
 fail_next(Op, KeyPat, Reason) ->
     true = ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, 1}),
+    ok.
+
+%% Fail every matching call to Op until reset/0. Use when a background call could
+%% race a one-shot failure (e.g. retention fetching a group object).
+-spec fail_matching(atom(), binary(), term()) -> ok.
+fail_matching(Op, KeyPat, Reason) ->
+    true = ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, infinity}),
     ok.
 
 %% Sleep Ms before every matching call to Op (persists until reset/0).
@@ -197,9 +209,10 @@ maybe_fail(Op, Key) ->
         {ok, {KeyPat, Reason, N}} ->
             case matches(KeyPat, Key) of
                 true ->
-                    case N =< 1 of
-                        true -> ets:delete(?TBL, {fail, Op});
-                        false -> ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, N - 1})
+                    case N of
+                        infinity -> ok;
+                        _ when N =< 1 -> ets:delete(?TBL, {fail, Op});
+                        _ -> ets:insert(?TBL, {{fail, Op}, KeyPat, Reason, N - 1})
                     end,
                     {error, Reason};
                 false ->

--- a/test/read_resolution_SUITE.erl
+++ b/test/read_resolution_SUITE.erl
@@ -1,0 +1,257 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(read_resolution_SUITE).
+-moduledoc """
+Property and falsification tests for the read-tier-resolution decisions in
+`rabbitmq_stream_s3_log_reader` (`resolve_first_lookup/1` and the routing in
+`resolve_remote_location/2`).
+
+The point of this suite is to falsify the bug class the fix is meant to make
+impossible: a *transient* fragment-fetch error being collapsed into the
+"remote tier is empty -> serve from local" branch, which silently skips the
+remote range below the local floor.
+
+The soundness oracle (`expected_class/1`) re-derives, from the lookup outcome
+alone, which tier the read must resolve to - independently of how
+`resolve_first_lookup/1` decides. A `{ok, ...}` lookup must resolve remote, an
+`end_of_manifest` must resolve local, and a transient `group_fetch_failed` must
+resolve to retry (never local).
+
+To prove the oracle has discriminating power, `resolve_first_lookup_buggy/1` - a
+faithful reproduction of the historical catch-all (`_ -> {local, first}`) that
+left `resolve_first` exposed - is run through it and the property must find a
+counterexample.
+""".
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("include/rabbitmq_stream_s3.hrl").
+
+-define(M, rabbitmq_stream_s3_log_reader).
+
+all() ->
+    [
+        correct_resolution_is_sound,
+        transient_error_never_resolves_local,
+        ok_resolves_to_remote_location,
+        end_of_manifest_resolves_local,
+        property_catches_collapsed_transient_error,
+        collapsed_transient_error_is_deterministically_caught,
+        routing_offset_in_local_tier_resolves_local,
+        routing_cold_cache_below_floor_resolves_first,
+        routing_empty_local_log_routes_remote
+    ].
+
+%% The routing properties drive the real `log_reader:resolve_remote_location/2`,
+%% which reads the cached manifest through `manifest_replica`. The pure-core cases
+%% above do not need it, but a singleton is cheap to keep for the whole suite.
+init_per_suite(Config) ->
+    {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
+    unlink(Pid),
+    [{manifest_replica, Pid} | Config].
+
+end_per_suite(Config) ->
+    catch gen_server:stop(?config(manifest_replica, Config)),
+    Config.
+
+%% =========================================================================
+%% Soundness property
+%% =========================================================================
+
+%% The real decision agrees with the oracle for every lookup outcome.
+correct_resolution_is_sound(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_sound(fun ?M:resolve_first_lookup/1) end, [], 5000
+    ).
+
+%% The no-silent-skip invariant in isolation: a transient fetch error must never
+%% resolve to the local tier, for any error reason.
+transient_error_never_resolves_local(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_transient_never_local() end, [], 5000
+    ).
+
+%% Falsification: the historical catch-all that collapses a transient error into
+%% the local fallback must be caught.
+property_catches_collapsed_transient_error(_Config) ->
+    CE = proper:counterexample(
+        prop_sound(fun resolve_first_lookup_buggy/1), [{numtests, 5000}, quiet]
+    ),
+    ct:pal("collapsed-transient-error counterexample: ~p", [CE]),
+    ?assertNotEqual(true, CE).
+
+%% =========================================================================
+%% Deterministic pins
+%% =========================================================================
+
+%% A transient group fetch error resolves to retry under the real decision and to
+%% the local tier under the buggy catch-all, which the oracle flags.
+collapsed_transient_error_is_deterministically_caught(_Config) ->
+    Lookup = {error, {group_fetch_failed, slow_down}},
+    ?assertEqual(retry, classify(?M:resolve_first_lookup(Lookup))),
+    ?assertEqual(local, classify(resolve_first_lookup_buggy(Lookup))).
+
+%% An `ok` lookup builds a remote location addressed at the fragment.
+ok_resolves_to_remote_location(_Config) ->
+    FragRef = #fragment_ref{offset = 4711, uid = 7, size = 123},
+    Iterator = an_iterator,
+    {remote, Location} = ?M:resolve_first_lookup({ok, FragRef, Iterator}),
+    ?assertEqual(4711, Location#remote_location.chunk_id),
+    ?assertEqual(?SEGMENT_HEADER_B, Location#remote_location.position),
+    ?assertEqual(FragRef, Location#remote_location.fragment_ref),
+    ?assertEqual(Iterator, Location#remote_location.iterator).
+
+%% A genuinely exhausted manifest resolves to the local first offset.
+end_of_manifest_resolves_local(_Config) ->
+    ?assertEqual({local, first}, ?M:resolve_first_lookup(end_of_manifest)).
+
+%% =========================================================================
+%% Routing invariant properties (light Step 2): drive the real
+%% log_reader:resolve_remote_location/2 routing decision over generated local
+%% floors and manifest shapes, generalizing the point cases in the log_reader
+%% eunit tests. These lock the floor/shape guards; the transient-error-never-
+%% local invariant is covered by the pure-core cases above.
+%% =========================================================================
+
+-define(LR, rabbitmq_stream_s3_log_reader).
+
+%% An offset at or above a populated local floor is served locally, regardless of
+%% the remote manifest (the floor branch returns before consulting it).
+routing_offset_in_local_tier_resolves_local(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_offset_in_local_tier_local() end, [], 1000
+    ).
+
+prop_offset_in_local_tier_local() ->
+    ?FORALL(
+        {Floor, Delta},
+        {range(0, 1_000_000), range(0, 1_000_000)},
+        begin
+            Shared = osiris_log_shared:new(),
+            ok = osiris_log_shared:set_first_chunk_id(Shared, Floor),
+            Offset = Floor + Delta,
+            Config = #{name => <<"routing-local-tier">>, shared => Shared},
+            ?LR:resolve_remote_location(Offset, Config) =:= {local, Offset}
+        end
+    ).
+
+%% An offset below the local floor with no cached manifest (a cold or
+%% not-yet-synced cache) attaches at the local first offset, never the tail.
+routing_cold_cache_below_floor_resolves_first(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_cold_cache_below_floor_first() end, [], 1000
+    ).
+
+prop_cold_cache_below_floor_first() ->
+    ?FORALL(
+        {Floor, BelowDelta},
+        {range(1, 1_000_000), range(1, 1_000_000)},
+        begin
+            Offset = max(0, Floor - BelowDelta),
+            Shared = osiris_log_shared:new(),
+            ok = osiris_log_shared:set_first_chunk_id(Shared, Floor),
+            %% A stream id with no manifest ever put: get_manifest -> undefined.
+            Config = #{name => <<"routing-cold-cache-never-put">>, shared => Shared},
+            ?LR:resolve_remote_location(Offset, Config) =:= {local, first}
+        end
+    ).
+
+%% With the local log empty (first_chunk_id = -1) and a populated remote tier,
+%% the beginning and any offset below the remote first resolve to the remote
+%% tier, while an offset at or beyond the remote tail waits at the live tail.
+routing_empty_local_log_routes_remote(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_empty_local_log_routes_remote() end, [], 1000
+    ).
+
+prop_empty_local_log_routes_remote() ->
+    ?FORALL(
+        {First, Span, BelowDelta, TailDelta},
+        {range(1, 1000), range(1, 1000), range(1, 1000), range(0, 1000)},
+        begin
+            Next = First + Span,
+            Below = max(0, First - BelowDelta),
+            Tail = Next + TailDelta,
+            StreamId = <<"routing-empty-local-log">>,
+            Entries = ?ENTRY(First, 1000, 2000, ?MANIFEST_KIND_FRAGMENT, 200, 42),
+            Manifest = #manifest{first_offset = First, next_offset = Next, entries = Entries},
+            ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, Manifest),
+            %% Fresh shared atomics: first_chunk_id defaults to -1 (empty local).
+            Shared = osiris_log_shared:new(),
+            Config = #{name => StreamId, shared => Shared},
+            is_remote(?LR:resolve_remote_location(first, Config)) andalso
+                is_remote(?LR:resolve_remote_location(Below, Config)) andalso
+                ?LR:resolve_remote_location(Tail, Config) =:= {local, next}
+        end
+    ).
+
+is_remote({ok, #remote_location{}}) -> true;
+is_remote(_) -> false.
+
+%% =========================================================================
+%% Properties
+%% =========================================================================
+
+prop_sound(ResolveFun) ->
+    ?FORALL(Lookup, lookup(), classify(ResolveFun(Lookup)) =:= expected_class(Lookup)).
+
+prop_transient_never_local() ->
+    ?FORALL(
+        Reason,
+        group_fetch_reason(),
+        classify(?M:resolve_first_lookup({error, {group_fetch_failed, Reason}})) =/= local
+    ).
+
+%% =========================================================================
+%% Soundness oracle: derives the required tier from the lookup outcome alone,
+%% independently of resolve_first_lookup/1.
+%% =========================================================================
+
+expected_class({ok, #fragment_ref{}, _Iterator}) -> remote;
+expected_class(end_of_manifest) -> local;
+expected_class({error, {group_fetch_failed, _}}) -> retry.
+
+classify({remote, #remote_location{}}) -> remote;
+classify({local, first}) -> local;
+classify({retry, {group_fetch_failed, _}}) -> retry.
+
+%% =========================================================================
+%% Faithful reproduction of the historical catch-all this module replaces. The
+%% `_ -> {local, first}` clause collapses a transient error and a genuinely empty
+%% manifest into the same local fallback; the property must find a counterexample.
+%% =========================================================================
+
+resolve_first_lookup_buggy({ok, #fragment_ref{offset = Offset} = FragRef, Iterator}) ->
+    {remote, #remote_location{
+        chunk_id = Offset,
+        position = ?SEGMENT_HEADER_B,
+        fragment_ref = FragRef,
+        iterator = Iterator
+    }};
+resolve_first_lookup_buggy(_) ->
+    {local, first}.
+
+%% =========================================================================
+%% Generators
+%% =========================================================================
+
+lookup() ->
+    oneof([
+        {ok, fragment_ref(), an_iterator},
+        end_of_manifest,
+        {error, {group_fetch_failed, group_fetch_reason()}}
+    ]).
+
+fragment_ref() ->
+    ?LET(
+        {Offset, Uid, Size},
+        {range(0, 1_000_000), range(0, 1000), range(0, 1000)},
+        #fragment_ref{offset = Offset, uid = Uid, size = Size}
+    ).
+
+group_fetch_reason() ->
+    oneof([slow_down, timeout, {http, 503}, econnrefused, enoent]).


### PR DESCRIPTION
This is sort of like #271 but much smaller in scope. We can property-test the offset resolution functionality and unify it in a helper. This helps us word towards verified correctness.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
