### PR TITLE
Guard do_commit against deleting a manifest with uid collision

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -791,7 +791,7 @@ do_commit(StreamId, Manifest, Epoch, Reference, ExpectedRevision) ->
         ok ->
             case commit_khepri(StreamId, Epoch, Reference, ExpectedRevision, Uid) of
                 {ok, OldRef, NewRevision} ->
-                    delete_old_manifest(StreamId, OldRef),
+                    delete_old_manifest(StreamId, Ref, OldRef),
                     {ok, NewRevision};
                 {error, _} = Err ->
                     Err
@@ -822,11 +822,29 @@ commit_khepri(StreamId, Epoch, Reference, ExpectedRevision, Uid) ->
             Err
     end.
 
-delete_old_manifest(_StreamId, undefined) ->
-    ok;
-delete_old_manifest(StreamId, #manifest_ref{} = Ref) ->
-    Key = rabbitmq_stream_s3:ref_key(StreamId, Ref),
-    rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]).
+delete_old_manifest(StreamId, NewRef, OldRef) ->
+    case stale_manifest_ref(NewRef, OldRef) of
+        {delete, Ref} ->
+            Key = rabbitmq_stream_s3:ref_key(StreamId, Ref),
+            rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]);
+        skip ->
+            ok
+    end.
+
+%% The prior manifest ref to delete after a commit, or `skip` when nothing can be
+%% safely deleted. The uid is a fresh 32-bit random value per commit
+%% (rabbitmq_stream_s3:uid/0), so it can collide with the immediately-prior
+%% commit's uid at the same epoch. A colliding ref maps to the same S3 key as the
+%% manifest just written, so deleting "the old" object would delete the live
+%% committed manifest. Skip the delete in that case.
+-spec stale_manifest_ref(#manifest_ref{}, #manifest_ref{} | undefined) ->
+    {delete, #manifest_ref{}} | skip.
+stale_manifest_ref(_NewRef, undefined) ->
+    skip;
+stale_manifest_ref(Ref, Ref) ->
+    skip;
+stale_manifest_ref(_NewRef, #manifest_ref{} = OldRef) ->
+    {delete, OldRef}.
 
 -spec serialize_manifest(#manifest{}) -> binary().
 serialize_manifest(#manifest{
@@ -2220,6 +2238,24 @@ on_remote_retention_deleted(Refs, StreamId, State) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+%% A fresh-random uid can collide with the immediately-prior commit's uid at the
+%% same epoch, so the "old" manifest ref maps to the same S3 key as the manifest
+%% just written. Deleting it would delete the live committed manifest, so the
+%% colliding ref must be skipped; an absent or genuinely distinct ref behaves as
+%% before (skip / delete respectively).
+stale_manifest_ref_skips_self_collision_test() ->
+    Ref = #manifest_ref{epoch = 7, uid = 42},
+    ?assertEqual(skip, stale_manifest_ref(Ref, undefined)),
+    ?assertEqual(skip, stale_manifest_ref(Ref, Ref)),
+    ?assertEqual(
+        {delete, #manifest_ref{epoch = 7, uid = 41}},
+        stale_manifest_ref(Ref, #manifest_ref{epoch = 7, uid = 41})
+    ),
+    ?assertEqual(
+        {delete, #manifest_ref{epoch = 6, uid = 42}},
+        stale_manifest_ref(Ref, #manifest_ref{epoch = 6, uid = 42})
+    ).
 
 %% A transient metadata-store error must schedule a retry, not resolve empty.
 classify_store_result_transient_error_retries_test() ->


### PR DESCRIPTION
The manifest uid is a fresh 32-bit random value per commit, so it can collide with the immediately-prior commit's uid at the same epoch. The manifest S3 key is a pure function of (stream, epoch, uid), so a colliding ref maps to the same key as the manifest just written. do_commit deleted the prior ref unconditionally after the Khepri CAS, which on such a collision deletes the live committed manifest, leaving Khepri pointing at a 404 until the next commit.

Extract the delete-or-skip decision into a pure stale_manifest_ref/2 and skip the delete when the prior ref equals the just-committed ref. Found by a P-model conformance audit (writer-fencing abstraction gap: uid assumed unique but not enforced).

Note that a UID collision is astronomically unlikely, so this is more of a defense-in-depth change than anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
