### PR TITLE
Improve CLI commands

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -459,53 +459,114 @@ A single `rabbitmq_stream_s3_archival_lag_bytes` metric would not give this deco
 
 The plugin adds commands to `rabbitmq-streams` for debugging the upload pipeline.
 
-**Stream S3 status** shows the current state of the tiered storage replica reader for a stream: manifest offsets, pipeline state, assembly progress, and whether persist/rebalance/retention operations are in flight.
+#### Stream S3 status
+
+Shows the current state of the tiered storage replica reader for a stream: manifest offsets, pipeline state, assembly progress, and whether persist/rebalance/retention operations are in flight.
 
 ```bash
 rabbitmq-streams stream_s3_status my-stream --vhost /
 # Status of tiered storage for stream my-stream in vhost / ...
-# stream:	<<"__my-stream_1781016420026141262">>
-# fragment_target_size:	67108864
-# log_next_offset:	1421556
-# manifest_first_offset:	0
-# manifest_next_offset:	1317635
-# manifest_total_size:	1339723340
-# persisted_next_offset:	1317635
-# transfers_in_flight:	1
-# transfers_pending_order:	0
-# since_persist:	0
-# persist_in_flight:	false
-# rebalance_in_flight:	false
-# retention_in_flight:	false
-# waiters:	0
-# assembly_payload_size:	38043104
-# assembly_target_size:	67108864
-# assembly_num_chunks:	6661
-# assembly_cut:	false
+#
+# Stream
+#
+# Stream ID: __my-stream_1781016420026141262
+# Node: rabbit@host
+# Log next offset: 1,421,556
+#
+# Remote tier
+#
+# First offset: 0
+# Next offset: 1,317,635
+# Persisted next offset: 1,317,635
+# Total size: 1.25 GiB (1,339,723,340 bytes)
+#
+# Upload pipeline
+#
+# Transfers in flight: 1
+# Completed transfers awaiting ordering: 0
+# Transfer deadlines armed: 1
+# Edits since last persist: 4
+# Edits in current persist: 0
+# Last persist: 3s ago
+# Persist in flight: no
+# Rebalance in flight: no
+# Retention in flight: no
+# Consumers awaiting offset: 0
+#
+# Current fragment (assembly)
+#
+# Fragment target size: 64.00 MiB (67,108,864 bytes)
+# First offset: 1,310,974
+# Next offset: 1,421,556
+# Payload size: 36.28 MiB (38,043,104 bytes)
+# On-disk size: 36.29 MiB (38,050,000 bytes)
+# Chunks: 6,661
+# Cut: no
 ```
 
-> [!TIP]
-> Use `--formatter=json` for machine-readable output: `rabbitmq-streams stream_s3_status my-stream --formatter=json`
+The report is grouped into four sections.
 
-**Evaluate local retention** triggers the local retention job for a stream. Useful to determine whether retention is correctly reclaiming segments after upload. Local retention is node-local: it acts on the local segments of the node the command runs on, so target the node whose disk you want reclaimed with `--node`.
+**Stream** identifies the stream and where this report comes from.
+
+- `Stream ID`: the plugin's internal id for the stream.
+- `Node`: the node whose replica reader answered. The command resolves the reader on any cluster node, so this names the node the rest of the report describes.
+- `Log next offset`: the next offset the local log will write, that is, the current tail of the stream.
+
+**Remote tier** describes the committed manifest, the index of data already in S3.
+
+- `First offset` and `Next offset`: the offset range covered by the remote tier. `Next offset` is one past the last uploaded offset.
+- `Persisted next offset`: the `Next offset` of the last manifest that was durably persisted. It lags `Next offset` while a persist is in flight.
+- `Total size`: total bytes stored in the remote tier.
+
+**Upload pipeline** shows in-flight work moving local data to the remote tier.
+
+- `Transfers in flight`: fragments currently uploading to S3.
+- `Completed transfers awaiting ordering`: fragments that finished uploading out of cut order, held until the earlier fragments complete so the manifest is updated in order.
+- `Transfer deadlines armed`: in-flight transfers with a timeout watchdog armed.
+- `Edits since last persist`: manifest edits accumulated since the last durable persist.
+- `Edits in current persist`: edits included in the persist currently in flight.
+- `Last persist`: time since the last durable manifest persist, computed on the reader's node.
+- `Persist in flight`, `Rebalance in flight`, `Retention in flight`: whether each background operation is currently running.
+- `Consumers awaiting offset`: consumers blocked waiting for an offset to become available.
+
+**Current fragment (assembly)** describes the fragment currently being assembled from local chunks.
+
+- `Fragment target size`: the size at which the in-progress fragment is cut and uploaded.
+- `First offset` and `Next offset`: the offset range of the chunks accumulated so far.
+- `Payload size`: uncompressed payload bytes accumulated. This drives the cut decision against the target size.
+- `On-disk size`: on-disk bytes accumulated.
+- `Chunks`: number of chunks accumulated.
+- `Cut`: whether the fragment has reached the cut threshold (or been force-cut) and is pending upload.
+
+A section reads `(not initialized)` before the reader has resolved the manifest (Remote tier and Upload pipeline) or opened the local log and started an assembly (Current fragment).
+
+#### Evaluate local retention
+
+Triggers the local retention job for a stream. Useful to determine whether retention is correctly reclaiming segments after upload. Local retention is node-local: it acts on the local segments of the node the command runs on, so target the node whose disk you want reclaimed with `--node`.
 
 ```bash
 rabbitmq-streams evaluate_local_retention my-stream --vhost /
 ```
 
-**Evaluate remote retention** triggers the remote retention job for a stream. Useful when the retention policy has changed and you want immediate effect, or to verify that remote retention is not stuck.
+#### Evaluate remote retention
+
+Triggers the remote retention job for a stream. Useful when the retention policy has changed and you want immediate effect, or to verify that remote retention is not stuck.
 
 ```bash
 rabbitmq-streams evaluate_remote_retention my-stream --vhost /
 ```
 
-**Force fragment cut** forces the current in-progress fragment to cut and upload immediately, regardless of whether it has reached the target size. Useful to verify that the upload pipeline works end-to-end without waiting for data to accumulate.
+#### Force fragment cut
+
+Forces the current in-progress fragment to cut and upload immediately, regardless of whether it has reached the target size. Useful to verify that the upload pipeline works end-to-end without waiting for data to accumulate.
 
 ```bash
 rabbitmq-streams force_fragment_cut my-stream --vhost /
 ```
 
-**Garbage collection** identifies (and optionally deletes) dangling S3 objects that are not referenced by any manifest. Defaults to `dry_run` mode which reports orphans without deleting them. Pass `--mode delete` to actually remove the objects.
+#### Garbage collection
+
+Identifies (and optionally deletes) dangling S3 objects that are not referenced by any manifest. Defaults to `dry_run` mode which reports orphans without deleting them. Pass `--mode delete` to actually remove the objects.
 
 ```bash
 rabbitmq-streams stream_s3_gc

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -487,7 +487,7 @@ rabbitmq-streams stream_s3_status my-stream --vhost /
 > [!TIP]
 > Use `--formatter=json` for machine-readable output: `rabbitmq-streams stream_s3_status my-stream --formatter=json`
 
-**Evaluate local retention** triggers the local retention job for a stream. Useful to determine whether retention is correctly reclaiming segments after upload.
+**Evaluate local retention** triggers the local retention job for a stream. Useful to determine whether retention is correctly reclaiming segments after upload. Local retention is node-local: it acts on the local segments of the node the command runs on, so target the node whose disk you want reclaimed with `--node`.
 
 ```bash
 rabbitmq-streams evaluate_local_retention my-stream --vhost /

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateLocalRetentionCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateLocalRetentionCommand.erl
@@ -67,7 +67,7 @@ output(ok, _Opts) ->
     {ok, <<"Local retention evaluated successfully.">>};
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
-        <<"Stream not found or replica reader not running on this node.">>};
+        <<"Stream not found, or no member of it is running on the target node.">>};
 output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.EvaluateRemoteRetentionCommand.erl
@@ -67,7 +67,7 @@ output(ok, _Opts) ->
     {ok, <<"Remote retention evaluated successfully.">>};
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
-        <<"Stream not found or replica reader not running on this node.">>};
+        <<"Stream not found, or no replica reader is running for it.">>};
 output({error, {in_progress, Blocker}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_tempfail(),
         erlang:iolist_to_binary(

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ForceFragmentCutCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ForceFragmentCutCommand.erl
@@ -73,7 +73,7 @@ output({error, empty_assembly}, _Opts) ->
         <<"Assembly is empty (no chunks accumulated yet).">>};
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
-        <<"Stream not found or replica reader not running on this node.">>};
+        <<"Stream not found, or no replica reader is running for it.">>};
 output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
@@ -71,7 +71,7 @@ output({ok, Info}, _Opts) ->
     {ok, erlang:iolist_to_binary(lists:join($\n, Lines))};
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
-        <<"Stream not found or replica reader not running on this node.">>};
+        <<"Stream not found, or no replica reader is running for it.">>};
 output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.StreamS3StatusCommand.erl
@@ -14,6 +14,7 @@
     merge_defaults/2,
     run/2,
     output/2,
+    formatter/0,
     description/0,
     help_section/0
 ]).
@@ -66,8 +67,14 @@ banner([Name], #{vhost := VHost}) ->
 output({ok, Info}, #{formatter := <<"json">>}) ->
     {ok, flatten(Info)};
 output({ok, Info}, _Opts) ->
-    KVs = flatten(Info),
-    Lines = [io_lib:format("~s:\t~tp", [K, V]) || {K, V} <- KVs],
+    Sections = [
+        stream_section(Info),
+        remote_tier_section(Info),
+        upload_pipeline_section(Info),
+        assembly_section(Info)
+    ],
+    %% Blank line between sections, mirroring cluster_status.
+    Lines = lists:append(lists:join([<<>>], Sections)),
     {ok, erlang:iolist_to_binary(lists:join($\n, Lines))};
 output({error, {not_found, _}}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
@@ -76,17 +83,173 @@ output({error, Reason}, _Opts) ->
     {error, 'Elixir.RabbitMQ.CLI.Core.ExitCodes':exit_software(),
         erlang:iolist_to_binary(io_lib:format("~tp", [Reason]))}.
 
+formatter() ->
+    'Elixir.RabbitMQ.CLI.Formatters.String'.
+
 %% ------------------------------------------------------------------
-%% Internal
+%% Human-readable sections
+%% ------------------------------------------------------------------
+
+stream_section(#{stream := StreamId, node := Node, log_next_offset := LogNext}) ->
+    [
+        header(<<"Stream">>),
+        <<>>,
+        kv(<<"Stream ID">>, string(StreamId)),
+        kv(<<"Node">>, atom(Node)),
+        kv(<<"Log next offset">>, integer(LogNext))
+    ].
+
+remote_tier_section(#{core := undefined}) ->
+    [header(<<"Remote tier">>), <<>>, not_initialized()];
+remote_tier_section(#{core := Core}) ->
+    [
+        header(<<"Remote tier">>),
+        <<>>,
+        kv(<<"First offset">>, integer(maps:get(manifest_first_offset, Core))),
+        kv(<<"Next offset">>, integer(maps:get(manifest_next_offset, Core))),
+        kv(<<"Persisted next offset">>, integer(maps:get(persisted_next_offset, Core))),
+        kv(<<"Total size">>, bytes(maps:get(manifest_total_size, Core)))
+    ].
+
+upload_pipeline_section(#{core := undefined} = Info) ->
+    [
+        header(<<"Upload pipeline">>),
+        <<>>,
+        kv(<<"Transfer deadlines armed">>, integer(maps:get(transfer_deadlines_armed, Info))),
+        not_initialized()
+    ];
+upload_pipeline_section(#{core := Core} = Info) ->
+    [
+        header(<<"Upload pipeline">>),
+        <<>>,
+        kv(<<"Transfers in flight">>, integer(maps:get(transfers_in_flight, Core))),
+        kv(
+            <<"Completed transfers awaiting ordering">>,
+            integer(maps:get(transfers_pending_order, Core))
+        ),
+        kv(<<"Transfer deadlines armed">>, integer(maps:get(transfer_deadlines_armed, Info))),
+        kv(<<"Edits since last persist">>, integer(maps:get(since_persist, Core))),
+        kv(<<"Edits in current persist">>, integer(maps:get(in_persist_count, Core))),
+        kv(<<"Last persist">>, age(maps:get(last_persist_age_ms, Core))),
+        kv(<<"Persist in flight">>, bool(maps:get(persist_in_flight, Core))),
+        kv(<<"Rebalance in flight">>, bool(maps:get(rebalance_in_flight, Core))),
+        kv(<<"Retention in flight">>, bool(maps:get(retention_in_flight, Core))),
+        kv(<<"Consumers awaiting offset">>, integer(maps:get(waiters, Core)))
+    ].
+
+assembly_section(#{assembly := undefined} = Info) ->
+    [
+        header(<<"Current fragment (assembly)">>),
+        <<>>,
+        kv(<<"Fragment target size">>, bytes(maps:get(fragment_target_size, Info))),
+        not_initialized()
+    ];
+assembly_section(#{assembly := Assembly} = Info) ->
+    [
+        header(<<"Current fragment (assembly)">>),
+        <<>>,
+        kv(<<"Fragment target size">>, bytes(maps:get(fragment_target_size, Info))),
+        kv(<<"First offset">>, integer(maps:get(first_offset, Assembly))),
+        kv(<<"Next offset">>, integer(maps:get(next_offset, Assembly))),
+        kv(<<"Payload size">>, bytes(maps:get(payload_size, Assembly))),
+        kv(<<"On-disk size">>, bytes(maps:get(size, Assembly))),
+        kv(<<"Chunks">>, integer(maps:get(num_chunks, Assembly))),
+        kv(<<"Cut">>, bool(maps:get(cut, Assembly)))
+    ].
+
+%% ------------------------------------------------------------------
+%% Rendering helpers
+%% ------------------------------------------------------------------
+
+header(Title) ->
+    'Elixir.RabbitMQ.CLI.Core.ANSI':bright(Title).
+
+not_initialized() ->
+    <<"(not initialized)">>.
+
+kv(Label, Value) ->
+    erlang:iolist_to_binary([Label, <<": ">>, Value]).
+
+string(Bin) when is_binary(Bin) ->
+    Bin.
+
+atom(A) when is_atom(A) ->
+    erlang:atom_to_binary(A, utf8).
+
+bool(true) -> <<"yes">>;
+bool(false) -> <<"no">>.
+
+%% An offset that has not been set yet (e.g. an empty assembly's first offset).
+integer(undefined) ->
+    <<"none">>;
+integer(N) when is_integer(N) ->
+    group_digits(N).
+
+%% Human-readable size with the exact byte count alongside, e.g.
+%% "64.00 MiB (67,108,864 bytes)".
+bytes(N) when is_integer(N) ->
+    erlang:iolist_to_binary(io_lib:format("~ts (~ts bytes)", [human_bytes(N), group_digits(N)])).
+
+human_bytes(N) when N >= (1 bsl 30) ->
+    io_lib:format("~.2f GiB", [N / (1 bsl 30)]);
+human_bytes(N) when N >= (1 bsl 20) ->
+    io_lib:format("~.2f MiB", [N / (1 bsl 20)]);
+human_bytes(N) when N >= (1 bsl 10) ->
+    io_lib:format("~.2f KiB", [N / (1 bsl 10)]);
+human_bytes(N) ->
+    io_lib:format("~ts B", [group_digits(N)]).
+
+%% Render a duration (milliseconds) as a coarse "Xd Yh" / "Xh Ym" / "Xm Ys" /
+%% "Xs ago" string. The age is computed server-side (see the reader core's
+%% format_state) so it reflects the node that owns the reader, not the CLI host.
+age(Ms) when is_integer(Ms), Ms < 1000 ->
+    <<"just now">>;
+age(Ms) when is_integer(Ms) ->
+    Secs = Ms div 1000,
+    erlang:iolist_to_binary([coarse_duration(Secs), <<" ago">>]).
+
+coarse_duration(Secs) when Secs < 60 ->
+    io_lib:format("~bs", [Secs]);
+coarse_duration(Secs) when Secs < 3600 ->
+    io_lib:format("~bm ~bs", [Secs div 60, Secs rem 60]);
+coarse_duration(Secs) when Secs < 86400 ->
+    io_lib:format("~bh ~bm", [Secs div 3600, (Secs rem 3600) div 60]);
+coarse_duration(Secs) ->
+    io_lib:format("~bd ~bh", [Secs div 86400, (Secs rem 86400) div 3600]).
+
+%% Group an integer's digits into thousands with commas, e.g. 1421556 ->
+%% "1,421,556".
+group_digits(N) when is_integer(N), N < 0 ->
+    [$- | group_digits(-N)];
+group_digits(N) when is_integer(N) ->
+    Reversed = lists:reverse(integer_to_list(N)),
+    lists:reverse(insert_commas(Reversed)).
+
+insert_commas([A, B, C, D | Rest]) ->
+    [A, B, C, $, | insert_commas([D | Rest])];
+insert_commas(Rest) ->
+    Rest.
+
+%% ------------------------------------------------------------------
+%% JSON projection (flat map, machine-readable)
 %% ------------------------------------------------------------------
 
 flatten(
-    #{stream := StreamId, core := Core, assembly := Assembly, log_next_offset := LogNext} = Info
+    #{
+        stream := StreamId,
+        node := Node,
+        core := Core,
+        assembly := Assembly,
+        log_next_offset := LogNext
+    } =
+        Info
 ) ->
     Target = maps:get(fragment_target_size, Info),
     Base = [
         {stream, StreamId},
+        {node, Node},
         {fragment_target_size, Target},
+        {transfer_deadlines_armed, maps:get(transfer_deadlines_armed, Info)},
         {log_next_offset, LogNext}
     ],
     Base ++ flatten_core(Core) ++ flatten_assembly(Assembly).
@@ -102,6 +265,8 @@ flatten_core(Core) ->
         {transfers_in_flight, maps:get(transfers_in_flight, Core)},
         {transfers_pending_order, maps:get(transfers_pending_order, Core)},
         {since_persist, maps:get(since_persist, Core)},
+        {in_persist_count, maps:get(in_persist_count, Core)},
+        {last_persist_age_ms, maps:get(last_persist_age_ms, Core)},
         {persist_in_flight, maps:get(persist_in_flight, Core)},
         {rebalance_in_flight, maps:get(rebalance_in_flight, Core)},
         {retention_in_flight, maps:get(retention_in_flight, Core)},
@@ -112,7 +277,10 @@ flatten_assembly(undefined) ->
     [{assembly, <<"not initialized">>}];
 flatten_assembly(Assembly) ->
     [
+        {assembly_first_offset, maps:get(first_offset, Assembly)},
+        {assembly_next_offset, maps:get(next_offset, Assembly)},
         {assembly_payload_size, maps:get(payload_size, Assembly)},
+        {assembly_size, maps:get(size, Assembly)},
         {assembly_target_size, maps:get(target_size, Assembly)},
         {assembly_num_chunks, maps:get(num_chunks, Assembly)},
         {assembly_cut, maps:get(cut, Assembly)}

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -69,7 +69,8 @@ No heartbeat or reconnection mechanism is needed because:
     sync/4,
     sync/5,
     register_replica_context/4,
-    is_context_registered/1
+    is_context_registered/1,
+    evaluate_local_retention/1
 ]).
 -export([
     init/1,
@@ -194,6 +195,11 @@ register_replica_context(StreamId, Dir, Shared, Counter) ->
 is_context_registered(StreamId) ->
     gen_server:call(?MODULE, {is_context_registered, StreamId}).
 
+-doc "Evaluate local-tier retention for a stream on this node.".
+-spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
+evaluate_local_retention(StreamId) ->
+    gen_server:call(?MODULE, {evaluate_local_retention, StreamId}).
+
 %% ------------------------------------------------------------------
 %% gen_server callbacks
 %% ------------------------------------------------------------------
@@ -262,6 +268,27 @@ handle_call(
     {reply, ok, State#state{contexts = Ctxs#{StreamId => Ctx}}};
 handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = State) ->
     {reply, maps:is_key(StreamId, Ctxs), State};
+handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs} = State) ->
+    Reply =
+        case maps:get(StreamId, Ctxs, undefined) of
+            #replica_ctx{} = Ctx ->
+                case get_manifest(StreamId) of
+                    #manifest{entries = <<>>} ->
+                        %% No remote tier yet: nothing has been uploaded, so no
+                        %% local segment is safe to delete. Returning early also
+                        %% avoids feeding the empty manifest's -1 first_timestamp
+                        %% sentinel into the counter (see run_local_retention).
+                        ok;
+                    #manifest{} = Manifest ->
+                        run_local_retention(StreamId, Manifest, Ctx),
+                        ok;
+                    undefined ->
+                        {error, manifest_not_resolved}
+                end;
+            undefined ->
+                {error, {not_found, StreamId}}
+        end,
+    {reply, Reply, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 
@@ -436,45 +463,12 @@ inc(Idx, N) ->
 maybe_evaluate_retention(
     StreamId,
     #manifest{next_offset = OldManifestNextOffset},
-    #manifest{
-        first_offset = ManifestFirstOffset,
-        first_timestamp = ManifestFirstTimestamp,
-        next_offset = NewManifestNextOffset
-    },
+    #manifest{next_offset = NewManifestNextOffset} = Manifest,
     #state{contexts = Ctxs}
 ) when NewManifestNextOffset > OldManifestNextOffset ->
     case maps:get(StreamId, Ctxs, undefined) of
-        #replica_ctx{dir = Dir, shared = Shared, counter = Cnt} ->
-            Spec = [{'fun', rabbitmq_stream_s3_hooks:local_retention_fun(StreamId)}],
-            EvalFun = fun
-                ({{FstOff, _}, FstTs, NumSegLeft}) when
-                    is_integer(FstOff), is_integer(FstTs)
-                ->
-                    osiris_log_shared:set_first_chunk_id(Shared, FstOff),
-                    counters:put(
-                        Cnt,
-                        ?C_OSIRIS_LOG_FIRST_OFFSET,
-                        min(FstOff, ManifestFirstOffset)
-                    ),
-                    %% Correct the first timestamp alongside the first offset.
-                    %% osiris sets it from the local tier's oldest surviving
-                    %% segment; the remote tier holds older data here (the
-                    %% manifest advanced), so the oldest message is the
-                    %% manifest's first_timestamp. Without this the UI's oldest
-                    %% message marches forward as local retention deletes
-                    %% segments. The manifest advanced past the old next_offset,
-                    %% so it is non-empty and first_timestamp is a real
-                    %% timestamp, not the empty-manifest -1 sentinel.
-                    counters:put(
-                        Cnt,
-                        ?C_OSIRIS_LOG_FIRST_TIMESTAMP,
-                        min(FstTs, ManifestFirstTimestamp)
-                    ),
-                    counters:put(Cnt, ?C_OSIRIS_LOG_SEGMENTS, NumSegLeft);
-                (_) ->
-                    ok
-            end,
-            osiris_retention:eval(StreamId, Dir, Spec, EvalFun);
+        #replica_ctx{} = Ctx ->
+            run_local_retention(StreamId, Manifest, Ctx);
         undefined ->
             ok
     end;
@@ -482,6 +476,46 @@ maybe_evaluate_retention(
     _StreamId, _OldManifest = #manifest{}, _NewManifest = #manifest{}, #state{}
 ) ->
     ok.
+
+%% Evaluate local-tier retention for a stream on this node against `Manifest`.
+%% Deletes local segments whose data is already uploaded (up to the manifest's
+%% next_offset, via local_retention_fun) and corrects the first offset/timestamp
+%% counters. Shared by the automatic edit-driven path (maybe_evaluate_retention)
+%% and the on-demand CLI path (evaluate_local_retention/1). Callers must ensure
+%% the manifest is non-empty so the -1 first_timestamp sentinel never reaches the
+%% counter.
+run_local_retention(
+    StreamId,
+    #manifest{first_offset = ManifestFirstOffset, first_timestamp = ManifestFirstTimestamp},
+    #replica_ctx{dir = Dir, shared = Shared, counter = Cnt}
+) ->
+    Spec = [{'fun', rabbitmq_stream_s3_hooks:local_retention_fun(StreamId)}],
+    EvalFun = fun
+        ({{FstOff, _}, FstTs, NumSegLeft}) when
+            is_integer(FstOff), is_integer(FstTs)
+        ->
+            osiris_log_shared:set_first_chunk_id(Shared, FstOff),
+            counters:put(
+                Cnt,
+                ?C_OSIRIS_LOG_FIRST_OFFSET,
+                min(FstOff, ManifestFirstOffset)
+            ),
+            %% Correct the first timestamp alongside the first offset.
+            %% osiris sets it from the local tier's oldest surviving
+            %% segment; the remote tier holds older data here, so the
+            %% oldest message is the manifest's first_timestamp. Without
+            %% this the UI's oldest message marches forward as local
+            %% retention deletes segments.
+            counters:put(
+                Cnt,
+                ?C_OSIRIS_LOG_FIRST_TIMESTAMP,
+                min(FstTs, ManifestFirstTimestamp)
+            ),
+            counters:put(Cnt, ?C_OSIRIS_LOG_SEGMENTS, NumSegLeft);
+        (_) ->
+            ok
+    end,
+    osiris_retention:eval(StreamId, Dir, Spec, EvalFun).
 
 %% Seed the osiris first-offset and first-timestamp counters from the manifest
 %% on sync. Without this, the counters reflect only the local tier until the

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -606,6 +606,7 @@ format_state(#state{
 }) ->
     #{
         stream => StreamId,
+        node => node(),
         fragment_target_size => Target,
         transfer_deadlines_armed => maps:size(Timers),
         core =>

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -282,12 +282,20 @@ status(VHost, QueueName) ->
 -doc "Trigger local retention evaluation for a stream on the current node.".
 -spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
 evaluate_local_retention(StreamId) ->
-    call(StreamId, evaluate_local_retention).
+    case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
+        Pid when is_pid(Pid) ->
+            gen_server:call(Pid, evaluate_local_retention);
+        undefined ->
+            rabbitmq_stream_s3_manifest_replica:evaluate_local_retention(StreamId)
+    end.
 
 -doc "Trigger local retention evaluation by vhost and queue name.".
 -spec evaluate_local_retention(rabbit_types:vhost(), binary()) -> ok | {error, term()}.
 evaluate_local_retention(VHost, QueueName) ->
-    call(VHost, QueueName, evaluate_local_retention).
+    case resolve_stream_id(VHost, QueueName) of
+        {ok, StreamId} -> evaluate_local_retention(StreamId);
+        {error, _} = Err -> Err
+    end.
 
 -doc "Trigger remote retention evaluation for a stream on the current node.".
 -spec evaluate_remote_retention(stream_id()) -> ok | {error, term()}.
@@ -622,9 +630,9 @@ format_state(#state{
 %% ------------------------------------------------------------------
 
 call(StreamId, Msg) ->
-    case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
-        undefined -> {error, {not_found, StreamId}};
-        Pid -> gen_server:call(Pid, Msg)
+    case find_reader(StreamId) of
+        {ok, Pid} -> gen_server:call(Pid, Msg);
+        undefined -> {error, {not_found, StreamId}}
     end.
 
 call(VHost, QueueName, Msg) ->
@@ -633,6 +641,18 @@ call(VHost, QueueName, Msg) ->
             call(StreamId, Msg);
         {error, _} = Err ->
             Err
+    end.
+
+-spec find_reader(stream_id()) -> {ok, pid()} | undefined.
+find_reader(StreamId) ->
+    find_reader(StreamId, [node() | nodes()]).
+
+find_reader(_StreamId, []) ->
+    undefined;
+find_reader(StreamId, [Node | Rest]) ->
+    case rabbitmq_stream_s3_registry:whereis_name({StreamId, Node}) of
+        undefined -> find_reader(StreamId, Rest);
+        Pid -> {ok, Pid}
     end.
 
 -doc "Resolve a vhost and queue name to the internal stream id.".

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -190,7 +190,10 @@ format_state(#state{
         since_persist => SincePersist,
         in_persist_count => InPersistCount,
         persist_in_flight => PersistInFlight,
-        last_persist_ts => LastPersistTs,
+        %% Age rather than the raw timestamp: last_persist_ts is on this node's
+        %% clock, but the CLI renders on a different node, so the duration must
+        %% be computed here against the same clock.
+        last_persist_age_ms => erlang:system_time(millisecond) - LastPersistTs,
         rebalance_in_flight => RebalanceInFlight,
         retention_in_flight => RetentionInFlight,
         waiters => length(Waiters)


### PR DESCRIPTION
Two improvements to the CLI commands:

* Allow them to be run from any node. For most commands this means redirecting to the node with the replica reader process. For local retention evaluation this means that we can run local retention against the requested node, even if it is not the writer.
* Improve the output of the `stream_s3_status` command. It should be human-readable. The new command adds comma-separators for large numbers and formats byte values in human readable format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
