### PR TITLE
manifest replica: Clean up when a replica (reader) exits

### DIFF
--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -80,7 +80,7 @@ on_init(writer, Pid, #{name := Name, dir := Dir, shared := Shared, counter := Co
             )
     end,
     append_retention(StreamId, Config);
-on_init(acceptor, _Pid, #{name := Name, leader_pid := LeaderPid, counter := Counter} = Config) ->
+on_init(acceptor, Pid, #{name := Name, leader_pid := LeaderPid, counter := Counter} = Config) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     WriterNode = node(LeaderPid),
     gen_server:cast(
@@ -89,13 +89,17 @@ on_init(acceptor, _Pid, #{name := Name, leader_pid := LeaderPid, counter := Coun
     ),
     Shared = maps:get(shared, Config),
     Dir = maps:get(dir, Config),
-    rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),
+    rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        StreamId, Pid, Dir, Shared, Counter
+    ),
     append_retention(StreamId, Config);
-on_init(acceptor, _Pid, #{name := Name, counter := Counter} = Config) ->
+on_init(acceptor, Pid, #{name := Name, counter := Counter} = Config) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     Shared = maps:get(shared, Config),
     Dir = maps:get(dir, Config),
-    rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),
+    rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        StreamId, Pid, Dir, Shared, Counter
+    ),
     append_retention(StreamId, Config).
 
 -doc """
@@ -267,7 +271,7 @@ register_replica_context(Pid, StreamId) ->
         osiris_util:get_reader_context(Pid),
     Counter = osiris_counters:fetch({osiris_replica, Reference}),
     rabbitmq_stream_s3_manifest_replica:register_replica_context(
-        StreamId, Dir, Shared, Counter
+        StreamId, Pid, Dir, Shared, Counter
     ).
 
 append_retention(StreamId, Config) ->
@@ -349,7 +353,9 @@ attach_replica(Pid) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     %% Seshat registers replica counters under {osiris_replica, Reference}.
     Counter = osiris_counters:fetch({osiris_replica, Reference}),
-    rabbitmq_stream_s3_manifest_replica:register_replica_context(StreamId, Dir, Shared, Counter),
+    rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        StreamId, Pid, Dir, Shared, Counter
+    ),
     %% Register with the writer's replica reader for manifest broadcast.
     %% If the writer's replica reader isn't up yet, the cast is dropped;
     %% the replica reader will proactively sync us on its startup.

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -68,9 +68,10 @@ No heartbeat or reconnection mechanism is needed because:
     apply_edits/5,
     sync/4,
     sync/5,
-    register_replica_context/4,
+    register_replica_context/5,
     is_context_registered/1,
-    evaluate_local_retention/1
+    evaluate_local_retention/1,
+    forget/1
 ]).
 -export([
     init/1,
@@ -83,14 +84,20 @@ No heartbeat or reconnection mechanism is needed because:
 -record(replica_ctx, {
     dir :: file:filename_all(),
     shared :: atomics:atomics_ref(),
-    counter :: counters:counters_ref()
+    counter :: counters:counters_ref(),
+    %% Monitor ref for the osiris member that registered this context. When the
+    %% member goes down the context is dropped; see handle_info/2.
+    mref :: reference()
 }).
 
 -record(state, {
     %% Per-stream osiris context for replica-side retention.
     contexts = #{} :: #{stream_id() => #replica_ctx{}},
     %% Per-stream last applied {seq, epoch, writer_node} for gap detection.
-    seqs = #{} :: #{stream_id() => {non_neg_integer(), non_neg_integer(), node()}}
+    seqs = #{} :: #{stream_id() => {non_neg_integer(), non_neg_integer(), node()}},
+    %% Reverse index from a member monitor ref to its stream, so a DOWN can find
+    %% which stream to release. Kept in lockstep with the mref in each context.
+    monitors = #{} :: #{reference() => stream_id()}
 }).
 
 %% ------------------------------------------------------------------
@@ -182,13 +189,21 @@ sync(StreamId, Seq, Epoch, Manifest) ->
 
 -doc """
 Register osiris log context for a stream on this node.
-Called from the acceptor hook when a replica starts.
+
+Called from the acceptor hook when a replica starts (and from discovery and
+reconciliation). `MemberPid` is the osiris member that owns the context; it is
+monitored so the context, sequence, and cached row are released when the member
+goes down. osiris has no terminate or delete hook, so this monitor is how
+per-node replica state is reclaimed when a replica moves off the node or the
+stream is deleted. Re-registering for a stream replaces any previous monitor, so
+a member restart re-points the monitor at the new incarnation rather than letting
+its predecessor's DOWN evict the live context.
 """.
 -spec register_replica_context(
-    stream_id(), file:filename_all(), atomics:atomics_ref(), counters:counters_ref()
+    stream_id(), pid(), file:filename_all(), atomics:atomics_ref(), counters:counters_ref()
 ) -> ok.
-register_replica_context(StreamId, Dir, Shared, Counter) ->
-    gen_server:call(?MODULE, {register_replica_context, StreamId, Dir, Shared, Counter}).
+register_replica_context(StreamId, MemberPid, Dir, Shared, Counter) ->
+    gen_server:call(?MODULE, {register_replica_context, StreamId, MemberPid, Dir, Shared, Counter}).
 
 -doc "Whether a replica context is registered for the stream on this node.".
 -spec is_context_registered(stream_id()) -> boolean().
@@ -199,6 +214,19 @@ is_context_registered(StreamId) ->
 -spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
 evaluate_local_retention(StreamId) ->
     gen_server:call(?MODULE, {evaluate_local_retention, StreamId}).
+
+-doc """
+Release all per-node state for a stream: its retention context (and member
+monitor), its gap-detection sequence, and its cached manifest row.
+
+Replica-side state is released automatically by the member monitor (see
+`register_replica_context/5`). This is the explicit path for the writer node,
+whose cached row is written by `put_manifest/3` and owned by the replica reader,
+which calls this from its `terminate/2` when the stream is torn down.
+""".
+-spec forget(stream_id()) -> ok.
+forget(StreamId) ->
+    gen_server:call(?MODULE, {forget, StreamId}).
 
 %% ------------------------------------------------------------------
 %% gen_server callbacks
@@ -260,12 +288,27 @@ handle_call({apply_edit, StreamId, Edit}, _From, State) ->
         end,
     {reply, Reply, State};
 handle_call(
-    {register_replica_context, StreamId, Dir, Shared, Counter},
+    {register_replica_context, StreamId, MemberPid, Dir, Shared, Counter},
     _From,
-    #state{contexts = Ctxs} = State
+    #state{contexts = Ctxs, monitors = Mons0} = State
 ) ->
-    Ctx = #replica_ctx{dir = Dir, shared = Shared, counter = Counter},
-    {reply, ok, State#state{contexts = Ctxs#{StreamId => Ctx}}};
+    %% Replace any previous registration's monitor first: a member restart
+    %% re-registers, and the old incarnation's DOWN must not evict the new
+    %% context. demonitor with flush drops any DOWN already queued for it.
+    Mons1 =
+        case maps:get(StreamId, Ctxs, undefined) of
+            #replica_ctx{mref = OldRef} ->
+                demonitor(OldRef, [flush]),
+                maps:remove(OldRef, Mons0);
+            undefined ->
+                Mons0
+        end,
+    MRef = monitor(process, MemberPid),
+    Ctx = #replica_ctx{dir = Dir, shared = Shared, counter = Counter, mref = MRef},
+    {reply, ok, State#state{
+        contexts = Ctxs#{StreamId => Ctx},
+        monitors = Mons1#{MRef => StreamId}
+    }};
 handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = State) ->
     {reply, maps:is_key(StreamId, Ctxs), State};
 handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs} = State) ->
@@ -289,6 +332,8 @@ handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs}
                 {error, {not_found, StreamId}}
         end,
     {reply, Reply, State};
+handle_call({forget, StreamId}, _From, State) ->
+    {reply, ok, release_stream(StreamId, State)};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
 
@@ -352,6 +397,16 @@ handle_cast({apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, #state{seqs 
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{monitors = Mons} = State) ->
+    %% A registered osiris member went down. Release its stream's state. A DOWN
+    %% whose ref is not in the map belongs to a registration already superseded
+    %% (re-register demonitored+flushed it) and is ignored.
+    case maps:get(MRef, Mons, undefined) of
+        undefined ->
+            {noreply, State};
+        StreamId ->
+            {noreply, release_stream(StreamId, State)}
+    end;
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -364,6 +419,25 @@ terminate(_Reason, _State) ->
 
 write_manifest(StreamId, Manifest, Epoch) ->
     ets:insert(?TABLE, {StreamId, Manifest, Epoch}).
+
+%% Drop all per-node state for a stream: its context (and member monitor), its
+%% gap-detection sequence, and its cached manifest row. Used by both the member
+%% DOWN handler and the explicit forget/1 (writer reader teardown).
+release_stream(StreamId, #state{contexts = Ctxs, seqs = Seqs, monitors = Mons} = State) ->
+    Mons1 =
+        case maps:get(StreamId, Ctxs, undefined) of
+            #replica_ctx{mref = MRef} ->
+                demonitor(MRef, [flush]),
+                maps:remove(MRef, Mons);
+            undefined ->
+                Mons
+        end,
+    ets:delete(?TABLE, StreamId),
+    State#state{
+        contexts = maps:remove(StreamId, Ctxs),
+        seqs = maps:remove(StreamId, Seqs),
+        monitors = Mons1
+    }.
 
 %% Apply a batch of edits, catching any failure from apply_edit/2. apply_edit/2
 %% raises on a structurally inconsistent edit (a gap, a diverged replica, or a

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -573,7 +573,8 @@ terminate(
     #state{
         cfg = #cfg{stream = StreamId},
         task_io = Io,
-        metrics_id = MetricsId
+        metrics_id = MetricsId,
+        stopping = Stopping
     } = State
 ) ->
     %% Kill any in-flight commit task to prevent orphaned Khepri writes.
@@ -592,6 +593,16 @@ terminate(
     ok = delete_metrics(MetricsId),
     rabbitmq_stream_s3_registry:unregister_name({StreamId, node()}),
     rabbitmq_stream_s3_manifest:evict_group_cache(StreamId),
+    %% On the writer node the manifest cache row is written by put_manifest and
+    %% has no osiris member registered to monitor it, so it is released here
+    %% when the stream is being torn down. `stopping` is set only when the
+    %% stream's metadata node was deleted; a transient reader restart leaves it
+    %% false so the cache survives (and is reseeded), avoiding a window where a
+    %% consumer resolves the remote tier as absent.
+    case Stopping of
+        true -> rabbitmq_stream_s3_manifest_replica:forget(StreamId);
+        false -> ok
+    end,
     ok.
 
 format_status(#{state := State} = Status) ->

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -26,7 +26,10 @@ all() ->
         sync_live_manifest_then_broadcast_double_applies,
         manifest_reset_requires_resync,
         cached_epoch_reflects_writer_epoch,
-        retention_evaluated_floors_first_offset_and_timestamp
+        retention_evaluated_floors_first_offset_and_timestamp,
+        member_down_releases_state,
+        forget_releases_writer_row,
+        reregister_repoints_monitor
     ].
 
 init_per_suite(Config) ->
@@ -48,6 +51,95 @@ end_per_testcase(_TC, Config) ->
 %% ------------------------------------------------------------------
 %% Tests
 %% ------------------------------------------------------------------
+
+%% osiris has no terminate/delete hook, so manifest_replica monitors the member
+%% that registered a context and releases the context, sequence, and cached row
+%% when it goes down. This is how per-node replica state is reclaimed when a
+%% replica moves off the node or the stream is deleted.
+member_down_releases_state(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"down-stream">>,
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+    Member = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+
+    ok = Replica:register_replica_context(Stream, Member, <<"/tmp/s">>, Shared, Counter),
+    ok = Replica:sync(Stream, 0, 1, Manifest),
+    ?assert(Replica:is_context_registered(Stream)),
+    ?assertNotEqual(undefined, Replica:get_manifest(Stream)),
+
+    %% The member dies: its DOWN releases context, sequence, and cached row.
+    exit(Member, kill),
+    ok = await(fun() -> not Replica:is_context_registered(Stream) end),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)).
+
+%% The writer node's cached row is written by put_manifest and has no member to
+%% monitor; the replica reader releases it explicitly via forget/1 on teardown.
+forget_releases_writer_row(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"writer-stream">>,
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+
+    ok = Replica:put_manifest(Stream, Manifest, 1),
+    ?assertNotEqual(undefined, Replica:get_manifest(Stream)),
+    ok = Replica:forget(Stream),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)).
+
+%% A member restart re-registers the context. The old incarnation's monitor must
+%% be dropped so its later DOWN cannot evict the new context.
+reregister_repoints_monitor(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"restart-stream">>,
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    Old = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    New = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+
+    ok = Replica:register_replica_context(Stream, Old, <<"/tmp/s">>, Shared, Counter),
+    ok = Replica:register_replica_context(Stream, New, <<"/tmp/s">>, Shared, Counter),
+
+    %% The old member dies. Its monitor was dropped on re-registration, so this
+    %% must not release the context now owned by the new member.
+    OwnRef = monitor(process, Old),
+    exit(Old, kill),
+    receive
+        {'DOWN', OwnRef, process, Old, _} -> ok
+    after 2000 -> ct:fail(old_member_did_not_exit)
+    end,
+    %% A synchronous call is processed after any message already enqueued in
+    %% manifest_replica; the context must still be registered.
+    ?assert(Replica:is_context_registered(Stream)),
+
+    %% The new member dies: now the context is released.
+    exit(New, kill),
+    ok = await(fun() -> not Replica:is_context_registered(Stream) end).
+
+await(Fun) ->
+    await(Fun, 2000).
+
+await(_Fun, Remaining) when Remaining =< 0 ->
+    {error, timeout};
+await(Fun, Remaining) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(20),
+            await(Fun, Remaining - 20)
+    end.
 
 unknown_stream(_Config) ->
     ?assertEqual(undefined, rabbitmq_stream_s3_manifest_replica:get_manifest(<<"unknown">>)),


### PR DESCRIPTION
The metadata stored in the manifest replica process did not have a clearing strategy. We can have this process monitor processes from the plugin and clear out metadata when the process exits. This avoids an incremental build of metadata over a long time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
