### PR TITLE
Show oldest timestamp across both tiers in counter

### DIFF
--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -114,20 +114,39 @@ on_retention_updated(Retention, #{name := Name}) ->
     [{'fun', local_retention_fun(StreamId)} | Retention].
 
 -doc """
-Called after retention evaluation sets the first_offset counter.
+Called after retention evaluation sets the first_offset and
+first_timestamp counters.
 
-Overrides `?C_FIRST_OFFSET` with the manifest's first offset when the
-remote tier holds older data than the local tier. Without this, the
-management UI reports only the local segment window as the message count.
+osiris sets both counters from the local tier's oldest surviving segment.
+This overrides them with the manifest's first offset and first timestamp
+when the remote tier holds older data than the local tier. Without this,
+the management UI reports only the local segment window: the message count
+is too low and, because local retention keeps deleting old segments, the
+"first timestamp" (oldest message) keeps marching forward even though that
+data still lives in the remote tier.
+
+The offset and timestamp must be corrected together. They describe the same
+oldest record, so taking the min independently is consistent: the remote
+tier's first offset and first timestamp both belong to the same chunk, which
+is older than anything still on local disk whenever the remote tier is
+non-empty.
 """.
 -spec on_retention_evaluated(counters:counters_ref(), map()) -> ok.
 on_retention_evaluated(Cnt, #{name := Name}) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
-    case rabbitmq_stream_s3_manifest_replica:get_range(StreamId) of
-        {RemoteFirst, _} ->
+    %% An empty manifest (entries = <<>>) carries a sentinel first_timestamp
+    %% of -1, which must never reach the counter. get_range/1 returns `empty`
+    %% in that case, so the override only runs when the remote tier actually
+    %% holds data and its first_timestamp is a real timestamp.
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        #manifest{entries = <<>>} ->
+            ok;
+        #manifest{first_offset = RemoteFirst, first_timestamp = RemoteFirstTs} ->
             LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
-            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst));
-        _ ->
+            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst)),
+            LocalFirstTs = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP),
+            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, min(LocalFirstTs, RemoteFirstTs));
+        undefined ->
             ok
     end.
 

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -428,19 +428,39 @@ inc(Idx, N) ->
 maybe_evaluate_retention(
     StreamId,
     #manifest{next_offset = OldManifestNextOffset},
-    #manifest{first_offset = ManifestFirstOffset, next_offset = NewManifestNextOffset},
+    #manifest{
+        first_offset = ManifestFirstOffset,
+        first_timestamp = ManifestFirstTimestamp,
+        next_offset = NewManifestNextOffset
+    },
     #state{contexts = Ctxs}
 ) when NewManifestNextOffset > OldManifestNextOffset ->
     case maps:get(StreamId, Ctxs, undefined) of
         #replica_ctx{dir = Dir, shared = Shared, counter = Cnt} ->
             Spec = [{'fun', rabbitmq_stream_s3_hooks:local_retention_fun(StreamId)}],
             EvalFun = fun
-                ({{FstOff, _}, _FstTs, NumSegLeft}) when is_integer(FstOff) ->
+                ({{FstOff, _}, FstTs, NumSegLeft}) when
+                    is_integer(FstOff), is_integer(FstTs)
+                ->
                     osiris_log_shared:set_first_chunk_id(Shared, FstOff),
                     counters:put(
                         Cnt,
                         ?C_OSIRIS_LOG_FIRST_OFFSET,
                         min(FstOff, ManifestFirstOffset)
+                    ),
+                    %% Correct the first timestamp alongside the first offset.
+                    %% osiris sets it from the local tier's oldest surviving
+                    %% segment; the remote tier holds older data here (the
+                    %% manifest advanced), so the oldest message is the
+                    %% manifest's first_timestamp. Without this the UI's oldest
+                    %% message marches forward as local retention deletes
+                    %% segments. The manifest advanced past the old next_offset,
+                    %% so it is non-empty and first_timestamp is a real
+                    %% timestamp, not the empty-manifest -1 sentinel.
+                    counters:put(
+                        Cnt,
+                        ?C_OSIRIS_LOG_FIRST_TIMESTAMP,
+                        min(FstTs, ManifestFirstTimestamp)
                     ),
                     counters:put(Cnt, ?C_OSIRIS_LOG_SEGMENTS, NumSegLeft);
                 (_) ->

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -25,7 +25,8 @@ all() ->
         retention_and_append_in_same_broadcast,
         sync_live_manifest_then_broadcast_double_applies,
         manifest_reset_requires_resync,
-        cached_epoch_reflects_writer_epoch
+        cached_epoch_reflects_writer_epoch,
+        retention_evaluated_floors_first_offset_and_timestamp
     ].
 
 init_per_suite(Config) ->
@@ -544,6 +545,59 @@ manifest_reset_requires_resync(_Config) ->
     ?assertEqual(150, Converged#manifest.next_offset),
     ?assertEqual(3000, Converged#manifest.total_size),
     ?assertNotEqual(OldManifest, Converged).
+
+%% After local retention runs, osiris sets the first_offset and first_timestamp
+%% counters from the local tier's oldest surviving segment. on_retention_evaluated/2
+%% must floor both to the remote tier whenever the manifest holds older data, so
+%% the management UI reports the true oldest message rather than letting the
+%% "first timestamp" march forward as local segments are deleted. Both counters
+%% are taken as the min so a smaller local value (an empty/lagging remote tier)
+%% is never clobbered.
+retention_evaluated_floors_first_offset_and_timestamp(_Config) ->
+    Hooks = rabbitmq_stream_s3_hooks,
+    Replica = rabbitmq_stream_s3_manifest_replica,
+
+    %% Remote tier holds older data than the local tier: the oldest message is
+    %% the manifest's first_offset/first_timestamp, not the local segment's.
+    Remote = <<"stream-floor-remote">>,
+    {Manifest, _} = build_manifest([
+        {fragment, #{offset => 50, first_ts => 500, size => 1000}}
+    ]),
+    ?assertEqual(50, Manifest#manifest.first_offset),
+    ?assertEqual(500, Manifest#manifest.first_timestamp),
+    ok = Replica:put_manifest(Remote, Manifest),
+    Cnt = counters:new(5, []),
+    counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, 200),
+    counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, 2000),
+    ok = Hooks:on_retention_evaluated(Cnt, #{name => Remote}),
+    ?assertEqual(50, counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET)),
+    ?assertEqual(500, counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP)),
+
+    %% Empty remote tier (manifest with no entries, carrying the -1
+    %% first_timestamp sentinel): the counters must be left untouched so the
+    %% sentinel never reaches the UI.
+    Empty = <<"stream-floor-empty">>,
+    ok = Replica:put_manifest(Empty, #manifest{}),
+    CntEmpty = counters:new(5, []),
+    counters:put(CntEmpty, ?C_OSIRIS_LOG_FIRST_OFFSET, 200),
+    counters:put(CntEmpty, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, 2000),
+    ok = Hooks:on_retention_evaluated(CntEmpty, #{name => Empty}),
+    ?assertEqual(200, counters:get(CntEmpty, ?C_OSIRIS_LOG_FIRST_OFFSET)),
+    ?assertEqual(2000, counters:get(CntEmpty, ?C_OSIRIS_LOG_FIRST_TIMESTAMP)),
+
+    %% Local tier is the oldest (remote lags behind it): min keeps the smaller
+    %% local values, it never raises them to the remote tier.
+    Lagging = <<"stream-floor-lagging">>,
+    {LagManifest, _} = build_manifest([
+        {fragment, #{offset => 50, first_ts => 500, size => 1000}}
+    ]),
+    ok = Replica:put_manifest(Lagging, LagManifest),
+    CntLocal = counters:new(5, []),
+    counters:put(CntLocal, ?C_OSIRIS_LOG_FIRST_OFFSET, 10),
+    counters:put(CntLocal, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, 100),
+    ok = Hooks:on_retention_evaluated(CntLocal, #{name => Lagging}),
+    ?assertEqual(10, counters:get(CntLocal, ?C_OSIRIS_LOG_FIRST_OFFSET)),
+    ?assertEqual(100, counters:get(CntLocal, ?C_OSIRIS_LOG_FIRST_TIMESTAMP)).
 
 fake_writer(TestPid) ->
     receive


### PR DESCRIPTION


*Issue #, if available:* fixes #278

*Description of changes:* We fix the first offset so that the total number of offsets in the stream includes both tiers. We need to do the same for the first timestamp too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
