### PR TITLE
GC: Fix durability bug

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       gc_reset: ${{ steps.filter.outputs.gc_reset }}
       gc_leading_group: ${{ steps.filter.outputs.gc_leading_group }}
+      gc_reset_leading_group: ${{ steps.filter.outputs.gc_reset_leading_group }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
@@ -40,9 +41,11 @@ jobs:
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "gc_reset=false" >> "$GITHUB_OUTPUT"
           echo "gc_leading_group=false" >> "$GITHUB_OUTPUT"
+          echo "gc_reset_leading_group=false" >> "$GITHUB_OUTPUT"
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-leading-group/' && echo "gc_leading_group=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/gc-reset-leading-group/' && echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
@@ -55,6 +58,7 @@ jobs:
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
+            echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
@@ -163,6 +167,53 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: carve-out-removed model deletes the referenced leading group."
+          echo "::endgroup::"
+
+  gc-reset-leading-group:
+    needs: changes
+    if: needs.changes.outputs.gc_reset_leading_group == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/gc-reset-leading-group
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/gc-reset-leading-group
+          for tc in tcLeadingGroupResetFixed tcLeadingGroupResetExplore tcLeadingGroupRetentionOnly; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcLeadingGroupResetExplore (PCT)"
+          p check -tc tcLeadingGroupResetExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (offset-only re-check must delete the live leading group)
+        run: |
+          cd p/gc-reset-leading-group
+          rm -rf PCheckerOutput/
+          echo "::group::tcLeadingGroupResetBug (expect the GC x reset x leading-group counterexample)"
+          if p check -tc tcLeadingGroupResetBug -i 2000; then
+            echo "ERROR: tcLeadingGroupResetBug passed; the model no longer deletes the live leading group."
+            echo "The offset-only still_dangling re-check must delete a reset-installed leading group,"
+            echo "otherwise the carve-out re-validation result is not trustworthy."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object (offset=850, uid=2) still referenced by the manifest (live leading group)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the offset-only run failed, but not with the expected INV#2 (850, uid 2) leading-group counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: the offset-only re-check deletes the live leading group."
           echo "::endgroup::"
 
   read-resolution:

--- a/p/gc-reset-leading-group/PSpec/Monitors.p
+++ b/p/gc-reset-leading-group/PSpec/Monitors.p
@@ -1,0 +1,87 @@
+/* Global safety monitors for the GC x reset x leading-group seam. They observe
+   announced events only and never participate in the protocol. The headline is
+   NoDanglingReference (INV#2): it keys protection on (offset, uid), so it tells a
+   legal stale-object delete from the illegal delete of a live referenced group. */
+
+/* INV#2: GC must never delete an object the live manifest references. */
+spec NoDanglingReference observes eObjectReferenced, eObjectUnreferenced, eGcDelete {
+  var live: set[ObjKey];
+
+  start state Watching {
+    on eObjectReferenced do (k: ObjKey) {
+      live += (k);
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k in live) {
+        live -= (k);
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      assert !(k in live),
+        format("INV#2 violated: GC deleted live object (offset={0}, uid={1}) still referenced by the manifest (live leading group)",
+          k.offset, k.uid);
+    }
+  }
+}
+
+/* INV#1: no lost acked data. An object covering an offset in the live range
+   [floor, next) must not be deleted. Keyed by (offset, uid) so a stale-object
+   delete is not mistaken for losing the live cover. */
+spec NoLostAckedData observes eObjectReferenced, eObjectUnreferenced, eFloorChanged, eGcDelete {
+  var floor: int;
+  var liveByOffset: map[int, int];
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      floor = p.newFloor;
+    }
+    on eObjectReferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        liveByOffset[k.offset] = k.uid;
+      } else {
+        liveByOffset += (k.offset, k.uid);
+      }
+    }
+    on eObjectUnreferenced do (k: ObjKey) {
+      if (k.offset in liveByOffset) {
+        if (liveByOffset[k.offset] == k.uid) {
+          liveByOffset -= (k.offset);
+        }
+      }
+    }
+    on eGcDelete do (k: ObjKey) {
+      if (k.offset >= floor) {
+        if (k.offset in liveByOffset) {
+          if (liveByOffset[k.offset] == k.uid) {
+            assert false,
+              format("INV#1 violated: GC deleted the live cover of acked offset {0} (uid={1}) at or above the live floor {2}",
+                k.offset, k.uid, floor);
+          }
+        }
+      }
+    }
+  }
+}
+
+/* INV#5: the first_offset frontier is monotonically non-decreasing except across
+   an explicitly labeled reset. */
+spec MonotonicFrontier observes eFloorChanged {
+  var floor: int;
+  var started: bool;
+
+  start state Watching {
+    on eFloorChanged do (p: (newFloor: int, isReset: bool)) {
+      if (!started) {
+        floor = p.newFloor;
+        started = true;
+      } else {
+        if (!p.isReset) {
+          assert p.newFloor >= floor,
+            format("INV#5 violated: first_offset moved backward from {0} to {1} without a labeled reset",
+              floor, p.newFloor);
+        }
+        floor = p.newFloor;
+      }
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PSrc/Common.p
+++ b/p/gc-reset-leading-group/PSrc/Common.p
@@ -1,0 +1,94 @@
+/* Shared types and events for the GC x reset x leading-group durability seam.
+
+   This model sits at the INTERSECTION that neither shipped sibling model
+   exercises:
+
+     - ../gc-reset proves still_dangling/1's live-floor re-check is sound for
+       DATA fragments keyed by (offset, uid): a fresh-UID re-tier coexists with a
+       stale UID at the same offset, so the (offset, uid)-keyed delete is legal.
+       It is flat-offset: it has no groups and no leading-group carve-out.
+
+     - ../gc-leading-group proves the classify-time carve-out
+       (classify_group / referenced_group_key): the leading group, which retention
+       has pushed below first_offset while it is still referenced, must not be
+       classified as a deletable orphan. It is static: no reset, no concurrency,
+       no still_dangling re-check.
+
+   The seam here is the three-way interaction of BOTH guards with a reset:
+
+     - The carve-out's referenced_group_key is computed ONCE, at the sweep's
+       snapshot (build_lookup / build_stream_lookup -> lookup_entry), and passed
+       by value through list_and_classify. It names the SNAPSHOT leading group.
+     - still_dangling/1, for a group finding, re-reads only the live FLOOR
+       (Offset < first_offset). It does NOT re-run leading_group_info/2, so it
+       never re-validates the carve-out against the LIVE manifest.
+
+   So a reset that installs a NEW leading group below the (lowered, then
+   retention-re-advanced) floor produces a group that is the LIVE referenced
+   leading group but is NOT the snapshot's leading group. classify flags it as a
+   below_first_offset orphan; still_dangling's offset-only re-check confirms the
+   delete; GC deletes a live referenced group. No UID collision is required - it
+   is an ordinary GC x reset x retention race. */
+
+/* An S3 object / manifest entry is identified by (offset, uid). */
+type ObjKey = (offset: int, uid: int);
+
+/* Objects carry a Kind: the data axis (FRAGMENT) and the group axis (GROUP)
+   classify differently (classify/2 -> classify_group/3 for groups). */
+enum Kind { FRAGMENT, GROUP }
+type Obj = (offset: int, uid: int, kind: Kind, epoch: int);
+
+/* Only the below_first_offset (offset) axis is modeled: the stale_epoch axis
+   applies to manifest root objects only, never to fragments or groups. */
+enum Reason { BELOW_FLOOR }
+type Candidate = (offset: int, uid: int, kind: Kind, reason: Reason);
+
+/* Khepri (durable consensus over the committed epoch). */
+event eGetConsistent: (from: machine);
+event eEpochResult: (ok: bool, epoch: int);
+
+/* Manifest replica: the serialized owner of the live first_offset, the live
+   (offset, uid) entries, and the leading-group carve-out info that
+   leading_group_info/2 derives from the manifest's first entry. */
+event eMRSetFloor: (from: machine, floor: int, isReset: bool);
+event eMRAddEntry: (from: machine, key: ObjKey);
+event eMRRemoveEntry: (from: machine, key: ObjKey);
+event eMRSetLeading: (from: machine, leadingKey: ObjKey, hasLeading: bool, skipGroups: bool);
+event eMRGetFloor: (from: machine);
+event eMRFloorResult: int;
+event eMRGetLeading: (from: machine);
+event eMRLeadingResult: (leadingKey: ObjKey, hasLeading: bool, skipGroups: bool);
+event eMRAck;
+
+/* S3 object store. */
+event eS3Put: (from: machine, obj: Obj);
+event eS3Delete: (from: machine, key: ObjKey);
+event eS3List: (from: machine);
+event eS3ListResult: seq[Obj];
+event eS3Has: (from: machine, key: ObjKey);
+event eS3HasResult: bool;
+event eS3Ack;
+
+/* Writer: the reset orchestrator plus normal forward retention. A reset lowers
+   the floor and installs a new leading group; retention then advances the floor
+   forward, leaving the new leading group straddling it (partial expiry). */
+event eDoReset: (from: machine, newFloor: int, newUid: int, oldLeading: ObjKey);
+event eAdvanceFloor: (from: machine, newFloor: int);
+event eResetDone;
+event eAdvanceDone;
+
+/* GC sweep steps, driven explicitly so a test driver can force the exact
+   interleaving for the validation gate, or race them for exploration. */
+event eGcSnapshot;
+event eGcSnapshotDone;
+event eGcListClassify;
+event eGcClassifyDone;
+event eGcExecute;
+event eGcExecuteDone;
+
+/* Spec events, delivered to monitors via announce. The AUTHORITATIVE manifest
+   state drives them. */
+event eObjectReferenced: ObjKey;
+event eObjectUnreferenced: ObjKey;
+event eFloorChanged: (newFloor: int, isReset: bool);
+event eGcDelete: ObjKey;

--- a/p/gc-reset-leading-group/PSrc/GC.p
+++ b/p/gc-reset-leading-group/PSrc/GC.p
@@ -1,0 +1,132 @@
+/* The orphan GC sweep (rabbitmq_stream_s3_gc) on the operator CLI path, split
+   into the three steps that matter for the decide-then-act window:
+
+     1. eGcSnapshot     - build_lookup / lookup_entry: capture the committed
+                          epoch, the snapshot first_offset, AND the snapshot
+                          leading-group carve-out (referenced_group_key +
+                          skip_groups) via leading_group_info/2. This carve-out is
+                          computed ONCE and passed by value through classify.
+     2. eGcListClassify - LIST S3 and classify each object against the SNAPSHOT
+                          floor and SNAPSHOT carve-out. Groups go through
+                          classify_group/3; fragments through the offset axis.
+     3. eGcExecute      - for each candidate, apply still_dangling/1 (re-read the
+                          LIVE floor) and delete.
+
+   The shipped still_dangling/1, for a group finding, re-reads only the live
+   FLOOR (Offset < first_offset). It does NOT re-run leading_group_info/2, so it
+   never re-validates the carve-out against the LIVE manifest.
+
+   recheckCarveOut models the FIX: in still_dangling, re-fetch the LIVE leading
+   group and skip a group that is now the live referenced leading group (or when
+   the live manifest is in conservative skip_groups mode). With it false the
+   shipped offset-only re-check stands, and the seam is reproduced. */
+machine GC {
+  var recheckCarveOut: bool;
+  var db: machine;
+  var manifest: machine;
+  var s3: machine;
+  var driver: machine;
+  var snapshotFloor: int;
+  var snapshotEpoch: int;
+  var snapLeadingKey: ObjKey;
+  var snapHasLeading: bool;
+  var snapSkipGroups: bool;
+  var candidates: seq[Candidate];
+
+  start state Idle {
+    entry (init: (recheckCarveOut: bool, db: machine, manifest: machine, s3: machine, driver: machine)) {
+      recheckCarveOut = init.recheckCarveOut;
+      db = init.db;
+      manifest = init.manifest;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+
+    on eGcSnapshot do {
+      var lg: (leadingKey: ObjKey, hasLeading: bool, skipGroups: bool);
+      send db, eGetConsistent, (from = this,);
+      receive { case eEpochResult: (r: (ok: bool, epoch: int)) { snapshotEpoch = r.epoch; } }
+      send manifest, eMRGetFloor, (from = this,);
+      receive { case eMRFloorResult: (f: int) { snapshotFloor = f; } }
+      /* leading_group_info/2 on the snapshot manifest: this is the carve-out
+         classify will use for the whole sweep. */
+      send manifest, eMRGetLeading, (from = this,);
+      receive { case eMRLeadingResult: (x: (leadingKey: ObjKey, hasLeading: bool, skipGroups: bool)) { lg = x; } }
+      snapLeadingKey = lg.leadingKey;
+      snapHasLeading = lg.hasLeading;
+      snapSkipGroups = lg.skipGroups;
+      send driver, eGcSnapshotDone;
+    }
+
+    on eGcListClassify do {
+      var objs: seq[Obj];
+      var i: int;
+      var o: Obj;
+      var key: ObjKey;
+      send s3, eS3List, (from = this,);
+      receive { case eS3ListResult: (lst: seq[Obj]) { objs = lst; } }
+      candidates = default(seq[Candidate]);
+      i = 0;
+      while (i < sizeof(objs)) {
+        o = objs[i];
+        if (o.offset < snapshotFloor) {
+          key = (offset = o.offset, uid = o.uid);
+          if (o.kind == FRAGMENT) {
+            /* Data axis: any fragment below the floor is a candidate. */
+            candidates += (sizeof(candidates), (offset = o.offset, uid = o.uid, kind = FRAGMENT, reason = BELOW_FLOOR));
+          } else {
+            /* classify_group/3, against the SNAPSHOT carve-out: skip the snapshot
+               leading group, and skip every group in conservative skip_groups
+               mode; otherwise the group below the floor is a candidate. */
+            if (!snapSkipGroups && !(snapHasLeading && key == snapLeadingKey)) {
+              candidates += (sizeof(candidates), (offset = o.offset, uid = o.uid, kind = GROUP, reason = BELOW_FLOOR));
+            }
+          }
+        }
+        i = i + 1;
+      }
+      send driver, eGcClassifyDone;
+    }
+
+    on eGcExecute do {
+      var i: int;
+      var c: Candidate;
+      var del: bool;
+      var liveFloor: int;
+      var lg: (leadingKey: ObjKey, hasLeading: bool, skipGroups: bool);
+      var key: ObjKey;
+      i = 0;
+      while (i < sizeof(candidates)) {
+        c = candidates[i];
+        key = (offset = c.offset, uid = c.uid);
+        del = true;
+        /* still_dangling/1: re-read the live floor and skip anything now at or
+           above it. This is the shipped offset-only re-check, applied to both
+           fragments and groups. */
+        send manifest, eMRGetFloor, (from = this,);
+        receive { case eMRFloorResult: (f: int) { liveFloor = f; } }
+        if (!(c.offset < liveFloor)) {
+          del = false;
+        }
+        /* The FIX: for a group finding, also re-validate the carve-out against
+           the LIVE manifest. A group that is now the live referenced leading
+           group (or any group when the live manifest is in skip_groups mode) must
+           not be deleted, even though it is below the live floor. */
+        if (del && c.kind == GROUP && recheckCarveOut) {
+          send manifest, eMRGetLeading, (from = this,);
+          receive { case eMRLeadingResult: (x: (leadingKey: ObjKey, hasLeading: bool, skipGroups: bool)) { lg = x; } }
+          if (lg.skipGroups || (lg.hasLeading && key == lg.leadingKey)) {
+            del = false;
+          }
+        }
+        if (del) {
+          send s3, eS3Delete, (from = this, key = key);
+          receive { case eS3Ack: { } }
+          announce eGcDelete, key;
+        }
+        i = i + 1;
+      }
+      send driver, eGcExecuteDone;
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PSrc/KhepriDB.p
+++ b/p/gc-reset-leading-group/PSrc/KhepriDB.p
@@ -1,0 +1,16 @@
+/* Durable consensus layer (rabbitmq_stream_s3_db). Holds the committed epoch and
+   answers strongly-consistent reads. The committed epoch is monotonic. Not the
+   focus here (the seam is on the offset/group axis), but the sweep still takes a
+   consistent read at snapshot, exactly as build_lookup does. */
+machine KhepriDB {
+  var committedEpoch: int;
+
+  start state Serving {
+    entry (init: (epoch: int)) {
+      committedEpoch = init.epoch;
+    }
+    on eGetConsistent do (p: (from: machine)) {
+      send p.from, eEpochResult, (ok = true, epoch = committedEpoch);
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PSrc/ManifestReplica.p
+++ b/p/gc-reset-leading-group/PSrc/ManifestReplica.p
@@ -1,0 +1,55 @@
+/* The per-node manifest replica (rabbitmq_stream_s3_manifest_replica): the
+   serialized owner of the live first_offset, the live (offset, uid) entries, and
+   the leading-group carve-out info that leading_group_info/2 derives from the
+   manifest's first entry (referenced_group_key + skip_groups). It is the single
+   source both GC's snapshot (build_lookup) and still_dangling/1 read. Every state
+   change is announced so the monitors track the live manifest. */
+machine ManifestReplica {
+  var floor: int;
+  var nextOffset: int;
+  var entries: set[ObjKey];
+  /* Live leading-group carve-out, as leading_group_info/2 would return it. */
+  var leadingKey: ObjKey;
+  var hasLeading: bool;
+  var skipGroups: bool;
+
+  start state Serving {
+    entry (init: (floor: int, nextOffset: int, leadingKey: ObjKey, hasLeading: bool, skipGroups: bool)) {
+      floor = init.floor;
+      nextOffset = init.nextOffset;
+      leadingKey = init.leadingKey;
+      hasLeading = init.hasLeading;
+      skipGroups = init.skipGroups;
+      announce eFloorChanged, (newFloor = floor, isReset = false);
+    }
+    on eMRSetFloor do (p: (from: machine, floor: int, isReset: bool)) {
+      floor = p.floor;
+      announce eFloorChanged, (newFloor = p.floor, isReset = p.isReset);
+      send p.from, eMRAck;
+    }
+    on eMRAddEntry do (p: (from: machine, key: ObjKey)) {
+      entries += (p.key);
+      announce eObjectReferenced, p.key;
+      send p.from, eMRAck;
+    }
+    on eMRRemoveEntry do (p: (from: machine, key: ObjKey)) {
+      if (p.key in entries) {
+        entries -= (p.key);
+      }
+      announce eObjectUnreferenced, p.key;
+      send p.from, eMRAck;
+    }
+    on eMRSetLeading do (p: (from: machine, leadingKey: ObjKey, hasLeading: bool, skipGroups: bool)) {
+      leadingKey = p.leadingKey;
+      hasLeading = p.hasLeading;
+      skipGroups = p.skipGroups;
+      send p.from, eMRAck;
+    }
+    on eMRGetFloor do (p: (from: machine)) {
+      send p.from, eMRFloorResult, floor;
+    }
+    on eMRGetLeading do (p: (from: machine)) {
+      send p.from, eMRLeadingResult, (leadingKey = leadingKey, hasLeading = hasLeading, skipGroups = skipGroups);
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PSrc/S3Store.p
+++ b/p/gc-reset-leading-group/PSrc/S3Store.p
@@ -1,0 +1,43 @@
+/* The S3 object store. Objects are keyed by (offset, uid); the stored value is
+   the object's (kind, epoch). LIST returns whatever is present at the moment of
+   the call, so a post-snapshot re-tier becomes visible to a sweep's classify. */
+machine S3Store {
+  var objects: map[ObjKey, (kind: Kind, epoch: int)];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, obj: Obj)) {
+      var k: ObjKey;
+      k = (offset = p.obj.offset, uid = p.obj.uid);
+      if (k in objects) {
+        objects[k] = (kind = p.obj.kind, epoch = p.obj.epoch);
+      } else {
+        objects += (k, (kind = p.obj.kind, epoch = p.obj.epoch));
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Delete do (p: (from: machine, key: ObjKey)) {
+      if (p.key in objects) {
+        objects -= (p.key);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Has do (p: (from: machine, key: ObjKey)) {
+      send p.from, eS3HasResult, (p.key in objects);
+    }
+    on eS3List do (p: (from: machine)) {
+      var out: seq[Obj];
+      var ks: seq[ObjKey];
+      var i: int;
+      var k: ObjKey;
+      ks = keys(objects);
+      i = 0;
+      while (i < sizeof(ks)) {
+        k = ks[i];
+        out += (sizeof(out),
+          (offset = k.offset, uid = k.uid, kind = objects[k].kind, epoch = objects[k].epoch));
+        i = i + 1;
+      }
+      send p.from, eS3ListResult, out;
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PSrc/Writer.p
+++ b/p/gc-reset-leading-group/PSrc/Writer.p
@@ -1,0 +1,51 @@
+/* The writer / reset orchestrator (rabbitmq_stream_s3_replica_reader) plus the
+   normal forward-retention floor advance.
+
+   eDoReset models restart_at_local_floor: the remote-tier-ahead reset rebuilds
+   the manifest from the local log floor, LOWERING first_offset and installing a
+   fresh leading group (a GROUP object with a fresh UID - rabbitmq_stream_s3:uid/0
+   is random per upload, so the new leading group never reuses the snapshot
+   leading group's key). The old leading group is superseded.
+
+   eAdvanceFloor models ordinary retention advancing first_offset FORWARD
+   (isReset = false). After the reset's leading group is in place at the reset
+   floor, retention advances the floor past it, so the leading group now straddles
+   the floor (partial expiry) while still being the live referenced leading
+   group - exactly the state the carve-out exists to protect. */
+machine Writer {
+  var epoch: int;
+  var manifest: machine;
+  var s3: machine;
+
+  start state Idle {
+    entry (init: (epoch: int, manifest: machine, s3: machine)) {
+      epoch = init.epoch;
+      manifest = init.manifest;
+      s3 = init.s3;
+    }
+    on eDoReset do (p: (from: machine, newFloor: int, newUid: int, oldLeading: ObjKey)) {
+      var nlg: ObjKey;
+      nlg = (offset = p.newFloor, uid = p.newUid);
+      /* Lower the floor first (the reset's atomic prefix), then supersede the old
+         leading group with the freshly re-tiered one. */
+      send manifest, eMRSetFloor, (from = this, floor = p.newFloor, isReset = true);
+      receive { case eMRAck: { } }
+      send manifest, eMRRemoveEntry, (from = this, key = p.oldLeading);
+      receive { case eMRAck: { } }
+      send manifest, eMRAddEntry, (from = this, key = nlg);
+      receive { case eMRAck: { } }
+      send manifest, eMRSetLeading, (from = this, leadingKey = nlg, hasLeading = true, skipGroups = false);
+      receive { case eMRAck: { } }
+      send s3, eS3Put, (from = this, obj = (offset = p.newFloor, uid = p.newUid, kind = GROUP, epoch = epoch));
+      receive { case eS3Ack: { } }
+      send p.from, eResetDone;
+    }
+    on eAdvanceFloor do (p: (from: machine, newFloor: int)) {
+      /* Forward retention: the leading group is unchanged, but now sits below the
+         floor (partial expiry). */
+      send manifest, eMRSetFloor, (from = this, floor = p.newFloor, isReset = false);
+      receive { case eMRAck: { } }
+      send p.from, eAdvanceDone;
+    }
+  }
+}

--- a/p/gc-reset-leading-group/PTst/TestDrivers.p
+++ b/p/gc-reset-leading-group/PTst/TestDrivers.p
@@ -1,0 +1,243 @@
+/* Test drivers and declarations for the GC x reset x leading-group seam.
+
+   Fixture (shared across scenarios):
+     - floor starts at 1000; a live fragment (1000, uid 10) covers it
+     - the snapshot leading group is (900, uid 1): a GROUP straddling the floor
+       (partial expiry), referenced - the carve-out target at snapshot time
+     - (500, uid 0): a genuine deep orphan GROUP, not referenced
+     - the reset lowers the floor to 850 and installs a fresh leading GROUP
+       (850, uid 2); retention then advances the floor to 870, so (850, uid 2) is
+       a leading group BELOW the live floor while still referenced
+
+   The validation gate is the contrast between tcLeadingGroupResetBug (the shipped
+   offset-only re-check, which MUST fail with INV#2 on the live leading group
+   (850, uid 2)) and tcLeadingGroupResetFixed (still_dangling re-validates the
+   carve-out against the live manifest, which MUST hold). */
+
+fun PutObj(self: machine, s3: machine, o: Obj) {
+  send s3, eS3Put, (from = self, obj = o);
+  receive { case eS3Ack: { } }
+}
+
+fun AddEntry(self: machine, mr: machine, k: ObjKey) {
+  send mr, eMRAddEntry, (from = self, key = k);
+  receive { case eMRAck: { } }
+}
+
+fun RemoveEntry(self: machine, mr: machine, k: ObjKey) {
+  send mr, eMRRemoveEntry, (from = self, key = k);
+  receive { case eMRAck: { } }
+}
+
+fun S3Has(self: machine, s3: machine, k: ObjKey): bool {
+  var present: bool;
+  send s3, eS3Has, (from = self, key = k);
+  receive { case eS3HasResult: (b: bool) { present = b; } }
+  return present;
+}
+
+/* Build the common fixture: durable consensus, S3, and a manifest whose leading
+   group is (900, 1). Returns nothing; the caller threads the handles. */
+
+/* Deterministic gate: snapshot, then reset + forward retention, then
+   list/classify/execute, each fully sequenced so the dangerous interleaving is
+   forced every run. */
+fun RunResetScenario(self: machine, recheckCarveOut: bool) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var writer: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 2000,
+        leadingKey = (offset = 900, uid = 1), hasLeading = true, skipGroups = false));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, kind = FRAGMENT, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 900, uid = 1, kind = GROUP, epoch = 1));
+  AddEntry(self, mr, (offset = 900, uid = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, kind = GROUP, epoch = 1));
+
+  writer = new Writer((epoch = 1, manifest = mr, s3 = s3));
+  gc = new GC((recheckCarveOut = recheckCarveOut, db = db, manifest = mr, s3 = s3, driver = self));
+
+  /* 1. Sweep captures the snapshot floor (1000) and leading group (900, 1). */
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
+  /* 2. Reset lowers floor to 850 and installs the fresh leading group (850, 2). */
+  send writer, eDoReset, (from = self, newFloor = 850, newUid = 2, oldLeading = (offset = 900, uid = 1));
+  receive { case eResetDone: { } }
+
+  /* 3. Retention advances the floor to 870; (850, 2) now straddles it. */
+  send writer, eAdvanceFloor, (from = self, newFloor = 870);
+  receive { case eAdvanceDone: { } }
+
+  /* 4. Sweep lists + classifies against the stale snapshot (floor 1000, leading
+     group (900, 1)). The live leading group (850, 2) is not the snapshot one. */
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+
+  /* 5. Sweep executes deletes. still_dangling re-reads the live floor (870). */
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+
+  /* Anti-vacuity for the fixed run: the genuine deep orphan (500, 0) must be
+     reclaimed AND the live leading group (850, 2) preserved. Without this a fix
+     that simply skips every group would also pass. */
+  if (recheckCarveOut) {
+    assert !S3Has(self, s3, (offset = 500, uid = 0)),
+      "fix over-suppressed: genuine deep orphan group (500, 0) was not reclaimed";
+    assert S3Has(self, s3, (offset = 850, uid = 2)),
+      "fix failed to preserve the live leading group (850, 2)";
+  }
+}
+
+/* Exploration: snapshot first, then race the reset + retention against the
+   list/classify/execute and let the checker interleave them. Fix on; no schedule
+   may violate safety. */
+fun RunResetExplore(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var writer: machine;
+  var gc: machine;
+  var done: int;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 2000,
+        leadingKey = (offset = 900, uid = 1), hasLeading = true, skipGroups = false));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, kind = FRAGMENT, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 900, uid = 1, kind = GROUP, epoch = 1));
+  AddEntry(self, mr, (offset = 900, uid = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, kind = GROUP, epoch = 1));
+
+  writer = new Writer((epoch = 1, manifest = mr, s3 = s3));
+  gc = new GC((recheckCarveOut = true, db = db, manifest = mr, s3 = s3, driver = self));
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
+  /* FIFO per machine keeps the writer's reset before its retention; the scheduler
+     interleaves those with the sweep's LIST and the guard's live-floor re-read. */
+  send writer, eDoReset, (from = self, newFloor = 850, newUid = 2, oldLeading = (offset = 900, uid = 1));
+  send writer, eAdvanceFloor, (from = self, newFloor = 870);
+  send gc, eGcListClassify;
+  send gc, eGcExecute;
+
+  done = 0;
+  while (done < 4) {
+    receive {
+      case eResetDone: { done = done + 1; }
+      case eAdvanceDone: { done = done + 1; }
+      case eGcClassifyDone: { done = done + 1; }
+      case eGcExecuteDone: { done = done + 1; }
+    }
+  }
+}
+
+/* Control: pure FORWARD retention, no reset. The floor only advances (1000 ->
+   1100); the old leading group (900, 1) fully expires (unreferenced) and a new
+   leading group forms at (1050, 3), ABOVE the snapshot floor, so it is never
+   classified. The shipped offset-only re-check (recheckCarveOut = false) is safe
+   here: this is the asymmetry that proves the DOWNWARD reset is the necessary
+   ingredient of the seam. Must hold. */
+fun RunRetentionOnly(self: machine) {
+  var db: machine;
+  var s3: machine;
+  var mr: machine;
+  var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  mr = new ManifestReplica((floor = 1000, nextOffset = 2000,
+        leadingKey = (offset = 900, uid = 1), hasLeading = true, skipGroups = false));
+
+  PutObj(self, s3, (offset = 1000, uid = 10, kind = FRAGMENT, epoch = 1));
+  AddEntry(self, mr, (offset = 1000, uid = 10));
+  PutObj(self, s3, (offset = 900, uid = 1, kind = GROUP, epoch = 1));
+  AddEntry(self, mr, (offset = 900, uid = 1));
+  PutObj(self, s3, (offset = 500, uid = 0, kind = GROUP, epoch = 1));
+
+  gc = new GC((recheckCarveOut = false, db = db, manifest = mr, s3 = s3, driver = self));
+
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+
+  /* Forward retention: floor 1000 -> 1100, old leading group expires, a new
+     leading group forms above the snapshot floor. */
+  send mr, eMRSetFloor, (from = self, floor = 1100, isReset = false);
+  receive { case eMRAck: { } }
+  RemoveEntry(self, mr, (offset = 900, uid = 1));
+  PutObj(self, s3, (offset = 1050, uid = 3, kind = GROUP, epoch = 1));
+  AddEntry(self, mr, (offset = 1050, uid = 3));
+  send mr, eMRSetLeading, (from = self, leadingKey = (offset = 1050, uid = 3), hasLeading = true, skipGroups = false);
+  receive { case eMRAck: { } }
+
+  send gc, eGcListClassify;
+  receive { case eGcClassifyDone: { } }
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+
+  /* The genuine orphan (500, 0) is reclaimed; the live fragment and the new
+     leading group survive. */
+  assert !S3Has(self, s3, (offset = 500, uid = 0)),
+    "retention control: genuine orphan group (500, 0) was not reclaimed";
+  assert S3Has(self, s3, (offset = 1050, uid = 3)),
+    "retention control: live leading group (1050, 3) was deleted";
+}
+
+machine DriverResetBug {
+  start state Init {
+    entry { RunResetScenario(this, false); }
+  }
+}
+
+machine DriverResetFixed {
+  start state Init {
+    entry { RunResetScenario(this, true); }
+  }
+}
+
+machine DriverResetExplore {
+  start state Init {
+    entry { RunResetExplore(this); }
+  }
+}
+
+machine DriverRetentionOnly {
+  start state Init {
+    entry { RunRetentionOnly(this); }
+  }
+}
+
+/* Shipped offset-only re-check: MUST fail with INV#2 on the live leading group
+   (850, uid 2). This failing run is the validation gate - the proof the seam is
+   real and the fix is meaningful. */
+test tcLeadingGroupResetBug [main = DriverResetBug]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverResetBug, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* still_dangling re-validates the carve-out against the live manifest: MUST hold,
+   and the anti-vacuity asserts the orphan is still reclaimed. */
+test tcLeadingGroupResetFixed [main = DriverResetFixed]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverResetFixed, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Fix on, reset + retention raced against the sweep across all interleavings.
+   Must hold. */
+test tcLeadingGroupResetExplore [main = DriverResetExplore]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverResetExplore, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* Forward-retention-only control (shipped offset-only re-check): must hold.
+   Proves the downward reset, not retention, is what defeats the offset-only
+   re-check. */
+test tcLeadingGroupRetentionOnly [main = DriverRetentionOnly]:
+  assert NoDanglingReference, NoLostAckedData, MonotonicFrontier in
+  { DriverRetentionOnly, KhepriDB, S3Store, ManifestReplica, GC };

--- a/p/gc-reset-leading-group/README.md
+++ b/p/gc-reset-leading-group/README.md
@@ -1,0 +1,78 @@
+# GC × reset × leading-group durability seam
+
+Models the three-way interaction that neither sibling model exercises: a **group**
+finding flowing through `still_dangling/1`'s offset-only re-check **across a
+remote-tier-ahead reset**, when the reset has installed a new leading group below
+the live floor.
+
+## The bug
+
+`rabbitmq_stream_s3_gc` has two independent live-deletion guards:
+
+- the **classify-time carve-out** (`classify_group/3` + `referenced_group_key`):
+  the leading group, which retention has pushed below `first_offset` while still
+  referenced, is excluded from offset-based classification. Validated in
+  `../gc-leading-group`
+- the **execute-time re-check** (`still_dangling/1`): an offset-based finding is
+  re-validated against the *live* floor immediately before deletion, so a
+  concurrent reset that lowered the floor and re-tiered live fragments does not
+  cause a live delete. Validated in `../gc-reset`
+
+The carve-out's `referenced_group_key` is captured **once**, at the sweep's
+snapshot (`build_lookup` / `lookup_entry`), and passed by value through
+`list_and_classify`. `still_dangling/1`, for a group finding, re-reads only the
+live **floor** (`Offset < first_offset`) — it does **not** re-run
+`leading_group_info/2`. So the two guards together leave a hole:
+
+1. GC snapshots at floor `1000` and records the snapshot leading group `(900,1)`
+2. A remote-tier-ahead reset lowers the floor to `850` and installs a fresh
+   leading group `(850,2)` (a GROUP with a fresh UID)
+3. Normal forward retention advances the floor to `870`, so `(850,2)` now
+   straddles the floor (partial expiry) and is the **live referenced leading
+   group**
+4. classify (against the stale snapshot) sees `(850,2)` below the snapshot floor
+   `1000` and `≠` the snapshot `referenced_group_key` `(900,1)` → **candidate**
+5. `still_dangling` re-reads the live floor `870`; `850 < 870` → deletes the
+   **live leading group** → INV#2 dangling reference
+
+No UID collision is required: it is an ordinary GC × reset × retention race. A
+consumer reading the surviving offsets in `(850,2)` can no longer fetch it.
+
+## The fix
+
+`still_dangling/1`, for a group finding, re-derives the leading-group carve-out
+from the **live** manifest (`live_leading_group/3`, mirroring
+`leading_group_info/2` + `classify_group/3`) and keeps the group if it is now the
+live referenced leading group or the live manifest is in conservative
+`skip_groups` mode.
+
+## What the model captures
+
+- Objects carry a `Kind` (`FRAGMENT` or `GROUP`); the manifest records the live
+  leading-group carve-out (`referenced_group_key` + `skip_groups`)
+- The snapshot carve-out is captured once and used for the whole sweep, exactly
+  as `lookup_entry` does
+- `recheckCarveOut` toggles the fix: re-validate the carve-out against the live
+  manifest in `still_dangling`
+- `NoDanglingReference` (INV#2, headline) keyed on `(offset, uid)`, plus
+  `NoLostAckedData` (INV#1) and `MonotonicFrontier` (INV#5)
+
+## Tests and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcLeadingGroupResetBug` | **fails** — offset-only re-check; `INV#2 violated: GC deleted live object (offset=850, uid=2) ... (live leading group)` |
+| `tcLeadingGroupResetFixed` | **holds** — re-check re-validates the carve-out; also asserts the deep orphan `(500,0)` is reclaimed and the live leading group `(850,2)` preserved (anti-vacuity) |
+| `tcLeadingGroupResetExplore` | **holds** — fix on, reset + retention raced against the sweep across all interleavings |
+| `tcLeadingGroupRetentionOnly` | **holds** — forward retention only, offset-only re-check; proves the downward reset, not retention, is what defeats the offset-only re-check |
+
+`tcLeadingGroupResetBug` is *expected to fail*: that counterexample is the proof
+the seam is real, so the fixed result is meaningful.
+
+```bash
+p compile
+p check -tc tcLeadingGroupResetBug       -i 2000   # 1 bug: INV#2 on the live leading group (850, uid 2)
+p check -tc tcLeadingGroupResetFixed     -i 2000   # 0 bugs
+p check -tc tcLeadingGroupResetExplore   -i 5000   # 0 bugs, multiple timelines
+p check -tc tcLeadingGroupRetentionOnly  -i 2000   # 0 bugs
+```

--- a/p/gc-reset-leading-group/gc-reset-leading-group.pproj
+++ b/p/gc-reset-leading-group/gc-reset-leading-group.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>GcResetLeadingGroup</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -135,21 +135,46 @@ make_handler(delete) ->
 %% and skipping anything now at or above it restores the assumption; a genuine
 %% orphan skipped by a transient drop is reclaimed by a later sweep. Epoch-based
 %% (manifest) findings need no re-check: epoch is genuinely monotonic.
+%%
+%% A group finding additionally re-validates the leading-group carve-out against
+%% the live manifest. classify_group/3 protected the SNAPSHOT leading group, but
+%% the carve-out (referenced_group_key) is captured once at build_lookup time. A
+%% reset followed by forward retention can install a NEW leading group below the
+%% live floor that the stale snapshot does not recognise, so an offset-only
+%% re-check here would delete the live referenced leading group. Re-deriving the
+%% carve-out from the live manifest closes that.
 -spec still_dangling(finding()) -> boolean().
 still_dangling(#{reason := stale_epoch}) ->
     true;
 still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key}) ->
     case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = FirstOffset} ->
+        #manifest{first_offset = FirstOffset} = Manifest ->
             case parse_key(Key) of
-                {data, _StreamId, Offset} -> Offset < FirstOffset;
-                {group, _StreamId, Offset} -> Offset < FirstOffset;
-                _ -> false
+                {data, _StreamId, Offset} ->
+                    Offset < FirstOffset;
+                {group, _StreamId, Offset} ->
+                    Offset < FirstOffset andalso
+                        not live_leading_group(StreamId, Key, Manifest);
+                _ ->
+                    false
             end;
         undefined ->
             %% No live manifest to compare against: do not delete (a later sweep
             %% reclaims a genuine orphan once a floor is known again).
             false
+    end.
+
+%% Whether the group object Key is protected by the LIVE manifest's leading-group
+%% carve-out: it is the live referenced leading group, or the live manifest is in
+%% conservative skip-groups mode (a leading kilo-/mega-group). Mirrors
+%% classify_group/3, but re-derived from the live manifest rather than the sweep
+%% snapshot. See leading_group_info/2.
+-spec live_leading_group(stream_id(), rabbitmq_stream_s3:key(), #manifest{}) -> boolean().
+live_leading_group(StreamId, Key, Manifest) ->
+    case leading_group_info(StreamId, Manifest) of
+        {_ReferencedGroupKey, true} -> true;
+        {Key, _SkipGroups} -> true;
+        {_Other, _SkipGroups} -> false
     end.
 
 %% ------------------------------------------------------------------
@@ -660,6 +685,64 @@ still_dangling_respects_live_first_offset_test_() ->
                 ?_assertNot(still_dangling(ReTiered)),
                 %% Epoch-based findings are not re-checked (epoch is monotonic).
                 ?_assert(still_dangling(StaleManifest))
+            ]
+        end}.
+
+%% A group finding re-validates the leading-group carve-out against the LIVE
+%% manifest, not just the live floor. A reset followed by forward retention can
+%% install a new leading group below the live floor; the sweep's snapshot carve-out
+%% predates it, so an offset-only re-check would delete the live referenced
+%% leading group. The live re-derivation must protect it while still reclaiming a
+%% genuine orphan group at the same range (distinguished by uid).
+still_dangling_group_respects_live_leading_group_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
+            unlink(Pid),
+            Pid
+        end,
+        fun(Pid) -> gen_server:stop(Pid) end, fun(_) ->
+            StreamId = <<"gc-leading-revalidate-stream">>,
+            LeadingUid = 16#0000002b,
+            %% Live manifest: floor 870, with a leading group at 850 (straddling
+            %% the floor after a reset + forward retention) still referenced.
+            ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
+                StreamId,
+                #manifest{
+                    first_offset = 870,
+                    next_offset = 2000,
+                    entries = group_entry(850, ?MANIFEST_KIND_GROUP, LeadingUid)
+                }
+            ),
+            LiveLeadingKey = rabbitmq_stream_s3:group_key(
+                StreamId, #group_ref{offset = 850, kind = ?MANIFEST_KIND_GROUP, uid = LeadingUid}
+            ),
+            LiveLeading = #{
+                stream_id => StreamId, key => LiveLeadingKey, reason => below_first_offset
+            },
+            %% Same offset, different uid: a stale group object, not the live
+            %% leading one, so a genuine orphan.
+            StaleAtLeadingOffset = #{
+                stream_id => StreamId,
+                key =>
+                    <<"rabbitmq/stream/gc-leading-revalidate-stream/metadata/00000000000000000850.0000002a.group">>,
+                reason => below_first_offset
+            },
+            %% A deep orphan group well below the floor.
+            DeepOrphanGroup = #{
+                stream_id => StreamId,
+                key =>
+                    <<"rabbitmq/stream/gc-leading-revalidate-stream/metadata/00000000000000000500.00000099.group">>,
+                reason => below_first_offset
+            },
+            [
+                %% The live leading group is below the floor but referenced: keep it.
+                ?_assertNot(still_dangling(LiveLeading)),
+                %% A stale object at the same offset (different uid) is a real
+                %% orphan: delete it.
+                ?_assert(still_dangling(StaleAtLeadingOffset)),
+                %% A deep orphan group below the floor: delete it.
+                ?_assert(still_dangling(DeepOrphanGroup))
             ]
         end}.
 


### PR DESCRIPTION
Fixes a durability bug where the orphan GC sweep can delete a live, referenced leading group during a remote-tier-ahead reset. No UID collision is required: it's an ordinary GC × reset × retention race.

rabbitmq_stream_s3_gc protects the referenced leading group with two independent guards:

- the classify-time carve-out (classify_group/3 + referenced_group_key), captured once at the sweep snapshot (lookup_entry) and passed by value through list_and_classify
- the execute-time re-check (still_dangling/1), which re-validates an offset finding against the live floor just before deletion

For a group finding, still_dangling/1 re-read only the live floor (Offset < first_offset) — it never re-ran leading_group_info/2. So this sequence within a single sweep deletes live data:

1. GC snapshots at floor 1000, records snapshot leading group (900,1)
2. A remote-tier-ahead reset lowers the floor to 850 and installs a fresh leading group (850,2)
3. Forward retention advances the floor to 870 — (850,2) now straddles the floor and is the live referenced leading group
4. classify (vs the stale snapshot) sees (850,2) below floor 1000 and ≠ snapshot referenced_group_key (900,1) → candidate
5. still_dangling re-reads live floor 870; 850 < 870 → deletes the live leading group (INV#2 dangling reference)

A consumer reading the surviving offsets in (850,2) can no longer fetch it.

The fix: still_dangling/1 now re-derives the carve-out from the live manifest (live_leading_group/3, mirroring classify_group/3) and keeps a group that is the live referenced leading group, or that the live manifest covers in conservative skip_groups mode. It reuses the manifest already fetched for the floor read — no extra round-trip.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
