### PR TITLE
Reclaim a stale registry entry with a single atomic update (#222)

### DIFF
--- a/src/rabbitmq_stream_s3_registry.erl
+++ b/src/rabbitmq_stream_s3_registry.erl
@@ -36,32 +36,43 @@ init() ->
 -spec register_name({stream_id(), node()}, pid()) -> yes | no.
 register_name({StreamId, Node}, Pid) when Node =:= node() ->
     case ets:insert_new(?TABLE, {StreamId, Pid}) of
+        true -> yes;
+        false -> register_over_existing(StreamId, Pid)
+    end.
+
+%% insert_new failed: an entry already exists for the name. If it is a stale
+%% dead pid - a reader that died without unregistering (e.g. a brutal kill) -
+%% reclaim it; otherwise a live reader holds the name, so refuse. Without this a
+%% stale entry permanently blocks re-attaching tiering to the stream.
+-spec register_over_existing(stream_id(), pid()) -> yes | no.
+register_over_existing(StreamId, Pid) ->
+    case ets:lookup(?TABLE, StreamId) of
+        [{_, Existing}] when Existing =/= Pid ->
+            reclaim_if_dead(StreamId, Existing, Pid);
+        _ ->
+            %% Raced away, or already ours; retry once.
+            retry_insert(StreamId, Pid)
+    end.
+
+-spec reclaim_if_dead(stream_id(), pid(), pid()) -> yes | no.
+reclaim_if_dead(StreamId, Existing, Pid) ->
+    case is_process_alive(Existing) of
         true ->
-            yes;
+            no;
         false ->
-            %% An entry already exists. If it is a stale dead pid - a reader that
-            %% died without unregistering (e.g. a brutal kill) - replace it;
-            %% otherwise a live reader holds the name, so refuse. Without this a
-            %% stale entry permanently blocks re-attaching tiering to the stream.
-            case ets:lookup(?TABLE, StreamId) of
-                [{_, Existing}] when Existing =/= Pid ->
-                    case is_process_alive(Existing) of
-                        true ->
-                            no;
-                        false ->
-                            ets:delete_object(?TABLE, {StreamId, Existing}),
-                            case ets:insert_new(?TABLE, {StreamId, Pid}) of
-                                true -> yes;
-                                false -> no
-                            end
-                    end;
-                _ ->
-                    %% Raced away, or already ours; retry once.
-                    case ets:insert_new(?TABLE, {StreamId, Pid}) of
-                        true -> yes;
-                        false -> no
-                    end
-            end
+            %% Swap the pid in place in a single atomic op. Unlike
+            %% delete_object + insert_new there is no window in which the key is
+            %% absent, so a concurrent whereis_name never observes the name as
+            %% momentarily unregistered.
+            true = ets:update_element(?TABLE, StreamId, {2, Pid}),
+            yes
+    end.
+
+-spec retry_insert(stream_id(), pid()) -> yes | no.
+retry_insert(StreamId, Pid) ->
+    case ets:insert_new(?TABLE, {StreamId, Pid}) of
+        true -> yes;
+        false -> no
     end.
 
 -doc "Unregister a name.".

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -86,6 +86,7 @@ groups() ->
             on_init_writer_tolerates_already_started,
             two_layer_supervision_structure,
             duplicate_start_child_no_orphan_supervisor,
+            killed_reader_re_registers_and_resumes,
             remote_retention_deletes_fragments,
             remote_retention_on_update,
             remote_retention_survives_multiple_persist_cycles,
@@ -269,6 +270,54 @@ duplicate_start_child_no_orphan_supervisor(Config) ->
     ?assertMatch([_], supervisor:which_children(rabbitmq_stream_s3_replica_reader_sup)),
     %% The original reader is untouched and still registered.
     ?assertEqual(ReaderPid, rabbitmq_stream_s3_registry:whereis_name({StreamId, node()})).
+
+killed_reader_re_registers_and_resumes(Config) ->
+    %% Regression for #222. An untrappable reader death (here exit/2 with kill,
+    %% standing in for an OOM kill or brutal_kill) skips terminate/2, so the
+    %% reader never unregisters and leaves a stale {StreamId, DeadPid} entry in
+    %% the registry. The per-stream supervisor restarts the reader, whose init
+    %% must reclaim that stale entry and re-register. Before the fix the restart
+    %% got `no` from register_name and exited during init, wedging the stream.
+    StreamId = ?config(stream_id, Config),
+
+    Writer = start_writer(Config, #{fragment_target_size => 500}),
+    lists:foreach(
+        fun(_) -> osiris_writer:write(Writer, <<"first generation data">>) end,
+        lists:seq(1, 100)
+    ),
+    ok = await_offset(StreamId, 50),
+    {0, RangeBeforeKill} = get_range(Config),
+
+    OldReader = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+    ?assert(is_pid(OldReader)),
+
+    %% Kill the reader untrappably: terminate/2 does not run, so the stale entry
+    %% survives and is still pointing at the now-dead pid.
+    ReaderMon = monitor(process, OldReader),
+    true = exit(OldReader, kill),
+    receive
+        {'DOWN', ReaderMon, process, OldReader, killed} -> ok
+    after 5000 ->
+        ct:fail("reader did not die after exit(Pid, kill)")
+    end,
+
+    %% The per-stream supervisor restarts the reader. The new reader reclaims
+    %% the stale entry and re-registers under a fresh pid.
+    ?awaitMatch(
+        P when is_pid(P) andalso P =/= OldReader,
+        rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+        5000
+    ),
+
+    %% The stream keeps tiering: more data uploads and the range advances past
+    %% where it was when the reader died.
+    lists:foreach(
+        fun(_) -> osiris_writer:write(Writer, <<"second generation data">>) end,
+        lists:seq(1, 100)
+    ),
+    ok = await_offset(StreamId, RangeBeforeKill + 50),
+    {0, RangeAfterRestart} = get_range(Config),
+    ?assert(RangeAfterRestart > RangeBeforeKill).
 
 uploads_fragments(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
Closes #222

## Problem

The replica reader registry's only deleter is the reader's `terminate/2`. An untrappable reader death (OOM kill, `brutal_kill`, `exit(Pid, kill)`) skips `terminate/2`, so the reader never unregisters and leaves a stale `{StreamId, DeadPid}` entry. `register_name/2` already reclaims such an entry when the recorded pid is dead, which is what keeps a hard-killed reader from wedging its stream out of tiering.

## Change

The reclaim path replaced its `delete_object` + `insert_new` pair with a single atomic `ets:update_element/3`. This removes the window in which the key is briefly absent, during which a concurrent `whereis_name` would report the name as unregistered, and drops the unreachable retry branch.

`register_name/2` was also flattened from three nested `case` expressions into single-responsibility helpers (`register_over_existing/2`, `reclaim_if_dead/3`, `retry_insert/2`), matching the earlier pool-module refactoring.

## Test

A new CT case, `killed_reader_re_registers_and_resumes`, kills a reader untrappably (so `terminate/2` does not run and the stale entry survives), then asserts the per-stream supervisor restarts a fresh reader that reclaims the entry, re-registers under a new pid, and resumes tiering past the pre-kill range.

## Verification

- Registry eunit passes
- The new CT case passes and the full `replica_reader_SUITE` `single_node` group passes
- Dialyzer shows no new warnings for the registry