### PR TITLE
Extend read_size_bytes histogram buckets to the 64 MiB AIMD cap (#294)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -355,6 +355,8 @@ Owned by `rabbitmq_stream_s3_remote_reader`. One counter set per node, summed ac
 |-------------------------------------|-------------------------------------------------------------------|
 | `rabbitmq_stream_s3_read_size_bytes_bucket`            | Distribution of read sizes from S3                                |
 
+Buckets: 48 B, 128 B, 512 B, 2 KiB, 8 KiB, 32 KiB, 128 KiB, 512 KiB, 2 MiB, 8 MiB, 16 MiB, 32 MiB, 64 MiB, +Inf. The top finite boundary matches the remote reader's 64 MiB AIMD read-size cap, so `+Inf` stays empty in normal operation.
+
 ## Dashboards
 
 A reference Grafana dashboard ships with the plugin at

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -52,8 +52,14 @@ synchronous feedback is generated.
     {remote_reader_fatal_errors, ?C_FATAL_ERRORS, counter,
         "Number of remote readers stopped by a non-retryable S3 error"}
 ]).
+%% Upper bucket boundaries span the AIMD read-size range, whose ceiling is
+%% read_size_max (64 MiB). The 16/32/64 MiB buckets resolve the high end where
+%% the prefetch window spends most of its time under sustained reads; without
+%% them every read above 8 MiB collapses into the +Inf bucket. Reads never
+%% exceed the 64 MiB cap, so in normal operation +Inf stays empty.
 -define(READ_SIZE_BUCKETS, [
-    48, 128, 512, 2_048, 8_192, 32_768, 131_072, 524_288, 2_097_152, 8_388_608, infinity
+    48, 128, 512, 2_048, 8_192, 32_768, 131_072, 524_288,
+    2_097_152, 8_388_608, 16_777_216, 33_554_432, 67_108_864, infinity
 ]).
 
 -type hint() :: chunk_boundary | within_chunk.

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -58,8 +58,20 @@ synchronous feedback is generated.
 %% them every read above 8 MiB collapses into the +Inf bucket. Reads never
 %% exceed the 64 MiB cap, so in normal operation +Inf stays empty.
 -define(READ_SIZE_BUCKETS, [
-    48, 128, 512, 2_048, 8_192, 32_768, 131_072, 524_288,
-    2_097_152, 8_388_608, 16_777_216, 33_554_432, 67_108_864, infinity
+    48,
+    128,
+    512,
+    2_048,
+    8_192,
+    32_768,
+    131_072,
+    524_288,
+    2_097_152,
+    8_388_608,
+    16_777_216,
+    33_554_432,
+    67_108_864,
+    infinity
 ]).
 
 -type hint() :: chunk_boundary | within_chunk.


### PR DESCRIPTION
Closes #294

## Problem

The `rabbitmq_stream_s3_read_size_bytes` histogram topped out at an 8 MiB bucket and then jumped straight to `+Inf`, but the remote reader's AIMD prefetch window ramps up to `read_size_max` (64 MiB). Every read above 8 MiB collapsed into the single `+Inf` bucket, so `histogram_quantile` could not resolve the distribution in the 8-64 MiB range that matters; in a soak it returned the 8 MiB boundary at every percentile.

## Change

- Add 16 MiB / 32 MiB / 64 MiB bucket boundaries so the high end of the AIMD range is measurable. Reads never exceed the 64 MiB cap, so `+Inf` stays empty in normal operation. Metric-only change with no effect on read behavior.
- Document the bucket boundaries in the Read size histogram section of `operations.md`, matching the style of the sibling S3 API histogram section.

## Grafana

No dashboard change required. The one panel that uses this metric (the "Read size distribution" heatmap) renders `le` buckets dynamically with no hardcoded boundaries, so it picks up the new buckets automatically and now resolves the high end instead of collapsing it into one band.

## Verification

- `gmake test-build` clean; plugin recompiles
- `gmake ct-read_resolution` passes (exercises histogram init and live remote readers)
- No tests reference the bucket list, so nothing else is affected