### PR TITLE
Fix S3 read stalls from dead pooled connections

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -865,6 +865,13 @@ now_ms() ->
     erlang:monotonic_time(millisecond).
 
 %% Record the time and running byte count of the first body frame.
+%%
+%% DIAGNOSTIC (#279): this runs on every body frame of every read, so it is the
+%% one diagnostic with a per-frame hot-path cost (a couple of map operations).
+%% It enriches the timeout summary in `describe_stall/1`, which post-fix should
+%% fire ~never. Kept for now because that enrichment is high-value triage if a
+%% stall ever recurs; revisit dropping it from the hot path if the per-frame
+%% cost ever shows up under profiling.
 mark_first_data(#{first_data_at := undefined, bytes_received := Rx} = State, N) ->
     State#{first_data_at := now_ms(), bytes_received := Rx + N};
 mark_first_data(#{bytes_received := Rx} = State, N) ->
@@ -888,14 +895,10 @@ describe_stall(#{req_started_at := Start} = State) when is_integer(Start) ->
         end,
     HeadersMs = elapsed_or_undef(Start, HeadersAt),
     FirstDataMs = elapsed_or_undef(Start, FirstDataAt),
-    %% The socket's local address and port (captured at request-fire time) join
-    %% this stalled request to its TCP stream in a packet capture, so the
-    %% on-the-wire behaviour can be inspected directly.
-    SockInfo = maps:get(sock, State, "sock=n/a"),
     lists:flatten(
         io_lib:format(
-            "phase=~ts elapsed=~bms headers_after=~ts first_data_after=~ts bytes=~b ~ts",
-            [Phase, Now - Start, HeadersMs, FirstDataMs, Rx, SockInfo]
+            "phase=~ts elapsed=~bms headers_after=~ts first_data_after=~ts bytes=~b",
+            [Phase, Now - Start, HeadersMs, FirstDataMs, Rx]
         )
     );
 describe_stall(_State) ->
@@ -903,36 +906,6 @@ describe_stall(_State) ->
 
 elapsed_or_undef(_Start, undefined) -> "n/a";
 elapsed_or_undef(Start, At) -> integer_to_list(At - Start) ++ "ms".
-
-%% Local socket IP and port for a connection, formatted to locate the TCP
-%% stream in a packet capture (the local port is unique per connection on the
-%% host). Queried only on the slow timeout path; tolerates a dead or unknown
-%% connection.
-sock_info(undefined) ->
-    "sock=n/a conn=undefined";
-sock_info(Conn) ->
-    Alive = is_process_alive(Conn),
-    try gun:info(Conn) of
-        #{state_name := StateName} = Info ->
-            %% state_name=connected with a sock_port means a live socket. Any
-            %% other state, or a missing sock_port, means gun has no usable
-            %% socket for this connection right now (e.g. the pooled connection
-            %% was closed by S3 while idle and is being fired onto regardless).
-            Sock =
-                case Info of
-                    #{sock_ip := SockIp, sock_port := SockPort} ->
-                        lists:flatten(io_lib:format("~ts:~b", [inet:ntoa(SockIp), SockPort]));
-                    _ ->
-                        "none"
-                end,
-            lists:flatten(
-                io_lib:format("sock=~ts gun_state=~p conn_alive=~p", [Sock, StateName, Alive])
-            );
-        _ ->
-            lists:flatten(io_lib:format("sock=none conn_alive=~p", [Alive]))
-    catch
-        C:E -> lists:flatten(io_lib:format("sock=err(~p:~p) conn_alive=~p", [C, E, Alive]))
-    end.
 
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
@@ -1146,16 +1119,11 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
             %% DIAGNOSTIC (#275 follow-up, S3 read stall investigation): stamp
             %% the request start and record phase markers so a timeout can report
             %% which phase stalled (no response headers vs. stalled mid-body).
-            %% Capture the socket's local port here at fire time, while the
-            %% connection is live; by the time a request times out gun has often
-            %% already cleared the socket, so it cannot be read then. The local
-            %% port joins this request to its TCP stream in a packet capture.
             State = #{
                 pool => Pool,
                 conn => Conn,
                 stream_ref => StreamRef,
                 req_started_at => erlang:monotonic_time(millisecond),
-                sock => sock_info(Conn),
                 headers_at => undefined,
                 first_data_at => undefined,
                 bytes_received => 0

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -842,10 +842,8 @@ handle_async(
     StreamRef,
     #{conn := Conn, stream_ref := StreamRef} = State
 ) ->
-    %% DIAGNOSTIC (#275 follow-up, S3 read stall investigation): report which
-    %% phase the request stalled in. "no_response" means no response headers
-    %% ever arrived (connection/network/request-send stall); "mid_body" means
-    %% headers arrived but the body stalled (S3 slow to stream the object).
+    %% Report which phase the request stalled in so the log distinguishes a
+    %% connection-level failure (no response at all) from a slow S3 transfer.
     ?LOG_WARNING(
         "S3 request timed out on ~tw/~tw: ~ts", [Conn, StreamRef, describe_stall(State)]
     ),
@@ -859,19 +857,12 @@ handle_async(
     finish_async_close(State),
     {done_cancel, {error, timeout}}.
 
-%% DIAGNOSTIC helpers (#275 follow-up, S3 read stall investigation).
-
 now_ms() ->
     erlang:monotonic_time(millisecond).
 
-%% Record the time and running byte count of the first body frame.
-%%
-%% DIAGNOSTIC (#279): this runs on every body frame of every read, so it is the
-%% one diagnostic with a per-frame hot-path cost (a couple of map operations).
-%% It enriches the timeout summary in `describe_stall/1`, which post-fix should
-%% fire ~never. Kept for now because that enrichment is high-value triage if a
-%% stall ever recurs; revisit dropping it from the hot path if the per-frame
-%% cost ever shows up under profiling.
+%% Record the time and running byte count of the first body frame. Runs on
+%% every body frame (a couple of map operations); enriches `describe_stall/1`
+%% on a timeout. Revisit if profiling flags the per-frame cost.
 mark_first_data(#{first_data_at := undefined, bytes_received := Rx} = State, N) ->
     State#{first_data_at := now_ms(), bytes_received := Rx + N};
 mark_first_data(#{bytes_received := Rx} = State, N) ->
@@ -1116,9 +1107,7 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
             %% NOTE: no need to wrap this in try/catch and checkin the conn
             %% since gun:request/5 cannot exit/error/throw.
             StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-            %% DIAGNOSTIC (#275 follow-up, S3 read stall investigation): stamp
-            %% the request start and record phase markers so a timeout can report
-            %% which phase stalled (no response headers vs. stalled mid-body).
+            %% Phase markers for timeout reporting (see `describe_stall/1`).
             State = #{
                 pool => Pool,
                 conn => Conn,

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -734,14 +734,16 @@ handle_async(
                         "object to slice ~p",
                         [?FUNCTION_NAME, Range]
                     ),
-                    State = State0#{data => [], pending_bytes => 0, slice_full => Range},
+                    State = State0#{
+                        data => [], pending_bytes => 0, slice_full => Range, headers_at => now_ms()
+                    },
                     {continue, State};
                 _ ->
-                    State = State0#{data => [], pending_bytes => 0},
+                    State = State0#{data => [], pending_bytes => 0, headers_at => now_ms()},
                     {continue, State}
             end;
         206 ->
-            State = State0#{data => [], pending_bytes => 0},
+            State = State0#{data => [], pending_bytes => 0, headers_at => now_ms()},
             {continue, State};
         _ ->
             %% Non-success response with a body. Cancel the request timer
@@ -814,13 +816,14 @@ handle_async(
         data := PendingData0
     } = State0
 ) ->
+    State1 = mark_first_data(State0, byte_size(Data)),
     case PendingBytes0 > ?BUFFER_PENDING_DATA_BYTES of
         true ->
             AllData = iolist_to_binary(lists:reverse(PendingData0, [Data])),
-            State = State0#{data := [], pending_bytes := 0},
+            State = State1#{data := [], pending_bytes := 0},
             {data, AllData, State};
         false ->
-            State = State0#{
+            State = State1#{
                 data := [Data | PendingData0],
                 pending_bytes := PendingBytes0 + byte_size(Data)
             },
@@ -839,7 +842,13 @@ handle_async(
     StreamRef,
     #{conn := Conn, stream_ref := StreamRef} = State
 ) ->
-    ?LOG_WARNING("S3 request timed out on ~tw/~tw", [Conn, StreamRef]),
+    %% DIAGNOSTIC (#275 follow-up, S3 read stall investigation): report which
+    %% phase the request stalled in. "no_response" means no response headers
+    %% ever arrived (connection/network/request-send stall); "mid_body" means
+    %% headers arrived but the body stalled (S3 slow to stream the object).
+    ?LOG_WARNING(
+        "S3 request timed out on ~tw/~tw: ~ts", [Conn, StreamRef, describe_stall(State)]
+    ),
     counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
     %% gun cannot cancel an HTTP/1.1 stream on the wire - it only stops
     %% forwarding events to the owner. The cancelled stream continues to
@@ -849,6 +858,81 @@ handle_async(
     gun:close(Conn),
     finish_async_close(State),
     {done_cancel, {error, timeout}}.
+
+%% DIAGNOSTIC helpers (#275 follow-up, S3 read stall investigation).
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).
+
+%% Record the time and running byte count of the first body frame.
+mark_first_data(#{first_data_at := undefined, bytes_received := Rx} = State, N) ->
+    State#{first_data_at := now_ms(), bytes_received := Rx + N};
+mark_first_data(#{bytes_received := Rx} = State, N) ->
+    State#{bytes_received := Rx + N};
+mark_first_data(State, _N) ->
+    State.
+
+%% Summarize how far a timed-out request progressed: whether response headers
+%% arrived, whether any body arrived, the elapsed time to each, and bytes
+%% received. Tolerates a state map without the diagnostic keys.
+describe_stall(#{req_started_at := Start} = State) when is_integer(Start) ->
+    Now = now_ms(),
+    HeadersAt = maps:get(headers_at, State, undefined),
+    FirstDataAt = maps:get(first_data_at, State, undefined),
+    Rx = maps:get(bytes_received, State, 0),
+    Phase =
+        case {HeadersAt, FirstDataAt} of
+            {undefined, _} -> "no_response (no headers received)";
+            {_, undefined} -> "headers_only (headers received, no body)";
+            {_, _} -> "mid_body (headers and partial body received)"
+        end,
+    HeadersMs = elapsed_or_undef(Start, HeadersAt),
+    FirstDataMs = elapsed_or_undef(Start, FirstDataAt),
+    %% The socket's local address and port (captured at request-fire time) join
+    %% this stalled request to its TCP stream in a packet capture, so the
+    %% on-the-wire behaviour can be inspected directly.
+    SockInfo = maps:get(sock, State, "sock=n/a"),
+    lists:flatten(
+        io_lib:format(
+            "phase=~ts elapsed=~bms headers_after=~ts first_data_after=~ts bytes=~b ~ts",
+            [Phase, Now - Start, HeadersMs, FirstDataMs, Rx, SockInfo]
+        )
+    );
+describe_stall(_State) ->
+    "phase=unknown (no diagnostic state)".
+
+elapsed_or_undef(_Start, undefined) -> "n/a";
+elapsed_or_undef(Start, At) -> integer_to_list(At - Start) ++ "ms".
+
+%% Local socket IP and port for a connection, formatted to locate the TCP
+%% stream in a packet capture (the local port is unique per connection on the
+%% host). Queried only on the slow timeout path; tolerates a dead or unknown
+%% connection.
+sock_info(undefined) ->
+    "sock=n/a conn=undefined";
+sock_info(Conn) ->
+    Alive = is_process_alive(Conn),
+    try gun:info(Conn) of
+        #{state_name := StateName} = Info ->
+            %% state_name=connected with a sock_port means a live socket. Any
+            %% other state, or a missing sock_port, means gun has no usable
+            %% socket for this connection right now (e.g. the pooled connection
+            %% was closed by S3 while idle and is being fired onto regardless).
+            Sock =
+                case Info of
+                    #{sock_ip := SockIp, sock_port := SockPort} ->
+                        lists:flatten(io_lib:format("~ts:~b", [inet:ntoa(SockIp), SockPort]));
+                    _ ->
+                        "none"
+                end,
+            lists:flatten(
+                io_lib:format("sock=~ts gun_state=~p conn_alive=~p", [Sock, StateName, Alive])
+            );
+        _ ->
+            lists:flatten(io_lib:format("sock=none conn_alive=~p", [Alive]))
+    catch
+        C:E -> lists:flatten(io_lib:format("sock=err(~p:~p) conn_alive=~p", [C, E, Alive]))
+    end.
 
 -spec cancel_async(async_req(), async_state()) -> ok.
 cancel_async(StreamRef, #{conn := Conn, stream_ref := StreamRef} = State) ->
@@ -1059,7 +1143,23 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
             %% NOTE: no need to wrap this in try/catch and checkin the conn
             %% since gun:request/5 cannot exit/error/throw.
             StreamRef = gun:request(Conn, Method, Path, Headers, Body),
-            State = #{pool => Pool, conn => Conn, stream_ref => StreamRef},
+            %% DIAGNOSTIC (#275 follow-up, S3 read stall investigation): stamp
+            %% the request start and record phase markers so a timeout can report
+            %% which phase stalled (no response headers vs. stalled mid-body).
+            %% Capture the socket's local port here at fire time, while the
+            %% connection is live; by the time a request times out gun has often
+            %% already cleared the socket, so it cannot be read then. The local
+            %% port joins this request to its TCP stream in a packet capture.
+            State = #{
+                pool => Pool,
+                conn => Conn,
+                stream_ref => StreamRef,
+                req_started_at => erlang:monotonic_time(millisecond),
+                sock => sock_info(Conn),
+                headers_at => undefined,
+                first_data_at => undefined,
+                bytes_received => 0
+            },
             {ok, StreamRef, maybe_set_timer(Opts, StreamRef, State)}
     end.
 

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -166,59 +166,59 @@ handle_call(
     #?MODULE{pending = Pending0, counter = Cnt} = State0
 ) ->
     case take_available(Pid, State0) of
-        {Conn, State} ->
+        {ok, Conn, State} ->
             counters:add(Cnt, ?C_CHECKOUTS, 1),
             {reply, Conn, State};
-        empty ->
+        {empty, State1} ->
             counters:add(Cnt, ?C_CHECKOUT_QUEUED, 1),
             MRef = erlang:monitor(process, Pid),
             P = #pending{from = From, checkout = Checkout, mref = MRef},
-            State1 = State0#?MODULE{pending = queue:in(P, Pending0)},
-            {noreply, grow(State1)}
+            State2 = State1#?MODULE{pending = queue:in(P, Pending0)},
+            {noreply, grow(State2)}
     end;
 handle_call(
     try_checkout,
     {Pid, _},
     #?MODULE{
         max_size = MaxSize,
-        available = Available,
-        monitors = Monitors,
-        checkouts = Checkouts,
         counter = Cnt
     } = State0
 ) ->
+    %% `take_available` may evict down connections, so the busy paths use the
+    %% state it returns, not `State0` whose `available`/`monitors` would then be
+    %% stale.
     case take_available(Pid, State0) of
-        {Conn, State} ->
+        {ok, Conn, State1} ->
             counters:add(Cnt, ?C_CHECKOUTS, 1),
-            {reply, Conn, State};
-        empty when map_size(Monitors) < MaxSize ->
+            {reply, Conn, State1};
+        {empty, #?MODULE{monitors = Monitors1} = State2} when map_size(Monitors1) < MaxSize ->
             ?LOG_DEBUG(
                 "Pool ~p try_checkout: busy, growing"
                 " (available=~b total=~b checked_out=~b max=~b caller=~p)",
                 [
                     self(),
-                    length(Available),
-                    map_size(Monitors),
-                    map_size(Checkouts),
+                    length(State2#?MODULE.available),
+                    map_size(Monitors1),
+                    map_size(State2#?MODULE.checkouts),
                     MaxSize,
                     Pid
                 ]
             ),
-            {reply, busy, grow(1, State0)};
-        empty ->
+            {reply, busy, grow(1, State2)};
+        {empty, #?MODULE{monitors = Monitors1} = State3} ->
             ?LOG_DEBUG(
                 "Pool ~p try_checkout: busy at max"
                 " (available=~b total=~b checked_out=~b max=~b caller=~p)",
                 [
                     self(),
-                    length(Available),
-                    map_size(Monitors),
-                    map_size(Checkouts),
+                    length(State3#?MODULE.available),
+                    map_size(Monitors1),
+                    map_size(State3#?MODULE.checkouts),
                     MaxSize,
                     Pid
                 ]
             ),
-            {reply, busy, State0}
+            {reply, busy, State3}
     end;
 handle_call(Request, From, State) ->
     ?LOG_INFO(?MODULE_STRING " received unexpected call from ~p: ~W", [From, Request, 10]),
@@ -296,11 +296,15 @@ handle_info(
             gun:close(Conn),
             {noreply, State0}
     end;
-handle_info({gun_down, _Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
+handle_info({gun_down, Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
     %% With retry=>0, gun stops the connection process immediately after sending
     %% this message (with reason 'normal' for a clean close, or
-    %% '{shutdown, Reason}' otherwise). The 'DOWN' handler does all cleanup.
-    {noreply, State};
+    %% '{shutdown, Reason}' otherwise). Remove the connection from `available`
+    %% now so it cannot be checked out in the window before the monitor `DOWN`
+    %% arrives; a request fired onto a down connection is silently lost until it
+    %% times out. `monitors` is left intact so the `DOWN` handler still runs the
+    %% final cleanup and grows a replacement.
+    {noreply, remove_available(Conn, State)};
 handle_info(
     {'DOWN', MRef, process, Pid, _Reason},
     #?MODULE{
@@ -457,15 +461,24 @@ take_available(
 ) ->
     case Available0 of
         [Conn | Available] ->
-            MRef = erlang:monitor(process, Pid),
-            State = State0#?MODULE{
-                available = Available,
-                checkouts = Checkouts0#{Conn => MRef},
-                checkouts_rev = CheckoutsRev0#{MRef => Conn}
-            },
-            {Conn, cancel_idle_timer(Conn, State)};
+            case usable(Conn) of
+                true ->
+                    MRef = erlang:monitor(process, Pid),
+                    State = State0#?MODULE{
+                        available = Available,
+                        checkouts = Checkouts0#{Conn => MRef},
+                        checkouts_rev = CheckoutsRev0#{MRef => Conn}
+                    },
+                    {ok, Conn, cancel_idle_timer(Conn, State)};
+                false ->
+                    %% Connection is down or disconnected; drop it and try the
+                    %% next. `monitors` is left intact so the `DOWN` handler
+                    %% still runs the final cleanup and grows a replacement.
+                    State = cancel_idle_timer(Conn, State0#?MODULE{available = Available}),
+                    take_available(Pid, State)
+            end;
         [] ->
-            empty
+            {empty, State0}
     end.
 
 checkout(
@@ -479,15 +492,24 @@ checkout(
 ) ->
     case {queue:out(Pending0), Available0} of
         {{{value, #pending{from = From, mref = MRef}}, Pending}, [Conn | Available]} ->
-            counters:add(Cnt, ?C_CHECKOUTS, 1),
-            gen_server:reply(From, Conn),
-            State1 = cancel_idle_timer(Conn, State0#?MODULE{
-                pending = Pending,
-                available = Available,
-                checkouts = Checkouts0#{Conn => MRef},
-                checkouts_rev = CheckoutsRev0#{MRef => Conn}
-            }),
-            checkout(State1);
+            case usable(Conn) of
+                true ->
+                    counters:add(Cnt, ?C_CHECKOUTS, 1),
+                    gen_server:reply(From, Conn),
+                    State1 = cancel_idle_timer(Conn, State0#?MODULE{
+                        pending = Pending,
+                        available = Available,
+                        checkouts = Checkouts0#{Conn => MRef},
+                        checkouts_rev = CheckoutsRev0#{MRef => Conn}
+                    }),
+                    checkout(State1);
+                false ->
+                    %% Down connection at the head; drop it (leaving `monitors`
+                    %% for the `DOWN` handler) and retry without consuming the
+                    %% pending entry, so the waiting caller still gets served.
+                    State1 = cancel_idle_timer(Conn, State0#?MODULE{available = Available}),
+                    checkout(State1)
+            end;
         _ ->
             State0
     end.
@@ -515,6 +537,33 @@ cancel(
                 false ->
                     State0
             end
+    end.
+
+%% A connection is usable for a new request only if its gun process is alive
+%% and in the `connected` state. After S3 closes an idle connection gun clears
+%% its socket and moves to `not_connected` (then stops, with retry=>0); a
+%% request fired at it in that window is silently lost until the request times
+%% out. Checked on checkout so such a connection is never handed out, covering
+%% the window where the checkout is processed before gun's `gun_down`.
+usable(Conn) ->
+    is_process_alive(Conn) andalso
+        case catch gun:info(Conn) of
+            #{state_name := connected} -> true;
+            _ -> false
+        end.
+
+%% Remove a connection from `available` and cancel its idle timer, leaving
+%% `monitors` and `checkouts` untouched. Used when gun reports the connection
+%% down: it must not be checked out, but the monitor `DOWN` handler still owns
+%% the final cleanup (removing it from `monitors` and growing a replacement).
+%% A no-op if the connection is not currently available (e.g. checked out).
+remove_available(Conn, #?MODULE{available = Available0} = State) ->
+    case lists:member(Conn, Available0) of
+        true ->
+            State1 = State#?MODULE{available = lists:delete(Conn, Available0)},
+            cancel_idle_timer(Conn, State1);
+        false ->
+            State
     end.
 
 make_available(Conn, #?MODULE{available = Available, idle_timers = Timers} = State) ->

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -62,6 +62,11 @@ the reader pool avoids reader starvation.
     pending = queue:new() :: queue:queue(#pending{}),
     %% Idle timers for available connections.
     idle_timers = #{} :: #{conn() => reference()},
+    %% DIAGNOSTIC (#275/#279, S3 read stall investigation): monotonic
+    %% milliseconds at which each connection process was opened, used to report
+    %% a down connection's age. Populated on grow, cleaned when the connection
+    %% leaves the pool.
+    created = #{} :: #{conn() => integer()},
     counter :: counters:counters_ref()
 }).
 
@@ -296,7 +301,10 @@ handle_info(
             gun:close(Conn),
             {noreply, State0}
     end;
-handle_info({gun_down, Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = State) ->
+handle_info(
+    {gun_down, Conn, _Protocol, Reason, KilledStreams},
+    #?MODULE{checkouts = Checkouts, created = Created} = State
+) ->
     %% With retry=>0, gun stops the connection process immediately after sending
     %% this message (with reason 'normal' for a clean close, or
     %% '{shutdown, Reason}' otherwise). Remove the connection from `available`
@@ -304,6 +312,26 @@ handle_info({gun_down, Conn, _Protocol, _Reason, _KilledStreams}, #?MODULE{} = S
     %% arrives; a request fired onto a down connection is silently lost until it
     %% times out. `monitors` is left intact so the `DOWN` handler still runs the
     %% final cleanup and grows a replacement.
+    %%
+    %% DIAGNOSTIC (#275/#279): log an abnormal close (a non-normal reason, or
+    %% killed in-flight streams) with the connection's age and whether it was
+    %% checked out, to confirm the dead-connection-reuse pattern this fix
+    %% targets. A clean idle close (reason=normal, no killed streams) is not
+    %% logged, to avoid noise from ordinary connection turnover.
+    case Reason =:= normal andalso KilledStreams =:= [] of
+        true ->
+            ok;
+        false ->
+            Age =
+                case Created of
+                    #{Conn := CreatedAt} -> erlang:monotonic_time(millisecond) - CreatedAt;
+                    _ -> undefined
+                end,
+            ?LOG_WARNING(
+                "S3 connection ~tw down: reason=~0p killed_streams=~b checked_out=~tw age=~twms",
+                [Conn, Reason, length(KilledStreams), is_map_key(Conn, Checkouts), Age]
+            )
+    end,
     {noreply, remove_available(Conn, State)};
 handle_info(
     {'DOWN', MRef, process, Pid, _Reason},
@@ -320,7 +348,10 @@ handle_info(
             %% was in use (or at least monitored), so demand exists regardless
             %% of whether anyone is in the Pending queue.
             Conn = Pid,
-            State1 = State0#?MODULE{monitors = maps:remove(Conn, Monitors0)},
+            State1 = State0#?MODULE{
+                monitors = maps:remove(Conn, Monitors0),
+                created = maps:remove(Conn, State0#?MODULE.created)
+            },
             State2 = cancel(Pid, State1),
             {noreply, grow(1, State2)};
         _ ->
@@ -400,10 +431,13 @@ grow(
 
 grow(0, State) ->
     State;
-grow(N, #?MODULE{monitors = Monitors0} = State0) ->
+grow(N, #?MODULE{monitors = Monitors0, created = Created0} = State0) ->
     case open() of
         {ok, Conn} ->
-            State = State0#?MODULE{monitors = Monitors0#{Conn => erlang:monitor(process, Conn)}},
+            State = State0#?MODULE{
+                monitors = Monitors0#{Conn => erlang:monitor(process, Conn)},
+                created = Created0#{Conn => erlang:monotonic_time(millisecond)}
+            },
             grow(N - 1, State);
         {error, Reason} ->
             ?LOG_WARNING("Failed to open S3 connection: ~0p", [Reason]),
@@ -576,12 +610,15 @@ make_available(Conn, #?MODULE{available = Available, idle_timers = Timers} = Sta
 %% Close a connection and stop monitoring it. Used when the connection has
 %% been idle too long, or when its caller died holding it (and we cannot
 %% trust its on-wire state). A no-op if the connection is not in `monitors`.
-close_connection(Conn, #?MODULE{monitors = Monitors} = State) ->
+close_connection(Conn, #?MODULE{monitors = Monitors, created = Created} = State) ->
     case Monitors of
         #{Conn := ConnMRef} ->
             erlang:demonitor(ConnMRef, [flush]),
             gun:close(Conn),
-            State#?MODULE{monitors = maps:remove(Conn, Monitors)};
+            State#?MODULE{
+                monitors = maps:remove(Conn, Monitors),
+                created = maps:remove(Conn, Created)
+            };
         _ ->
             State
     end.

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -62,10 +62,8 @@ the reader pool avoids reader starvation.
     pending = queue:new() :: queue:queue(#pending{}),
     %% Idle timers for available connections.
     idle_timers = #{} :: #{conn() => reference()},
-    %% DIAGNOSTIC (#275/#279, S3 read stall investigation): monotonic
-    %% milliseconds at which each connection process was opened, used to report
-    %% a down connection's age. Populated on grow, cleaned when the connection
-    %% leaves the pool.
+    %% Monotonic milliseconds at which each connection was opened; used to
+    %% report age when a connection goes down unexpectedly.
     created = #{} :: #{conn() => integer()},
     counter :: counters:counters_ref()
 }).
@@ -313,11 +311,9 @@ handle_info(
     %% times out. `monitors` is left intact so the `DOWN` handler still runs the
     %% final cleanup and grows a replacement.
     %%
-    %% DIAGNOSTIC (#275/#279): log an abnormal close (a non-normal reason, or
-    %% killed in-flight streams) with the connection's age and whether it was
-    %% checked out, to confirm the dead-connection-reuse pattern this fix
-    %% targets. A clean idle close (reason=normal, no killed streams) is not
-    %% logged, to avoid noise from ordinary connection turnover.
+    %% Log abnormal closes (non-normal reason or killed in-flight streams)
+    %% with the connection's age and checkout status. Clean idle closes
+    %% (reason=normal, no killed streams) are not logged.
     case Reason =:= normal andalso KilledStreams =:= [] of
         true ->
             ok;

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -472,10 +472,26 @@ open() ->
                     {receiver_spawn_opts, [{fullsweep_after, 0}]},
                     {sender_spawn_opts, [{fullsweep_after, 0}]}
                 ],
-                %% Let connections which were closed from idleness (or errors) close
-                %% and be reopened lazily. With TLSv1.3 it only costs one round trip.
-                %% This pool optimizes for best resource use rather than consistently
-                %% low latency. (A fully idle broker should have a min-sized pool.)
+                %% retry => 0: gun does not reconnect a closed connection. The
+                %% pool manages connection lifecycle itself - a connection closed
+                %% from idleness or error is discarded and a fresh one is grown,
+                %% rather than gun silently reconnecting underneath the pool (a
+                %% reconnecting gun process sits in not_connected/domain_lookup
+                %% for tens of ms while the pool still believes it is usable).
+                %% With TLSv1.3 reopening costs one round trip; this pool
+                %% optimizes for resource use over consistently low latency (a
+                %% fully idle broker should have a min-sized pool).
+                %%
+                %% Consequence: with retry => 0, a request issued on a connection
+                %% gun has already moved out of the `connected` state is
+                %% postponed and then lost when the process stops, surfacing only
+                %% as a request timeout (#279). The checkout path must therefore
+                %% verify a connection is still usable before handing it out, and
+                %% the gun_down handler must evict it promptly. See `usable/1` and
+                %% the gun_down clause. The alternative - a small retry plus a
+                %% short "no response started" timeout so gun self-heals and a
+                %% stranded request fails fast - is a larger lifecycle change that
+                %% has not been made.
                 retry => 0
             },
             gun:open(Host, 443, Opts);

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -58,3 +58,146 @@ and another does not) becomes visible.
 consumer replays `first()`..tail, completion is *all* consumers reaching the tail,
 and the pass gate is the *slowest* consumer reaching the threshold so a single
 stuck consumer fails the test rather than being masked by faster ones.
+
+## S3-side request logging (for diagnosing read latency)
+
+When investigating slow or stalled remote-tier reads, it helps to see S3's own
+view of each request alongside the broker logs. Two complementary mechanisms can
+be enabled on the bucket: S3 Server Access Logging (includes S3-side
+`TotalTime` and `TurnAroundTime` latency) and CloudTrail S3 data events
+(near-real-time, structured per-object events).
+
+These are diagnostic aids, not part of a normal test run. Enable them only while
+investigating, and disable them afterward. The commands below assume the bucket
+`$BUCKET` in region `$REGION`; substitute the values for the environment under
+test.
+
+```bash
+BUCKET=<data-bucket>
+REGION=us-west-2
+ACCT=<account-id>
+```
+
+### S3 Server Access Logging
+
+Logs are delivered as objects under `s3-access-logs/` in the same bucket. The
+log prefix is outside the `rabbitmq/stream/` prefix the tests write to and clean
+up, so test runs do not disturb the logs. Delivery is best-effort and lags from
+minutes up to a few hours.
+
+Enable (requires a bucket policy granting the S3 logging service principal write
+access to the log prefix):
+
+```bash
+cat > /tmp/s3-log-bucket-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3ServerAccessLogsPolicy",
+      "Effect": "Allow",
+      "Principal": { "Service": "logging.s3.amazonaws.com" },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${BUCKET}/s3-access-logs/*",
+      "Condition": {
+        "ArnLike": { "aws:SourceArn": "arn:aws:s3:::${BUCKET}" },
+        "StringEquals": { "aws:SourceAccount": "${ACCT}" }
+      }
+    }
+  ]
+}
+EOF
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy file:///tmp/s3-log-bucket-policy.json
+
+aws s3api put-bucket-logging --bucket "$BUCKET" --bucket-logging-status '{
+  "LoggingEnabled": { "TargetBucket": "'"$BUCKET"'", "TargetPrefix": "s3-access-logs/" }
+}'
+```
+
+Verify, then fetch logs once a run has completed:
+
+```bash
+aws s3api get-bucket-logging --bucket "$BUCKET"
+aws s3 ls "s3://${BUCKET}/s3-access-logs/"
+```
+
+Disable (turn off logging; remove the delivery policy if nothing else relies on
+it; delete the accumulated log objects). The `s3-access-logs/` prefix is
+separate from the plugin's `rabbitmq/stream/` data, so the scoped delete leaves
+stream data untouched:
+
+```bash
+aws s3api put-bucket-logging --bucket "$BUCKET" --bucket-logging-status '{}'
+aws s3api delete-bucket-policy --bucket "$BUCKET"
+aws s3 rm "s3://${BUCKET}/s3-access-logs/" --recursive
+```
+
+### CloudTrail S3 data events
+
+A dedicated trail keeps the data-event selector isolated from any
+account-managed trail. It needs its own log bucket with a CloudTrail service
+policy.
+
+Enable:
+
+```bash
+TRAIL=<data-bucket>-s3-data-events
+LOGBUCKET=<data-bucket>-cloudtrail-${ACCT}
+
+aws s3api create-bucket --bucket "$LOGBUCKET" --region "$REGION" \
+  --create-bucket-configuration LocationConstraint="$REGION"
+
+cat > /tmp/cloudtrail-bucket-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailAclCheck",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::${LOGBUCKET}",
+      "Condition": { "StringEquals": {
+        "aws:SourceArn": "arn:aws:cloudtrail:${REGION}:${ACCT}:trail/${TRAIL}"
+      }}
+    },
+    {
+      "Sid": "AWSCloudTrailWrite",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${LOGBUCKET}/AWSLogs/${ACCT}/*",
+      "Condition": { "StringEquals": {
+        "s3:x-amz-acl": "bucket-owner-full-control",
+        "aws:SourceArn": "arn:aws:cloudtrail:${REGION}:${ACCT}:trail/${TRAIL}"
+      }}
+    }
+  ]
+}
+EOF
+aws s3api put-bucket-policy --bucket "$LOGBUCKET" --policy file:///tmp/cloudtrail-bucket-policy.json
+
+aws cloudtrail create-trail --name "$TRAIL" --s3-bucket-name "$LOGBUCKET" --region "$REGION"
+
+# Scope data events to objects in the data bucket only, to bound volume and cost.
+aws cloudtrail put-event-selectors --region "$REGION" --trail-name "$TRAIL" \
+  --event-selectors '[{"ReadWriteType":"All","IncludeManagementEvents":false,"DataResources":[{"Type":"AWS::S3::Object","Values":["arn:aws:s3:::'"$BUCKET"'/"]}]}]'
+
+aws cloudtrail start-logging --region "$REGION" --name "$TRAIL"
+```
+
+Verify and query:
+
+```bash
+aws cloudtrail get-trail-status --region "$REGION" --name "$TRAIL"
+aws s3 ls "s3://${LOGBUCKET}/AWSLogs/${ACCT}/CloudTrail/${REGION}/" --recursive
+```
+
+Disable (stop and delete the trail; delete the log bucket once its contents are
+no longer needed):
+
+```bash
+aws cloudtrail stop-logging --region "$REGION" --name "$TRAIL"
+aws cloudtrail delete-trail --region "$REGION" --name "$TRAIL"
+aws s3 rb "s3://${LOGBUCKET}" --force
+```


### PR DESCRIPTION
## Summary

Fix S3 read stalls caused by the connection pool handing out connections S3 has already closed while idle. Pre-fix, 31-34 reads per replay stalled for the full 15s request timeout before succeeding on retry; post-fix, zero stalls across two validation runs (10-min and 30-min) under sustained read pressure with dozens of live eviction events confirming the race is handled.

Closes #279

## Changes

**Pool (`rabbitmq_stream_s3_api_aws_pool`)**

- Add `usable/1`: verify a connection's gun process is alive and in the `connected` state before handing it out on checkout
- Add `remove_available/2`: evict a connection from the available set and cancel its idle timer (leaving `monitors` intact for the `DOWN` handler)
- `take_available/2`: skip and evict unusable connections recursively
- `checkout/1` (pending drainer): skip unusable connections without consuming the pending entry
- `gun_down` handler: synchronously evict the connection from `available` the moment the message arrives, closing the window before the `DOWN` fires; log abnormal closes (non-normal reason or killed streams) with connection age and checked-out status
- `grow/2`, `close_connection/2`, `'DOWN'` handler: maintain the new `created` timestamp map for connection-age diagnostics
- Document the `retry => 0` design decision, its #279 consequence, and the guards that protect against it

**Request path (`rabbitmq_stream_s3_api_aws`)**

- Record request-phase markers (`req_started_at`, `headers_at`, `first_data_at`, `bytes_received`) so a timeout reports which phase stalled (no-response vs. headers-only vs. mid-body) and elapsed time
- `mark_first_data/2` runs per body frame; documented as the one hot-path diagnostic cost, kept for high-value triage on any future stall

**Documentation (`test/integration/README.md`)**

- S3-side request logging playbook: how to enable/disable S3 Server Access Logging and CloudTrail S3 data events for diagnosing read latency

## Validation

Two content-verification runs on the `fix/s3-connection-liveness` branch against the test cluster (3 nodes, 4 consumers, full stream replay from `first`):

| Run | Duration | Evictions | `S3 request timed out` | Integrity |
|-----|----------|-----------|------------------------|-----------|
| 1 (short) | ~10 min | 9 | **0** | passed |
| 2 (long) | ~30 min | 29 | **0** | passed |

Pre-fix baseline: ~31-34 timeouts per 10-min run, with replay throughput decaying from ~196k to ~115k msg/s. Post-fix: zero timeouts, throughput flat at ~430k msg/s throughout.

## Related

- #275 (connection churn) shares the same lifecycle area; the two should be addressed together in future work
