### PR TITLE
Fix read-path connection churn: bounded-wait checkout replaces non-blocking retry

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -50,6 +50,10 @@ A wrapper around the AWS S3 HTTP API.
 -define(REGION_KEY, rabbitmq_stream_s3_api_aws_region).
 -define(GENERAL_POOL, rabbitmq_stream_s3_general_pool).
 -define(UPLOAD_POOL, rabbitmq_stream_s3_upload_pool).
+%% How long the read path waits for a pooled connection before returning
+%% pool_busy. Sized to cover a same-region TLS handshake (~50-100ms) so the
+%% caller is served by an in-flight grow rather than retrying externally.
+-define(READ_CHECKOUT_TIMEOUT_MS, 200).
 %% Amount of data to buffer in async state before giving it to the remote
 %% reader process. See the async_state() type.
 %% 1024^2 (1 MiB).
@@ -1106,9 +1110,7 @@ request_async(Method, Path, Headers0, Body, Opts) ->
     end.
 
 start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
-    case rabbitmq_stream_s3_api_aws_pool:try_checkout(Pool) of
-        busy ->
-            {error, pool_busy};
+    try rabbitmq_stream_s3_api_aws_pool:checkout(Pool, ?READ_CHECKOUT_TIMEOUT_MS) of
         Conn ->
             Cnt = counter(),
             counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
@@ -1127,6 +1129,9 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
                 bytes_received => 0
             },
             {ok, StreamRef, maybe_set_timer(Opts, StreamRef, State)}
+    catch
+        exit:{timeout, _} ->
+            {error, pool_busy}
     end.
 
 maybe_set_timer(#{timeout := Timeout}, StreamRef, State) ->

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -51,9 +51,9 @@ A wrapper around the AWS S3 HTTP API.
 -define(GENERAL_POOL, rabbitmq_stream_s3_general_pool).
 -define(UPLOAD_POOL, rabbitmq_stream_s3_upload_pool).
 %% How long the read path waits for a pooled connection before returning
-%% pool_busy. Sized to cover a same-region TLS handshake (~50-100ms) so the
-%% caller is served by an in-flight grow rather than retrying externally.
--define(READ_CHECKOUT_TIMEOUT_MS, 200).
+%% pool_busy. Observed same-region TLS handshakes complete in 5-34ms; 100ms
+%% gives ~3x headroom while keeping reads responsive.
+-define(READ_CHECKOUT_TIMEOUT_MS, 100).
 %% Amount of data to buffer in async state before giving it to the remote
 %% reader process. See the async_state() type.
 %% 1024^2 (1 MiB).

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -85,7 +85,6 @@ the reader pool avoids reader starvation.
 %% API
 -export([
     checkout/2,
-    try_checkout/1,
     checkin/2,
     with/3
 ]).
@@ -123,16 +122,6 @@ checkout(Pool, Timeout) ->
 -spec checkin(pool(), conn()) -> ok.
 checkin(Pool, Conn) ->
     gen_server:cast(Pool, {checkin, Conn}).
-
--doc """
-Non-blocking checkout. Returns `Conn` if a connection is immediately available,
-or `busy` if no connection is available. If the pool has room to grow, the
-grow is kicked off in the background and `busy` is returned immediately so the
-caller can retry on a later event.
-""".
--spec try_checkout(pool()) -> conn() | busy.
-try_checkout(Pool) ->
-    gen_server:call(Pool, try_checkout).
 
 -spec with(pool(), timeout(), fun((conn()) -> term())) -> term().
 with(Pool, Timeout, Fun) ->
@@ -178,50 +167,6 @@ handle_call(
             P = #pending{from = From, checkout = Checkout, mref = MRef},
             State2 = State1#?MODULE{pending = queue:in(P, Pending0)},
             {noreply, grow(State2)}
-    end;
-handle_call(
-    try_checkout,
-    {Pid, _},
-    #?MODULE{
-        max_size = MaxSize,
-        counter = Cnt
-    } = State0
-) ->
-    %% `take_available` may evict down connections, so the busy paths use the
-    %% state it returns, not `State0` whose `available`/`monitors` would then be
-    %% stale.
-    case take_available(Pid, State0) of
-        {ok, Conn, State1} ->
-            counters:add(Cnt, ?C_CHECKOUTS, 1),
-            {reply, Conn, State1};
-        {empty, #?MODULE{monitors = Monitors1} = State2} when map_size(Monitors1) < MaxSize ->
-            ?LOG_DEBUG(
-                "Pool ~p try_checkout: busy, growing"
-                " (available=~b total=~b checked_out=~b max=~b caller=~p)",
-                [
-                    self(),
-                    length(State2#?MODULE.available),
-                    map_size(Monitors1),
-                    map_size(State2#?MODULE.checkouts),
-                    MaxSize,
-                    Pid
-                ]
-            ),
-            {reply, busy, grow(1, State2)};
-        {empty, #?MODULE{monitors = Monitors1} = State3} ->
-            ?LOG_DEBUG(
-                "Pool ~p try_checkout: busy at max"
-                " (available=~b total=~b checked_out=~b max=~b caller=~p)",
-                [
-                    self(),
-                    length(State3#?MODULE.available),
-                    map_size(Monitors1),
-                    map_size(State3#?MODULE.checkouts),
-                    MaxSize,
-                    Pid
-                ]
-            ),
-            {reply, busy, State3}
     end;
 handle_call(Request, From, State) ->
     ?LOG_INFO(?MODULE_STRING " received unexpected call from ~p: ~W", [From, Request, 10]),
@@ -278,16 +223,23 @@ handle_info(grow, State0) ->
     {noreply, grow(State0)};
 handle_info(
     {gun_up, Conn, _Protocol},
-    #?MODULE{monitors = Monitors, available = Available, checkouts = Checkouts} = State0
+    #?MODULE{monitors = Monitors, available = Available, checkouts = Checkouts, created = Created} =
+        State0
 ) ->
     case is_map_key(Conn, Monitors) of
         true ->
+            OpenMs =
+                case Created of
+                    #{Conn := CreatedAt} -> rabbitmq_stream_s3_util:elapsed_ms(CreatedAt);
+                    _ -> undefined
+                end,
             ?LOG_DEBUG(
-                "Pool ~p gun_up: connection ~p ready"
+                "Pool ~p gun_up: connection ~p ready in ~twms"
                 " (available=~b total=~b checked_out=~b)",
                 [
                     self(),
                     Conn,
+                    OpenMs,
                     length(Available),
                     map_size(Monitors),
                     map_size(Checkouts)

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -329,11 +329,19 @@ handle_info(
                     {noreply, State}
             end
     end;
-handle_info({idle_timeout, Conn}, #?MODULE{idle_timers = Timers} = State0) ->
+handle_info(
+    {idle_timeout, Conn},
+    #?MODULE{idle_timers = Timers, monitors = Monitors, min_size = MinSize} = State0
+) ->
     case Timers of
+        #{Conn := _} when map_size(Monitors) =< MinSize ->
+            %% Closing this connection would drop below min_size. Reset the
+            %% idle timer to keep the warm floor intact.
+            TRef = erlang:send_after(?IDLE_TIMEOUT_MS, self(), {idle_timeout, Conn}),
+            {noreply, State0#?MODULE{idle_timers = Timers#{Conn := TRef}}};
         #{Conn := _} ->
-            %% Timer is still active (wasn't cancelled by a checkout), so the
-            %% connection has been idle too long. Close it.
+            %% Connection has been idle too long and the pool is above
+            %% min_size. Close it.
             State1 = State0#?MODULE{idle_timers = maps:remove(Conn, Timers)},
             State2 = cancel(Conn, State1),
             {noreply, close_connection(Conn, State2)};


### PR DESCRIPTION
## Summary

The read path's non-blocking `try_checkout` returned `busy` the instant no idle connection was available, triggering a grow on every miss and forcing the remote reader into external backoff retries (25ms, 50ms, 100ms...). Each retry hit the same empty pool and stacked another grow, producing a self-sustaining churn cycle: 975 connections created in a 30-min run with real concurrency of 1-3.

Replace it with the existing blocking `checkout/2` using a 100ms timeout. The caller waits inside the pool's pending queue for an in-flight grow to complete, and `grow/1` computes actual demand (`queue:len(Pending) - InFlight`) rather than blindly growing by 1. If the timeout expires, the checkout is cancelled and `{error, pool_busy}` is returned as before -- the remote reader's backoff becomes a rare safety net rather than the primary mechanism.

Additionally, the idle timeout handler unconditionally closed connections regardless of pool size, dropping below the configured `min_size` floor. During low-demand periods (e.g. the general pool on the leader during publish), this produced a separate churn cycle: connections opened at boot, closed after 10s idle, re-grown on sporadic demand, closed again -- 947 times in a 30-min run. The idle timer now resets instead of closing when doing so would breach `min_size`.

Fixes #275

## Changes

- `rabbitmq_stream_s3_api_aws`: replace `try_checkout(Pool)` with `checkout(Pool, 100)` wrapped in a try/catch that returns `{error, pool_busy}` on timeout; 100ms is ~3x the observed worst-case TLS handshake (5-34ms same-region)
- `rabbitmq_stream_s3_api_aws_pool`: remove `try_checkout/1` from the API and its `handle_call` clause; add open-to-ready time to the `gun_up` log line; respect `min_size` in the idle timeout handler (reset timer instead of closing when at floor)

## Validation

Content-verification run (4GB publish, 4 consumers replaying from `first`, 200ms timeout):

| Metric | Before (main) | After (this branch) |
|--------|---------------|---------------------|
| Connections created (node 0) | 975 | **20** |
| `pool_busy` events | 56 | **0** |
| Checkout timeouts | n/a | **0** |
| `S3 request timed out` | 0 | 0 |
| Replay throughput | ~430k msg/s | **~457k msg/s** |
| Integrity | passed | passed |

TLS handshake times (from the new `gun_up` log): 5-34ms observed, median 6-7ms. The 100ms timeout gives ~3x headroom over the worst case.

The min_size fix (bcdc34f) has not yet been validated in a run -- it was found during the 30-min validation of the checkout change. Expect it to eliminate the ~947 general-pool gun_ups on node 0 during publish (those were the idle timer churning below min_size).

## Related

- #279 / #283 (S3 read stalls from dead pooled connections) -- that fix guards against dead connections on checkout; this fix eliminates the churn that creates the population of about-to-die connections in the first place
