### PR TITLE
CI: Supply-chain harden the P install

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -14,6 +14,14 @@ on:
 permissions:
   contents: read
 
+env:
+  # Enforce NuGet package signature verification on the install steps below.
+  # On Linux/macOS this verification is opt-in (it defaults on only on Windows),
+  # so without this the signatureValidationMode=require in NuGet.config is a
+  # no-op on these runners.
+  # https://learn.microsoft.com/en-us/nuget/reference/signed-package-verification-options
+  DOTNET_NUGET_SIGNATURE_VERIFICATION: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -81,7 +89,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -145,7 +153,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -192,7 +200,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -231,7 +239,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -278,7 +286,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -322,7 +330,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -366,7 +374,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -410,7 +418,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |
@@ -449,7 +457,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install the P checker
         run: |
-          dotnet tool install --global P --version 3.1.0
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Compile
         run: |

--- a/p/NuGet.config
+++ b/p/NuGet.config
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Supply-chain hardening for the P checker install in .github/workflows/p-model-check.yaml.
+
+  The only .NET tooling this repository consumes is the P model checker
+  (installed as a global dotnet tool). This file constrains where that package
+  and its dependencies may come from, and requires that they carry a valid
+  nuget.org repository signature.
+
+  This file lives in p/ alongside the P models, the directory all P tooling
+  uses. The "p compile" / "p check" steps run from p/<model>/ and so discover
+  this file by NuGet's normal upward walk. The "dotnet tool install" step, which
+  is the step that actually fetches the P package from nuget.org, runs from the
+  repository root instead, where p/NuGet.config is NOT on the upward path. The
+  workflow therefore passes it explicitly: each "dotnet tool install" step sets
+  the configfile option to $GITHUB_WORKSPACE/p/NuGet.config. Any new job that
+  installs the P checker must pass the same option, otherwise that install
+  silently loses both protections below.
+
+  Two independent protections:
+
+  1. Source locking (platform-independent). <clear /> drops any inherited
+     (machine- or user-level) package sources, leaving nuget.org as the only
+     source. packageSourceMapping then forces every package id, including P's
+     transitive dependencies, to resolve from nuget.org and nowhere else. This
+     is what defeats dependency-confusion and rogue-feed attacks.
+
+  2. Signature enforcement. signatureValidationMode=require plus the trusted
+     nuget.org repository certificates below means a package is only accepted
+     if it carries a nuget.org repository signature from one of these certs.
+     NOTE: on Linux and macOS this check is OFF unless the environment variable
+     DOTNET_NUGET_SIGNATURE_VERIFICATION=true is set (it defaults on only on
+     Windows). The workflow sets that variable so the runners actually enforce.
+     See https://learn.microsoft.com/en-us/nuget/reference/signed-package-verification-options
+
+  The trustedSigners fingerprints are the SHA-256 fingerprints nuget.org
+  advertises at
+  https://api.nuget.org/v3-index/repository-signatures/5.0.0/index.json
+  All three currently-advertised certificates are listed so that packages
+  signed under any of them validate. nuget.org keeps older certs listed because
+  packages signed under them remain valid; mirror that set here. If nuget.org
+  rotates its signing certificate, refresh this list by running
+  "dotnet nuget trust sync nuget.org" against this config file.
+-->
+<configuration>
+  <config>
+    <add key="signatureValidationMode" value="require" />
+  </config>
+
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+
+  <trustedSigners>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+      <!-- Valid 2018-04-10 .. 2021-04-14, DigiCert SHA2 Assured ID Code Signing CA -->
+      <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D"
+                   hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <!-- Valid 2021-02-16 .. 2024-05-15, DigiCert SHA2 Assured ID Code Signing CA -->
+      <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4"
+                   hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <!-- Valid 2024-02-23 .. 2027-05-18, DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1 (current) -->
+      <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D"
+                   hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </repository>
+  </trustedSigners>
+</configuration>


### PR DESCRIPTION
Minor defense-in-depth. I believe NuGet already does signature verification natively, so this might be overkill.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
