### PR TITLE
Tolerate retention overtake and consolidate publish options in the content-verification test

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -31,13 +31,17 @@ run: package
 	$(JAVA) -jar $(JAR) $(ARGS)
 
 # --- Integration tests ---
+#
+# Every publishing test shares the same publish-phase flags, provided by the
+# PublishOptions mixin: --publish-duration, --publish-messages, --publish-bytes
+# (publishing stops on whichever is reached first; 0 disables a limit, the
+# duration aside), --message-size, and --max-length-bytes. Each target passes
+# explicit per-test values below so behavior is independent of the mixin's
+# unified code defaults.
 
 STREAM ?= s3-high-throughput
-DURATION ?= 2700
 PRODUCERS ?= 4
 CONSUMERS ?= 2
-MESSAGE_SIZE ?= 1024
-MAX_LENGTH_BYTES ?= 10000000000
 REPLAY_TIMEOUT ?= 3600
 
 .PHONY: cleanup content-verification high-throughput multi-offset-consumer stream-deletion
@@ -47,7 +51,13 @@ cleanup: package
 		--mgmt-uri $(MGMT_URI) \
 		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
 
-CONTENT_VERIFY_DURATION ?= 300
+CONTENT_VERIFY_PUBLISH_DURATION ?= 300
+# Amount-based publish limits (0 disables). Set a message or byte limit below
+# max-length-bytes to publish a bounded amount with no retention, so the replay
+# reads the whole stream back.
+CONTENT_VERIFY_PUBLISH_MESSAGES ?= 0
+CONTENT_VERIFY_PUBLISH_BYTES ?= 0
+CONTENT_VERIFY_MESSAGE_SIZE ?= 256
 CONTENT_VERIFY_PRODUCERS ?= 1
 # This must exceed the peak un-uploaded backlog: when the publisher outruns the
 # S3 upload, local retention trims un-uploaded segments once the backlog crosses
@@ -62,11 +72,20 @@ content-verification: package
 		--mgmt-uri $(MGMT_URI) \
 		--metrics-uris $(METRICS_URIS) \
 		--stream s3-content-verify \
-		--duration $(CONTENT_VERIFY_DURATION) \
+		--publish-duration $(CONTENT_VERIFY_PUBLISH_DURATION) \
+		--publish-messages $(CONTENT_VERIFY_PUBLISH_MESSAGES) \
+		--publish-bytes $(CONTENT_VERIFY_PUBLISH_BYTES) \
+		--message-size $(CONTENT_VERIFY_MESSAGE_SIZE) \
 		--producers $(CONTENT_VERIFY_PRODUCERS) \
 		--max-length-bytes $(CONTENT_VERIFY_MAX_LENGTH_BYTES) \
 		--replay-consumers $(CONTENT_VERIFY_REPLAY_CONSUMERS) \
 		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
+
+HIGH_THROUGHPUT_PUBLISH_DURATION ?= 2700
+HIGH_THROUGHPUT_PUBLISH_MESSAGES ?= 0
+HIGH_THROUGHPUT_PUBLISH_BYTES ?= 0
+HIGH_THROUGHPUT_MESSAGE_SIZE ?= 1024
+HIGH_THROUGHPUT_MAX_LENGTH_BYTES ?= 10000000000
 
 high-throughput: package
 	$(JAVA) -jar $(JAR) high-throughput \
@@ -74,14 +93,21 @@ high-throughput: package
 		--mgmt-uri $(MGMT_URI) \
 		--metrics-uris $(METRICS_URIS) \
 		--stream $(STREAM) \
-		--duration $(DURATION) \
+		--publish-duration $(HIGH_THROUGHPUT_PUBLISH_DURATION) \
+		--publish-messages $(HIGH_THROUGHPUT_PUBLISH_MESSAGES) \
+		--publish-bytes $(HIGH_THROUGHPUT_PUBLISH_BYTES) \
+		--message-size $(HIGH_THROUGHPUT_MESSAGE_SIZE) \
 		--producers $(PRODUCERS) \
 		--consumers $(CONSUMERS) \
-		--message-size $(MESSAGE_SIZE) \
-		--max-length-bytes $(MAX_LENGTH_BYTES) \
+		--max-length-bytes $(HIGH_THROUGHPUT_MAX_LENGTH_BYTES) \
 		--replay-timeout $(REPLAY_TIMEOUT) \
 		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
 
+MULTI_OFFSET_PUBLISH_DURATION ?= 600
+MULTI_OFFSET_PUBLISH_MESSAGES ?= 0
+MULTI_OFFSET_PUBLISH_BYTES ?= 0
+MULTI_OFFSET_MESSAGE_SIZE ?= 1024
+MULTI_OFFSET_MAX_LENGTH_BYTES ?= 500000000
 CONSUMER_RATE ?= 5000
 WARMUP ?= 120
 
@@ -91,12 +117,20 @@ multi-offset-consumer: package
 		--mgmt-uri $(MGMT_URI) \
 		--metrics-uris $(METRICS_URIS) \
 		--stream s3-multi-offset \
-		--duration $(DURATION) \
+		--publish-duration $(MULTI_OFFSET_PUBLISH_DURATION) \
+		--publish-messages $(MULTI_OFFSET_PUBLISH_MESSAGES) \
+		--publish-bytes $(MULTI_OFFSET_PUBLISH_BYTES) \
+		--message-size $(MULTI_OFFSET_MESSAGE_SIZE) \
 		--consumer-rate $(CONSUMER_RATE) \
 		--warmup $(WARMUP) \
-		--max-length-bytes $(MAX_LENGTH_BYTES) \
+		--max-length-bytes $(MULTI_OFFSET_MAX_LENGTH_BYTES) \
 		$(if $(S3_BUCKET),--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION))
 
+STREAM_DELETION_PUBLISH_DURATION ?= 120
+STREAM_DELETION_PUBLISH_MESSAGES ?= 0
+STREAM_DELETION_PUBLISH_BYTES ?= 0
+STREAM_DELETION_MESSAGE_SIZE ?= 1024
+STREAM_DELETION_MAX_LENGTH_BYTES ?= 500000000
 DELETE_TIMEOUT ?= 60
 
 stream-deletion: package
@@ -104,9 +138,12 @@ stream-deletion: package
 		--uris $(STREAM_URIS) \
 		--mgmt-uri $(MGMT_URI) \
 		--stream s3-stream-deletion \
-		--duration $(DURATION) \
+		--publish-duration $(STREAM_DELETION_PUBLISH_DURATION) \
+		--publish-messages $(STREAM_DELETION_PUBLISH_MESSAGES) \
+		--publish-bytes $(STREAM_DELETION_PUBLISH_BYTES) \
+		--message-size $(STREAM_DELETION_MESSAGE_SIZE) \
 		--delete-timeout $(DELETE_TIMEOUT) \
-		--max-length-bytes 500000000 \
+		--max-length-bytes $(STREAM_DELETION_MAX_LENGTH_BYTES) \
 		--s3-bucket $(S3_BUCKET) --s3-region $(S3_REGION)
 
 # --- Dependency management ---

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
@@ -35,29 +35,13 @@ public class ContentVerificationTest implements Runnable {
 
   @CommandLine.Mixin private ClusterOptions cluster;
 
-  @CommandLine.Option(
-      names = "--duration",
-      description = "Publishing duration in seconds",
-      defaultValue = "300")
-  private int durationSeconds;
+  @CommandLine.Mixin private PublishOptions publish;
 
   @CommandLine.Option(
       names = "--producers",
       description = "Number of producers (use 1 for strict ordering verification)",
       defaultValue = "1")
   private int numProducers;
-
-  @CommandLine.Option(
-      names = "--message-size",
-      description = "Message body size in bytes (minimum 8 for the sequence header)",
-      defaultValue = "256")
-  private int messageSize;
-
-  @CommandLine.Option(
-      names = "--max-length-bytes",
-      description = "Stream max-length-bytes (small to force data into S3 quickly)",
-      defaultValue = "500000000")
-  private long maxLengthBytes;
 
   @CommandLine.Option(
       names = "--progress-interval",
@@ -80,18 +64,17 @@ public class ContentVerificationTest implements Runnable {
   @Override
   public void run() {
     LOG.info(
-        "Starting content-verification test: stream={} duration={}s producers={}"
-            + " msg-size={} max-length-bytes={}",
+        "Starting content-verification test: stream={} publish-duration={}s publish-messages={}"
+            + " publish-bytes={} producers={} msg-size={} max-length-bytes={}",
         cluster.stream,
-        durationSeconds,
+        publish.publishDurationSeconds,
+        publish.publishMessages,
+        publish.publishBytes,
         numProducers,
-        messageSize,
-        maxLengthBytes);
+        publish.messageSize,
+        publish.maxLengthBytes);
 
-    if (messageSize < 8) {
-      LOG.error("FAIL: --message-size must be >= 8 (need 8 bytes for sequence number)");
-      System.exit(1);
-    }
+    publish.validateStopConditions();
 
     ManagementApi mgmt = new ManagementApi(cluster.mgmtUri);
     MetricsClient metrics = new MetricsClient(cluster.metricsUris);
@@ -104,7 +87,7 @@ public class ContentVerificationTest implements Runnable {
 
     long[] result;
     try (Environment env = cluster.buildEnvironment()) {
-      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, maxLengthBytes);
+      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, publish.maxLengthBytes);
       result = publishPhase(env, metrics, health, s3Monitor, confirmed);
     } catch (Exception e) {
       LOG.error("FAILED during publish phase", e);
@@ -154,7 +137,7 @@ public class ContentVerificationTest implements Runnable {
       Thread t =
           new Thread(
               () -> {
-                byte[] padding = new byte[messageSize - 8];
+                byte[] padding = new byte[publish.messageSize - 8];
                 try {
                   while (!stop.await(0, TimeUnit.MILLISECONDS)) {
                     long seq = sequence.getAndIncrement();
@@ -180,12 +163,11 @@ public class ContentVerificationTest implements Runnable {
     }
 
     long startTime = System.currentTimeMillis();
-    long deadline = startTime + Duration.ofSeconds(durationSeconds).toMillis();
     long nextReport = startTime + Duration.ofSeconds(progressInterval).toMillis();
 
-    LOG.info("Publishing for {}s...", durationSeconds);
+    LOG.info("Publishing until {}...", publish.describeStop());
 
-    while (System.currentTimeMillis() < deadline) {
+    while (!publish.publishStopReached(startTime, totalConfirmed.get())) {
       Thread.sleep(1000);
       long now = System.currentTimeMillis();
       if (now >= nextReport) {

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/ContentVerificationTest.java
@@ -19,8 +19,9 @@ import picocli.CommandLine;
     description =
         "Publish messages with sequential IDs, then replay the whole stream from "
             + "'first' independently from every consumer and verify ordering, no "
-            + "duplicates, and no gaps in the confirmed sequences. Catches corruption, "
-            + "reordering, and silent message skips.")
+            + "duplicates, and no gaps above the readable floor. Catches corruption, "
+            + "reordering, and silent message skips, while tolerating ranges reclaimed "
+            + "by max_bytes retention mid-replay (#237).")
 public class ContentVerificationTest implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(ContentVerificationTest.class);
@@ -487,13 +488,17 @@ public class ContentVerificationTest implements Runnable {
     }
 
     // Fan-out consistency: every consumer subscribed at 'first' and read to the
-    // same tail, so they must all observe the same number of messages. The
-    // consumers subscribe in a tight loop with no reads in between, so retention
-    // cannot advance the readable start between them and skew the counts. A
-    // divergence therefore means a consumer saw a different view of the log.
+    // same tail. Under active max_bytes retention a consumer attached at 'first'
+    // can be overtaken by retention mid-replay (see #237), and different
+    // consumers can be overtaken by different amounts, so they legitimately read
+    // different totals. Count divergence is therefore informational here;
+    // correctness is enforced by the above-floor gap check below, not by count
+    // agreement.
     if (min != max) {
-      LOG.error("REPLAY FAILED: consumers disagree on message count (min={} max={})", min, max);
-      System.exit(1);
+      LOG.info(
+          "Per-consumer counts differ (min={} max={}); expected under retention overtake",
+          min,
+          max);
     }
     if (min == 0) {
       LOG.error("REPLAY FAILED: consumers read zero messages");
@@ -503,10 +508,37 @@ public class ContentVerificationTest implements Runnable {
       LOG.error("CORRUPTION DETECTED: {} messages had invalid sequence numbers", corrupt);
       System.exit(1);
     }
-    // gaps counts only confirmed sequences that were skipped, so any gap is a
-    // real missing message rather than a hole left by an unconfirmed send.
-    if (gap > 0) {
-      LOG.error("GAP DETECTED: {} confirmed sequences were never delivered", gap);
+    // A gap is only real loss if the consumer resumed *above* the readable floor,
+    // i.e. it jumped past data that was still resident. A resume at or below the
+    // floor is an expected retention overtake: max_bytes retention reclaimed that
+    // range mid-replay, exactly as it would for a non-tiered stream (#237). Below
+    // the floor the data is gone for every reader and the cause (overtake vs.
+    // loss) cannot be told apart from the outside, so only above-floor holes
+    // fail. firstOffsetAtEnd is the final, highest floor (retention only advances
+    // it), so any data still resident then was resident throughout the replay.
+    boolean realLoss = false;
+    for (int i = 0; i < replayConsumers; i++) {
+      // Resume offsets increase monotonically per consumer, so the last gap's
+      // resume offset is the highest. If even that is at or below the final
+      // floor, every gap this consumer saw was a retention overtake.
+      if (lastGapOffset[i] > firstOffsetAtEnd) {
+        realLoss = true;
+        LOG.error(
+            "GAP DETECTED: consumer {} resumed at offset {} above the readable floor {}"
+                + " (jumped past resident data)",
+            i,
+            lastGapOffset[i],
+            firstOffsetAtEnd);
+      }
+    }
+    if (gap > 0 && !realLoss) {
+      LOG.info(
+          "Retention overtake: {} confirmed sequences fell below the readable floor {} during"
+              + " replay and were reclaimed (expected; mirrors non-tiered stream behavior)",
+          gap,
+          firstOffsetAtEnd);
+    }
+    if (realLoss) {
       System.exit(1);
     }
     if (dups > 0) {

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/HighThroughputTest.java
@@ -27,11 +27,7 @@ public class HighThroughputTest implements Runnable {
 
   @CommandLine.Mixin private ClusterOptions cluster;
 
-  @CommandLine.Option(
-      names = "--duration",
-      description = "Publishing duration in seconds",
-      defaultValue = "2700")
-  private int durationSeconds;
+  @CommandLine.Mixin private PublishOptions publish;
 
   @CommandLine.Option(
       names = "--producers",
@@ -44,18 +40,6 @@ public class HighThroughputTest implements Runnable {
       description = "Number of head-tracking consumers during publish phase",
       defaultValue = "2")
   private int numConsumers;
-
-  @CommandLine.Option(
-      names = "--message-size",
-      description = "Message body size in bytes",
-      defaultValue = "1024")
-  private int messageSize;
-
-  @CommandLine.Option(
-      names = "--max-length-bytes",
-      description = "Stream max-length-bytes (remote tier retention)",
-      defaultValue = "10000000000")
-  private long maxLengthBytes;
 
   @CommandLine.Option(
       names = "--progress-interval",
@@ -86,14 +70,18 @@ public class HighThroughputTest implements Runnable {
   @Override
   public void run() {
     LOG.info(
-        "Starting high-throughput test: stream={} duration={}s producers={} consumers={} "
-            + "msg-size={} max-length-bytes={}",
+        "Starting high-throughput test: stream={} publish-duration={}s publish-messages={}"
+            + " publish-bytes={} producers={} consumers={} msg-size={} max-length-bytes={}",
         cluster.stream,
-        durationSeconds,
+        publish.publishDurationSeconds,
+        publish.publishMessages,
+        publish.publishBytes,
         numProducers,
         numConsumers,
-        messageSize,
-        maxLengthBytes);
+        publish.messageSize,
+        publish.maxLengthBytes);
+
+    publish.validateStopConditions();
 
     ManagementApi mgmt = new ManagementApi(cluster.mgmtUri);
     MetricsClient metrics = new MetricsClient(cluster.metricsUris);
@@ -148,7 +136,7 @@ public class HighThroughputTest implements Runnable {
   }
 
   private void setupStream(Environment env, ManagementApi mgmt, S3Monitor s3Monitor) {
-    TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, maxLengthBytes);
+    TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, publish.maxLengthBytes);
   }
 
   private long publishPhase(
@@ -158,7 +146,7 @@ public class HighThroughputTest implements Runnable {
       ClusterHealthMonitor health,
       S3Monitor s3Monitor)
       throws InterruptedException {
-    byte[] body = new byte[messageSize];
+    byte[] body = new byte[publish.messageSize];
     AtomicLong totalPublished = new AtomicLong(0);
     AtomicLong totalConsumed = new AtomicLong(0);
     AtomicLong headOffset = new AtomicLong(-1);
@@ -208,7 +196,6 @@ public class HighThroughputTest implements Runnable {
     }
 
     long startTime = System.currentTimeMillis();
-    long deadline = startTime + Duration.ofSeconds(durationSeconds).toMillis();
     long nextReport = startTime + Duration.ofSeconds(progressInterval).toMillis();
     int zeroSentIntervals = 0;
     int reportCount = 0;
@@ -216,9 +203,11 @@ public class HighThroughputTest implements Runnable {
     long cumulativeBytesSent = 0;
 
     LOG.info(
-        "Publishing for {}s with {} head-tracking consumer(s)...", durationSeconds, numConsumers);
+        "Publishing until {} with {} head-tracking consumer(s)...",
+        publish.describeStop(),
+        numConsumers);
 
-    while (System.currentTimeMillis() < deadline) {
+    while (!publish.publishStopReached(startTime, totalPublished.get())) {
       Thread.sleep(1000);
       long now = System.currentTimeMillis();
       if (now >= nextReport) {
@@ -242,7 +231,7 @@ public class HighThroughputTest implements Runnable {
           }
           // Only check for retention stalls after enough data has been sent to
           // S3 to exceed max-length-bytes — retention cannot fire until then.
-          if (cumulativeBytesSent > maxLengthBytes
+          if (cumulativeBytesSent > publish.maxLengthBytes
               && !retentionSeen
               && s3Snap.monotonicGrowthIntervals >= retentionStallThreshold) {
             LOG.error(
@@ -251,7 +240,7 @@ public class HighThroughputTest implements Runnable {
                     + " — retention may not be working",
                 s3Snap.monotonicGrowthIntervals,
                 cumulativeBytesSent,
-                maxLengthBytes);
+                publish.maxLengthBytes);
             System.exit(1);
           }
         }

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/MultiOffsetConsumerTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/MultiOffsetConsumerTest.java
@@ -28,23 +28,7 @@ public class MultiOffsetConsumerTest implements Runnable {
 
   @CommandLine.Mixin private ClusterOptions cluster;
 
-  @CommandLine.Option(
-      names = "--duration",
-      description = "How long to run in seconds",
-      defaultValue = "600")
-  private int durationSeconds;
-
-  @CommandLine.Option(
-      names = "--message-size",
-      description = "Message body size in bytes",
-      defaultValue = "1024")
-  private int messageSize;
-
-  @CommandLine.Option(
-      names = "--max-length-bytes",
-      description = "Stream max-length-bytes (small to force S3 spill quickly)",
-      defaultValue = "500000000")
-  private long maxLengthBytes;
+  @CommandLine.Mixin private PublishOptions publish;
 
   @CommandLine.Option(
       names = "--consumer-rate",
@@ -67,13 +51,15 @@ public class MultiOffsetConsumerTest implements Runnable {
   @Override
   public void run() {
     LOG.info(
-        "Starting multi-offset-consumer: stream={} duration={}s consumer-rate={} msg/s"
+        "Starting multi-offset-consumer: stream={} publish-stop=[{}] consumer-rate={} msg/s"
             + " max-length-bytes={} warmup={}s",
         cluster.stream,
-        durationSeconds,
+        publish.describeStop(),
         consumerRate,
-        maxLengthBytes,
+        publish.maxLengthBytes,
         warmupSeconds);
+
+    publish.validateStopConditions();
 
     ManagementApi mgmt = new ManagementApi(cluster.mgmtUri);
     MetricsClient metrics = new MetricsClient(cluster.metricsUris);
@@ -81,7 +67,7 @@ public class MultiOffsetConsumerTest implements Runnable {
     S3Monitor s3Monitor = cluster.buildS3Monitor();
 
     try (Environment env = cluster.buildEnvironment()) {
-      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, maxLengthBytes);
+      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, publish.maxLengthBytes);
 
       AtomicLong totalPublished = new AtomicLong(0);
       AtomicLong headConsumed = new AtomicLong(0);
@@ -90,7 +76,7 @@ public class MultiOffsetConsumerTest implements Runnable {
       AtomicLong laggingOffset = new AtomicLong(-1);
       CountDownLatch stop = new CountDownLatch(1);
 
-      byte[] body = new byte[messageSize];
+      byte[] body = new byte[publish.messageSize];
       Producer producer = env.producerBuilder().stream(cluster.stream).build();
 
       Thread publisherThread =
@@ -176,12 +162,14 @@ public class MultiOffsetConsumerTest implements Runnable {
 
       LOG.info("Lagging consumer started at 'first' with rate limit {} msg/s", consumerRate);
 
+      // The publish stop conditions bound the post-warmup run. The duration is
+      // measured from here (after warmup), matching the original behavior; the
+      // message and byte limits count all confirmed messages, warmup included.
       long startTime = System.currentTimeMillis();
-      long deadline = startTime + Duration.ofSeconds(durationSeconds).toMillis();
       long nextReport = startTime + Duration.ofSeconds(progressInterval).toMillis();
       boolean s3RecvSeen = false;
 
-      while (System.currentTimeMillis() < deadline) {
+      while (!publish.publishStopReached(startTime, totalPublished.get())) {
         Thread.sleep(1000);
         long now = System.currentTimeMillis();
         if (now >= nextReport) {

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/PublishOptions.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/PublishOptions.java
@@ -1,0 +1,96 @@
+package com.amazon.mq.rabbitmq.stream.s3;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+// Publish-phase options shared by every test harness that produces messages.
+// Consolidates the duration, message-size, and max-length-bytes options that
+// were previously duplicated per command, and adds amount-based publish limits.
+// Publishing stops on whichever of the duration, message, or byte limit is
+// reached first; each is independently disabled with 0 (the duration aside,
+// which defaults to a finite value).
+public class PublishOptions {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PublishOptions.class);
+
+  @CommandLine.Option(
+      names = "--publish-duration",
+      description = "Publishing duration in seconds (0 for no time limit)",
+      defaultValue = "300")
+  int publishDurationSeconds;
+
+  @CommandLine.Option(
+      names = "--publish-messages",
+      description = "Stop publishing after this many confirmed messages (0 for no limit)",
+      defaultValue = "0")
+  long publishMessages;
+
+  @CommandLine.Option(
+      names = "--publish-bytes",
+      description =
+          "Stop publishing after this many confirmed message-body bytes (0 for no limit). "
+              + "Counts message bodies only, not on-disk framing, so it is a lower bound on the "
+              + "segment bytes that max-length-bytes measures",
+      defaultValue = "0")
+  long publishBytes;
+
+  @CommandLine.Option(
+      names = "--message-size",
+      description = "Message body size in bytes (minimum 8 for the sequence header)",
+      defaultValue = "1024")
+  int messageSize;
+
+  @CommandLine.Option(
+      names = "--max-length-bytes",
+      description = "Stream max-length-bytes (remote tier retention)",
+      defaultValue = "500000000")
+  long maxLengthBytes;
+
+  // At least one publish stop condition must be set, or publishing would never
+  // terminate. Logs and exits on a misconfiguration rather than hanging.
+  void validateStopConditions() {
+    if (messageSize < 8) {
+      LOG.error("FAIL: --message-size must be >= 8 (need 8 bytes for the sequence header)");
+      System.exit(1);
+    }
+    if (publishDurationSeconds <= 0 && publishMessages <= 0 && publishBytes <= 0) {
+      LOG.error(
+          "FAIL: set at least one of --publish-duration, --publish-messages, --publish-bytes");
+      System.exit(1);
+    }
+  }
+
+  // True once any active publish limit has been reached. Confirmed body bytes
+  // are derived from the confirmed count, since every message body is
+  // messageSize bytes.
+  boolean publishStopReached(long startTimeMillis, long confirmedMessages) {
+    if (publishDurationSeconds > 0
+        && System.currentTimeMillis() - startTimeMillis
+            >= Duration.ofSeconds(publishDurationSeconds).toMillis()) {
+      return true;
+    }
+    if (publishMessages > 0 && confirmedMessages >= publishMessages) {
+      return true;
+    }
+    return publishBytes > 0 && confirmedMessages * messageSize >= publishBytes;
+  }
+
+  // Describes the active stop conditions for the startup log.
+  String describeStop() {
+    List<String> parts = new ArrayList<>();
+    if (publishDurationSeconds > 0) {
+      parts.add(publishDurationSeconds + "s elapse");
+    }
+    if (publishMessages > 0) {
+      parts.add(publishMessages + " confirmed messages");
+    }
+    if (publishBytes > 0) {
+      parts.add(publishBytes + " confirmed body bytes");
+    }
+    return String.join(" or ", parts) + " (whichever first)";
+  }
+}

--- a/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/StreamDeletionTest.java
+++ b/test/integration/src/main/java/com/amazon/mq/rabbitmq/stream/s3/StreamDeletionTest.java
@@ -21,11 +21,7 @@ public class StreamDeletionTest implements Runnable {
 
   @CommandLine.Mixin private ClusterOptions cluster;
 
-  @CommandLine.Option(
-      names = "--duration",
-      description = "Max seconds to publish waiting for S3 to populate",
-      defaultValue = "120")
-  private int durationSeconds;
+  @CommandLine.Mixin private PublishOptions publish;
 
   @CommandLine.Option(
       names = "--delete-timeout",
@@ -33,27 +29,17 @@ public class StreamDeletionTest implements Runnable {
       defaultValue = "60")
   private int deleteTimeoutSeconds;
 
-  @CommandLine.Option(
-      names = "--max-length-bytes",
-      description = "Stream max-length-bytes (small to force S3 spill quickly)",
-      defaultValue = "500000000")
-  private long maxLengthBytes;
-
-  @CommandLine.Option(
-      names = "--message-size",
-      description = "Message body size in bytes",
-      defaultValue = "1024")
-  private int messageSize;
-
   @Override
   public void run() {
     LOG.info(
-        "Starting stream-deletion test: stream={} max-length-bytes={} duration={}s"
+        "Starting stream-deletion test: stream={} max-length-bytes={} publish-stop=[{}]"
             + " delete-timeout={}s",
         cluster.stream,
-        maxLengthBytes,
-        durationSeconds,
+        publish.maxLengthBytes,
+        publish.describeStop(),
         deleteTimeoutSeconds);
+
+    publish.validateStopConditions();
 
     ManagementApi mgmt = new ManagementApi(cluster.mgmtUri);
     S3Monitor s3Monitor = cluster.buildS3Monitor();
@@ -63,11 +49,11 @@ public class StreamDeletionTest implements Runnable {
     }
 
     try (Environment env = cluster.buildEnvironment()) {
-      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, maxLengthBytes);
+      TestSetup.setupStream(env, mgmt, s3Monitor, cluster.stream, publish.maxLengthBytes);
 
       AtomicLong totalPublished = new AtomicLong(0);
       CountDownLatch stop = new CountDownLatch(1);
-      byte[] body = new byte[messageSize];
+      byte[] body = new byte[publish.messageSize];
 
       Producer producer = env.producerBuilder().stream(cluster.stream).build();
       Thread publisherThread =
@@ -90,10 +76,12 @@ public class StreamDeletionTest implements Runnable {
               "publisher");
       publisherThread.start();
 
-      LOG.info("Publishing until S3 is populated (max {}s)...", durationSeconds);
-      long deadline = System.currentTimeMillis() + Duration.ofSeconds(durationSeconds).toMillis();
+      // Publish until S3 is populated, bounded by the publish stop conditions
+      // (duration, messages, or bytes) as a ceiling.
+      LOG.info("Publishing until S3 is populated (max [{}])...", publish.describeStop());
+      long startTime = System.currentTimeMillis();
       long s3ObjectCount = 0;
-      while (System.currentTimeMillis() < deadline) {
+      while (!publish.publishStopReached(startTime, totalPublished.get())) {
         Thread.sleep(5000);
         S3Monitor.Snapshot snap = s3Monitor.snapshot();
         s3ObjectCount = snap.objectCount;
@@ -108,7 +96,7 @@ public class StreamDeletionTest implements Runnable {
       producer.close();
 
       if (s3ObjectCount == 0) {
-        LOG.error("FAIL: S3 was never populated within {}s", durationSeconds);
+        LOG.error("FAIL: S3 was never populated before the publish limit ([{}])", publish.describeStop());
         System.exit(1);
       }
 


### PR DESCRIPTION
## Summary

Two changes to the content-verification integration test, both stemming from #237.

### Tolerate retention overtake in the replay phase

A consumer attached at `first` can be overtaken by `max_bytes` retention mid-replay: retention advances the readable floor and reclaims the range the consumer is reading, so the read path resumes at the new floor and skips the reclaimed range. This is intentional and mirrors non-tiered stream behavior (osiris does the same silent forward clamp), so the replay check should not treat it as data loss. See #237 for the full investigation.

The replay verification now classifies a forward skip by where the consumer resumed:

- A resume **above** the final readable floor jumped past data that was still resident: real loss, fails.
- A resume **at or below** the floor was reclaimed by retention: expected, logged as info.

The per-consumer count check is relaxed to informational, since consumers can be overtaken by different amounts and legitimately read different totals. The zero-messages, corruption, duplicate, and ordering checks are unchanged.

### Consolidate publish options into a shared mixin

The publish-phase options were duplicated across every test harness, each with its own `--duration`, `--message-size`, and `--max-length-bytes` plus a hand-rolled duration-deadline publish loop.

A `PublishOptions` picocli mixin now owns these options and the publish stop logic, adopted by the content-verification, high-throughput, multi-offset-consumer, and stream-deletion commands. Amount-based publish limits are added alongside the duration:

- `--publish-duration` seconds to publish (0 for no time limit; `--duration` is renamed to this)
- `--publish-messages` stop after N confirmed messages (0 for no limit)
- `--publish-bytes` stop after N confirmed body bytes (0 for no limit)

Publishing stops on whichever limit is reached first. The byte limit counts message bodies only, not on-disk framing, so it is a lower bound on the segment bytes `max-length-bytes` measures; this is documented on the option. Setting a message or byte limit below `max-length-bytes` publishes a bounded amount with no retention, so the replay can read the whole stream back.

The mixin carries unified code defaults; each Makefile target passes explicit per-test values so runtime behavior is unchanged (notably content-verification keeps its 256-byte messages).

## Testing

Validated against a cluster:

- **Retention-overtake path:** an 8 GB-bound run where retention trims mid-replay now classifies the skip as expected and passes (previously failed with a spurious gap).
- **No-retention path:** `--publish-bytes 4000000000` with `max-length-bytes=8000000000` publishes a bounded amount, retention never fires, and all consumers replay the full stream from offset 0 with zero gaps.

## Related

- #237 the retention-overtake behavior this test change accommodates
