### PR TITLE
GC: Tie first offset to epoch

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
+      gc_reset_multinode: ${{ steps.filter.outputs.gc_reset_multinode }}
       gc_leading_group: ${{ steps.filter.outputs.gc_leading_group }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
@@ -39,9 +40,11 @@ jobs:
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "gc_reset=false" >> "$GITHUB_OUTPUT"
+          echo "gc_reset_multinode=false" >> "$GITHUB_OUTPUT"
           echo "gc_leading_group=false" >> "$GITHUB_OUTPUT"
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/gc-reset-multinode/' && echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-leading-group/' && echo "gc_leading_group=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
@@ -54,6 +57,7 @@ jobs:
           echo "$CHANGED" | grep -q '^p/writer-fencing/' && echo "writer_fencing=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
+            echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
@@ -124,6 +128,53 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: floor-last ordering fails with the expected dangling reference."
+          echo "::endgroup::"
+
+  gc-reset-multinode:
+    needs: changes
+    if: needs.changes.outputs.gc_reset_multinode == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/gc-reset-multinode
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/gc-reset-multinode
+          for tc in tcMultiNodeStaleGuarded tcMultiNodeSyncedGuarded tcMultiNodeExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcMultiNodeExplore (PCT)"
+          p check -tc tcMultiNodeExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (a stale replica cache must defeat still_dangling)
+        run: |
+          cd p/gc-reset-multinode
+          rm -rf PCheckerOutput/
+          echo "::group::tcMultiNodeStaleUnguarded (expect the cross-node GC x reset counterexample)"
+          if p check -tc tcMultiNodeStaleUnguarded -i 2000; then
+            echo "ERROR: tcMultiNodeStaleUnguarded passed; the model no longer reproduces the stale-cache delete."
+            echo "With the epoch guard off and the reset sync dropped, the shipped still_dangling/1 guard"
+            echo "must re-read the stale floor and delete a live object, otherwise the guarded result is not trustworthy."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object (offset=850, uid=2)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the unguarded run failed, but not with the expected INV#2 (850, uid 2) counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: a stale replica cache defeats still_dangling and deletes the re-tiered live object."
           echo "::endgroup::"
 
   gc-leading-group:

--- a/p/gc-reset-multinode/PSpec/Monitors.p
+++ b/p/gc-reset-multinode/PSpec/Monitors.p
@@ -1,0 +1,90 @@
+/* Global safety monitors for the multi-node durability seam. Identical in intent
+   to ../gc-reset: they observe the AUTHORITATIVE manifest state announced by the
+   writer/driver and assert GC never deletes a live (offset, uid). The lagging
+   cache is never a source of these events, so "live" always means what the
+   committed manifest references, regardless of which node's cache the sweep
+   read. */
+
+/* INV#2: GC must never delete an object the live (committed) manifest references. */
+spec NoDanglingReference observes eObjectReferenced, eObjectUnreferenced, eGcDelete {
+  var live: set[ObjKey];
+
+  start state Watching {
+    on eObjectReferenced do (k: ObjKey) {
+      live += (k);
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k in live) {
+        live -= (k);
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      assert !(k in live),
+        format("INV#2 violated: GC deleted live object (offset={0}, uid={1}) still referenced by the committed manifest (stale-cache sweep)",
+          k.offset, k.uid);
+    }
+  }
+}
+
+/* INV#1: no lost acked data. The object currently covering an offset at or above
+   the live floor must not be deleted. Keyed by (offset, uid) so a stale-UID
+   delete is not mistaken for losing the live cover. */
+spec NoLostAckedData observes eObjectReferenced, eObjectUnreferenced, eFloorChanged, eGcDelete {
+  var floor: int;
+  var liveByOffset: map[int, int];
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      floor = p.newFloor;
+    }
+    on eObjectReferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        liveByOffset[k.offset] = k.uid;
+      } else {
+        liveByOffset += (k.offset, k.uid);
+      }
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        if (liveByOffset[k.offset] == k.uid) {
+          liveByOffset -= (k.offset);
+        }
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      if (k.offset >= floor) {
+        if (k.offset in liveByOffset) {
+          if (liveByOffset[k.offset] == k.uid) {
+            assert false,
+              format("INV#1 violated: GC deleted the live cover of acked offset {0} (uid={1}) at or above the live floor {2}",
+                k.offset, k.uid, floor);
+          }
+        }
+      }
+    }
+  }
+}
+
+/* INV#5: the committed first_offset frontier is monotonically non-decreasing
+   except across an explicitly labeled reset. Only the authoritative writer
+   announces floor changes. */
+spec MonotonicFrontier observes eFloorChanged {
+  var floor: int;
+  var started: bool;
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      if (!started) {
+        floor = p.newFloor;
+        started = true;
+      } else {
+        if (!p.isReset) {
+          assert p.newFloor >= floor,
+            format("INV#5 violated: first_offset moved backward from {0} to {1} without a labeled reset",
+              floor, p.newFloor);
+        }
+        floor = p.newFloor;
+      }
+    }
+  }
+}

--- a/p/gc-reset-multinode/PSrc/Common.p
+++ b/p/gc-reset-multinode/PSrc/Common.p
@@ -1,0 +1,73 @@
+/* Shared types and events for the multi-node GC x reset durability seam.
+
+   This model is the cross-node companion to ../gc-reset. That model collapses
+   every node into one synchronous manifest_replica, so GC and the writer always
+   read the same live floor. Here the floor GC reads comes from a SEPARATE,
+   lagging per-node replica cache (rabbitmq_stream_s3_manifest_replica), updated
+   from the writer by a fire-and-forget sync that may be dropped or delayed.
+
+   The seam: rabbitmq_stream_s3_gc:build_lookup reads the committed epoch with a
+   quorum read (rabbitmq_stream_s3_db:get_consistent) but reads first_offset from
+   the LOCAL replica ETS cache (manifest_replica:get_manifest). Nothing ties the
+   cached floor's freshness to the committed epoch. An operator CLI delete sweep
+   (stream_s3_gc --mode delete) against a node that has not yet applied the
+   reset's sync reads a stale-HIGH floor; still_dangling/1 re-reads the same
+   stale cache, so the offset guard defends nothing and a freshly re-tiered live
+   object below the stale floor is deleted. */
+
+/* An S3 object / manifest entry is identified by (offset, uid): two objects can
+   share an offset (a stale UID and a freshly re-tiered one). */
+type ObjKey = (offset: int, uid: int);
+
+/* Why GC flagged a data object. Only the below_first_offset (offset) axis is
+   modeled: in rabbitmq_stream_s3_gc:classify/2 the stale_epoch axis applies only
+   to manifest root objects, never to fragments, so it is irrelevant here. */
+enum Reason { BELOW_FLOOR }
+type Candidate = (offset: int, uid: int, reason: Reason);
+
+/* Khepri (durable consensus over the committed epoch). The reset bumps it. */
+event eGetConsistent: (from: machine);
+event eEpochResult: (ok: bool, epoch: int);
+event eSetCommittedEpoch: (from: machine, epoch: int);
+event eDbAck;
+
+/* Per-node manifest replica cache. eMRSync is the fire-and-forget propagation
+   of a reset from the writer; the replica applies it only if the incoming epoch
+   is at least the cached one (is_stale_sync: epoch dominates). When the sync is
+   dropped/delayed the cache keeps its stale-high floor at its old epoch. */
+event eMRSync: (from: machine, floor: int, epoch: int);
+event eMRGetFloor: (from: machine);
+event eMRFloorResult: int;
+event eMRGetFloorEpoch: (from: machine);
+event eMRFloorEpochResult: (floor: int, epoch: int);
+
+/* S3 object store. */
+event eS3Put: (from: machine, key: ObjKey);
+event eS3Delete: (from: machine, key: ObjKey);
+event eS3List: (from: machine);
+event eS3ListResult: set[ObjKey];
+event eS3Has: (from: machine, key: ObjKey);
+event eS3HasResult: bool;
+event eS3Ack;
+
+/* Writer: orchestrates the committed remote-tier-ahead reset (the durable side
+   is already done; the only open question is whether the cache learns of it). */
+event eDoReset: (from: machine, newFloor: int, newUid: int, newEpoch: int);
+event eResetDone;
+
+/* GC sweep steps, driven explicitly so a test driver can force an exact
+   interleaving for the validation gate, or race the sync against them. */
+event eGcSnapshot;
+event eGcSnapshotDone;
+event eGcListClassify;
+event eGcClassifyDone;
+event eGcExecute;
+event eGcExecuteDone;
+
+/* Spec events, delivered to monitors via announce. The AUTHORITATIVE manifest
+   state (writer/committed) drives them; the lagging cache is a silent observer
+   of the truth, never its source. */
+event eObjectReferenced: ObjKey;
+event eObjectUnreferenced: ObjKey;
+event eFloorChanged: (newFloor: int, isReset: bool);
+event eGcDelete: ObjKey;

--- a/p/gc-reset-multinode/PSrc/GC.p
+++ b/p/gc-reset-multinode/PSrc/GC.p
@@ -1,0 +1,111 @@
+/* The orphan GC sweep (rabbitmq_stream_s3_gc) on the operator CLI path
+   (stream_s3_gc --mode delete via run/1 -> build_lookup), targeting ONE node's
+   replica cache. Split into the three steps that matter:
+
+     1. eGcSnapshot     - build_lookup: read the committed epoch with a quorum
+                          read AND the floor from the local replica cache. The
+                          epoch guard (the fix) compares the two and fails closed
+                          when the cache is behind the committed epoch.
+     2. eGcListClassify - LIST S3 and classify each object against the SNAPSHOT
+                          floor (offset axis only; data objects have no epoch
+                          axis - see classify/2).
+     3. eGcExecute      - for each candidate, apply still_dangling/1 (re-read the
+                          LIVE cache floor) and delete.
+
+   Two independent guards:
+     - stillDanglingEnabled: the SHIPPED offset guard (still_dangling/1). Always
+       on in these tests, because the point is that it is INSUFFICIENT here: it
+       re-reads the SAME lagging cache, so a stale-high floor defeats it.
+     - epochGuardEnabled: the FIX. Skip the stream unless the cache's epoch
+       equals the committed epoch, so a node that has not applied the reset's
+       sync never sweeps against its stale floor. */
+machine GC {
+  var stillDanglingEnabled: bool;
+  var epochGuardEnabled: bool;
+  var db: machine;
+  var target: machine;
+  var s3: machine;
+  var driver: machine;
+  var snapshotFloor: int;
+  var committedEpoch: int;
+  var cacheEpoch: int;
+  var skipped: bool;
+  var candidates: seq[Candidate];
+
+  start state Idle {
+    entry (init: (stillDanglingEnabled: bool, epochGuardEnabled: bool,
+                  db: machine, target: machine, s3: machine, driver: machine)) {
+      stillDanglingEnabled = init.stillDanglingEnabled;
+      epochGuardEnabled = init.epochGuardEnabled;
+      db = init.db;
+      target = init.target;
+      s3 = init.s3;
+      driver = init.driver;
+      skipped = false;
+    }
+
+    on eGcSnapshot do {
+      var fe: (floor: int, epoch: int);
+      /* Quorum read of the committed epoch (get_consistent). */
+      send db, eGetConsistent, (from = this,);
+      receive { case eEpochResult: (r: (ok: bool, epoch: int)) { committedEpoch = r.epoch; } }
+      /* Floor (and its epoch) from the LOCAL replica cache (get_manifest). */
+      send target, eMRGetFloorEpoch, (from = this,);
+      receive { case eMRFloorEpochResult: (x: (floor: int, epoch: int)) { fe = x; } }
+      snapshotFloor = fe.floor;
+      cacheEpoch = fe.epoch;
+      /* The fix: a cache behind the committed epoch has a floor that predates the
+         committed reset, so its floor may be stale-high. Fail closed and skip. */
+      if (epochGuardEnabled && cacheEpoch != committedEpoch) {
+        skipped = true;
+      }
+      send driver, eGcSnapshotDone;
+    }
+
+    on eGcListClassify do {
+      var objs: set[ObjKey];
+      var o: ObjKey;
+      candidates = default(seq[Candidate]);
+      if (!skipped) {
+        send s3, eS3List, (from = this,);
+        receive { case eS3ListResult: (lst: set[ObjKey]) { objs = lst; } }
+        foreach (o in objs) {
+          /* classify/2 data axis: below the snapshot floor is a candidate. */
+          if (o.offset < snapshotFloor) {
+            candidates += (sizeof(candidates), (offset = o.offset, uid = o.uid, reason = BELOW_FLOOR));
+          }
+        }
+      }
+      send driver, eGcClassifyDone;
+    }
+
+    on eGcExecute do {
+      var i: int;
+      var c: Candidate;
+      var del: bool;
+      var liveFloor: int;
+      i = 0;
+      while (i < sizeof(candidates)) {
+        c = candidates[i];
+        del = true;
+        /* still_dangling/1: re-read the live floor from the SAME replica cache.
+           On a lagging node this returns the stale-high floor, so the re-read
+           confirms the (wrong) delete - the offset guard defends nothing. */
+        if (c.reason == BELOW_FLOOR && stillDanglingEnabled) {
+          send target, eMRGetFloor, (from = this,);
+          receive { case eMRFloorResult: (f: int) { liveFloor = f; } }
+          if (!(c.offset < liveFloor)) {
+            del = false;
+          }
+        }
+        if (del) {
+          send s3, eS3Delete, (from = this, key = (offset = c.offset, uid = c.uid));
+          receive { case eS3Ack: { } }
+          announce eGcDelete, (offset = c.offset, uid = c.uid);
+        }
+        i = i + 1;
+      }
+      send driver, eGcExecuteDone;
+    }
+  }
+}

--- a/p/gc-reset-multinode/PSrc/KhepriDB.p
+++ b/p/gc-reset-multinode/PSrc/KhepriDB.p
@@ -1,0 +1,21 @@
+/* Durable consensus layer (rabbitmq_stream_s3_db). Holds the committed epoch and
+   answers strongly-consistent reads. The committed epoch is monotonic and is the
+   authoritative truth a quorum read returns; the per-node replica cache may lag
+   it. The reset commits a new (higher) epoch here BEFORE the sync that updates
+   the lagging cache, which is exactly why the cache can be behind. */
+machine KhepriDB {
+  var committedEpoch: int;
+
+  start state Serving {
+    entry (init: (epoch: int)) {
+      committedEpoch = init.epoch;
+    }
+    on eGetConsistent do (p: (from: machine)) {
+      send p.from, eEpochResult, (ok = true, epoch = committedEpoch);
+    }
+    on eSetCommittedEpoch do (p: (from: machine, epoch: int)) {
+      committedEpoch = p.epoch;
+      send p.from, eDbAck;
+    }
+  }
+}

--- a/p/gc-reset-multinode/PSrc/ManifestReplica.p
+++ b/p/gc-reset-multinode/PSrc/ManifestReplica.p
@@ -1,0 +1,46 @@
+/* A single per-node manifest replica cache (rabbitmq_stream_s3_manifest_replica).
+   This is the lagging, non-writer node that an operator CLI sweep happens to
+   target. It holds a cached first_offset (floor) and the epoch that floor was
+   synced at - the real cache tracks {seq, epoch, writer_node} per stream for gap
+   detection, but get_manifest/1 (the read GC uses) drops the epoch, which is the
+   crux of the seam.
+
+   The cache learns of a reset only via eMRSync, a fire-and-forget cast. It is
+   applied only when the incoming epoch is at least the cached one (modeling
+   is_stale_sync, where epoch dominates sequence), so a higher epoch always wins
+   and a stale delayed sync is rejected. When the sync is never delivered the
+   cache keeps its stale-high floor at its old epoch. The cache never announces
+   to the monitors: it is not the source of truth, only a possibly-stale view. */
+machine ManifestReplica {
+  var floor: int;
+  var epoch: int;
+
+  start state Serving {
+    entry (init: (floor: int, epoch: int)) {
+      floor = init.floor;
+      epoch = init.epoch;
+    }
+
+    /* Fire-and-forget sync from the writer. is_stale_sync: apply only if the
+       incoming epoch is not behind the cached epoch. No ack (cast). */
+    on eMRSync do (p: (from: machine, floor: int, epoch: int)) {
+      if (p.epoch >= epoch) {
+        floor = p.floor;
+        epoch = p.epoch;
+      }
+    }
+
+    /* get_manifest/1: returns only the cached floor (epoch dropped) - the read
+       still_dangling/1 re-uses, hence its blindness to cache staleness. */
+    on eMRGetFloor do (p: (from: machine)) {
+      send p.from, eMRFloorResult, floor;
+    }
+
+    /* The epoch-aware read the fix needs: returns the cached floor together with
+       the epoch it was synced at, so build_lookup can compare it to the
+       committed epoch and fail closed when the cache is behind. */
+    on eMRGetFloorEpoch do (p: (from: machine)) {
+      send p.from, eMRFloorEpochResult, (floor = floor, epoch = epoch);
+    }
+  }
+}

--- a/p/gc-reset-multinode/PSrc/S3Store.p
+++ b/p/gc-reset-multinode/PSrc/S3Store.p
@@ -1,0 +1,27 @@
+/* The S3 object store. Objects are keyed by (offset, uid). LIST returns whatever
+   is present at the moment of the call. The committed reset has already put the
+   re-tiered live object here (the durable side of the reset is done); the open
+   question the model explores is whether the lagging cache the sweep reads knows
+   about the lowered floor. */
+machine S3Store {
+  var objects: set[ObjKey];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, key: ObjKey)) {
+      objects += (p.key);
+      send p.from, eS3Ack;
+    }
+    on eS3Delete do (p: (from: machine, key: ObjKey)) {
+      if (p.key in objects) {
+        objects -= (p.key);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Has do (p: (from: machine, key: ObjKey)) {
+      send p.from, eS3HasResult, (p.key in objects);
+    }
+    on eS3List do (p: (from: machine)) {
+      send p.from, eS3ListResult, objects;
+    }
+  }
+}

--- a/p/gc-reset-multinode/PSrc/Writer.p
+++ b/p/gc-reset-multinode/PSrc/Writer.p
@@ -1,0 +1,38 @@
+/* The writer / reset orchestrator (rabbitmq_stream_s3_replica_reader). By the
+   time the dangerous CLI sweep runs, the reset is already COMMITTED: the new
+   (higher) epoch is in Khepri, the floor is lowered in the authoritative
+   manifest, and the live fragment has been re-tiered to S3 with a fresh UID.
+
+   The only modeled uncertainty is whether the lagging replica cache the sweep
+   reads has learned of it - that propagation (eMRSync) is driven by the test
+   driver so a scenario can drop it (the bug) or deliver it (anti-vacuity), and
+   the explore driver can race it against the sweep.
+
+   The writer announces the AUTHORITATIVE manifest state to the monitors: the
+   lowered (reset) floor and the re-tiered live (offset, uid). The cache is never
+   the source of truth for the spec. */
+machine Writer {
+  var db: machine;
+  var s3: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (db: machine, s3: machine, driver: machine)) {
+      db = init.db;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+    on eDoReset do (p: (from: machine, newFloor: int, newUid: int, newEpoch: int)) {
+      /* Commit the new epoch (the quorum truth a sweep's get_consistent sees). */
+      send db, eSetCommittedEpoch, (from = this, epoch = p.newEpoch);
+      receive { case eDbAck: { } }
+      /* Lower the authoritative floor (labeled reset) before referencing the
+         re-tiered object, then put it into S3. */
+      announce eFloorChanged, (newFloor = p.newFloor, isReset = true);
+      announce eObjectReferenced, (offset = p.newFloor, uid = p.newUid);
+      send s3, eS3Put, (from = this, key = (offset = p.newFloor, uid = p.newUid));
+      receive { case eS3Ack: { } }
+      send driver, eResetDone;
+    }
+  }
+}

--- a/p/gc-reset-multinode/PTst/TestDrivers.p
+++ b/p/gc-reset-multinode/PTst/TestDrivers.p
@@ -1,0 +1,206 @@
+/* Test drivers for the multi-node GC x reset durability seam.
+
+   Fixture (parallels ../gc-reset so the contrast is clear):
+     - committed epoch starts at 1; the lagging replica cache starts at
+       (floor = 1000, epoch = 1)
+     - S3 holds a live (1000, 10), a pre-existing stale orphan (850, 1), and a
+       genuine deep orphan (500, 0)
+     - a COMMITTED remote-tier-ahead reset bumps the epoch to 2, lowers the floor
+       to 850, and re-tiers a live (850, 2)
+
+   The sweep targets the lagging replica. Whether that cache learns of the reset
+   (eMRSync delivered) is the variable.
+
+   Validation gate: tcMultiNodeStaleUnguarded (epoch guard off, sync dropped)
+   MUST fail with the INV#2 dangling reference on (850, 2) - and crucially the
+   shipped still_dangling/1 guard is ON, proving it is insufficient cross-node.
+   tcMultiNodeStaleGuarded (epoch guard on) MUST hold by failing closed. */
+
+fun S3Put(self: machine, s3: machine, k: ObjKey) {
+  send s3, eS3Put, (from = self, key = k);
+  receive { case eS3Ack: { } }
+}
+
+fun S3Has(self: machine, s3: machine, k: ObjKey): bool {
+  var present: bool;
+  send s3, eS3Has, (from = self, key = k);
+  receive { case eS3HasResult: (b: bool) { present = b; } }
+  return present;
+}
+
+/* Build the common fixture: returns the handles via the caller's variables by
+   convention (P has no multiple return, so this is inlined per driver). */
+
+/* Deterministic gate: the reset commits, its sync to the target is DROPPED, then
+   the sweep runs fully sequenced so the dangerous stale-cache read is forced
+   every run. epochGuardEnabled toggles the fix; stillDanglingEnabled stays true. */
+fun RunStaleScenario(self: machine, epochGuardEnabled: bool) {
+  var db: machine;
+  var s3: machine;
+  var target: machine;
+  var writer: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  target = new ManifestReplica((floor = 1000, epoch = 1));
+
+  /* Authoritative initial state announced to the monitors. */
+  announce eFloorChanged, (newFloor = 1000, isReset = false);
+  announce eObjectReferenced, (offset = 1000, uid = 10);
+
+  S3Put(self, s3, (offset = 1000, uid = 10));
+  S3Put(self, s3, (offset = 850, uid = 1));
+  S3Put(self, s3, (offset = 500, uid = 0));
+
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((stillDanglingEnabled = true, epochGuardEnabled = epochGuardEnabled,
+               db = db, target = target, s3 = s3, driver = self));
+
+  /* Reset commits (epoch 2, floor 850, re-tier (850, 2)). Sync is NOT delivered:
+     the target cache keeps its stale-high floor 1000 at epoch 1. */
+  send writer, eDoReset, (from = self, newFloor = 850, newUid = 2, newEpoch = 2);
+  receive { case eResetDone: { } }
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+}
+
+/* Anti-vacuity: the reset commits AND its sync is delivered, so the cache is now
+   at the committed epoch. The guarded sweep must proceed (not skip), preserve the
+   live re-tiered (850, 2), and still reclaim the genuine deep orphan (500, 0). */
+fun RunSyncedScenario(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var target: machine;
+  var writer: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  target = new ManifestReplica((floor = 1000, epoch = 1));
+
+  announce eFloorChanged, (newFloor = 1000, isReset = false);
+  announce eObjectReferenced, (offset = 1000, uid = 10);
+
+  S3Put(self, s3, (offset = 1000, uid = 10));
+  S3Put(self, s3, (offset = 850, uid = 1));
+  S3Put(self, s3, (offset = 500, uid = 0));
+
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((stillDanglingEnabled = true, epochGuardEnabled = true,
+               db = db, target = target, s3 = s3, driver = self));
+
+  send writer, eDoReset, (from = self, newFloor = 850, newUid = 2, newEpoch = 2);
+  receive { case eResetDone: { } }
+
+  /* Deliver the reset's sync to the cache before the sweep reads it. */
+  send target, eMRSync, (from = self, floor = 850, epoch = 2);
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+
+  assert !S3Has(self, s3, (offset = 500, uid = 0)),
+    "guard over-suppressed: genuine deep orphan (500, 0) was not reclaimed after the cache caught up";
+  assert S3Has(self, s3, (offset = 850, uid = 2)),
+    "guard failed to preserve the live re-tiered object (850, 2)";
+}
+
+/* Exploration: the reset commits, then the cache sync is RACED against the sweep
+   (fire-and-forget, not sequenced). Guard on. No interleaving may violate safety:
+   either the snapshot sees the stale epoch and skips, or it sees the caught-up
+   epoch and sweeps against the correct floor. */
+fun RunExploreScenario(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var target: machine;
+  var writer: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  target = new ManifestReplica((floor = 1000, epoch = 1));
+
+  announce eFloorChanged, (newFloor = 1000, isReset = false);
+  announce eObjectReferenced, (offset = 1000, uid = 10);
+
+  S3Put(self, s3, (offset = 1000, uid = 10));
+  S3Put(self, s3, (offset = 850, uid = 1));
+  S3Put(self, s3, (offset = 500, uid = 0));
+
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((stillDanglingEnabled = true, epochGuardEnabled = true,
+               db = db, target = target, s3 = s3, driver = self));
+
+  send writer, eDoReset, (from = self, newFloor = 850, newUid = 2, newEpoch = 2);
+  receive { case eResetDone: { } }
+
+  /* Fire the sync without waiting: the scheduler may deliver it before, during,
+     or after the sweep's reads. */
+  send target, eMRSync, (from = self, floor = 850, epoch = 2);
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+}
+
+machine DriverStaleUnguarded {
+  start state Init {
+    entry { RunStaleScenario(this, false); }
+  }
+}
+
+machine DriverStaleGuarded {
+  start state Init {
+    entry { RunStaleScenario(this, true); }
+  }
+}
+
+machine DriverSynced {
+  start state Init {
+    entry { RunSyncedScenario(this); }
+  }
+}
+
+machine DriverExplore {
+  start state Init {
+    entry { RunExploreScenario(this); }
+  }
+}
+
+/* GATE (MUST fail): epoch guard off, reset sync dropped. The shipped
+   still_dangling/1 guard is ON but re-reads the same stale cache, so the
+   re-tiered live (850, 2) is deleted - INV#2. This failing run proves the model
+   reproduces the cross-node bug, so the guarded result is meaningful. */
+test tcMultiNodeStaleUnguarded [main = DriverStaleUnguarded]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverStaleUnguarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* The fix (MUST hold): epoch guard on, sync dropped. The cache epoch is behind
+   the committed epoch, so the sweep fails closed and deletes nothing. */
+test tcMultiNodeStaleGuarded [main = DriverStaleGuarded]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverStaleGuarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Anti-vacuity (MUST hold): epoch guard on, sync delivered. The caught-up cache
+   lets the sweep proceed, preserve the live (850, 2), and reclaim the deep
+   orphan (500, 0). Proves the guard does not simply suppress all sweeps. */
+test tcMultiNodeSyncedGuarded [main = DriverSynced]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverSynced, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Exploration (MUST hold): epoch guard on, sync raced against the sweep. */
+test tcMultiNodeExplore [main = DriverExplore]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverExplore, KhepriDB, S3Store, ManifestReplica, Writer, GC };

--- a/p/gc-reset-multinode/README.md
+++ b/p/gc-reset-multinode/README.md
@@ -1,0 +1,107 @@
+# GC × reset durability seam, across nodes
+
+The cross-node companion to [`../gc-reset`](../gc-reset). That model collapses
+every node into one synchronous `manifest_replica`, so GC and the writer always
+read the same live floor — it cannot express a sweep that reads a *different*,
+lagging node's cache. This model splits them apart and shows that the shipped
+`still_dangling/1` guard is **insufficient** when the floor it re-reads comes
+from a stale replica.
+
+## The seam
+
+`rabbitmq_stream_s3_gc:build_lookup` reads two things from two different places:
+
+- the committed epoch, via a strongly-consistent quorum read
+  (`rabbitmq_stream_s3_db:get_consistent`)
+- `first_offset` (the floor), via a direct read of the **local** per-node
+  replica ETS cache (`rabbitmq_stream_s3_manifest_replica:get_manifest`)
+
+Nothing ties the cached floor's freshness to the committed epoch. The replica
+cache is updated from the writer by a fire-and-forget sync that can be dropped,
+delayed, or reordered (`is_stale_sync`). So a node that has not yet applied a
+reset's sync still holds the **pre-reset, high** floor.
+
+An operator CLI delete sweep (`stream_s3_gc --mode delete`, the `run/1` path)
+can target such a lagging node:
+
+1. A remote-tier-ahead reset commits: epoch `1 → 2`, floor `1000 → 850`, and a
+   live fragment is re-tiered as `(850, uid 2)`
+2. The reset's sync to the target node is dropped — its cache still says floor
+   `1000`, epoch `1`
+3. The sweep reads committed epoch `2` (quorum) but floor `1000` (stale cache),
+   classifies `(850, uid 2)` as `below_first_offset`, and — because
+   `still_dangling/1` re-reads the **same stale cache** — confirms and deletes a
+   live object
+
+The reset-triggered GC path (`gc_stream_async`) is safe because its
+`put_manifest` is synchronous on the writer node; the exposure is strictly the
+cross-node operator-CLI path.
+
+## The guard this model proves
+
+Skip the stream unless the cache's epoch equals the committed epoch. A cache
+behind the committed epoch has a floor that predates the committed reset, so the
+sweep must fail closed rather than trust it. This requires exposing the epoch the
+cached manifest was synced at (the replica already tracks it per stream as
+`{seq, epoch, writer_node}`; `get_manifest/1` currently drops it).
+
+Crucially, `still_dangling/1` (the offset guard) stays **on** in every test:
+the point is that it does not help here, so a second, epoch-based guard is
+needed.
+
+### Machines (`PSrc/`)
+
+- `Writer` — commits the reset (bumps the committed epoch, lowers the
+  authoritative floor, re-tiers the live object) and announces the authoritative
+  manifest state. It does **not** update the target cache; that propagation is
+  the modeled uncertainty
+- `ManifestReplica` — one lagging per-node cache. Learns of the reset only via
+  `eMRSync` (driver-controlled: dropped, delivered, or raced), applied only if
+  the incoming epoch is not behind (`is_stale_sync`). Never announces to the
+  monitors — it is a possibly-stale view, not the source of truth
+- `KhepriDB` — the committed epoch (quorum truth), bumped by the reset
+- `S3Store` — the object store; the committed reset has already put `(850, 2)`
+- `GC` — the CLI sweep, with two independent guards: `stillDanglingEnabled` (the
+  shipped offset re-read, always on) and `epochGuardEnabled` (the fix)
+
+### Monitors (`PSpec/`)
+
+Same as `../gc-reset`: `NoDanglingReference` (INV#2, headline), `NoLostAckedData`
+(INV#1), `MonotonicFrontier` (INV#5), driven by the authoritative writer/driver.
+
+## Tests (`PTst/`) and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcMultiNodeStaleUnguarded` | **fails** — epoch guard off, sync dropped; `still_dangling/1` is on but re-reads the stale cache, so `INV#2 violated: GC deleted live object (offset=850, uid=2)`. The gate |
+| `tcMultiNodeStaleGuarded` | **holds** — epoch guard on, sync dropped; the cache epoch is behind the committed epoch, so the sweep fails closed and deletes nothing |
+| `tcMultiNodeSyncedGuarded` | **holds** — epoch guard on, sync delivered; the caught-up cache lets the sweep proceed, preserve the live `(850, 2)`, and reclaim the deep orphan `(500, 0)` (anti-vacuity) |
+| `tcMultiNodeExplore` | **holds** — epoch guard on, sync raced against the sweep across all interleavings |
+
+`tcMultiNodeStaleUnguarded` is *expected to fail*: that failing counterexample
+is the proof the model reproduces the cross-node bug, so the guarded result is
+meaningful. The CI job inverts it (a passing buggy run = CI failure = the model
+rotted).
+
+```bash
+p compile
+p check -tc tcMultiNodeStaleGuarded   -i 2000   # 0 bugs
+p check -tc tcMultiNodeSyncedGuarded   -i 2000   # 0 bugs (anti-vacuity)
+p check -tc tcMultiNodeStaleUnguarded  -i 2000   # 1 bug: INV#2 on (850, uid 2)
+p check -tc tcMultiNodeExplore         -i 5000   # 0 bugs
+p check -tc tcMultiNodeExplore --sch-pct 10 -i 5000  # 0 bugs (PCT)
+```
+
+## Corresponding code fix
+
+The model's `epochGuardEnabled` guard is implemented in
+`rabbitmq_stream_s3_gc:build_lookup` / `build_stream_lookup`: after the quorum
+`get_consistent` read, they read the cached manifest with
+`rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch/1` and sweep the
+stream only when the cached epoch equals the committed epoch, skipping otherwise.
+Skipping is always safe (GC is idempotent and operator-driven), so failing closed
+costs only a deferred sweep.
+
+The cached epoch is recorded in the replica's ETS row, stamped on every write —
+including the writer's own local `put_manifest`, which previously dropped it — so
+the check is correct on the writer node as well as on lagging replicas.

--- a/p/gc-reset-multinode/gc-reset-multinode.pproj
+++ b/p/gc-reset-multinode/gc-reset-multinode.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>GcResetMultiNode</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -168,14 +168,32 @@ build_lookup(Streams) ->
             %% which is acceptable for an infrequent operator-driven sweep.
             case rabbitmq_stream_s3_db:get_consistent(StreamId) of
                 {ok, #{epoch := Epoch}} ->
-                    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                        #manifest{entries = <<>>} ->
+                    %% The floor comes from the local replica cache, but the
+                    %% committed epoch comes from the quorum read above. On a node
+                    %% that has not yet applied a floor-lowering reset's sync, the
+                    %% cache still holds the pre-reset high floor at the old epoch,
+                    %% and still_dangling/1 would re-read that same stale floor.
+                    %% Sweep only when the cached manifest's epoch matches the
+                    %% committed epoch; otherwise fail closed (the cache lags the
+                    %% committed reset). The `Epoch` in the matching clause is the
+                    %% committed epoch bound above, so the clause only matches an
+                    %% up-to-date cache.
+                    case rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId) of
+                        {#manifest{entries = <<>>}, _} ->
                             %% Empty manifest: nothing in the remote tier to
                             %% compare against (matches the prior get_range/1
                             %% `empty` skip).
                             Acc;
-                        #manifest{first_offset = FirstOffset} = Manifest ->
+                        {#manifest{first_offset = FirstOffset} = Manifest, Epoch} ->
                             Acc#{StreamId => lookup_entry(StreamId, Epoch, FirstOffset, Manifest)};
+                        {#manifest{}, CacheEpoch} ->
+                            ?LOG_INFO(
+                                "GC for stream ~ts skipped: local manifest cache epoch ~p "
+                                "does not match the committed epoch ~p; the cache lags the "
+                                "committed reset, so its floor may be stale-high",
+                                [StreamId, CacheEpoch, Epoch]
+                            ),
+                            Acc;
                         undefined ->
                             Acc
                     end;
@@ -260,13 +278,27 @@ build_stream_lookup(StreamId, Config) ->
                     %% first_offset at the local floor, and that floor is precisely
                     %% what the orphaned fragments sit below. Using get_range/1
                     %% here would skip the stream and reclaim nothing.
-                    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                        #manifest{first_offset = FirstOffset} = Manifest ->
+                    %% Sweep only against a cache at the committed epoch (see
+                    %% build_lookup/1). On the reset path the writer's own cache
+                    %% was just updated synchronously at this epoch, so this is a
+                    %% no-op there; it fails closed for any caller reading a node
+                    %% whose cache lags the committed reset. The matching clause
+                    %% reuses CommittedEpoch, so it only matches an up-to-date cache.
+                    case rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId) of
+                        {#manifest{first_offset = FirstOffset} = Manifest, CommittedEpoch} ->
                             {ok, #{
                                 StreamId => lookup_entry(
                                     StreamId, CommittedEpoch, FirstOffset, Manifest
                                 )
                             }};
+                        {#manifest{}, CacheEpoch} ->
+                            ?LOG_INFO(
+                                "GC for stream ~ts skipped: local manifest cache epoch ~p "
+                                "does not match the committed epoch ~p; the cache lags the "
+                                "committed reset, so its floor may be stale-high",
+                                [StreamId, CacheEpoch, CommittedEpoch]
+                            ),
+                            skip;
                         undefined ->
                             skip
                     end;

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -58,6 +58,7 @@ No heartbeat or reconnection mechanism is needed because:
 -export([init_counters/0]).
 -export([
     get_manifest/1,
+    get_manifest_and_epoch/1,
     get_range/1,
     put_manifest/2,
     put_manifest/3,
@@ -103,7 +104,20 @@ start_link() ->
 -spec get_manifest(stream_id()) -> #manifest{} | undefined.
 get_manifest(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
-        [{_, Manifest}] -> Manifest;
+        [{_, Manifest, _Epoch}] -> Manifest;
+        [] -> undefined
+    end.
+
+-doc """
+Get the cached manifest together with the writer epoch it was stored at. Direct
+ETS read. The epoch is `undefined` when the manifest was stored without one. GC
+uses this to skip a stream whose cache lags the committed epoch.
+""".
+-spec get_manifest_and_epoch(stream_id()) ->
+    {#manifest{}, non_neg_integer() | undefined} | undefined.
+get_manifest_and_epoch(StreamId) ->
+    case ets:lookup(?TABLE, StreamId) of
+        [{_, Manifest, Epoch}] -> {Manifest, Epoch};
         [] -> undefined
     end.
 
@@ -111,25 +125,33 @@ get_manifest(StreamId) ->
 -spec get_range(stream_id()) -> rabbitmq_stream_s3:range().
 get_range(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
-        [{_, #manifest{entries = <<>>}}] -> empty;
-        [{_, #manifest{first_offset = First, next_offset = Next}}] -> {First, Next};
+        [{_, #manifest{entries = <<>>}, _}] -> empty;
+        [{_, #manifest{first_offset = First, next_offset = Next}, _}] -> {First, Next};
         [] -> empty
     end.
 
--doc "Store a manifest locally (synchronous).".
+-doc """
+Store a manifest locally (synchronous), recording the writer epoch that produced
+it. The cached epoch lets a reader (notably GC) tell whether this node's cache
+reflects the committed reset or still lags it. The writer node updates its own
+cache through this path, so without the epoch its floor would be trusted blindly.
+""".
+-spec put_manifest(stream_id(), #manifest{}, non_neg_integer()) -> ok.
+put_manifest(StreamId, Manifest, Epoch) ->
+    gen_server:call(?MODULE, {put_manifest, StreamId, Manifest, Epoch}).
+
+-doc """
+Store a manifest locally without a known epoch (the cached epoch is left
+undefined). Only for callers that do not participate in epoch-gated reads.
+""".
 -spec put_manifest(stream_id(), #manifest{}) -> ok.
 put_manifest(StreamId, Manifest) ->
-    gen_server:call(?MODULE, {put_manifest, StreamId, Manifest}).
+    gen_server:call(?MODULE, {put_manifest, StreamId, Manifest, undefined}).
 
 -doc "Apply an edit locally (synchronous).".
 -spec apply_edit(stream_id(), #edit{}) -> ok.
 apply_edit(StreamId, Edit) ->
     gen_server:call(?MODULE, {apply_edit, StreamId, Edit}).
-
--doc "Seed the cache on a remote node. Fire-and-forget.".
--spec put_manifest(stream_id(), #manifest{}, node()) -> ok.
-put_manifest(StreamId, Manifest, Node) ->
-    gen_server:cast({?MODULE, Node}, {put_manifest, StreamId, Manifest}).
 
 -doc "Apply an edit on a remote node. Fire-and-forget.".
 -spec apply_edit(stream_id(), #edit{}, node()) -> ok.
@@ -180,8 +202,8 @@ init([]) ->
     _ = ets:new(?TABLE, [named_table, public, set, {read_concurrency, true}]),
     {ok, #state{}}.
 
-handle_call({put_manifest, StreamId, Manifest}, _From, State) ->
-    write_manifest(StreamId, Manifest),
+handle_call({put_manifest, StreamId, Manifest, Epoch}, _From, State) ->
+    write_manifest(StreamId, Manifest, Epoch),
     {reply, ok, State};
 handle_call({sync, StreamId, Seq, Epoch, Manifest, WriterNode}, _From, #state{seqs = Seqs} = State) ->
     Seqs1 = maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs),
@@ -192,10 +214,10 @@ handle_call(
     case maps:get(StreamId, Seqs, undefined) of
         {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
             case ets:lookup(?TABLE, StreamId) of
-                [{_, Manifest0}] ->
+                [{_, Manifest0, _}] ->
                     case apply_edits_catching(StreamId, Edits, Manifest0) of
                         {ok, Manifest} ->
-                            write_manifest(StreamId, Manifest),
+                            write_manifest(StreamId, Manifest, Epoch),
                             maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
                             {reply, ok, State#state{
                                 seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
@@ -214,10 +236,10 @@ handle_call(
 handle_call({apply_edit, StreamId, Edit}, _From, State) ->
     Reply =
         case ets:lookup(?TABLE, StreamId) of
-            [{_, Manifest0}] ->
+            [{_, Manifest0, Epoch0}] ->
                 case apply_edits_catching(StreamId, [Edit], Manifest0) of
                     {ok, Manifest} ->
-                        write_manifest(StreamId, Manifest),
+                        write_manifest(StreamId, Manifest, Epoch0),
                         maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
                         ok;
                     {error, _} = Err ->
@@ -239,15 +261,15 @@ handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = 
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 
-handle_cast({put_manifest, StreamId, Manifest}, State) ->
-    write_manifest(StreamId, Manifest),
+handle_cast({put_manifest, StreamId, Manifest, Epoch}, State) ->
+    write_manifest(StreamId, Manifest, Epoch),
     {noreply, State};
 handle_cast({apply_edit, StreamId, Edit}, State) ->
     case ets:lookup(?TABLE, StreamId) of
-        [{_, Manifest0}] ->
+        [{_, Manifest0, Epoch0}] ->
             case apply_edits_catching(StreamId, [Edit], Manifest0) of
                 {ok, Manifest} ->
-                    write_manifest(StreamId, Manifest),
+                    write_manifest(StreamId, Manifest, Epoch0),
                     maybe_evaluate_retention(StreamId, Manifest0, Manifest, State);
                 {error, _} ->
                     %% No writer node on this path to resync from; keep the last
@@ -267,10 +289,10 @@ handle_cast({apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, #state{seqs 
         {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
             %% In sequence: apply edits.
             case ets:lookup(?TABLE, StreamId) of
-                [{_, Manifest0}] ->
+                [{_, Manifest0, _}] ->
                     case apply_edits_catching(StreamId, Edits, Manifest0) of
                         {ok, Manifest} ->
-                            write_manifest(StreamId, Manifest),
+                            write_manifest(StreamId, Manifest, Epoch),
                             maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
                             {noreply, State#state{
                                 seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
@@ -306,8 +328,8 @@ terminate(_Reason, _State) ->
 %% Internal
 %% ------------------------------------------------------------------
 
-write_manifest(StreamId, Manifest) ->
-    ets:insert(?TABLE, {StreamId, Manifest}).
+write_manifest(StreamId, Manifest, Epoch) ->
+    ets:insert(?TABLE, {StreamId, Manifest, Epoch}).
 
 %% Apply a batch of edits, catching any failure from apply_edit/2. apply_edit/2
 %% raises on a structurally inconsistent edit (a gap, a diverged replica, or a
@@ -359,7 +381,7 @@ maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs) ->
             ),
             Seqs;
         false ->
-            write_manifest(StreamId, Manifest),
+            write_manifest(StreamId, Manifest, Epoch),
             Seqs#{StreamId => {Seq, Epoch, WriterNode}}
     end.
 

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -658,7 +658,7 @@ identity_formatter(Evt) -> Evt.
 %% Only repairs a genuine cache miss; a no-op once seeded.
 maybe_reseed_local_cache(#state{core = undefined}) ->
     ok;
-maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId}}) ->
+maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId, epoch = Epoch}}) ->
     case rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core) of
         #manifest{next_offset = 0} ->
             %% No remote tier yet; nothing to cache.
@@ -671,7 +671,9 @@ maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId}}) ->
                         "stream ~ts after a manifest_replica restart",
                         [StreamId]
                     ),
-                    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, Manifest);
+                    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
+                        StreamId, Manifest, Epoch
+                    );
                 _ ->
                     ok
             end
@@ -938,7 +940,7 @@ execute_effect({update_range, _FirstOffset, _NextOffset}, #state{cfg = Cfg, core
     %% these offsets in the same batch), so the carried offsets are redundant
     %% and intentionally ignored. Do not change this back to manifest/1.
     Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
-    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(Cfg#cfg.stream, Manifest),
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(Cfg#cfg.stream, Manifest, Cfg#cfg.epoch),
     on_persist_completed(Manifest, State);
 execute_effect(
     {broadcast, StreamId, Edits},
@@ -1396,7 +1398,7 @@ restart_at_local_floor(
 ) ->
     FreshManifest = reset_manifest(LocalFirst, Revision),
     {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(FreshManifest, State#state.config),
-    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest),
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest, Epoch),
     %% Propagate the reset to replicas. The fresh manifest carries the discarded
     %% manifest's revision (the broadcast sequence number), so the sync is not
     %% rejected as stale and subsequent broadcasts continue in sequence. Replicas

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -24,7 +24,8 @@ all() ->
         stale_edit_after_resync_ignored,
         retention_and_append_in_same_broadcast,
         sync_live_manifest_then_broadcast_double_applies,
-        manifest_reset_requires_resync
+        manifest_reset_requires_resync,
+        cached_epoch_reflects_writer_epoch
     ].
 
 init_per_suite(Config) ->
@@ -50,6 +51,31 @@ end_per_testcase(_TC, Config) ->
 unknown_stream(_Config) ->
     ?assertEqual(undefined, rabbitmq_stream_s3_manifest_replica:get_manifest(<<"unknown">>)),
     ?assertEqual(empty, rabbitmq_stream_s3_manifest_replica:get_range(<<"unknown">>)).
+
+%% The cache records the writer epoch that produced each manifest, so GC can tell
+%% whether this node reflects the committed reset or lags it. put_manifest/3 and
+%% sync stamp the epoch; put_manifest/2 leaves it undefined.
+cached_epoch_reflects_writer_epoch(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    StreamId = <<"epoch-stream">>,
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+
+    %% put_manifest/3 (the writer's local update) records its epoch.
+    ok = Replica:put_manifest(StreamId, Manifest, 7),
+    ?assertEqual({Manifest, 7}, Replica:get_manifest_and_epoch(StreamId)),
+
+    %% A sync at a higher epoch advances the cached epoch.
+    {Manifest2, _} = build_manifest([{fragment, #{offset => 0, size => 2000}}]),
+    ok = Replica:sync(StreamId, 0, 9, Manifest2),
+    ?assertMatch({_, 9}, Replica:get_manifest_and_epoch(StreamId)),
+
+    %% put_manifest/2 stores no epoch: the cached epoch is undefined.
+    LegacyStream = <<"epoch-stream-legacy">>,
+    ok = Replica:put_manifest(LegacyStream, Manifest),
+    ?assertEqual({Manifest, undefined}, Replica:get_manifest_and_epoch(LegacyStream)),
+
+    %% Unknown stream resolves to undefined, like get_manifest/1.
+    ?assertEqual(undefined, Replica:get_manifest_and_epoch(<<"unknown">>)).
 
 put_and_get(_Config) ->
     StreamId = <<"stream-1">>,


### PR DESCRIPTION
GC reads the deletion floor (first_offset) from the local node's manifest cache, but the committed epoch from a quorum read — with nothing tying them together. On a node lagging a floor-lowering reset, an operator stream_s3_gc --mode delete reads a stale-high floor; still_dangling/1 re-reads that same stale cache, so the safety guard defends nothing and a live re-tiered object gets deleted. Fix: record the writer epoch on every cache write and only sweep when the cached epoch matches the committed epoch (fail closed otherwise).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
