### PR TITLE
Add formal models in P

### DIFF
--- a/.github/workflows/build-rabbitmq-server.yaml
+++ b/.github/workflows/build-rabbitmq-server.yaml
@@ -19,7 +19,7 @@ jobs:
             otp-version: 27
             elixir-version: 1.18
     steps:
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
@@ -28,7 +28,7 @@ jobs:
           git clone --branch ${{ matrix.rmq-version }} https://github.com/amazon-mq/upstream-to-rabbitmq-server.git ${{ github.workspace }}/rabbitmq-server
       - id: build-rabbitmq-server
         run: make -C ${{ github.workspace }}/rabbitmq-server
-      - uses: actions/cache/save@v5
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         # Always overwrite an existing cache entry:
         if: always()
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -24,24 +24,24 @@ jobs:
             elixir-version: 1.18
     steps:
       - id: restore-rabbitmq-server-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/rabbitmq-server
           key: rmq-${{ matrix.rmq-version }}-otp-${{ matrix.otp-version }}-elixir-${{ matrix.elixir-version }}
       - id: maybe-fail-rabbitmq-server-miss
         if: steps.restore-rabbitmq-server-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('could not restore cached rabbitmq-server build');
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: rabbitmq-server/deps/rabbitmq_stream_s3
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3/.rabbitmq_stream_s3.plt
           key: plt-${{ matrix.rmq-version }}-otp-${{ matrix.otp-version }}-elixir-${{ matrix.elixir-version }}
@@ -51,7 +51,7 @@ jobs:
         run: make -C ${{ github.workspace }}/rabbitmq-server/deps/rabbitmq_stream_s3 EUNIT_OPTS=verbose tests
       - name: maybe upload CT logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ct-logs-${{ matrix.rmq-version }}-otp-${{ matrix.otp-version }}
           path: ${{ github.workspace }}/rabbitmq-server/logs/

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -14,8 +14,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: '27'
           rebar3-version: '3.27'

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
+      gc_leading_group: ${{ steps.filter.outputs.gc_leading_group }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
@@ -36,8 +37,10 @@ jobs:
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "gc_reset=false" >> "$GITHUB_OUTPUT"
+          echo "gc_leading_group=false" >> "$GITHUB_OUTPUT"
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/gc-leading-group/' && echo "gc_leading_group=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
@@ -45,6 +48,7 @@ jobs:
           echo "$CHANGED" | grep -q '^p/orphan-leak/' && echo "orphan_leak=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
+            echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
@@ -110,6 +114,45 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: floor-last ordering fails with the expected dangling reference."
+          echo "::endgroup::"
+
+  gc-leading-group:
+    needs: changes
+    if: needs.changes.outputs.gc_leading_group == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/gc-leading-group
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/gc-leading-group
+          echo "::group::tcLeadingGroupGuarded (expect hold)"
+          p check -tc tcLeadingGroupGuarded -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (removing the carve-out must delete the leading group)
+        run: |
+          cd p/gc-leading-group
+          echo "::group::tcLeadingGroupUnguarded (expect the INV#2 dangling reference)"
+          if p check -tc tcLeadingGroupUnguarded -i 2000; then
+            echo "ERROR: tcLeadingGroupUnguarded passed; the model no longer deletes the leading group."
+            echo "Removing the referenced_group_key carve-out must delete a live group."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted referenced object (offset=80, uid=2)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the carve-out-removed run failed, but not with the expected INV#2 (80, uid 2) counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: carve-out-removed model deletes the referenced leading group."
           echo "::endgroup::"
 
   read-resolution:

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -26,7 +26,7 @@ jobs:
       tier_routing: ${{ steps.filter.outputs.tier_routing }}
       writer_fencing: ${{ steps.filter.outputs.writer_fencing }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Detect changed paths
@@ -67,8 +67,8 @@ jobs:
     if: needs.changes.outputs.gc_reset == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -129,8 +129,8 @@ jobs:
     if: needs.changes.outputs.gc_leading_group == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -168,8 +168,8 @@ jobs:
     if: needs.changes.outputs.read_resolution == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -212,8 +212,8 @@ jobs:
     if: needs.changes.outputs.trimmed_segment == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -256,8 +256,8 @@ jobs:
     if: needs.changes.outputs.orphan_leak == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -300,8 +300,8 @@ jobs:
     if: needs.changes.outputs.tier_routing == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker
@@ -339,8 +339,8 @@ jobs:
     if: needs.changes.outputs.writer_fencing == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '8.0.x'
       - name: Install the P checker

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
+      read_resolution: ${{ steps.filter.outputs.read_resolution }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,8 +34,13 @@ jobs:
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "gc_reset=false" >> "$GITHUB_OUTPUT"
+          echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
-          echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
+          if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
+            echo "gc_reset=true" >> "$GITHUB_OUTPUT"
+            echo "read_resolution=true" >> "$GITHUB_OUTPUT"
+          fi
 
   gc-reset:
     needs: changes
@@ -75,4 +81,45 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: guard-removed model fails with the expected dangling reference."
+          echo "::endgroup::"
+
+  read-resolution:
+    needs: changes
+    if: needs.changes.outputs.read_resolution == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/read-resolution
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/read-resolution
+          for tc in tcReadResolveGuarded tcReadResolveExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+      - name: Validation gate (the catch-all model must reproduce the silent skip)
+        run: |
+          cd p/read-resolution
+          echo "::group::tcReadResolveBuggy (expect the INV#4 silent remote skip)"
+          if p check -tc tcReadResolveBuggy -i 2000; then
+            echo "ERROR: tcReadResolveBuggy passed; the model no longer reproduces the silent remote skip."
+            echo "The catch-all model must fail, otherwise the guarded result is not trustworthy."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#4 violated: resolved' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the catch-all run failed, but not with the expected INV#4 silent-skip counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: catch-all model fails with the expected silent remote skip."
           echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -94,6 +94,7 @@ jobs:
       - name: Validation gate (the guard-removed model must reproduce GC x reset)
         run: |
           cd p/gc-reset
+          rm -rf PCheckerOutput/
           echo "::group::tcGcResetUnguarded (expect the GC x reset counterexample)"
           if p check -tc tcGcResetUnguarded -i 2000; then
             echo "ERROR: tcGcResetUnguarded passed; the model no longer reproduces GC x reset."
@@ -109,6 +110,7 @@ jobs:
       - name: Validation gate (the reset atomic-prefix ordering is load-bearing)
         run: |
           cd p/gc-reset
+          rm -rf PCheckerOutput/
           # The floor-last ordering deletes a live object even with the guard on.
           # It is a rare interleaving that the random strategy misses, so use PCT.
           echo "::group::tcGcResetFloorLast (expect the GC x reset counterexample under PCT)"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -75,6 +75,10 @@ jobs:
             p check -tc "$tc" -i 5000
             echo "::endgroup::"
           done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcGcResetExplore (PCT)"
+          p check -tc tcGcResetExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
       - name: Validation gate (the guard-removed model must reproduce GC x reset)
         run: |
           cd p/gc-reset
@@ -133,6 +137,9 @@ jobs:
             p check -tc "$tc" -i 5000
             echo "::endgroup::"
           done
+          echo "::group::tcReadResolveExplore (PCT)"
+          p check -tc tcReadResolveExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
       - name: Validation gate (the catch-all model must reproduce the silent skip)
         run: |
           cd p/read-resolution
@@ -174,6 +181,9 @@ jobs:
             p check -tc "$tc" -i 5000
             echo "::endgroup::"
           done
+          echo "::group::tcTrimExplore (PCT)"
+          p check -tc tcTrimExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
       - name: Validation gate (removing local_log_ahead must wedge the transfer)
         run: |
           cd p/trimmed-segment
@@ -215,6 +225,9 @@ jobs:
             p check -tc "$tc" -i 5000
             echo "::endgroup::"
           done
+          echo "::group::tcOrphanExplore (PCT)"
+          p check -tc tcOrphanExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
       - name: Validation gate (removing the GC re-sweep must leak an orphan)
         run: |
           cd p/orphan-leak

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -24,6 +24,7 @@ jobs:
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
       tier_routing: ${{ steps.filter.outputs.tier_routing }}
+      writer_fencing: ${{ steps.filter.outputs.writer_fencing }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -49,6 +50,8 @@ jobs:
           echo "$CHANGED" | grep -q '^p/orphan-leak/' && echo "orphan_leak=true" >> "$GITHUB_OUTPUT" || true
           echo "tier_routing=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/tier-routing/' && echo "tier_routing=true" >> "$GITHUB_OUTPUT" || true
+          echo "writer_fencing=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/writer-fencing/' && echo "writer_fencing=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
@@ -56,6 +59,7 @@ jobs:
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
             echo "tier_routing=true" >> "$GITHUB_OUTPUT"
+            echo "writer_fencing=true" >> "$GITHUB_OUTPUT"
           fi
 
   gc-reset:
@@ -328,4 +332,48 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: the guard-removed model routes a remote-only offset to the local tier."
+          echo "::endgroup::"
+
+  writer-fencing:
+    needs: changes
+    if: needs.changes.outputs.writer_fencing == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/writer-fencing
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/writer-fencing
+          for tc in tcFencingGuarded tcFencingExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          echo "::group::tcFencingExplore (PCT)"
+          p check -tc tcFencingExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (removing the epoch fence must allow split-brain)
+        run: |
+          cd p/writer-fencing
+          echo "::group::tcFencingUnguarded (expect the epoch regression)"
+          if p check -tc tcFencingUnguarded -i 2000; then
+            echo "ERROR: tcFencingUnguarded passed; the model no longer regresses the committed epoch."
+            echo "Removing the epoch fence must let a deposed writer overwrite a newer one."
+            exit 1
+          fi
+          if ! grep -rqF 'split-brain: committed epoch regressed' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the fence-removed run failed, but not with the expected split-brain regression."
+            exit 1
+          fi
+          echo "Gate satisfied: the fence-removed model regresses the committed epoch."
           echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -21,6 +21,7 @@ jobs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
+      orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -40,10 +41,13 @@ jobs:
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
+          echo "orphan_leak=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/orphan-leak/' && echo "orphan_leak=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
+            echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
           fi
 
   gc-reset:
@@ -167,4 +171,45 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: the check-removed model leaves the transfer permanently unresolved."
+          echo "::endgroup::"
+
+  orphan-leak:
+    needs: changes
+    if: needs.changes.outputs.orphan_leak == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/orphan-leak
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/orphan-leak
+          for tc in tcOrphanGuarded tcOrphanExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+      - name: Validation gate (removing the GC re-sweep must leak an orphan)
+        run: |
+          cd p/orphan-leak
+          echo "::group::tcOrphanBuggy (expect the liveness obligation to fail)"
+          if p check -tc tcOrphanBuggy -i 2000; then
+            echo "ERROR: tcOrphanBuggy passed; the model no longer leaks a transiently-failed delete."
+            echo "Removing the GC re-sweep must leave an orphan permanently outstanding."
+            exit 1
+          fi
+          if ! grep -rqF "hot state 'Dirty'" PCheckerOutput/BugFinding/; then
+            echo "ERROR: the buggy run failed, but not via the OrphanEventuallyReclaimed liveness obligation."
+            exit 1
+          fi
+          echo "Gate satisfied: the re-sweep-removed model leaks an orphan forever."
           echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
+      trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,9 +38,12 @@ jobs:
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
+          echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
+            echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
           fi
 
   gc-reset:
@@ -122,4 +126,45 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: catch-all model fails with the expected silent remote skip."
+          echo "::endgroup::"
+
+  trimmed-segment:
+    needs: changes
+    if: needs.changes.outputs.trimmed_segment == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/trimmed-segment
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/trimmed-segment
+          for tc in tcTrimGuarded tcTrimExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+      - name: Validation gate (removing local_log_ahead must wedge the transfer)
+        run: |
+          cd p/trimmed-segment
+          echo "::group::tcTrimBuggy (expect the liveness obligation to fail)"
+          if p check -tc tcTrimBuggy -i 2000; then
+            echo "ERROR: tcTrimBuggy passed; the model no longer wedges on a trimmed segment."
+            echo "Removing the local_log_ahead recovery must leave the transfer unresolved forever."
+            exit 1
+          fi
+          if ! grep -rqF "hot state 'AwaitingResolution'" PCheckerOutput/BugFinding/; then
+            echo "ERROR: the buggy run failed, but not via the TransferEventuallyResolves liveness obligation."
+            exit 1
+          fi
+          echo "Gate satisfied: the check-removed model leaves the transfer permanently unresolved."
           echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -23,6 +23,7 @@ jobs:
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
+      tier_routing: ${{ steps.filter.outputs.tier_routing }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,12 +47,15 @@ jobs:
           echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
           echo "orphan_leak=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/orphan-leak/' && echo "orphan_leak=true" >> "$GITHUB_OUTPUT" || true
+          echo "tier_routing=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/tier-routing/' && echo "tier_routing=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
+            echo "tier_routing=true" >> "$GITHUB_OUTPUT"
           fi
 
   gc-reset:
@@ -285,4 +289,43 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: the re-sweep-removed model leaks an orphan forever."
+          echo "::endgroup::"
+
+  tier-routing:
+    needs: changes
+    if: needs.changes.outputs.tier_routing == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/tier-routing
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/tier-routing
+          echo "::group::tcTierRoutingGuarded (expect hold)"
+          p check -tc tcTierRoutingGuarded -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (removing the first_chunk_id == -1 guard must misroute)
+        run: |
+          cd p/tier-routing
+          echo "::group::tcTierRoutingBuggy (expect the INV#4 silent remote skip)"
+          if p check -tc tcTierRoutingBuggy -i 2000; then
+            echo "ERROR: tcTierRoutingBuggy passed; the model no longer misroutes an empty-local read."
+            echo "Removing the first_chunk_id =/= -1 guard must route a remote-only offset locally."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#4 violated: an offset held only by the remote tier' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the guard-removed run failed, but not with the expected INV#4 misrouting counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: the guard-removed model routes a remote-only offset to the local tier."
           echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -1,0 +1,78 @@
+name: P Model Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'p/**'
+      - '.github/workflows/p-model-check.yaml'
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      gc_reset: ${{ steps.filter.outputs.gc_reset }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          echo "gc_reset=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
+
+  gc-reset:
+    needs: changes
+    if: needs.changes.outputs.gc_reset == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/gc-reset
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/gc-reset
+          for tc in tcGcResetGuarded tcGcResetExplore tcEpochAxisSafe; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+      - name: Validation gate (the guard-removed model must reproduce GC x reset)
+        run: |
+          cd p/gc-reset
+          echo "::group::tcGcResetUnguarded (expect the GC x reset counterexample)"
+          if p check -tc tcGcResetUnguarded -i 2000; then
+            echo "ERROR: tcGcResetUnguarded passed; the model no longer reproduces GC x reset."
+            echo "The guard-removed model must fail, otherwise the guarded result is not trustworthy."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object (offset=850, uid=2)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the unguarded run failed, but not with the expected INV#2 (850, uid 2) counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: guard-removed model fails with the expected dangling reference."
+          echo "::endgroup::"

--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -90,6 +90,23 @@ jobs:
           fi
           echo "Gate satisfied: guard-removed model fails with the expected dangling reference."
           echo "::endgroup::"
+      - name: Validation gate (the reset atomic-prefix ordering is load-bearing)
+        run: |
+          cd p/gc-reset
+          # The floor-last ordering deletes a live object even with the guard on.
+          # It is a rare interleaving that the random strategy misses, so use PCT.
+          echo "::group::tcGcResetFloorLast (expect the GC x reset counterexample under PCT)"
+          if p check -tc tcGcResetFloorLast --sch-pct 10 -i 5000; then
+            echo "ERROR: tcGcResetFloorLast passed; lowering the floor after the re-tier no longer"
+            echo "deletes a live object. The atomic-prefix ordering is supposed to be necessary."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object (offset=850, uid=2)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the floor-last run failed, but not with the expected INV#2 (850, uid 2) counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: floor-last ordering fails with the expected dangling reference."
+          echo "::endgroup::"
 
   read-resolution:
     needs: changes

--- a/.github/workflows/s3-integration.yaml
+++ b/.github/workflows/s3-integration.yaml
@@ -38,25 +38,25 @@ jobs:
             elixir-version: 1.18
     steps:
       - id: restore-rabbitmq-server-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/rabbitmq-server
           key: rmq-${{ matrix.rmq-version }}-otp-${{ matrix.otp-version }}-elixir-${{ matrix.elixir-version }}
       - id: maybe-fail-rabbitmq-server-miss
         if: steps.restore-rabbitmq-server-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('could not restore cached rabbitmq-server build');
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: rabbitmq-server/deps/rabbitmq_stream_s3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.2.0
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -69,7 +69,7 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: CommonTest logs
           if-no-files-found: ignore

--- a/.github/workflows/tla-model-check.yaml
+++ b/.github/workflows/tla-model-check.yaml
@@ -21,7 +21,7 @@ jobs:
       osiris: ${{ steps.filter.outputs.osiris }}
       manifest: ${{ steps.filter.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Detect changed paths
@@ -44,8 +44,8 @@ jobs:
     if: needs.changes.outputs.osiris == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: '21'
@@ -61,8 +61,8 @@ jobs:
     if: needs.changes.outputs.manifest == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: '21'

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,9 @@ tla/*/states/
 tla/*/*.dot
 tla/*/MC_TTrace_*
 
+# P model checker output
+p/*/PGenerated/
+p/*/PCheckerOutput/
+
 # CSE security scanner artifacts (auto-added by cse init)
 .security-scan/

--- a/p/README.md
+++ b/p/README.md
@@ -22,6 +22,14 @@ that the `still_dangling/1` guard in `rabbitmq_stream_s3_gc` prevents the sweep
 from deleting a live fragment that a concurrent reset re-tiered below the sweep's
 snapshot floor. See [`gc-reset/README.md`](gc-reset/README.md).
 
+### `read-resolution/`
+
+The read / tier-resolution seam: resolving the `first` offset spec when the
+leading manifest group fetch fails transiently. Verifies that
+`log_reader:resolve_first_lookup/1` surfaces a `group_fetch_failed` as a retry
+rather than silently falling back to the local tier (the pre-`e3f931b` catch-all
+bug). See [`read-resolution/README.md`](read-resolution/README.md).
+
 ## Running
 
 Requires the `p` CLI (provided by the repository Nix dev shell). From a model

--- a/p/README.md
+++ b/p/README.md
@@ -24,6 +24,11 @@ The models target five global invariants of the tiered-storage design:
 | INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
 | INV#4 | tier resolution total / gap-free | `read-resolution/`, `tier-routing/` |
 | INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
+| (foundation) | epoch monotonicity / split-brain safety | `writer-fencing/` |
+
+The last row is the mechanism the others assume: `writer-fencing/` proves the
+committed epoch is monotonic, which is what gc-reset's epoch axis and the
+durability guards rely on.
 
 ## Models
 
@@ -66,6 +71,14 @@ trimmed by retention before the upload reads it. Verifies that
 `local_log_ahead` branch) rather than resubmitting forever. This is a *liveness*
 property, checked with a `hot`-state monitor. See
 [`trimmed-segment/README.md`](trimmed-segment/README.md).
+
+### `writer-fencing/`
+
+The manifest-commit fencing seam (`db.erl` optimistic-lock CAS): a commit
+succeeds only if the revision matches and the new epoch is `>=` the stored epoch.
+Verifies that removing the epoch fence lets a deposed lower-epoch writer overwrite
+a newer one (split-brain / epoch regression). This proves the epoch monotonicity
+the other models assume. See [`writer-fencing/README.md`](writer-fencing/README.md).
 
 ### `orphan-leak/`
 

--- a/p/README.md
+++ b/p/README.md
@@ -1,0 +1,41 @@
+# P Models
+
+This directory contains [P](https://p-org.github.io/P/) formal models of the
+plugin's concurrent protocols. P is an actor-model verification language: each
+component is a state machine communicating by asynchronous events, and the
+checker explores the interleavings of event delivery. This maps cleanly onto the
+plugin's `gen_server` / message-passing architecture, which is why P complements
+the [`tla/`](../tla) models (those cover replication; the P models target the
+decide-then-act races between independently-scheduled components).
+
+Models are built one seam at a time. A model is only trusted once it reproduces a
+known bug when its guard is removed (the *validation gate*), so each model ships
+both a guarded test that must hold and an unguarded test that must fail with a
+specific counterexample.
+
+## Models
+
+### `gc-reset/`
+
+The durability seam: orphan GC versus a remote-tier-ahead manifest reset. Verifies
+that the `still_dangling/1` guard in `rabbitmq_stream_s3_gc` prevents the sweep
+from deleting a live fragment that a concurrent reset re-tiered below the sweep's
+snapshot floor. See [`gc-reset/README.md`](gc-reset/README.md).
+
+## Running
+
+Requires the `p` CLI (provided by the repository Nix dev shell). From a model
+directory:
+
+```bash
+cd gc-reset/
+p compile
+p check -tc <testCase> -i 2000
+```
+
+`p compile` generates C# and builds it; `p check` runs the explicit-state
+checker. `-i N` sets the number of schedules to explore; `-tc` selects a test
+case. Counterexample traces are written under `PCheckerOutput/BugFinding/`.
+
+Generated code (`PGenerated/`) and checker output (`PCheckerOutput/`) are build
+artifacts and are gitignored.

--- a/p/README.md
+++ b/p/README.md
@@ -20,7 +20,7 @@ The models target five global invariants of the tiered-storage design:
 | Invariant | Property | Model |
 | --- | --- | --- |
 | INV#1 | no lost acked data | `gc-reset/` |
-| INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/` |
+| INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/`, `gc-leading-group/` |
 | INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
 | INV#4 | tier resolution total / gap-free | `read-resolution/` |
 | INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
@@ -33,6 +33,14 @@ The durability seam: orphan GC versus a remote-tier-ahead manifest reset. Verifi
 that the `still_dangling/1` guard in `rabbitmq_stream_s3_gc` prevents the sweep
 from deleting a live fragment that a concurrent reset re-tiered below the sweep's
 snapshot floor. See [`gc-reset/README.md`](gc-reset/README.md).
+
+### `gc-leading-group/`
+
+A second, independent live-deletion guard in the GC seam: `classify_group`
+protects the one leading group that straddles `first_offset` (retention advanced
+the floor into it on partial expiry) while deleting other groups below the floor.
+Verifies that removing the `referenced_group_key` carve-out deletes a live group.
+See [`gc-leading-group/README.md`](gc-leading-group/README.md).
 
 ### `read-resolution/`
 

--- a/p/README.md
+++ b/p/README.md
@@ -22,7 +22,7 @@ The models target five global invariants of the tiered-storage design:
 | INV#1 | no lost acked data | `gc-reset/` |
 | INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/`, `gc-leading-group/` |
 | INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
-| INV#4 | tier resolution total / gap-free | `read-resolution/` |
+| INV#4 | tier resolution total / gap-free | `read-resolution/`, `tier-routing/` |
 | INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
 
 ## Models
@@ -49,6 +49,14 @@ leading manifest group fetch fails transiently. Verifies that
 `log_reader:resolve_first_lookup/1` surfaces a `group_fetch_failed` as a retry
 rather than silently falling back to the local tier (the pre-`e3f931b` catch-all
 bug). See [`read-resolution/README.md`](read-resolution/README.md).
+
+### `tier-routing/`
+
+The offset -> tier routing branch of `resolve_remote_location`: when the local
+log is empty (`first_chunk_id == -1`), every offset must fall through to the
+remote tier. Verifies that dropping the `=/= -1` guard routes a remote-only
+offset to the local tail (a silent remote skip). A second INV#4 guard, distinct
+from the group-fetch catch-all. See [`tier-routing/README.md`](tier-routing/README.md).
 
 ### `trimmed-segment/`
 

--- a/p/README.md
+++ b/p/README.md
@@ -13,6 +13,18 @@ known bug when its guard is removed (the *validation gate*), so each model ships
 both a guarded test that must hold and an unguarded test that must fail with a
 specific counterexample.
 
+## Invariant coverage
+
+The models target five global invariants of the tiered-storage design:
+
+| Invariant | Property | Model |
+| --- | --- | --- |
+| INV#1 | no lost acked data | `gc-reset/` |
+| INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/` |
+| INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
+| INV#4 | tier resolution total / gap-free | `read-resolution/` |
+| INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
+
 ## Models
 
 ### `gc-reset/`
@@ -38,6 +50,14 @@ trimmed by retention before the upload reads it. Verifies that
 `local_log_ahead` branch) rather than resubmitting forever. This is a *liveness*
 property, checked with a `hot`-state monitor. See
 [`trimmed-segment/README.md`](trimmed-segment/README.md).
+
+### `orphan-leak/`
+
+The GC reclamation seam: the reaper tolerates partial-batch DeleteObjects
+failures by leaving unconfirmed objects for orphan GC. Verifies that GC's
+re-sweep eventually reclaims a transiently-failed delete rather than leaking it
+forever. A *liveness* property (`hot`-state monitor). See
+[`orphan-leak/README.md`](orphan-leak/README.md).
 
 ## Running
 

--- a/p/README.md
+++ b/p/README.md
@@ -30,6 +30,15 @@ leading manifest group fetch fails transiently. Verifies that
 rather than silently falling back to the local tier (the pre-`e3f931b` catch-all
 bug). See [`read-resolution/README.md`](read-resolution/README.md).
 
+### `trimmed-segment/`
+
+The upload-pipeline seam (issue #225): a head fragment whose local segment is
+trimmed by retention before the upload reads it. Verifies that
+`handle_transfer_failure` recovers via `restart_at_local_floor` (the
+`local_log_ahead` branch) rather than resubmitting forever. This is a *liveness*
+property, checked with a `hot`-state monitor. See
+[`trimmed-segment/README.md`](trimmed-segment/README.md).
+
 ## Running
 
 Requires the `p` CLI (provided by the repository Nix dev shell). From a model

--- a/p/README.md
+++ b/p/README.md
@@ -74,5 +74,10 @@ p check -tc <testCase> -i 2000
 checker. `-i N` sets the number of schedules to explore; `-tc` selects a test
 case. Counterexample traces are written under `PCheckerOutput/BugFinding/`.
 
+The default random strategy can miss rare interleavings (the gc-reset
+atomic-prefix bug eludes it even at 50k schedules). Add `--sch-pct N` to use the
+PCT strategy, which is designed to surface low-probability concurrency bugs; CI
+runs the exploration tests under both strategies.
+
 Generated code (`PGenerated/`) and checker output (`PCheckerOutput/`) are build
 artifacts and are gitignored.

--- a/p/gc-leading-group/GcLeadingGroup.pproj
+++ b/p/gc-leading-group/GcLeadingGroup.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>GcLeadingGroup</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/gc-leading-group/PSpec/Monitors.p
+++ b/p/gc-leading-group/PSpec/Monitors.p
@@ -1,0 +1,17 @@
+/* INV#2 (no dangling reference): GC must never delete a referenced object. Here
+   the protected object is the leading group, which is referenced by the manifest
+   even though its offset is below the live floor. */
+spec NoDanglingReference observes eObjectReferenced, eGcDelete {
+  var live: set[ObjKey];
+
+  start state Watching {
+    on eObjectReferenced do (k: ObjKey) {
+      live += (k);
+    }
+    on eGcDelete do (k: ObjKey) {
+      assert !(k in live),
+        format("INV#2 violated: GC deleted referenced object (offset={0}, uid={1})",
+          k.offset, k.uid);
+    }
+  }
+}

--- a/p/gc-leading-group/PSrc/Common.p
+++ b/p/gc-leading-group/PSrc/Common.p
@@ -1,0 +1,38 @@
+/* Shared types and events for the GC leading-group carve-out.
+
+   classify_group (rabbitmq_stream_s3_gc) deletes a group object below
+   first_offset as an orphan, EXCEPT the one leading group that still straddles
+   the floor: retention advances first_offset INTO the leading group on partial
+   expiry, so that group remains referenced even though its offset is below the
+   floor. referenced_group_key carves it out of offset-based deletion. Removing
+   the carve-out deletes a live group (a dangling reference). */
+
+enum Kind { FRAGMENT, GROUP }
+type ObjKey = (offset: int, uid: int);
+type Obj = (offset: int, uid: int, kind: Kind);
+
+/* Manifest replica: live floor, referenced entries, and the leading group key. */
+event eMRGetFloor: (from: machine);
+event eMRFloorResult: int;
+event eMRGetLeadingGroup: (from: machine);
+event eMRLeadingGroupResult: (has: bool, key: ObjKey);
+event eMRAddEntry: (from: machine, key: ObjKey);
+event eMRSetLeadingGroup: (from: machine, key: ObjKey);
+event eMRAck;
+
+/* S3 object store. */
+event eS3Put: (from: machine, obj: Obj);
+event eS3List: (from: machine);
+event eS3ListResult: seq[Obj];
+event eS3Delete: (from: machine, key: ObjKey);
+event eS3Has: (from: machine, key: ObjKey);
+event eS3HasResult: bool;
+event eS3Ack;
+
+/* GC sweep. */
+event eGcSweep;
+event eGcSweepDone;
+
+/* Spec events (announce). */
+event eObjectReferenced: ObjKey;
+event eGcDelete: ObjKey;

--- a/p/gc-leading-group/PSrc/GC.p
+++ b/p/gc-leading-group/PSrc/GC.p
@@ -1,0 +1,58 @@
+/* The orphan GC sweep, modeling classify/classify_group. It snapshots the floor
+   and the leading group key (build_lookup), lists S3, and deletes objects below
+   the floor. A group below the floor is deletable UNLESS it is the referenced
+   leading group; guardLeadingGroup toggles that carve-out. */
+machine GC {
+  var guardLeadingGroup: bool;
+  var manifest: machine;
+  var s3: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (guardLeadingGroup: bool, manifest: machine, s3: machine, driver: machine)) {
+      guardLeadingGroup = init.guardLeadingGroup;
+      manifest = init.manifest;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+    on eGcSweep do {
+      var floor: int;
+      var lg: (has: bool, key: ObjKey);
+      var objs: seq[Obj];
+      var i: int;
+      var o: Obj;
+      var del: bool;
+      send manifest, eMRGetFloor, (from = this,);
+      receive { case eMRFloorResult: (f: int) { floor = f; } }
+      send manifest, eMRGetLeadingGroup, (from = this,);
+      receive { case eMRLeadingGroupResult: (r: (has: bool, key: ObjKey)) { lg = r; } }
+      send s3, eS3List, (from = this,);
+      receive { case eS3ListResult: (l: seq[Obj]) { objs = l; } }
+      i = 0;
+      while (i < sizeof(objs)) {
+        o = objs[i];
+        del = false;
+        if (o.offset < floor) {
+          if (o.kind == GROUP) {
+            /* classify_group: the leading group below the floor is still
+               referenced and must be protected. */
+            if (guardLeadingGroup && lg.has && o.offset == lg.key.offset && o.uid == lg.key.uid) {
+              del = false;
+            } else {
+              del = true;
+            }
+          } else {
+            del = true;
+          }
+        }
+        if (del) {
+          send s3, eS3Delete, (from = this, key = (offset = o.offset, uid = o.uid));
+          receive { case eS3Ack: { } }
+          announce eGcDelete, (offset = o.offset, uid = o.uid);
+        }
+        i = i + 1;
+      }
+      send driver, eGcSweepDone;
+    }
+  }
+}

--- a/p/gc-leading-group/PSrc/ManifestReplica.p
+++ b/p/gc-leading-group/PSrc/ManifestReplica.p
@@ -1,0 +1,31 @@
+/* The manifest replica: owns the live floor, the set of referenced (offset, uid)
+   entries, and the leading group key (leading_group_info/2's referenced_group_key).
+   The leading group is referenced even though it sits below the floor. */
+machine ManifestReplica {
+  var floor: int;
+  var entries: set[ObjKey];
+  var hasLeadingGroup: bool;
+  var leadingGroup: ObjKey;
+
+  start state Serving {
+    entry (init: (floor: int)) {
+      floor = init.floor;
+    }
+    on eMRAddEntry do (p: (from: machine, key: ObjKey)) {
+      entries += (p.key);
+      announce eObjectReferenced, p.key;
+      send p.from, eMRAck;
+    }
+    on eMRSetLeadingGroup do (p: (from: machine, key: ObjKey)) {
+      hasLeadingGroup = true;
+      leadingGroup = p.key;
+      send p.from, eMRAck;
+    }
+    on eMRGetFloor do (p: (from: machine)) {
+      send p.from, eMRFloorResult, floor;
+    }
+    on eMRGetLeadingGroup do (p: (from: machine)) {
+      send p.from, eMRLeadingGroupResult, (has = hasLeadingGroup, key = leadingGroup);
+    }
+  }
+}

--- a/p/gc-leading-group/PSrc/S3Store.p
+++ b/p/gc-leading-group/PSrc/S3Store.p
@@ -1,0 +1,29 @@
+/* The S3 object store, holding fragments and groups keyed by (offset, uid). */
+machine S3Store {
+  var objects: map[ObjKey, Obj];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, obj: Obj)) {
+      var k: ObjKey;
+      k = (offset = p.obj.offset, uid = p.obj.uid);
+      if (k in objects) {
+        objects[k] = p.obj;
+      } else {
+        objects += (k, p.obj);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3List do (p: (from: machine)) {
+      send p.from, eS3ListResult, values(objects);
+    }
+    on eS3Delete do (p: (from: machine, key: ObjKey)) {
+      if (p.key in objects) {
+        objects -= (p.key);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Has do (p: (from: machine, key: ObjKey)) {
+      send p.from, eS3HasResult, (p.key in objects);
+    }
+  }
+}

--- a/p/gc-leading-group/PTst/TestDrivers.p
+++ b/p/gc-leading-group/PTst/TestDrivers.p
@@ -1,0 +1,90 @@
+/* Test drivers and declarations for the GC leading-group carve-out.
+
+   Fixture (floor = 100):
+     - (50, uid 1) GROUP    : a genuinely expired orphan group, deletable
+     - (60, uid 0) FRAGMENT : an orphan fragment, deletable
+     - (80, uid 2) GROUP    : the leading group, straddling the floor, REFERENCED
+     - (100, uid 10) FRAGMENT: a live fragment at the floor, referenced
+
+   The gate contrasts tcLeadingGroupGuarded (the carve-out protects the leading
+   group, must hold) with tcLeadingGroupUnguarded (carve-out removed: the leading
+   group is deleted, must fail with the INV#2 dangling reference on (80, uid 2)). */
+
+fun PutObj(self: machine, s3: machine, o: Obj) {
+  send s3, eS3Put, (from = self, obj = o);
+  receive { case eS3Ack: { } }
+}
+
+fun AddEntry(self: machine, mr: machine, k: ObjKey) {
+  send mr, eMRAddEntry, (from = self, key = k);
+  receive { case eMRAck: { } }
+}
+
+fun SetLeadingGroup(self: machine, mr: machine, k: ObjKey) {
+  send mr, eMRSetLeadingGroup, (from = self, key = k);
+  receive { case eMRAck: { } }
+}
+
+fun S3Has(self: machine, s3: machine, k: ObjKey): bool {
+  var present: bool;
+  send s3, eS3Has, (from = self, key = k);
+  receive { case eS3HasResult: (b: bool) { present = b; } }
+  return present;
+}
+
+fun RunLeadingGroup(self: machine, guard: bool) {
+  var mr: machine;
+  var s3: machine;
+  var gc: machine;
+
+  mr = new ManifestReplica((floor = 100,));
+  s3 = new S3Store();
+  gc = new GC((guardLeadingGroup = guard, manifest = mr, s3 = s3, driver = self));
+
+  PutObj(self, s3, (offset = 50, uid = 1, kind = GROUP));
+  PutObj(self, s3, (offset = 60, uid = 0, kind = FRAGMENT));
+  PutObj(self, s3, (offset = 80, uid = 2, kind = GROUP));
+  PutObj(self, s3, (offset = 100, uid = 10, kind = FRAGMENT));
+
+  /* The leading group and the live fragment are referenced; the leading group
+     is also recorded as the protected leading group key. */
+  AddEntry(self, mr, (offset = 80, uid = 2));
+  AddEntry(self, mr, (offset = 100, uid = 10));
+  SetLeadingGroup(self, mr, (offset = 80, uid = 2));
+
+  send gc, eGcSweep;
+  receive { case eGcSweepDone: { } }
+
+  /* Anti-vacuity for the guarded run: the genuine orphans are reclaimed and the
+     leading group is preserved, so a carve-out that skips everything would not
+     pass. */
+  if (guard) {
+    assert !S3Has(self, s3, (offset = 50, uid = 1)),
+      "orphan group (50, 1) was not reclaimed";
+    assert !S3Has(self, s3, (offset = 60, uid = 0)),
+      "orphan fragment (60, 0) was not reclaimed";
+    assert S3Has(self, s3, (offset = 80, uid = 2)),
+      "leading group (80, 2) was wrongly deleted";
+  }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunLeadingGroup(this, true); }
+  }
+}
+
+machine DriverUnguarded {
+  start state Init {
+    entry { RunLeadingGroup(this, false); }
+  }
+}
+
+/* Current code: the carve-out protects the leading group. Must hold. */
+test tcLeadingGroupGuarded [main = DriverGuarded]:
+  assert NoDanglingReference in { DriverGuarded, ManifestReplica, S3Store, GC };
+
+/* Carve-out removed: the leading group below the floor is deleted. MUST fail
+   with the INV#2 dangling reference on (80, uid 2). This failing run is the gate. */
+test tcLeadingGroupUnguarded [main = DriverUnguarded]:
+  assert NoDanglingReference in { DriverUnguarded, ManifestReplica, S3Store, GC };

--- a/p/gc-leading-group/README.md
+++ b/p/gc-leading-group/README.md
@@ -1,0 +1,51 @@
+# GC leading-group carve-out
+
+Models the second, independent live-deletion guard in `rabbitmq_stream_s3_gc`:
+`classify_group` and the `referenced_group_key` carve-out.
+
+## The bug class
+
+A group object below `first_offset` is normally a dead orphan and is deleted by
+the offset heuristic. There is one exception: the *leading* group. On partial
+expiry retention advances `first_offset` *into* the leading group, so that group
+still sits below the floor yet remains referenced (its surviving fragments are at
+or above the floor). `leading_group_info/2` records that group's key as
+`referenced_group_key`, and `classify_group` skips it.
+
+Removing the carve-out (treating every group below the floor as a deletable
+orphan) deletes a live group - a dangling reference: a consumer reading the
+surviving offsets in that group can no longer fetch it.
+
+This is a *distinct* guard from `still_dangling/1` (the gc-reset model): that one
+re-validates an offset-based finding against the live floor after a reset; this
+one excludes the referenced leading group from offset-based classification in the
+first place. The flat-offset gc-reset model does not exercise it, so it lives
+here.
+
+## What the model captures
+
+- Objects carry a `Kind` (`FRAGMENT` or `GROUP`); S3 holds genuine orphans below
+  the floor, the referenced leading group (also below the floor), and a live
+  fragment at the floor
+- The manifest records the referenced leading group key
+- `guardLeadingGroup` toggles the `classify_group` carve-out
+- `NoDanglingReference` (INV#2): GC never deletes a referenced object
+
+This is a classification-correctness property, not a concurrency race, so there
+is no exploration test.
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcLeadingGroupGuarded` | **holds** - the carve-out protects the leading group; also asserts the genuine orphans are reclaimed and the leading group preserved (anti-vacuity) |
+| `tcLeadingGroupUnguarded` | **fails** - carve-out removed; `INV#2 violated: GC deleted referenced object (offset=80, uid=2)` |
+
+`tcLeadingGroupUnguarded` is *expected to fail*; that counterexample is the proof
+the model reproduces the live-group deletion.
+
+```bash
+p compile
+p check -tc tcLeadingGroupGuarded   -i 5000   # 0 bugs
+p check -tc tcLeadingGroupUnguarded -i 2000   # 1 bug: INV#2 on the leading group (80, uid 2)
+```

--- a/p/gc-reset/GcReset.pproj
+++ b/p/gc-reset/GcReset.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>GcReset</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/gc-reset/PSpec/Monitors.p
+++ b/p/gc-reset/PSpec/Monitors.p
@@ -1,0 +1,90 @@
+/* Global safety monitors (the spec yardstick) for the durability seam.
+
+   They observe announced events only and never participate in the protocol. The
+   headline is NoDanglingReference (INV#2): it must key protection on
+   (offset, uid), not offset alone, so it can tell a legal stale-UID delete from
+   the illegal fresh-UID delete at the same offset. */
+
+/* INV#2: GC must never delete an object that the live manifest references. */
+spec NoDanglingReference observes eObjectReferenced, eObjectUnreferenced, eGcDelete {
+  var live: set[ObjKey];
+
+  start state Watching {
+    on eObjectReferenced do (k: ObjKey) {
+      live += (k);
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k in live) {
+        live -= (k);
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      assert !(k in live),
+        format("INV#2 violated: GC deleted live object (offset={0}, uid={1}) still referenced by the manifest",
+          k.offset, k.uid);
+    }
+  }
+}
+
+/* INV#1: no lost acked data. An offset in the durable live range [floor, next)
+   must keep its covering object. Deleting the object that currently covers an
+   in-range offset destroys acked data. Keyed by (offset, uid) so a stale-UID
+   delete is not mistaken for losing the live cover. */
+spec NoLostAckedData observes eObjectReferenced, eObjectUnreferenced, eFloorChanged, eGcDelete {
+  var floor: int;
+  var liveByOffset: map[int, int];
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      floor = p.newFloor;
+    }
+    on eObjectReferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        liveByOffset[k.offset] = k.uid;
+      } else {
+        liveByOffset += (k.offset, k.uid);
+      }
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        if (liveByOffset[k.offset] == k.uid) {
+          liveByOffset -= (k.offset);
+        }
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      if (k.offset >= floor) {
+        if (k.offset in liveByOffset) {
+          if (liveByOffset[k.offset] == k.uid) {
+            assert false,
+              format("INV#1 violated: GC deleted the live cover of acked offset {0} (uid={1}) at or above the live floor {2}",
+                k.offset, k.uid, floor);
+          }
+        }
+      }
+    }
+  }
+}
+
+/* INV#5: the first_offset frontier is monotonically non-decreasing except across
+   an explicitly labeled reset. */
+spec MonotonicFrontier observes eFloorChanged {
+  var floor: int;
+  var started: bool;
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      if (!started) {
+        floor = p.newFloor;
+        started = true;
+      } else {
+        if (!p.isReset) {
+          assert p.newFloor >= floor,
+            format("INV#5 violated: first_offset moved backward from {0} to {1} without a labeled reset",
+              floor, p.newFloor);
+        }
+        floor = p.newFloor;
+      }
+    }
+  }
+}

--- a/p/gc-reset/PSrc/Common.p
+++ b/p/gc-reset/PSrc/Common.p
@@ -1,0 +1,59 @@
+/* Shared types, enums, and events for the GC x reset durability-seam model.
+
+   Models the decide-then-act window in rabbitmq_stream_s3_gc: a sweep captures
+   a snapshot first_offset, a concurrent remote-tier-ahead reset lowers the live
+   first_offset and re-tiers a live fragment (with a fresh UID) below the
+   snapshot floor, and the sweep then deletes against the stale snapshot. The
+   still_dangling/1 guard re-reads the live floor before each delete. */
+
+/* An S3 object is identified by (offset, uid): the on-disk key is
+   <offset>.<uid>.fragment, so two objects can share an offset (a stale UID and
+   a freshly re-tiered one). */
+type ObjKey = (offset: int, uid: int);
+type Obj = (offset: int, uid: int, epoch: int);
+
+/* Why GC flagged an object. below_first_offset is re-validated by still_dangling
+   against the live floor; stale_epoch is not, because epoch is monotonic. */
+enum Reason { BELOW_FLOOR, STALE_EPOCH }
+type Candidate = (offset: int, uid: int, epoch: int, reason: Reason);
+
+/* Khepri (durable consensus over the committed epoch). */
+event eGetConsistent: (from: machine);
+event eEpochResult: (ok: bool, epoch: int);
+
+/* Manifest replica: the serialized owner of the live first_offset and the set
+   of live (offset, uid) entries. */
+event eMRSetFloor: (from: machine, floor: int, isReset: bool);
+event eMRAddEntry: (from: machine, key: ObjKey);
+event eMRRemoveEntry: (from: machine, key: ObjKey);
+event eMRGetFloor: (from: machine);
+event eMRFloorResult: int;
+event eMRAck;
+
+/* S3 object store. */
+event eS3Put: (from: machine, obj: Obj);
+event eS3Delete: (from: machine, key: ObjKey);
+event eS3List: (from: machine);
+event eS3ListResult: seq[Obj];
+event eS3Has: (from: machine, key: ObjKey);
+event eS3HasResult: bool;
+event eS3Ack;
+
+/* Writer: orchestrates the remote-tier-ahead reset. */
+event eDoReset: (localFloor: int, newUid: int);
+event eResetDone;
+
+/* GC sweep steps, driven explicitly so a test driver can force an exact
+   interleaving for the validation gate, or race them for exploration. */
+event eGcSnapshot;
+event eGcSnapshotDone;
+event eGcListClassify;
+event eGcClassifyDone;
+event eGcExecute;
+event eGcExecuteDone;
+
+/* Spec events, delivered to monitors via announce. */
+event eObjectReferenced: ObjKey;
+event eObjectUnreferenced: ObjKey;
+event eFloorChanged: (newFloor: int, isReset: bool);
+event eGcDelete: ObjKey;

--- a/p/gc-reset/PSrc/GC.p
+++ b/p/gc-reset/PSrc/GC.p
@@ -1,0 +1,95 @@
+/* The orphan GC sweep (rabbitmq_stream_s3_gc), split into the three steps that
+   matter for the decide-then-act window:
+
+     1. eGcSnapshot     - build_lookup: capture the committed epoch and the
+                          snapshot first_offset (once).
+     2. eGcListClassify - LIST S3 and classify each object against the SNAPSHOT
+                          floor/epoch. The LIST runs after the snapshot, so a
+                          post-snapshot re-tier can appear here.
+     3. eGcExecute      - for each candidate, apply still_dangling/1 and delete.
+
+   guardEnabled toggles still_dangling/1: with it on, a below_first_offset
+   finding is re-validated against the LIVE floor immediately before deletion;
+   with it off, the sweep deletes against the stale snapshot (the bug). */
+machine GC {
+  var guardEnabled: bool;
+  var db: machine;
+  var manifest: machine;
+  var s3: machine;
+  var driver: machine;
+  var snapshotFloor: int;
+  var snapshotEpoch: int;
+  var candidates: seq[Candidate];
+
+  start state Idle {
+    entry (init: (guardEnabled: bool, db: machine, manifest: machine, s3: machine, driver: machine)) {
+      guardEnabled = init.guardEnabled;
+      db = init.db;
+      manifest = init.manifest;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+
+    on eGcSnapshot do {
+      send db, eGetConsistent, (from = this,);
+      receive { case eEpochResult: (r: (ok: bool, epoch: int)) { snapshotEpoch = r.epoch; } }
+      send manifest, eMRGetFloor, (from = this,);
+      receive { case eMRFloorResult: (f: int) { snapshotFloor = f; } }
+      send driver, eGcSnapshotDone;
+    }
+
+    on eGcListClassify do {
+      var objs: seq[Obj];
+      var i: int;
+      var o: Obj;
+      send s3, eS3List, (from = this,);
+      receive { case eS3ListResult: (lst: seq[Obj]) { objs = lst; } }
+      candidates = default(seq[Candidate]);
+      i = 0;
+      while (i < sizeof(objs)) {
+        o = objs[i];
+        /* below_first_offset takes priority, matching classify/2: an object
+           below the snapshot floor is a candidate regardless of epoch. */
+        if (o.offset < snapshotFloor) {
+          candidates += (sizeof(candidates),
+            (offset = o.offset, uid = o.uid, epoch = o.epoch, reason = BELOW_FLOOR));
+        } else if (o.epoch < snapshotEpoch) {
+          candidates += (sizeof(candidates),
+            (offset = o.offset, uid = o.uid, epoch = o.epoch, reason = STALE_EPOCH));
+        }
+        i = i + 1;
+      }
+      send driver, eGcClassifyDone;
+    }
+
+    on eGcExecute do {
+      var i: int;
+      var c: Candidate;
+      var del: bool;
+      var liveFloor: int;
+      i = 0;
+      while (i < sizeof(candidates)) {
+        c = candidates[i];
+        del = true;
+        /* still_dangling/1: re-validate below_first_offset findings against the
+           LIVE floor; epoch-based findings need no re-check (epoch is
+           monotonic). When the guard is disabled, the stale snapshot decision
+           stands. */
+        if (c.reason == BELOW_FLOOR && guardEnabled) {
+          send manifest, eMRGetFloor, (from = this,);
+          receive { case eMRFloorResult: (f: int) { liveFloor = f; } }
+          if (!(c.offset < liveFloor)) {
+            del = false;
+          }
+        }
+        if (del) {
+          send s3, eS3Delete, (from = this, key = (offset = c.offset, uid = c.uid));
+          receive { case eS3Ack: { } }
+          announce eGcDelete, (offset = c.offset, uid = c.uid);
+        }
+        i = i + 1;
+      }
+      send driver, eGcExecuteDone;
+    }
+  }
+}

--- a/p/gc-reset/PSrc/KhepriDB.p
+++ b/p/gc-reset/PSrc/KhepriDB.p
@@ -1,0 +1,16 @@
+/* Durable consensus layer (rabbitmq_stream_s3_db). Holds the committed epoch and
+   answers strongly-consistent reads. Modeled as a single serialized actor; a
+   real partition would surface as ok = false (no quorum), which a sweep treats
+   as fail-closed. The committed epoch is monotonic. */
+machine KhepriDB {
+  var committedEpoch: int;
+
+  start state Serving {
+    entry (init: (epoch: int)) {
+      committedEpoch = init.epoch;
+    }
+    on eGetConsistent do (p: (from: machine)) {
+      send p.from, eEpochResult, (ok = true, epoch = committedEpoch);
+    }
+  }
+}

--- a/p/gc-reset/PSrc/ManifestReplica.p
+++ b/p/gc-reset/PSrc/ManifestReplica.p
@@ -1,0 +1,38 @@
+/* The per-node manifest replica (rabbitmq_stream_s3_manifest_replica): the
+   serialized owner of the live first_offset and the set of live (offset, uid)
+   entries. It is the single source GC's still_dangling/1 re-reads. Every state
+   change is announced so the monitors track the live manifest. */
+machine ManifestReplica {
+  var floor: int;
+  var nextOffset: int;
+  var entries: set[ObjKey];
+
+  start state Serving {
+    entry (init: (floor: int, nextOffset: int)) {
+      floor = init.floor;
+      nextOffset = init.nextOffset;
+      /* Establish the initial floor for the frontier monitor. */
+      announce eFloorChanged, (newFloor = floor, isReset = false);
+    }
+    on eMRSetFloor do (p: (from: machine, floor: int, isReset: bool)) {
+      floor = p.floor;
+      announce eFloorChanged, (newFloor = p.floor, isReset = p.isReset);
+      send p.from, eMRAck;
+    }
+    on eMRAddEntry do (p: (from: machine, key: ObjKey)) {
+      entries += (p.key);
+      announce eObjectReferenced, p.key;
+      send p.from, eMRAck;
+    }
+    on eMRRemoveEntry do (p: (from: machine, key: ObjKey)) {
+      if (p.key in entries) {
+        entries -= (p.key);
+      }
+      announce eObjectUnreferenced, p.key;
+      send p.from, eMRAck;
+    }
+    on eMRGetFloor do (p: (from: machine)) {
+      send p.from, eMRFloorResult, floor;
+    }
+  }
+}

--- a/p/gc-reset/PSrc/S3Store.p
+++ b/p/gc-reset/PSrc/S3Store.p
@@ -1,0 +1,42 @@
+/* The S3 object store. Objects are keyed by (offset, uid); the stored value is
+   the object's epoch. LIST returns whatever is present at the moment of the call
+   (this is what lets a post-snapshot re-tier become visible to a sweep). */
+machine S3Store {
+  var objects: map[ObjKey, int];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, obj: Obj)) {
+      var k: ObjKey;
+      k = (offset = p.obj.offset, uid = p.obj.uid);
+      if (k in objects) {
+        objects[k] = p.obj.epoch;
+      } else {
+        objects += (k, p.obj.epoch);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Delete do (p: (from: machine, key: ObjKey)) {
+      if (p.key in objects) {
+        objects -= (p.key);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Has do (p: (from: machine, key: ObjKey)) {
+      send p.from, eS3HasResult, (p.key in objects);
+    }
+    on eS3List do (p: (from: machine)) {
+      var out: seq[Obj];
+      var ks: seq[ObjKey];
+      var i: int;
+      var k: ObjKey;
+      ks = keys(objects);
+      i = 0;
+      while (i < sizeof(ks)) {
+        k = ks[i];
+        out += (sizeof(out), (offset = k.offset, uid = k.uid, epoch = objects[k]));
+        i = i + 1;
+      }
+      send p.from, eS3ListResult, out;
+    }
+  }
+}

--- a/p/gc-reset/PSrc/Writer.p
+++ b/p/gc-reset/PSrc/Writer.p
@@ -1,0 +1,34 @@
+/* The writer / reset orchestrator (rabbitmq_stream_s3_replica_reader). The only
+   modeled behaviour is the remote-tier-ahead reset (restart_at_local_floor):
+   lower the durable first_offset, then re-tier the live fragment at that offset
+   with a fresh UID.
+
+   Ordering is load-bearing: the floor is lowered and the new entry committed
+   (each acknowledged) BEFORE the re-tiered object is put into S3. This is the
+   atomic-prefix that prevents the illegal "object present in S3 while the floor
+   is still high" state. The guard relies on the live floor being lowered before
+   the object it protects can be observed by a sweep. */
+machine Writer {
+  var epoch: int;
+  var manifest: machine;
+  var s3: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (epoch: int, manifest: machine, s3: machine, driver: machine)) {
+      epoch = init.epoch;
+      manifest = init.manifest;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+    on eDoReset do (p: (localFloor: int, newUid: int)) {
+      send manifest, eMRSetFloor, (from = this, floor = p.localFloor, isReset = true);
+      receive { case eMRAck: { } }
+      send manifest, eMRAddEntry, (from = this, key = (offset = p.localFloor, uid = p.newUid));
+      receive { case eMRAck: { } }
+      send s3, eS3Put, (from = this, obj = (offset = p.localFloor, uid = p.newUid, epoch = epoch));
+      receive { case eS3Ack: { } }
+      send driver, eResetDone;
+    }
+  }
+}

--- a/p/gc-reset/PSrc/Writer.p
+++ b/p/gc-reset/PSrc/Writer.p
@@ -3,31 +3,46 @@
    lower the durable first_offset, then re-tier the live fragment at that offset
    with a fresh UID.
 
-   Ordering is load-bearing: the floor is lowered and the new entry committed
-   (each acknowledged) BEFORE the re-tiered object is put into S3. This is the
-   atomic-prefix that prevents the illegal "object present in S3 while the floor
-   is still high" state. The guard relies on the live floor being lowered before
-   the object it protects can be observed by a sweep. */
+   Ordering is load-bearing: the floor is lowered (floorFirst) BEFORE the new
+   entry is referenced and the re-tiered object is put into S3. This is the
+   atomic-prefix that prevents the illegal "object live/observable while the
+   floor is still high" state. The guard relies on the live floor being lowered
+   before the object it protects can be observed by a sweep; floorFirst = false
+   reverses the order to show the guard alone is not sufficient. */
 machine Writer {
   var epoch: int;
+  var floorFirst: bool;
   var manifest: machine;
   var s3: machine;
   var driver: machine;
 
   start state Idle {
-    entry (init: (epoch: int, manifest: machine, s3: machine, driver: machine)) {
+    entry (init: (epoch: int, floorFirst: bool, manifest: machine, s3: machine, driver: machine)) {
       epoch = init.epoch;
+      floorFirst = init.floorFirst;
       manifest = init.manifest;
       s3 = init.s3;
       driver = init.driver;
     }
     on eDoReset do (p: (localFloor: int, newUid: int)) {
-      send manifest, eMRSetFloor, (from = this, floor = p.localFloor, isReset = true);
-      receive { case eMRAck: { } }
-      send manifest, eMRAddEntry, (from = this, key = (offset = p.localFloor, uid = p.newUid));
-      receive { case eMRAck: { } }
-      send s3, eS3Put, (from = this, obj = (offset = p.localFloor, uid = p.newUid, epoch = epoch));
-      receive { case eS3Ack: { } }
+      if (floorFirst) {
+        send manifest, eMRSetFloor, (from = this, floor = p.localFloor, isReset = true);
+        receive { case eMRAck: { } }
+        send manifest, eMRAddEntry, (from = this, key = (offset = p.localFloor, uid = p.newUid));
+        receive { case eMRAck: { } }
+        send s3, eS3Put, (from = this, obj = (offset = p.localFloor, uid = p.newUid, epoch = epoch));
+        receive { case eS3Ack: { } }
+      } else {
+        /* Atomic-prefix violation: the re-tiered object becomes referenced and
+           observable while the floor is still high, so a sweep's guard re-read
+           still sees the stale-high floor and deletes a live object. */
+        send manifest, eMRAddEntry, (from = this, key = (offset = p.localFloor, uid = p.newUid));
+        receive { case eMRAck: { } }
+        send s3, eS3Put, (from = this, obj = (offset = p.localFloor, uid = p.newUid, epoch = epoch));
+        receive { case eS3Ack: { } }
+        send manifest, eMRSetFloor, (from = this, floor = p.localFloor, isReset = true);
+        receive { case eMRAck: { } }
+      }
       send driver, eResetDone;
     }
   }

--- a/p/gc-reset/PTst/TestDrivers.p
+++ b/p/gc-reset/PTst/TestDrivers.p
@@ -48,7 +48,7 @@ fun RunGcResetScenario(self: machine, guardEnabled: bool) {
   PutObj(self, s3, (offset = 850, uid = 1, epoch = 1));
   PutObj(self, s3, (offset = 500, uid = 0, epoch = 1));
 
-  writer = new Writer((epoch = 1, manifest = mr, s3 = s3, driver = self));
+  writer = new Writer((epoch = 1, floorFirst = true, manifest = mr, s3 = s3, driver = self));
   gc = new GC((guardEnabled = guardEnabled, db = db, manifest = mr, s3 = s3, driver = self));
 
   /* 1. Sweep captures the snapshot floor (1000) and epoch (1). */
@@ -97,7 +97,7 @@ fun RunGcResetExplore(self: machine) {
   PutObj(self, s3, (offset = 850, uid = 1, epoch = 1));
   PutObj(self, s3, (offset = 500, uid = 0, epoch = 1));
 
-  writer = new Writer((epoch = 1, manifest = mr, s3 = s3, driver = self));
+  writer = new Writer((epoch = 1, floorFirst = true, manifest = mr, s3 = s3, driver = self));
   gc = new GC((guardEnabled = true, db = db, manifest = mr, s3 = s3, driver = self));
 
   send gc, eGcSnapshot;
@@ -106,6 +106,47 @@ fun RunGcResetExplore(self: machine) {
   /* Fire the reset and the rest of the sweep without sequencing: the scheduler
      interleaves the reset's manifest/S3 effects with the LIST and the guard's
      live-floor re-read. */
+  send writer, eDoReset, (localFloor = 850, newUid = 2);
+  send gc, eGcListClassify;
+  send gc, eGcExecute;
+
+  done = 0;
+  while (done < 3) {
+    receive {
+      case eResetDone: { done = done + 1; }
+      case eGcClassifyDone: { done = done + 1; }
+      case eGcExecuteDone: { done = done + 1; }
+    }
+  }
+}
+
+/* Atomic-prefix mutation: the reset references and uploads the re-tiered object
+   BEFORE lowering the floor (floorFirst = false). The guard is ON. This proves
+   the ordering is load-bearing: the guard alone does not protect the object,
+   because a sweep's live-floor re-read can land while the floor is still high. */
+fun RunGcResetFloorLast(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var writer: machine;
+  var gc: machine;
+  var done: int;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 1001));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 850, uid = 1, epoch = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, epoch = 1));
+
+  writer = new Writer((epoch = 1, floorFirst = false, manifest = mr, s3 = s3, driver = self));
+  gc = new GC((guardEnabled = true, db = db, manifest = mr, s3 = s3, driver = self));
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
   send writer, eDoReset, (localFloor = 850, newUid = 2);
   send gc, eGcListClassify;
   send gc, eGcExecute;
@@ -167,6 +208,12 @@ machine DriverExplore {
   }
 }
 
+machine DriverFloorLast {
+  start state Init {
+    entry { RunGcResetFloorLast(this); }
+  }
+}
+
 machine DriverEpochAxis {
   start state Init {
     entry { RunEpochAxisScenario(this); }
@@ -189,6 +236,12 @@ test tcGcResetUnguarded [main = DriverUnguarded]:
 test tcGcResetExplore [main = DriverExplore]:
   assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
   { DriverExplore, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Atomic-prefix mutation (guard on, floor lowered last): MUST fail. Proves the
+   floor-before-object ordering is load-bearing - the guard alone is insufficient. */
+test tcGcResetFloorLast [main = DriverFloorLast]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverFloorLast, KhepriDB, S3Store, ManifestReplica, Writer, GC };
 
 /* Epoch-axis deletions are safe without a re-check. Must hold. */
 test tcEpochAxisSafe [main = DriverEpochAxis]:

--- a/p/gc-reset/PTst/TestDrivers.p
+++ b/p/gc-reset/PTst/TestDrivers.p
@@ -1,0 +1,196 @@
+/* Test drivers and declarations for the GC x reset durability seam.
+
+   Fixture offsets/uids (shared across scenarios):
+     - floor starts at 1000; a live object (1000, uid 10) covers it
+     - (850, uid 1): a pre-existing stale orphan at the eventual reset offset
+     - (500, uid 0): a genuine deep orphan, below even the reset floor
+     - the reset lowers the floor to 850 and re-tiers (850, uid 2) as live
+
+   The validation gate is the contrast between tcGcResetGuarded (guard on, must
+   hold) and tcGcResetUnguarded (guard off, must fail with the INV#2 dangling
+   reference on (850, uid 2)). */
+
+fun PutObj(self: machine, s3: machine, o: Obj) {
+  send s3, eS3Put, (from = self, obj = o);
+  receive { case eS3Ack: { } }
+}
+
+fun AddEntry(self: machine, mr: machine, k: ObjKey) {
+  send mr, eMRAddEntry, (from = self, key = k);
+  receive { case eMRAck: { } }
+}
+
+fun S3Has(self: machine, s3: machine, k: ObjKey): bool {
+  var present: bool;
+  send s3, eS3Has, (from = self, key = k);
+  receive { case eS3HasResult: (b: bool) { present = b; } }
+  return present;
+}
+
+/* Build the common fixture and return the machine handles via the caller's own
+   variables. P has no multiple return, so this is inlined per driver below. */
+
+/* Deterministic gate: snapshot, then reset, then list/classify/execute, each
+   fully sequenced so the dangerous interleaving is forced every run. */
+fun RunGcResetScenario(self: machine, guardEnabled: bool) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var writer: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 1001));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 850, uid = 1, epoch = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, epoch = 1));
+
+  writer = new Writer((epoch = 1, manifest = mr, s3 = s3, driver = self));
+  gc = new GC((guardEnabled = guardEnabled, db = db, manifest = mr, s3 = s3, driver = self));
+
+  /* 1. Sweep captures the snapshot floor (1000) and epoch (1). */
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
+  /* 2. Remote-tier-ahead reset: floor -> 850, re-tier (850, uid 2) live. */
+  send writer, eDoReset, (localFloor = 850, newUid = 2);
+  receive { case eResetDone: { } }
+
+  /* 3. Sweep lists + classifies against the stale snapshot floor (1000). */
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+
+  /* 4. Sweep executes deletes (still_dangling toggled by guardEnabled). */
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+
+  /* Anti-vacuity for the guarded run: the guard must reclaim the genuine deep
+     orphan (500, 0) AND preserve the live re-tiered object (850, 2). Without
+     this, a guard that simply skips everything would also pass. */
+  if (guardEnabled) {
+    assert !S3Has(self, s3, (offset = 500, uid = 0)),
+      "guard over-suppressed: genuine deep orphan (500, 0) was not reclaimed";
+    assert S3Has(self, s3, (offset = 850, uid = 2)),
+      "guard failed to preserve the live re-tiered object (850, 2)";
+  }
+}
+
+/* Exploration: snapshot first, then race the reset against list/classify/execute
+   and let the checker interleave them. Guard on; no schedule may violate safety. */
+fun RunGcResetExplore(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var writer: machine;
+  var gc: machine;
+  var done: int;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 1001));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 850, uid = 1, epoch = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, epoch = 1));
+
+  writer = new Writer((epoch = 1, manifest = mr, s3 = s3, driver = self));
+  gc = new GC((guardEnabled = true, db = db, manifest = mr, s3 = s3, driver = self));
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
+  /* Fire the reset and the rest of the sweep without sequencing: the scheduler
+     interleaves the reset's manifest/S3 effects with the LIST and the guard's
+     live-floor re-read. */
+  send writer, eDoReset, (localFloor = 850, newUid = 2);
+  send gc, eGcListClassify;
+  send gc, eGcExecute;
+
+  done = 0;
+  while (done < 3) {
+    receive {
+      case eResetDone: { done = done + 1; }
+      case eGcClassifyDone: { done = done + 1; }
+      case eGcExecuteDone: { done = done + 1; }
+    }
+  }
+}
+
+/* Epoch-axis safety: a stale-epoch object above the live floor is deleted
+   unconditionally (no guard on that axis). Because epoch is monotonic the
+   object is genuinely dead, so no safety monitor may fire. This is the
+   asymmetry that proves the guard is only needed on the offset axis. */
+fun RunEpochAxisScenario(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 2,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 500, nextOffset = 1001));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, epoch = 2));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  /* Stale-epoch orphan above the floor: not below_first_offset, but epoch 1 < 2. */
+  PutObj(self, s3, (offset = 800, uid = 8, epoch = 1));
+
+  gc = new GC((guardEnabled = true, db = db, manifest = mr, s3 = s3, driver = self));
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunGcResetScenario(this, true); }
+  }
+}
+
+machine DriverUnguarded {
+  start state Init {
+    entry { RunGcResetScenario(this, false); }
+  }
+}
+
+machine DriverExplore {
+  start state Init {
+    entry { RunGcResetExplore(this); }
+  }
+}
+
+machine DriverEpochAxis {
+  start state Init {
+    entry { RunEpochAxisScenario(this); }
+  }
+}
+
+/* Guard on: the seam is safe. Must hold. */
+test tcGcResetGuarded [main = DriverGuarded]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverGuarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Guard off (still_dangling collapsed on the offset axis): MUST fail with the
+   INV#2 dangling reference on the re-tiered (850, uid 2). This failing run is
+   the validation gate. */
+test tcGcResetUnguarded [main = DriverUnguarded]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverUnguarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Guard on, all interleavings of reset vs sweep explored. Must hold. */
+test tcGcResetExplore [main = DriverExplore]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverExplore, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Epoch-axis deletions are safe without a re-check. Must hold. */
+test tcEpochAxisSafe [main = DriverEpochAxis]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverEpochAxis, KhepriDB, S3Store, ManifestReplica, GC };

--- a/p/gc-reset/README.md
+++ b/p/gc-reset/README.md
@@ -54,7 +54,17 @@ monotonic.
 | `tcGcResetGuarded` | **holds** - guard on; also asserts the genuine deep orphan `(500,0)` is reclaimed and the live `(850,2)` preserved (anti-vacuity) |
 | `tcGcResetUnguarded` | **fails** - guard off; `INV#2 violated: GC deleted live object (offset=850, uid=2)` |
 | `tcGcResetExplore` | **holds** - guard on, reset raced against the sweep across all interleavings |
+| `tcGcResetFloorLast` | **fails** - guard *on*, but the reset lowers the floor *after* re-tiering the object; the same INV#2 violation. Proves the atomic-prefix ordering is load-bearing - the guard alone is insufficient |
 | `tcEpochAxisSafe` | **holds** - a `stale_epoch` object is deleted with no re-check; safe because the epoch is monotonic (the asymmetry that proves the guard is only needed on the offset axis) |
+
+`tcGcResetFloorLast` is a rare interleaving (the guard's live-floor re-read must
+land in the window after the object is referenced but before the floor is
+lowered). The random strategy misses it even at 50k schedules; use the PCT
+strategy:
+
+```bash
+p check -tc tcGcResetFloorLast --sch-pct 10 -i 5000   # 1 bug: INV#2 on (850, uid 2)
+```
 
 `tcGcResetUnguarded` is *expected to fail*: that failing counterexample is the
 proof the model reproduces the real bug, so the guarded result is meaningful.

--- a/p/gc-reset/README.md
+++ b/p/gc-reset/README.md
@@ -1,0 +1,68 @@
+# GC × reset durability seam
+
+Models the decide-then-act window in `rabbitmq_stream_s3_gc` between an orphan
+sweep and a remote-tier-ahead manifest reset.
+
+## The race
+
+The sweep is safe under one assumption: `first_offset` only moves forward, so a
+snapshot floor is never above the live floor. A remote-tier-ahead reset
+(`restart_at_local_floor`) breaks that assumption — it *lowers* `first_offset`
+and re-tiers live fragments, with fresh UIDs, at offsets below the snapshot
+floor:
+
+1. The sweep captures a snapshot floor (`build_lookup`), e.g. `1000`
+2. A reset lowers the live floor to `850` and re-tiers `(850, uid2)` as live
+3. The sweep's LIST (which runs after the snapshot) now sees `(850, uid2)`,
+   classifies it against the stale snapshot floor `1000` as `below_first_offset`,
+   and — without re-validation — deletes a live object
+
+The mitigation is `still_dangling/1`: it re-reads the *live* floor immediately
+before each `below_first_offset` deletion and skips anything now at or above it.
+Epoch-based (`stale_epoch`) findings need no re-check because the epoch is
+monotonic.
+
+## What the model captures
+
+- S3 objects are keyed by `(offset, uid)`, so a stale UID and a freshly re-tiered
+  UID can coexist at the same offset. The headline monitor keys protection on
+  `(offset, uid)`, not offset alone — otherwise it cannot distinguish a legal
+  stale-UID delete from the illegal fresh-UID delete
+- The reset lowers the floor and commits the new entry *before* the re-tiered
+  object is put into S3 (handler ordering), modeling the atomic prefix that keeps
+  the "object present while floor still high" state unreachable
+- Faults are deliberately off: this is an ordering bug, not a fault-driven one
+
+### Machines (`PSrc/`)
+
+- `Writer` - the reset orchestrator
+- `GC` - the sweep, split into snapshot / list-classify / execute steps
+- `ManifestReplica` - serialized owner of the live floor and live entries
+- `KhepriDB` - committed epoch (monotonic)
+- `S3Store` - the object store
+
+### Monitors (`PSpec/`)
+
+- `NoDanglingReference` (INV#2, headline) - GC never deletes a live `(offset, uid)`
+- `NoLostAckedData` (INV#1) - GC never deletes the live cover of an in-range offset
+- `MonotonicFrontier` (INV#5) - `first_offset` only decreases across a labeled reset
+
+## Tests (`PTst/`) and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcGcResetGuarded` | **holds** - guard on; also asserts the genuine deep orphan `(500,0)` is reclaimed and the live `(850,2)` preserved (anti-vacuity) |
+| `tcGcResetUnguarded` | **fails** - guard off; `INV#2 violated: GC deleted live object (offset=850, uid=2)` |
+| `tcGcResetExplore` | **holds** - guard on, reset raced against the sweep across all interleavings |
+| `tcEpochAxisSafe` | **holds** - a `stale_epoch` object is deleted with no re-check; safe because the epoch is monotonic (the asymmetry that proves the guard is only needed on the offset axis) |
+
+`tcGcResetUnguarded` is *expected to fail*: that failing counterexample is the
+proof the model reproduces the real bug, so the guarded result is meaningful.
+
+```bash
+p compile
+p check -tc tcGcResetGuarded  -i 2000   # 0 bugs
+p check -tc tcGcResetUnguarded -i 2000  # 1 bug: INV#2 on (850, uid 2)
+p check -tc tcGcResetExplore  -i 5000   # 0 bugs, multiple timelines
+p check -tc tcEpochAxisSafe   -i 2000   # 0 bugs
+```

--- a/p/orphan-leak/OrphanLeak.pproj
+++ b/p/orphan-leak/OrphanLeak.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>OrphanLeak</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/orphan-leak/PSpec/Monitors.p
+++ b/p/orphan-leak/PSpec/Monitors.p
@@ -1,0 +1,31 @@
+/* INV#3 (no unbounded orphan leak): every orphaned object must eventually be
+   reclaimed. Dirty is a hot state: an execution that ends (or loops) with an
+   orphan still outstanding is a liveness violation. */
+spec OrphanEventuallyReclaimed observes eOrphanCreated, eOrphanDeleted {
+  var outstanding: set[int];
+
+  start state Clean {
+    on eOrphanCreated do (id: int) {
+      outstanding += (id);
+      goto Dirty;
+    }
+    on eOrphanDeleted do (id: int) {
+      if (id in outstanding) {
+        outstanding -= (id);
+      }
+    }
+  }
+  hot state Dirty {
+    on eOrphanCreated do (id: int) {
+      outstanding += (id);
+    }
+    on eOrphanDeleted do (id: int) {
+      if (id in outstanding) {
+        outstanding -= (id);
+      }
+      if (sizeof(outstanding) == 0) {
+        goto Clean;
+      }
+    }
+  }
+}

--- a/p/orphan-leak/PSrc/Common.p
+++ b/p/orphan-leak/PSrc/Common.p
@@ -1,0 +1,23 @@
+/* Shared events for the orphan-leak seam.
+
+   The reaper issues batched DeleteObjects and tolerates partial failures: a
+   per-key failure is a routine transient and the unconfirmed object is "left
+   for orphan GC" (rabbitmq_stream_s3_reaper:delete_batch/1). Reclamation
+   liveness therefore rests on GC RE-SWEEPING: the next sweep re-lists and
+   re-deletes what a previous delete missed. Without the re-run a transiently
+   failed delete leaks forever. */
+
+event eList: (from: machine);
+event eListResult: seq[int];
+event eDelete: (from: machine, id: int);
+event eDeleteOk: int;
+event eDeleteFailed: int;
+event eAddOrphan: (from: machine, id: int);
+event eAddAck;
+
+event eSweep;
+event eSweepFinished;
+
+/* Spec events (announce). */
+event eOrphanCreated: int;
+event eOrphanDeleted: int;

--- a/p/orphan-leak/PSrc/GC.p
+++ b/p/orphan-leak/PSrc/GC.p
@@ -1,0 +1,45 @@
+/* The orphan GC sweep. It lists orphans and issues deletes (the reaper batch);
+   failed deletes are simply left behind, as the real reaper does. reSweep is the
+   liveness mechanism: when set, the sweep re-lists and re-deletes until the store
+   is clean, so a transiently failed delete is reclaimed on a later pass. With it
+   off (the bug) a single pass leaves a failed delete leaked forever. */
+machine GC {
+  var reSweep: bool;
+  var s3: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (reSweep: bool, s3: machine, driver: machine)) {
+      reSweep = init.reSweep;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+    on eSweep do {
+      var orphans: seq[int];
+      var i: int;
+      var clean: bool;
+      clean = false;
+      while (!clean) {
+        send s3, eList, (from = this,);
+        receive { case eListResult: (l: seq[int]) { orphans = l; } }
+        if (sizeof(orphans) == 0) {
+          clean = true;
+        } else {
+          i = 0;
+          while (i < sizeof(orphans)) {
+            send s3, eDelete, (from = this, id = orphans[i]);
+            receive {
+              case eDeleteOk: (x: int) { }
+              case eDeleteFailed: (x: int) { }
+            }
+            i = i + 1;
+          }
+          if (!reSweep) {
+            clean = true;
+          }
+        }
+      }
+      send driver, eSweepFinished;
+    }
+  }
+}

--- a/p/orphan-leak/PSrc/S3Store.p
+++ b/p/orphan-leak/PSrc/S3Store.p
@@ -1,0 +1,39 @@
+/* The S3 object store, holding orphaned objects (failed/unreferenced uploads).
+   A delete fails transiently while faultsRemaining > 0, modeling the reaper's
+   routine partial-batch DeleteObjects failures; once the budget is exhausted the
+   delete succeeds (the transient clears). Objects are a map id -> present so
+   keys/0 yields the listing. */
+machine S3Store {
+  var objects: map[int, bool];
+  var faultsRemaining: int;
+
+  start state Serving {
+    entry (init: (faultsRemaining: int)) {
+      faultsRemaining = init.faultsRemaining;
+    }
+    on eAddOrphan do (p: (from: machine, id: int)) {
+      if (p.id in objects) {
+        objects[p.id] = true;
+      } else {
+        objects += (p.id, true);
+      }
+      announce eOrphanCreated, p.id;
+      send p.from, eAddAck;
+    }
+    on eList do (p: (from: machine)) {
+      send p.from, eListResult, keys(objects);
+    }
+    on eDelete do (p: (from: machine, id: int)) {
+      if (faultsRemaining > 0) {
+        faultsRemaining = faultsRemaining - 1;
+        send p.from, eDeleteFailed, p.id;
+      } else {
+        if (p.id in objects) {
+          objects -= (p.id);
+          announce eOrphanDeleted, p.id;
+        }
+        send p.from, eDeleteOk, p.id;
+      }
+    }
+  }
+}

--- a/p/orphan-leak/PTst/TestDrivers.p
+++ b/p/orphan-leak/PTst/TestDrivers.p
@@ -1,0 +1,55 @@
+/* Test drivers and declarations for the orphan-leak seam.
+
+   The gate contrasts tcOrphanGuarded (GC re-sweeps until clean: a transiently
+   failed delete is reclaimed on a later pass, liveness holds) with
+   tcOrphanBuggy (a single pass: the failed delete leaks and the Dirty hot state
+   never clears). */
+
+fun RunOrphanScenario(self: machine, reSweep: bool, faults: int, numOrphans: int) {
+  var s3: machine;
+  var gc: machine;
+  var i: int;
+  s3 = new S3Store((faultsRemaining = faults,));
+  gc = new GC((reSweep = reSweep, s3 = s3, driver = self));
+  i = 0;
+  while (i < numOrphans) {
+    send s3, eAddOrphan, (from = self, id = i + 1);
+    receive { case eAddAck: { } }
+    i = i + 1;
+  }
+  send gc, eSweep;
+  receive { case eSweepFinished: { } }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunOrphanScenario(this, true, 1, 1); }
+  }
+}
+
+machine DriverBuggy {
+  start state Init {
+    entry { RunOrphanScenario(this, false, 1, 1); }
+  }
+}
+
+/* Guard on, more orphans and a larger transient-fault budget: every orphan is
+   still reclaimed across the re-sweeps. */
+machine DriverExplore {
+  start state Init {
+    entry { RunOrphanScenario(this, true, 2, 2); }
+  }
+}
+
+/* Current code: GC re-sweeps, so a transiently failed delete is reclaimed. Holds. */
+test tcOrphanGuarded [main = DriverGuarded]:
+  assert OrphanEventuallyReclaimed in { DriverGuarded, S3Store, GC };
+
+/* Bug (no re-sweep): a single pass leaves a transiently failed delete leaked.
+   MUST fail the liveness obligation. This failing run is the gate. */
+test tcOrphanBuggy [main = DriverBuggy]:
+  assert OrphanEventuallyReclaimed in { DriverBuggy, S3Store, GC };
+
+/* Guard on, multiple orphans and faults. Holds. */
+test tcOrphanExplore [main = DriverExplore]:
+  assert OrphanEventuallyReclaimed in { DriverExplore, S3Store, GC };

--- a/p/orphan-leak/README.md
+++ b/p/orphan-leak/README.md
@@ -1,0 +1,47 @@
+# Orphan-leak GC seam
+
+Models orphan reclamation: the reaper tolerates partial-batch `DeleteObjects`
+failures, so eventual reclamation depends on GC re-sweeping.
+
+## The bug class
+
+`rabbitmq_stream_s3_reaper:delete_batch/1` treats a per-key delete failure as a
+routine transient and leaves the unconfirmed object "for orphan GC" - it does not
+retry within the batch. Reclamation liveness therefore rests entirely on GC
+**re-sweeping**: a later sweep re-lists the object and re-issues the delete. If GC
+runs only once (or never re-sweeps), a transiently-failed delete leaks forever,
+and orphaned objects accumulate unbounded in the bucket.
+
+## Why this is a liveness model
+
+The property is INV#3: *every orphan is eventually reclaimed*. The failure is the
+absence of progress, so the monitor uses a P `hot` state (`Dirty`, entered while
+any orphan is outstanding). An execution that ends - or loops - with an orphan
+still outstanding is a liveness violation.
+
+## What the model captures
+
+- An `S3Store` holding orphans, whose delete fails transiently while a bounded
+  fault budget remains (modeling the reaper's routine partial failures) and then
+  succeeds once the transient clears
+- A `GC` sweep that lists and deletes, leaving failed deletes behind; `reSweep`
+  is the liveness mechanism (re-list and re-delete until clean)
+- `OrphanEventuallyReclaimed` (INV#3, liveness)
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcOrphanGuarded` | **holds** - GC re-sweeps, so the transiently-failed delete is reclaimed on a later pass |
+| `tcOrphanBuggy` | **fails** - a single pass leaves the failed delete leaked; the `Dirty` hot state never clears |
+| `tcOrphanExplore` | **holds** - guard on, multiple orphans and a larger fault budget |
+
+`tcOrphanBuggy` is *expected to fail*; that liveness counterexample is the proof
+the model reproduces the unbounded leak.
+
+```bash
+p compile
+p check -tc tcOrphanGuarded -i 5000   # 0 bugs
+p check -tc tcOrphanBuggy   -i 2000   # 1 bug: OrphanEventuallyReclaimed never discharged
+p check -tc tcOrphanExplore -i 5000   # 0 bugs
+```

--- a/p/read-resolution/PSpec/Monitors.p
+++ b/p/read-resolution/PSpec/Monitors.p
@@ -1,0 +1,24 @@
+/* INV#4 (tier resolution totality / no silent remote skip): resolving 'first'
+   may return the local tier only when the remote tier is genuinely empty. A
+   transient group fetch failure must surface as a retry; collapsing it to a
+   local-tier resolution silently skips the remote range below the local floor.
+
+   remoteEmpty tracks whether retention has emptied the remote tier. Because
+   eRemoteEmptied is announced inside the (serialized) retention handler, it
+   strictly precedes any resolution that observes the emptied state, so a
+   legitimate post-retention local resolution does not trip this monitor. */
+spec NoSilentRemoteSkip observes eRemoteEmptied, eResolution {
+  var remoteEmpty: bool;
+
+  start state Watching {
+    on eRemoteEmptied do {
+      remoteEmpty = true;
+    }
+    on eResolution do (r: Resolution) {
+      if (r == LOCAL_FIRST) {
+        assert remoteEmpty,
+          "INV#4 violated: resolved 'first' to the local tier while the remote tier is non-empty (a transient group fetch must surface as retry, not a silent skip of remote data)";
+      }
+    }
+  }
+}

--- a/p/read-resolution/PSrc/Common.p
+++ b/p/read-resolution/PSrc/Common.p
@@ -1,0 +1,35 @@
+/* Shared types and events for the read / tier-resolution seam.
+
+   Models log_reader:resolve_first/2 and resolve_first_lookup/1: resolving the
+   'first' offset spec descends into the leading manifest group (a fragment_iterator
+   step that fetches the group from S3). A transient group fetch failure must
+   surface as a retry, NOT a silent fallback to the local tier. The pre-e3f931b
+   catch-all collapsed group_fetch_failed into {local, first}, silently skipping
+   the remote range below the local floor. */
+
+/* The three resolution outcomes of resolve_first_lookup/1:
+   {remote, _} | {local, first} | {retry, _} (surfaced as {error, _}). */
+enum Resolution { REMOTE, LOCAL_FIRST, RETRY }
+
+/* Manifest store (remote tier metadata + retention). */
+event eGetRemoteState: (from: machine);
+event eRemoteStateResult: (nonEmpty: bool, remoteFirst: int, localFloor: int);
+event eAdvanceRetention: (from: machine);
+event eMSAck;
+
+/* Group store (the leading group fetched while descending to the first fragment).
+   A fetch returns ok, or group_fetch_failed (a transient S3 error or a group a
+   concurrent retention has deleted). */
+event eFetchGroup: (from: machine);
+event eFetchOk;
+event eFetchFailed;
+event eSetPresent: (from: machine, present: bool);
+event eGSAck;
+
+/* Reader. */
+event eResolveFirst: (from: machine);
+event eResolveDone: Resolution;
+
+/* Spec events (announce). */
+event eRemoteEmptied;
+event eResolution: Resolution;

--- a/p/read-resolution/PSrc/GroupStore.p
+++ b/p/read-resolution/PSrc/GroupStore.p
@@ -1,0 +1,32 @@
+/* The S3-backed group object fetched while descending to the first fragment
+   (manifest:get_group_fun -> GetGroup). A fetch fails (group_fetch_failed) when
+   the group is absent (deleted by retention) or transiently unfetchable (an S3
+   error surviving retries). alwaysFail forces the deterministic transient case
+   for the validation gate; otherwise a present group fails nondeterministically. */
+machine GroupStore {
+  var present: bool;
+  var alwaysFail: bool;
+
+  start state Serving {
+    entry (init: (present: bool, alwaysFail: bool)) {
+      present = init.present;
+      alwaysFail = init.alwaysFail;
+    }
+    on eSetPresent do (p: (from: machine, present: bool)) {
+      present = p.present;
+      send p.from, eGSAck;
+    }
+    on eFetchGroup do (p: (from: machine)) {
+      if (!present) {
+        send p.from, eFetchFailed;
+      } else if (alwaysFail) {
+        send p.from, eFetchFailed;
+      } else if ($) {
+        /* Transient S3 error: the group is present but momentarily unfetchable. */
+        send p.from, eFetchFailed;
+      } else {
+        send p.from, eFetchOk;
+      }
+    }
+  }
+}

--- a/p/read-resolution/PSrc/ManifestStore.p
+++ b/p/read-resolution/PSrc/ManifestStore.p
@@ -1,0 +1,31 @@
+/* The manifest replica's remote-tier metadata as seen by a reader resolving an
+   offset spec. Retention can empty the remote tier (advance first_offset to the
+   local floor and delete the leading group); after that, resolving 'first' to
+   the local tier is correct. */
+machine ManifestStore {
+  var nonEmpty: bool;
+  var remoteFirst: int;
+  var localFloor: int;
+  var groups: machine;
+
+  start state Serving {
+    entry (init: (nonEmpty: bool, remoteFirst: int, localFloor: int, groups: machine)) {
+      nonEmpty = init.nonEmpty;
+      remoteFirst = init.remoteFirst;
+      localFloor = init.localFloor;
+      groups = init.groups;
+    }
+    on eGetRemoteState do (p: (from: machine)) {
+      send p.from, eRemoteStateResult,
+        (nonEmpty = nonEmpty, remoteFirst = remoteFirst, localFloor = localFloor);
+    }
+    on eAdvanceRetention do (p: (from: machine)) {
+      nonEmpty = false;
+      remoteFirst = localFloor;
+      send groups, eSetPresent, (from = this, present = false);
+      receive { case eGSAck: { } }
+      announce eRemoteEmptied;
+      send p.from, eMSAck;
+    }
+  }
+}

--- a/p/read-resolution/PSrc/Reader.p
+++ b/p/read-resolution/PSrc/Reader.p
@@ -1,0 +1,49 @@
+/* The reader resolving the 'first' offset spec (log_reader:resolve_first/2 ->
+   fragment_iterator:next -> GetGroup -> resolve_first_lookup/1).
+
+   When the remote tier is non-empty it descends into the leading group; the
+   fetch outcome maps to a resolution:
+     - ok                 -> {remote, _}
+     - group_fetch_failed -> {retry, _}  (correct)  OR  {local, first}  (the
+                             pre-e3f931b catch-all bug, toggled by bugCatchAll)
+   When the remote tier is empty, 'first' is correctly served by the local tier. */
+machine Reader {
+  var bugCatchAll: bool;
+  var manifest: machine;
+  var groups: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (bugCatchAll: bool, manifest: machine, groups: machine, driver: machine)) {
+      bugCatchAll = init.bugCatchAll;
+      manifest = init.manifest;
+      groups = init.groups;
+      driver = init.driver;
+    }
+    on eResolveFirst do (p: (from: machine)) {
+      var st: (nonEmpty: bool, remoteFirst: int, localFloor: int);
+      var res: Resolution;
+      send manifest, eGetRemoteState, (from = this,);
+      receive {
+        case eRemoteStateResult: (s: (nonEmpty: bool, remoteFirst: int, localFloor: int)) { st = s; }
+      }
+      if (!st.nonEmpty) {
+        res = LOCAL_FIRST;
+      } else {
+        send groups, eFetchGroup, (from = this,);
+        receive {
+          case eFetchOk: { res = REMOTE; }
+          case eFetchFailed: {
+            if (bugCatchAll) {
+              res = LOCAL_FIRST;
+            } else {
+              res = RETRY;
+            }
+          }
+        }
+      }
+      announce eResolution, res;
+      send p.from, eResolveDone, res;
+    }
+  }
+}

--- a/p/read-resolution/PTst/TestDrivers.p
+++ b/p/read-resolution/PTst/TestDrivers.p
@@ -1,0 +1,88 @@
+/* Test drivers and declarations for the read / tier-resolution seam.
+
+   The validation gate contrasts tcReadResolveGuarded (the current exhaustive
+   resolve_first_lookup/1: a transient group fetch surfaces as RETRY, must hold)
+   with tcReadResolveBuggy (the pre-e3f931b catch-all collapsing group_fetch_failed
+   to {local, first}: must fail with the INV#4 silent remote skip). */
+
+/* Deterministic: remote tier non-empty, the leading group fetch always fails
+   transiently, no retention. The only correct outcome is RETRY. */
+fun RunResolve(self: machine, bugCatchAll: bool, alwaysFail: bool) {
+  var ms: machine;
+  var gs: machine;
+  var reader: machine;
+  var res: Resolution;
+
+  gs = new GroupStore((present = true, alwaysFail = alwaysFail));
+  ms = new ManifestStore((nonEmpty = true, remoteFirst = 0, localFloor = 100, groups = gs));
+  reader = new Reader((bugCatchAll = bugCatchAll, manifest = ms, groups = gs, driver = self));
+
+  send reader, eResolveFirst, (from = self,);
+  receive { case eResolveDone: (r: Resolution) { res = r; } }
+
+  /* Anti-vacuity for the guarded run: a transient fetch must actually surface as
+     RETRY, not merely "not local". */
+  if (!bugCatchAll && alwaysFail) {
+    assert res == RETRY,
+      "guarded resolve_first must surface RETRY on a transient group fetch failure";
+  }
+}
+
+/* Exploration: remote tier non-empty, group fetch fails nondeterministically,
+   and a retention advance races the resolution. Guard on; no schedule may
+   resolve to the local tier while the remote tier is still non-empty. */
+fun RunResolveExplore(self: machine) {
+  var ms: machine;
+  var gs: machine;
+  var reader: machine;
+  var done: int;
+
+  gs = new GroupStore((present = true, alwaysFail = false));
+  ms = new ManifestStore((nonEmpty = true, remoteFirst = 0, localFloor = 100, groups = gs));
+  reader = new Reader((bugCatchAll = false, manifest = ms, groups = gs, driver = self));
+
+  send ms, eAdvanceRetention, (from = self,);
+  send reader, eResolveFirst, (from = self,);
+
+  done = 0;
+  while (done < 2) {
+    receive {
+      case eMSAck: { done = done + 1; }
+      case eResolveDone: (r: Resolution) { done = done + 1; }
+    }
+  }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunResolve(this, false, true); }
+  }
+}
+
+machine DriverBuggy {
+  start state Init {
+    entry { RunResolve(this, true, true); }
+  }
+}
+
+machine DriverExplore {
+  start state Init {
+    entry { RunResolveExplore(this); }
+  }
+}
+
+/* Current code: a transient group fetch surfaces as RETRY. Must hold. */
+test tcReadResolveGuarded [main = DriverGuarded]:
+  assert NoSilentRemoteSkip in
+  { DriverGuarded, ManifestStore, GroupStore, Reader };
+
+/* Pre-e3f931b catch-all: group_fetch_failed collapses to local fallback. MUST
+   fail with the INV#4 silent remote skip. This failing run is the gate. */
+test tcReadResolveBuggy [main = DriverBuggy]:
+  assert NoSilentRemoteSkip in
+  { DriverBuggy, ManifestStore, GroupStore, Reader };
+
+/* Guard on, nondeterministic transient fetch raced against retention. Must hold. */
+test tcReadResolveExplore [main = DriverExplore]:
+  assert NoSilentRemoteSkip in
+  { DriverExplore, ManifestStore, GroupStore, Reader };

--- a/p/read-resolution/README.md
+++ b/p/read-resolution/README.md
@@ -1,0 +1,55 @@
+# Read / tier-resolution seam
+
+Models `log_reader:resolve_first/2` and `resolve_first_lookup/1`: resolving the
+`first` offset spec when descending into the leading manifest group requires
+fetching that group from S3, and the fetch can fail transiently.
+
+## The bug class
+
+Resolving `first` descends into the leading group (`fragment_iterator:next` ->
+`GetGroup`). The fetch has three outcomes, mapped by `resolve_first_lookup/1`:
+
+- `{ok, FragRef, _}` -> `{remote, _}`
+- `end_of_manifest` -> `{local, first}`
+- `{error, {group_fetch_failed, _}}` -> `{retry, _}` (surfaced as `{error, _}`,
+  so the consumer retries)
+
+The pre-[`e3f931b`](https://github.com/amazon-mq/rabbitmq-stream-s3/commit/e3f931b)
+code had a catch-all that collapsed `group_fetch_failed` into `{local, first}`.
+A transient S3 error while fetching a live group then silently attached the
+reader at the local first offset, skipping the entire remote range below the
+local floor. (A sibling fix, `649a5fc`, addressed the same collapse in
+`remote_reader_core:try_fragment_transition` during streaming; not yet modeled.)
+
+A retry is always the safe answer for `group_fetch_failed`: even if the group was
+deleted by a concurrent retention, the retry re-reads a fresh manifest (with the
+advanced `first_offset`) and resolves correctly. A local fallback cannot
+self-correct.
+
+## What the model captures
+
+- A `Reader` resolving `first`, a `ManifestStore` (remote-tier metadata plus a
+  retention advance that empties the remote tier), and a `GroupStore` whose fetch
+  can fail transiently or because retention deleted the group
+- The `bugCatchAll` toggle selects the buggy mapping (`group_fetch_failed` ->
+  `LOCAL_FIRST`) versus the correct one (`-> RETRY`)
+- INV#4 (`NoSilentRemoteSkip`): resolving to the local tier is allowed only when
+  the remote tier is genuinely empty
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcReadResolveGuarded` | **holds** - a transient fetch surfaces as `RETRY` (asserted, not merely "not local") |
+| `tcReadResolveBuggy` | **fails** - the catch-all collapses to local; `INV#4 violated: resolved 'first' to the local tier while the remote tier is non-empty` |
+| `tcReadResolveExplore` | **holds** - guard on, nondeterministic transient fetch raced against retention |
+
+`tcReadResolveBuggy` is *expected to fail*; that counterexample is the proof the
+model reproduces the real bug.
+
+```bash
+p compile
+p check -tc tcReadResolveGuarded -i 5000   # 0 bugs
+p check -tc tcReadResolveBuggy   -i 2000   # 1 bug: INV#4 silent remote skip
+p check -tc tcReadResolveExplore -i 5000   # 0 bugs
+```

--- a/p/read-resolution/ReadResolution.pproj
+++ b/p/read-resolution/ReadResolution.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>ReadResolution</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/tier-routing/PSpec/Monitors.p
+++ b/p/tier-routing/PSpec/Monitors.p
@@ -1,0 +1,15 @@
+/* INV#4 (tier resolution total / correct): an offset held only by the remote
+   tier (covered by the remote extent, not by the local log) must route to the
+   remote tier. Routing it locally silently skips the remote data. An offset the
+   local tier also holds may route locally (osiris prefers the local reader), so
+   the obligation is only on offsets the local tier does NOT cover. */
+spec TierRoutingCorrect observes eResolution {
+  start state Watching {
+    on eResolution do (r: (tier: Tier, remoteCovers: bool, localCovers: bool)) {
+      if (r.remoteCovers && !r.localCovers) {
+        assert r.tier == REMOTE,
+          "INV#4 violated: an offset held only by the remote tier routed to the local tier (silent remote skip)";
+      }
+    }
+  }
+}

--- a/p/tier-routing/PSrc/Common.p
+++ b/p/tier-routing/PSrc/Common.p
@@ -1,0 +1,25 @@
+/* Shared types and events for the offset -> tier routing seam.
+
+   log_reader:resolve_remote_location/2 routes an integer offset to the local or
+   remote tier. The local-tier check is
+
+     first_chunk_id =/= -1 andalso Offset >= first_chunk_id
+
+   first_chunk_id = -1 means the local log is empty (fully trimmed or not yet
+   populated). Without the =/= -1 guard, Offset >= -1 is always true, so an empty
+   local log routes every offset to the local tail and silently skips the remote
+   tier. The =/= -1 guard makes an empty local log fall through to remote
+   resolution. */
+
+enum Tier { LOCAL, REMOTE }
+
+/* Manifest store (remote tier extent). */
+event eGetManifest: (from: machine);
+event eManifestResult: (nonEmpty: bool, remoteFirst: int, remoteNext: int);
+
+/* Reader. */
+event eResolve: (from: machine, firstChunkId: int, offset: int);
+event eResolveDone: Tier;
+
+/* Spec event (announce): the routing decision plus the ground-truth coverage. */
+event eResolution: (tier: Tier, remoteCovers: bool, localCovers: bool);

--- a/p/tier-routing/PSrc/ManifestStore.p
+++ b/p/tier-routing/PSrc/ManifestStore.p
@@ -1,0 +1,19 @@
+/* The remote-tier extent as seen by a reader: whether the remote tier has any
+   entries, and the offset range [remoteFirst, remoteNext) it covers. */
+machine ManifestStore {
+  var nonEmpty: bool;
+  var remoteFirst: int;
+  var remoteNext: int;
+
+  start state Serving {
+    entry (init: (nonEmpty: bool, remoteFirst: int, remoteNext: int)) {
+      nonEmpty = init.nonEmpty;
+      remoteFirst = init.remoteFirst;
+      remoteNext = init.remoteNext;
+    }
+    on eGetManifest do (p: (from: machine)) {
+      send p.from, eManifestResult,
+        (nonEmpty = nonEmpty, remoteFirst = remoteFirst, remoteNext = remoteNext);
+    }
+  }
+}

--- a/p/tier-routing/PSrc/Reader.p
+++ b/p/tier-routing/PSrc/Reader.p
@@ -1,0 +1,47 @@
+/* The reader routing an integer offset to a tier (resolve_remote_location/2).
+   bugNoMinusOneGuard drops the `first_chunk_id =/= -1` guard from the local-tier
+   check, reproducing the empty-local-log silent remote skip. */
+machine Reader {
+  var bugNoMinusOneGuard: bool;
+  var manifest: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (bug: bool, manifest: machine, driver: machine)) {
+      bugNoMinusOneGuard = init.bug;
+      manifest = init.manifest;
+      driver = init.driver;
+    }
+    on eResolve do (p: (from: machine, firstChunkId: int, offset: int)) {
+      var m: (nonEmpty: bool, remoteFirst: int, remoteNext: int);
+      var tier: Tier;
+      var localCheck: bool;
+      var localCovers: bool;
+      var remoteCovers: bool;
+      send manifest, eGetManifest, (from = this,);
+      receive {
+        case eManifestResult: (r: (nonEmpty: bool, remoteFirst: int, remoteNext: int)) { m = r; }
+      }
+      if (bugNoMinusOneGuard) {
+        localCheck = p.offset >= p.firstChunkId;
+      } else {
+        localCheck = (p.firstChunkId != -1) && (p.offset >= p.firstChunkId);
+      }
+      if (localCheck) {
+        tier = LOCAL;
+      } else if (!m.nonEmpty) {
+        /* No remote tier: emulate osiris_log and attach locally. */
+        tier = LOCAL;
+      } else if (p.firstChunkId == -1 && p.offset >= m.remoteNext) {
+        /* Local empty and the offset is beyond the remote tail: local tail wait. */
+        tier = LOCAL;
+      } else {
+        tier = REMOTE;
+      }
+      localCovers = (p.firstChunkId != -1) && (p.offset >= p.firstChunkId);
+      remoteCovers = m.nonEmpty && (p.offset >= m.remoteFirst) && (p.offset < m.remoteNext);
+      announce eResolution, (tier = tier, remoteCovers = remoteCovers, localCovers = localCovers);
+      send p.from, eResolveDone, tier;
+    }
+  }
+}

--- a/p/tier-routing/PTst/TestDrivers.p
+++ b/p/tier-routing/PTst/TestDrivers.p
@@ -1,0 +1,72 @@
+/* Test drivers and declarations for the offset -> tier routing seam.
+
+   The remote tier covers [0, 100). The gate contrasts tcTierRoutingGuarded
+   (the first_chunk_id =/= -1 guard present: routing is correct for every probed
+   offset and local floor, must hold) with tcTierRoutingBuggy (the guard removed:
+   an empty local log routes a remote-only offset to the local tier, must fail
+   with the INV#4 silent remote skip). */
+
+/* Deterministically probe every combination of a local floor (including -1 =
+   empty local) and an offset spanning below / within / beyond the remote extent.
+   One run covers the whole grid, so totality does not rely on random sampling. */
+fun RunRouteAll(self: machine, bug: bool) {
+  var manifest: machine;
+  var reader: machine;
+  var fcids: seq[int];
+  var fi: int;
+  var oi: int;
+  var t: Tier;
+
+  manifest = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+  reader = new Reader((bug = bug, manifest = manifest, driver = self));
+
+  fcids += (0, -1);
+  fcids += (1, 0);
+  fcids += (2, 30);
+
+  fi = 0;
+  while (fi < sizeof(fcids)) {
+    oi = 0;
+    while (oi < 8) {
+      send reader, eResolve, (from = self, firstChunkId = fcids[fi], offset = oi * 25);
+      receive { case eResolveDone: (tt: Tier) { t = tt; } }
+      oi = oi + 1;
+    }
+    fi = fi + 1;
+  }
+}
+
+/* Deterministic empty-local case with the offset inside the remote extent. */
+fun RunRouteFixed(self: machine, bug: bool, fcid: int, off: int) {
+  var manifest: machine;
+  var reader: machine;
+  var t: Tier;
+
+  manifest = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+  reader = new Reader((bug = bug, manifest = manifest, driver = self));
+
+  send reader, eResolve, (from = self, firstChunkId = fcid, offset = off);
+  receive { case eResolveDone: (tt: Tier) { t = tt; } }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunRouteAll(this, false); }
+  }
+}
+
+machine DriverBuggy {
+  start state Init {
+    entry { RunRouteFixed(this, true, -1, 50); }
+  }
+}
+
+/* Current code: routing is correct for every local floor and offset. Must hold. */
+test tcTierRoutingGuarded [main = DriverGuarded]:
+  assert TierRoutingCorrect in { DriverGuarded, ManifestStore, Reader };
+
+/* Guard removed: an empty local log (first_chunk_id = -1) routes a remote-only
+   offset to the local tier. MUST fail with the INV#4 silent remote skip. This
+   failing run is the gate. */
+test tcTierRoutingBuggy [main = DriverBuggy]:
+  assert TierRoutingCorrect in { DriverBuggy, ManifestStore, Reader };

--- a/p/tier-routing/README.md
+++ b/p/tier-routing/README.md
@@ -1,0 +1,52 @@
+# Offset to tier routing
+
+Models the integer-offset branch of `log_reader:resolve_remote_location/2`: the
+decision to serve an offset from the local log or the remote tier.
+
+## The bug class
+
+The local-tier check is:
+
+```erlang
+first_chunk_id =/= -1 andalso Offset >= first_chunk_id
+```
+
+`first_chunk_id = -1` means the local log is empty (fully trimmed or not yet
+populated). Without the `=/= -1` guard, `Offset >= -1` is always true, so an
+empty local log routes *every* offset to the local tail and silently skips the
+remote tier - the consumer sees no data (or waits at the tail) for offsets the
+remote tier actually holds. The guard makes an empty local log fall through to
+remote resolution.
+
+This is a second INV#4 guard, distinct from the `read-resolution/`
+group-fetch catch-all: that one is about a transient failure while descending
+into a group; this one is about routing the offset to the correct tier in the
+first place.
+
+## What the model captures
+
+- A `Reader` routing an offset given `first_chunk_id` (the local floor, `-1` when
+  empty) and the remote extent `[remoteFirst, remoteNext)`
+- The full branch lattice: local-covered, no-remote, empty-local-beyond-tail, and
+  remote
+- `bugNoMinusOneGuard` drops the `=/= -1` guard
+- `TierRoutingCorrect` (INV#4): an offset held only by the remote tier (covered
+  by the remote extent, not by the local log) must route to the remote tier. An
+  offset the local tier also holds may route locally (osiris prefers the local
+  reader), so the obligation is only on offsets the local tier does not cover
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcTierRoutingGuarded` | **holds** - the guarded driver deterministically probes every combination of local floor (`-1`, `0`, `30`) and offset (`0`..`175`), so totality does not rely on random sampling |
+| `tcTierRoutingBuggy` | **fails** - the `=/= -1` guard removed; an empty-local read of a remote-only offset routes local; `INV#4 violated: an offset held only by the remote tier routed to the local tier` |
+
+`tcTierRoutingBuggy` is *expected to fail*; that counterexample is the proof the
+model reproduces the empty-local silent remote skip.
+
+```bash
+p compile
+p check -tc tcTierRoutingGuarded -i 5000   # 0 bugs (full floor x offset grid)
+p check -tc tcTierRoutingBuggy   -i 2000   # 1 bug: INV#4 misrouting
+```

--- a/p/tier-routing/TierRouting.pproj
+++ b/p/tier-routing/TierRouting.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>TierRouting</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/trimmed-segment/PSpec/Monitors.p
+++ b/p/trimmed-segment/PSpec/Monitors.p
@@ -1,0 +1,24 @@
+/* INV#3 (progress / no unbounded wedge): every submitted transfer must
+   eventually resolve - either by completing or by recovering via
+   restart_at_local_floor. A trimmed-segment failure that is resubmitted forever
+   leaves this obligation undischarged. AwaitingResolution is a hot state: an
+   execution that stays in it (the #225 resubmit loop) is a liveness violation. */
+spec TransferEventuallyResolves observes eTransferSubmitted, eTransferResolved {
+  start state Idle {
+    on eTransferSubmitted goto AwaitingResolution;
+  }
+  hot state AwaitingResolution {
+    on eTransferResolved goto Idle;
+  }
+}
+
+/* Safety: a recovery reset targets the live local floor (the only correct
+   restart point once the original range is permanently trimmed). */
+spec ResetTargetsLocalFloor observes eFrontierReset {
+  start state Watching {
+    on eFrontierReset do (p: (target: int)) {
+      assert p.target > 0,
+        "recovery reset must target a positive local floor (restart_at_local_floor)";
+    }
+  }
+}

--- a/p/trimmed-segment/PSrc/Common.p
+++ b/p/trimmed-segment/PSrc/Common.p
@@ -1,0 +1,29 @@
+/* Shared events for the #225 trimmed-segment seam.
+
+   A head fragment (first offset == manifest next_offset) is submitted for
+   transfer; the upload worker preads the local segment. If local retention
+   trims the log past next_offset first, the segment is permanently gone and the
+   pread fails (enoent). handle_transfer_failure must then recover via
+   restart_at_local_floor (the local_log_ahead branch) rather than resubmit
+   forever, otherwise tiering wedges and local disk grows unbounded. */
+
+/* Local log (osiris segments) and retention trim. */
+event eQueryFloor: (from: machine);
+event eFloorResult: (localFirst: int, nextOffset: int);
+event eReadSegment: (from: machine);
+event eReadOk;
+event eReadTrimmed;
+event eTrim: (from: machine);
+event eTrimAck;
+
+/* Upload worker (governor task). */
+event eDoUpload: (reader: machine, log: machine);
+event eTransferResult: (ok: bool);
+
+/* Reader control. */
+event eStartTransfer;
+
+/* Spec events (announce). */
+event eTransferSubmitted;
+event eTransferResolved;
+event eFrontierReset: (target: int);

--- a/p/trimmed-segment/PSrc/LocalLog.p
+++ b/p/trimmed-segment/PSrc/LocalLog.p
@@ -1,0 +1,30 @@
+/* The local osiris log and its retention. A trim past next_offset removes the
+   segment backing the head fragment permanently; subsequent preads fail
+   (enoent), and the local floor (localFirst) advances past next_offset. */
+machine LocalLog {
+  var trimmed: bool;
+  var localFirst: int;
+  var nextOffset: int;
+
+  start state Serving {
+    entry (init: (localFirst: int, nextOffset: int)) {
+      localFirst = init.localFirst;
+      nextOffset = init.nextOffset;
+    }
+    on eTrim do (p: (from: machine)) {
+      trimmed = true;
+      localFirst = nextOffset + 1;
+      send p.from, eTrimAck;
+    }
+    on eQueryFloor do (p: (from: machine)) {
+      send p.from, eFloorResult, (localFirst = localFirst, nextOffset = nextOffset);
+    }
+    on eReadSegment do (p: (from: machine)) {
+      if (trimmed) {
+        send p.from, eReadTrimmed;
+      } else {
+        send p.from, eReadOk;
+      }
+    }
+  }
+}

--- a/p/trimmed-segment/PSrc/Reader.p
+++ b/p/trimmed-segment/PSrc/Reader.p
@@ -1,0 +1,46 @@
+/* The replica reader driving a fragment transfer. On a transfer failure it
+   mirrors handle_transfer_failure: when checkLocalLogAhead is set it consults
+   local_log_ahead and, if the local floor has advanced past next_offset (the
+   segment is permanently trimmed), recovers via restart_at_local_floor rather
+   than resubmitting. With the check disabled (the #225 bug) every failure is
+   treated as retriable and resubmitted, so a trimmed segment loops forever. */
+machine Reader {
+  var checkLocalLogAhead: bool;
+  var log: machine;
+  var worker: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (checkLLA: bool, log: machine, worker: machine, driver: machine)) {
+      checkLocalLogAhead = init.checkLLA;
+      log = init.log;
+      worker = init.worker;
+      driver = init.driver;
+    }
+    on eStartTransfer do {
+      announce eTransferSubmitted;
+      send worker, eDoUpload, (reader = this, log = log);
+    }
+    on eTransferResult do (p: (ok: bool)) {
+      var f: (localFirst: int, nextOffset: int);
+      if (p.ok) {
+        announce eTransferResolved;
+      } else {
+        if (checkLocalLogAhead) {
+          send log, eQueryFloor, (from = this,);
+          receive { case eFloorResult: (r: (localFirst: int, nextOffset: int)) { f = r; } }
+          if (f.localFirst > f.nextOffset) {
+            /* restart_at_local_floor: discard the unreachable range and reset
+               the frontier to the live local floor. This is forward progress. */
+            announce eFrontierReset, (target = f.localFirst,);
+            announce eTransferResolved;
+          } else {
+            send worker, eDoUpload, (reader = this, log = log);
+          }
+        } else {
+          send worker, eDoUpload, (reader = this, log = log);
+        }
+      }
+    }
+  }
+}

--- a/p/trimmed-segment/PSrc/Worker.p
+++ b/p/trimmed-segment/PSrc/Worker.p
@@ -1,0 +1,15 @@
+/* The upload worker (a governor transfer task): preads the local segment and
+   reports success, or failure when the segment has been trimmed away. */
+machine Worker {
+  start state Ready {
+    on eDoUpload do (p: (reader: machine, log: machine)) {
+      var ok: bool;
+      send p.log, eReadSegment, (from = this,);
+      receive {
+        case eReadOk: { ok = true; }
+        case eReadTrimmed: { ok = false; }
+      }
+      send p.reader, eTransferResult, (ok = ok,);
+    }
+  }
+}

--- a/p/trimmed-segment/PTst/TestDrivers.p
+++ b/p/trimmed-segment/PTst/TestDrivers.p
@@ -1,0 +1,76 @@
+/* Test drivers and declarations for the #225 trimmed-segment seam.
+
+   The gate contrasts tcTrimGuarded (the local_log_ahead recovery: a trimmed
+   transfer resolves via reset, liveness holds) with tcTrimBuggy (the check
+   removed: the transfer resubmits forever, the liveness obligation is never
+   discharged). */
+
+fun BuildAndTrim(self: machine, checkLLA: bool): machine {
+  var log: machine;
+  var worker: machine;
+  var reader: machine;
+  log = new LocalLog((localFirst = 0, nextOffset = 5));
+  worker = new Worker();
+  reader = new Reader((checkLLA = checkLLA, log = log, worker = worker, driver = self));
+  /* Retention trims the local log past next_offset before the upload reads it. */
+  send log, eTrim, (from = self,);
+  receive { case eTrimAck: { } }
+  return reader;
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry {
+      var reader: machine;
+      reader = BuildAndTrim(this, true);
+      send reader, eStartTransfer;
+    }
+  }
+}
+
+machine DriverBuggy {
+  start state Init {
+    entry {
+      var reader: machine;
+      reader = BuildAndTrim(this, false);
+      send reader, eStartTransfer;
+    }
+  }
+}
+
+/* Exploration: race the trim against the transfer (guard on). The transfer must
+   resolve whether the trim lands before, during, or after the upload. */
+machine DriverExplore {
+  start state Init {
+    entry {
+      var log: machine;
+      var worker: machine;
+      var reader: machine;
+      log = new LocalLog((localFirst = 0, nextOffset = 5));
+      worker = new Worker();
+      reader = new Reader((checkLLA = true, log = log, worker = worker, driver = this));
+      /* Race the trim against the transfer: both are dispatched before either is
+         awaited, so the upload's eReadSegment and the eTrim interleave at the
+         log's queue. The eTrimAck is consumed so it is not an unhandled event. */
+      send log, eTrim, (from = this,);
+      send reader, eStartTransfer;
+      receive { case eTrimAck: { } }
+    }
+  }
+}
+
+/* Current code: a trimmed transfer recovers. Liveness holds. */
+test tcTrimGuarded [main = DriverGuarded]:
+  assert TransferEventuallyResolves, ResetTargetsLocalFloor in
+  { DriverGuarded, LocalLog, Worker, Reader };
+
+/* #225 bug (local_log_ahead check removed): the transfer resubmits forever.
+   MUST fail the liveness obligation. This failing run is the gate. */
+test tcTrimBuggy [main = DriverBuggy]:
+  assert TransferEventuallyResolves, ResetTargetsLocalFloor in
+  { DriverBuggy, LocalLog, Worker, Reader };
+
+/* Guard on, trim raced against the transfer. Liveness holds. */
+test tcTrimExplore [main = DriverExplore]:
+  assert TransferEventuallyResolves, ResetTargetsLocalFloor in
+  { DriverExplore, LocalLog, Worker, Reader };

--- a/p/trimmed-segment/README.md
+++ b/p/trimmed-segment/README.md
@@ -1,0 +1,56 @@
+# Trimmed-segment upload seam (issue #225)
+
+Models the TOCTOU between submitting a fragment for transfer and the upload
+worker reading the local segment, when retention trims that segment in between.
+
+## The bug class
+
+A head fragment (its first offset equals the manifest `next_offset`) is submitted
+for transfer. The upload worker `pread`s the local segment. If local retention
+trims the log past `next_offset` first, the segment is permanently gone and the
+`pread` fails with `enoent`.
+
+`handle_transfer_failure` must distinguish this from a transient error. It checks
+`local_log_ahead` (`LocalFirst > NextOffset`): if the local floor has advanced
+past the stalled fragment, no retry can ever make that range durable, so it
+recovers via `restart_at_local_floor` (reset the frontier to the live local
+floor and re-tier from there). Without that check every failure is treated as
+retriable and resubmitted - the upload loops forever, tiering wedges, and local
+disk grows unbounded (local retention only reclaims offsets below the pinned
+`next_offset`).
+
+## Why this is a liveness model
+
+The bug is not a bad state the system reaches; it is the *absence* of progress -
+the transfer never resolves. That is a liveness property, so the monitor uses a
+P `hot` state (`AwaitingResolution`): an execution that stays in it forever (the
+resubmit loop) is a liveness violation, which the checker reports when the hot
+state persists past the max-steps temperature bound.
+
+## What the model captures
+
+- A `Reader` driving a transfer, a `Worker` that preads, and a `LocalLog` whose
+  retention trim removes the segment and advances the local floor
+- The `checkLocalLogAhead` toggle selects the `local_log_ahead` recovery versus
+  the #225 bug (always resubmit)
+- `TransferEventuallyResolves` (INV#3, liveness): a submitted transfer must
+  eventually complete or recover
+- `ResetTargetsLocalFloor` (safety): a recovery reset targets the live local floor
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcTrimGuarded` | **holds** - a trimmed transfer recovers via reset |
+| `tcTrimBuggy` | **fails** - the recovery check removed; the transfer resubmits forever and the `AwaitingResolution` hot state never clears |
+| `tcTrimExplore` | **holds** - guard on, the trim raced against the transfer at the log's queue |
+
+`tcTrimBuggy` is *expected to fail*; that liveness counterexample is the proof
+the model reproduces the #225 wedge.
+
+```bash
+p compile
+p check -tc tcTrimGuarded -i 5000   # 0 bugs
+p check -tc tcTrimBuggy   -i 2000   # 1 bug: TransferEventuallyResolves never discharged
+p check -tc tcTrimExplore -i 5000   # 0 bugs
+```

--- a/p/trimmed-segment/TrimmedSegment.pproj
+++ b/p/trimmed-segment/TrimmedSegment.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>TrimmedSegment</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/p/writer-fencing/PSpec/Monitors.p
+++ b/p/writer-fencing/PSpec/Monitors.p
@@ -1,0 +1,20 @@
+/* Split-brain safety: the committed epoch never regresses. A commit that lowers
+   the epoch means a deposed (lower-epoch) writer overwrote a newer writer's
+   manifest - exactly what the epoch fence prevents. This is the monotonicity the
+   gc-reset model's epoch axis assumes. */
+spec NoEpochRegression observes eCommitted {
+  var maxEpoch: int;
+  var started: bool;
+
+  start state Watching {
+    on eCommitted do (e: int) {
+      if (started) {
+        assert e >= maxEpoch,
+          format("split-brain: committed epoch regressed from {0} to {1} (a deposed writer overwrote a newer writer)",
+            maxEpoch, e);
+      }
+      maxEpoch = e;
+      started = true;
+    }
+  }
+}

--- a/p/writer-fencing/PSrc/Common.p
+++ b/p/writer-fencing/PSrc/Common.p
@@ -1,0 +1,23 @@
+/* Shared events for the writer/epoch fencing seam.
+
+   rabbitmq_stream_s3_db:do_put/5 commits a manifest root with an optimistic lock:
+   the put succeeds only if the current revision matches the expected one AND the
+   new epoch is >= the stored epoch (the #if_data_matches {'>=', Epoch, '$1'}
+   fence). The fence stops a deposed (lower-epoch) writer that has read the
+   current revision from overwriting a newer writer's commit. This is what makes
+   the committed epoch monotonic - the assumption the gc-reset model's epoch axis
+   relies on. */
+
+/* Khepri metadata store. */
+event eGet: (from: machine);
+event eGetResult: (uid: int, epoch: int, revision: int);
+event ePut: (from: machine, expectedRev: int, epoch: int, uid: int);
+event ePutOk: int;
+event ePutConflict: (uid: int, epoch: int, revision: int);
+
+/* Writer control. */
+event eAttemptCommit;
+event eCommitDone: bool;
+
+/* Spec event (announce): a committed epoch. */
+event eCommitted: int;

--- a/p/writer-fencing/PSrc/KhepriDB.p
+++ b/p/writer-fencing/PSrc/KhepriDB.p
@@ -1,0 +1,35 @@
+/* The Khepri metadata store with the optimistic-lock CAS from do_put/5. A put
+   commits only if the expected revision matches the current one AND (when the
+   fence is enabled) the new epoch is at least the stored epoch. On success the
+   revision advances and the (uid, epoch) is replaced. */
+machine KhepriDB {
+  var uid: int;
+  var epoch: int;
+  var revision: int;
+  var fence: bool;
+
+  start state Serving {
+    entry (init: (uid: int, epoch: int, revision: int, fence: bool)) {
+      uid = init.uid;
+      epoch = init.epoch;
+      revision = init.revision;
+      fence = init.fence;
+    }
+    on eGet do (p: (from: machine)) {
+      send p.from, eGetResult, (uid = uid, epoch = epoch, revision = revision);
+    }
+    on ePut do (p: (from: machine, expectedRev: int, epoch: int, uid: int)) {
+      var epochOk: bool;
+      epochOk = (!fence) || (p.epoch >= epoch);
+      if (p.expectedRev == revision && epochOk) {
+        revision = revision + 1;
+        epoch = p.epoch;
+        uid = p.uid;
+        announce eCommitted, epoch;
+        send p.from, ePutOk, revision;
+      } else {
+        send p.from, ePutConflict, (uid = uid, epoch = epoch, revision = revision);
+      }
+    }
+  }
+}

--- a/p/writer-fencing/PSrc/Writer.p
+++ b/p/writer-fencing/PSrc/Writer.p
@@ -1,0 +1,30 @@
+/* A writer attempting to commit a manifest root: it reads the current revision,
+   then CASes its own (epoch, uid) against that revision. A deposed writer keeps
+   its old (lower) epoch. */
+machine Writer {
+  var myEpoch: int;
+  var myUid: int;
+  var db: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (epoch: int, uid: int, db: machine, driver: machine)) {
+      myEpoch = init.epoch;
+      myUid = init.uid;
+      db = init.db;
+      driver = init.driver;
+    }
+    on eAttemptCommit do {
+      var rev: int;
+      var ok: bool;
+      send db, eGet, (from = this,);
+      receive { case eGetResult: (r: (uid: int, epoch: int, revision: int)) { rev = r.revision; } }
+      send db, ePut, (from = this, expectedRev = rev, epoch = myEpoch, uid = myUid);
+      receive {
+        case ePutOk: (nr: int) { ok = true; }
+        case ePutConflict: (c: (uid: int, epoch: int, revision: int)) { ok = false; }
+      }
+      send driver, eCommitDone, ok;
+    }
+  }
+}

--- a/p/writer-fencing/PTst/TestDrivers.p
+++ b/p/writer-fencing/PTst/TestDrivers.p
@@ -1,0 +1,74 @@
+/* Test drivers and declarations for the writer/epoch fencing seam.
+
+   Two writers contend: W2 is the new writer (epoch 2), W1 is a deposed writer
+   (epoch 1) that does not yet know it lost leadership. The gate contrasts
+   tcFencingGuarded (the epoch fence rejects W1's stale commit, must hold) with
+   tcFencingUnguarded (fence removed: W1 overwrites W2's commit at a lower epoch,
+   must fail with the split-brain epoch regression). */
+
+fun RunFencing(self: machine, fence: bool) {
+  var db: machine;
+  var w1: machine;
+  var w2: machine;
+  var ok: bool;
+
+  db = new KhepriDB((uid = 0, epoch = 0, revision = 1, fence = fence));
+  w1 = new Writer((epoch = 1, uid = 1, db = db, driver = self));
+  w2 = new Writer((epoch = 2, uid = 2, db = db, driver = self));
+
+  /* The new writer commits first. */
+  send w2, eAttemptCommit;
+  receive { case eCommitDone: (o: bool) { ok = o; } }
+
+  /* The deposed writer then reads the current revision and tries to commit. */
+  send w1, eAttemptCommit;
+  receive { case eCommitDone: (o: bool) { ok = o; } }
+}
+
+machine DriverGuarded {
+  start state Init {
+    entry { RunFencing(this, true); }
+  }
+}
+
+machine DriverUnguarded {
+  start state Init {
+    entry { RunFencing(this, false); }
+  }
+}
+
+/* Exploration: both writers contend with their reads and commits interleaved
+   freely (fence on). No interleaving may regress the committed epoch. */
+machine DriverExplore {
+  start state Init {
+    entry {
+      var db: machine;
+      var w1: machine;
+      var w2: machine;
+      var done: int;
+      db = new KhepriDB((uid = 0, epoch = 0, revision = 1, fence = true));
+      w1 = new Writer((epoch = 1, uid = 1, db = db, driver = this));
+      w2 = new Writer((epoch = 2, uid = 2, db = db, driver = this));
+      send w1, eAttemptCommit;
+      send w2, eAttemptCommit;
+      done = 0;
+      while (done < 2) {
+        receive { case eCommitDone: (o: bool) { done = done + 1; } }
+      }
+    }
+  }
+}
+
+/* Current code: the epoch fence rejects the deposed writer. Must hold. */
+test tcFencingGuarded [main = DriverGuarded]:
+  assert NoEpochRegression in { DriverGuarded, KhepriDB, Writer };
+
+/* Fence removed: the deposed writer's stale-epoch commit succeeds and overwrites
+   the newer writer. MUST fail with the split-brain epoch regression. This
+   failing run is the gate. */
+test tcFencingUnguarded [main = DriverUnguarded]:
+  assert NoEpochRegression in { DriverUnguarded, KhepriDB, Writer };
+
+/* Fence on, both writers' reads/commits interleaved. Must hold. */
+test tcFencingExplore [main = DriverExplore]:
+  assert NoEpochRegression in { DriverExplore, KhepriDB, Writer };

--- a/p/writer-fencing/README.md
+++ b/p/writer-fencing/README.md
@@ -1,0 +1,51 @@
+# Writer / epoch fencing
+
+Models the optimistic-lock CAS in `rabbitmq_stream_s3_db:do_put/5` that fences a
+deposed writer off the manifest root.
+
+## The property
+
+A manifest-root commit goes through a conditional `adv_put`:
+
+```erlang
+[#if_payload_version{version = ExpectedRevision},
+ #if_data_matches{pattern = {'_', '$1'}, conditions = [{'>=', Epoch, '$1'}]}]
+```
+
+The put succeeds only if **both** hold: the current revision matches the expected
+one (the optimistic lock), and the new epoch is `>=` the stored epoch (the
+fence). The revision lock alone is not enough: a deposed writer can read the
+*current* revision after a newer writer committed and then CAS with that
+revision. The epoch fence rejects it because its epoch is lower.
+
+This is the mechanism that makes the committed epoch monotonic - the assumption
+the `gc-reset/` epoch axis (and the durability guards generally) rely on. So this
+model proves a foundation the others build on.
+
+## What the model captures
+
+- A `KhepriDB` with the CAS: a put commits iff `expectedRev == revision` and
+  (`fence` off, or `newEpoch >= storedEpoch`); on success the revision advances
+- Two `Writer`s: a new writer (epoch 2) and a deposed writer (epoch 1) that still
+  attempts to commit
+- `fence` toggles the `>=` epoch condition
+- `NoEpochRegression`: the committed epoch never decreases (a decrease means a
+  deposed writer overwrote a newer one - split-brain)
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcFencingGuarded` | **holds** - the new writer commits (epoch 2); the deposed writer (epoch 1) is rejected by the fence |
+| `tcFencingUnguarded` | **fails** - fence removed; the deposed writer's revision-matching commit succeeds and lowers the epoch; `split-brain: committed epoch regressed from 2 to 1` |
+| `tcFencingExplore` | **holds** - both writers' reads and commits interleaved freely; no schedule regresses the epoch |
+
+`tcFencingUnguarded` is *expected to fail*; that counterexample is the proof the
+model reproduces split-brain.
+
+```bash
+p compile
+p check -tc tcFencingGuarded   -i 5000   # 0 bugs
+p check -tc tcFencingUnguarded -i 2000   # 1 bug: epoch regression (split-brain)
+p check -tc tcFencingExplore   -i 5000   # 0 bugs
+```

--- a/p/writer-fencing/WriterFencing.pproj
+++ b/p/writer-fencing/WriterFencing.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>WriterFencing</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>


### PR DESCRIPTION
This is a handful of formal models based on the components of the plugin and, especially, recently fixed bugs. These are written in [P](https://github.com/p-org/P) rather than TLA+. P is a natural choice for Erlang since it models state machines communicating via message passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
