### PR TITLE
Add a Jepsen testing suite

### DIFF
--- a/.github/workflows/jepsen.yaml
+++ b/.github/workflows/jepsen.yaml
@@ -1,0 +1,92 @@
+name: Jepsen
+
+# Black-box, real-cluster Jepsen test for rabbitmq_stream_s3. It builds the
+# broker tarball, brings up a 5-node cluster with MinIO behind Toxiproxy via
+# docker compose, drives the kafka workload under faults, and fails the build if
+# the checker reports anomalies. See jepsen/README.md.
+#
+# This is a heavy test (a full server build plus a multi-node cluster), so it
+# runs on demand, on a schedule, and on changes to the harness itself, rather
+# than on every pull request; the scheduled run is what catches plugin
+# regressions over time. It builds the broker from a fresh clone rather than the
+# Build-RMQ cache, because package-generic-unix must run on a clean source tree
+# (a pre-compiled tree duplicates entries in the CLI escript and fails to zip).
+
+on:
+  workflow_dispatch:
+    inputs:
+      time-limit:
+        description: 'Seconds to run the workload'
+        default: '120'
+      rate:
+        description: 'Approximate request rate per second'
+        default: '100'
+      concurrency:
+        description: 'Number of concurrent workers'
+        default: '20'
+  schedule:
+    - cron: '0 6 * * 1' # Weekly, Mondays 06:00 UTC
+  pull_request:
+    paths:
+      - 'jepsen/**'
+      - '.github/workflows/jepsen.yaml'
+
+permissions:
+  contents: read
+
+# Jepsen runs are expensive and each binds the same host ports, so never run two
+# for the same ref at once.
+concurrency:
+  group: jepsen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jepsen:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rmq-version: ['streams-tiered-storage']
+        # One job per scenario: storage-tier faults, and writer fencing.
+        faults:
+          - 'partition,s3-outage,s3-latency,trim'
+          - 'leader-move,trim'
+        include:
+          - rmq-version: 'streams-tiered-storage'
+            otp-version: 27
+            elixir-version: 1.18
+    steps:
+      - name: Free up disk space
+        # A full server build plus five brokers, MinIO and Toxiproxy is
+        # disk-hungry; drop preinstalled toolchains the job does not need.
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/.ghcup
+          df -h /
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          otp-version: ${{ matrix.otp-version }}
+          elixir-version: ${{ matrix.elixir-version }}
+      - name: Clone rabbitmq-server
+        run: git clone --depth 1 --branch ${{ matrix.rmq-version }} https://github.com/amazon-mq/upstream-to-rabbitmq-server.git ${{ github.workspace }}/rabbitmq-server
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: rabbitmq-server/deps/rabbitmq_stream_s3
+      - name: Run Jepsen
+        working-directory: rabbitmq-server/deps/rabbitmq_stream_s3
+        run: jepsen/ci/run-jepsen.sh
+        env:
+          FAULTS: ${{ matrix.faults }}
+          TIME_LIMIT: ${{ github.event.inputs.time-limit || '120' }}
+          RATE: ${{ github.event.inputs.rate || '100' }}
+          CONCURRENCY: ${{ github.event.inputs.concurrency || '20' }}
+      - name: Upload Jepsen store
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jepsen-store-${{ strategy.job-index }}
+          if-no-files-found: ignore
+          path: rabbitmq-server/deps/rabbitmq_stream_s3/jepsen/jepsen.streams3/store/
+      - name: Tear down cluster
+        if: always()
+        working-directory: rabbitmq-server/deps/rabbitmq_stream_s3/jepsen/docker
+        run: docker compose down -v || true

--- a/jepsen/.gitignore
+++ b/jepsen/.gitignore
@@ -1,0 +1,7 @@
+# Build/run artifacts — never commit
+docker/shared/
+jepsen.streams3/store/
+jepsen.streams3/target/
+jepsen.streams3/classes/
+jepsen.streams3/.clj-kondo/.cache/
+*.tar.xz

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -67,11 +67,12 @@ docker compose exec control \
     --faults leader-move,trim
 ```
 
+GitHub Actions runs both of these scenarios with the `Jepsen` workflow (`.github/workflows/jepsen.yaml`), on a schedule and on demand. It clones the server, checks the plugin out into the umbrella, and invokes `ci/run-jepsen.sh`, which builds the tarball from the clean tree, brings the cluster up, runs one test, and fails the job if the checker reports anomalies.
+
 ## Planned
 
 - A bounded-durability checker for aggressive retention (a `force-trim` past the upload seam, with the checker scoped to `[f, n)`)
 - Super-streams (multi-partition)
-- CI (see `ci/`)
 
 [kafka]: https://jepsen-io.github.io/jepsen/jepsen.tests.kafka.html
 [rakv]: https://github.com/rabbitmq/ra-kv-store

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -1,0 +1,52 @@
+# Jepsen test for RabbitMQ streams with S3 tiered storage
+
+This is a black-box, real-cluster Jepsen test for the `rabbitmq_stream_s3` plugin. It runs a multi-node RabbitMQ cluster against a MinIO S3 store, drives it with the [`jepsen.tests.kafka`][kafka] ordered-log workload over the RabbitMQ Stream protocol, injects faults, and checks the resulting history for lost writes, duplicates, reordering and offset anomalies.
+
+It complements, and does not replace, the per-seam P and TLA+ models and the `prop_SUITE` tests. Those prove seams in isolation; this exercises the whole stack against a real S3 emulator under composed faults.
+
+## Why the Kafka workload
+
+A RabbitMQ stream is an offset-addressed, append-only, single-writer log, structurally a Kafka topic-partition rather than a register. So we reuse Jepsen's Kafka log model (generator and anomaly checkers) rather than the register/set model used by [`ra-kv-store`][rakv]. Each integer key is one stream (`jepsen-<k>`). Publish confirms return a `publishingId`, not the committed offset, so `:send` results carry `offset = nil`; the checker derives ordering and loss from consumer-observed offsets, which the Stream client exposes.
+
+## Bounded durability: read before tuning retention
+
+The plugin promises durability for the range `[f, n)` only, not for the un-uploaded tail past the user's retention bound (see `../docs/invariants.md`, "Non-guarantee"). A stock "no acknowledged write is lost" checker is therefore only sound when retention is wide enough that nothing legitimately drops, so retention is configured wide for exactly this reason. Aggressive retention faults will need a bounded-durability checker that only flags loss inside `[f, n)`.
+
+## Topology
+
+```
+control ──ssh──► n1..n5 (RabbitMQ + rabbitmq_stream_s3, Erlang 27)
+                    │
+                    └─ https://jepsen.s3.jepsen.local:443
+                         └─ toxiproxy (L4 passthrough, fault injection)
+                              └─ minio:443  (virtual-host routing, our CA)
+```
+
+The AWS backend is hardwired to TLS/443 with `verify_peer` and virtual-hosted addressing (`<bucket>.<endpoint>`). MinIO therefore serves HTTPS with a cert our nodes trust, and the S3 vhost DNS names alias to Toxiproxy so S3 faults are injectable. Static credentials in `rabbitmq.conf` keep the IMDS/container credential paths out of the picture.
+
+## Running
+
+Requires Docker and Compose and a working `make package-generic-unix` at the umbrella root.
+
+```sh
+cd docker
+./up.sh                       # builds tarball + certs, brings the cluster up
+docker compose exec control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit 300 --rate 200 --concurrency 20
+```
+
+## Status
+
+The partition nemesis runs against a 5-node cluster with the kafka anomaly checkers and retention wide. A run under partition faults reports `:valid? true`, with fault-induced failures correctly classified as indeterminate rather than lost or duplicate, and broker logs collected back to the control node.
+
+## Planned
+
+- Storage-tier nemeses: S3 outage and latency (via Toxiproxy), forced trim, and forced leader move
+- A bounded-durability checker for aggressive retention (a `force-trim` past the upload seam, with the checker scoped to `[f, n)`)
+- Super-streams (multi-partition)
+- CI (see `ci/`)
+
+[kafka]: https://jepsen-io.github.io/jepsen/jepsen.tests.kafka.html
+[rakv]: https://github.com/rabbitmq/ra-kv-store

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -6,7 +6,9 @@ It complements, and does not replace, the per-seam P and TLA+ models and the `pr
 
 ## Why the Kafka workload
 
-A RabbitMQ stream is an offset-addressed, append-only, single-writer log, structurally a Kafka topic-partition rather than a register. So we reuse Jepsen's Kafka log model (generator and anomaly checkers) rather than the register/set model used by [`ra-kv-store`][rakv]. Each integer key is one stream (`jepsen-<k>`). Publish confirms return a `publishingId`, not the committed offset, so `:send` results carry `offset = nil`; the checker derives ordering and loss from consumer-observed offsets, which the Stream client exposes.
+A RabbitMQ stream is an offset-addressed, append-only, single-writer log, structurally a Kafka topic-partition rather than a register. So we reuse Jepsen's Kafka log model (generator and anomaly checkers) rather than the register/set model used by [`ra-kv-store`][rakv]. Each integer key is one stream (`jepsen-<k>`).
+
+A publish confirm returns only a `publishingId`, not the committed offset, and the Stream client exposes no offset on confirm. For a single uninterrupted writer on a stream that starts empty the publishingId equals the offset, so we report it as the `:send` offset (the kafka workload needs it to learn each key's tail for its final reads). That equality breaks under the leader-move nemesis: producer recovery makes the publishingId drift from the true offset, so the kafka offset-consistency analyzers go red on artifacts (a value appears at both its true offset and its drifted publishingId) even though nothing is actually lost. Under leader-move we therefore downgrade the kafka workload checker to advisory and let the durability checker carry the safety verdict: it reads every stream end-to-end after the run, over a fresh client using true consumer offsets only, and fails if any acknowledged write is missing or duplicated. See `jepsen.streams3/src/jepsen/streams3/client.clj` and `checker.clj`.
 
 ## Bounded durability: read before tuning retention
 
@@ -41,7 +43,9 @@ docker compose exec control \
 
 The partition nemesis runs against a 5-node cluster with the kafka anomaly checkers and retention wide. A run under partition faults reports `:valid? true`, with fault-induced failures correctly classified as indeterminate rather than lost or duplicate, and broker logs collected back to the control node.
 
-The storage-tier nemeses make data really tier to S3 and exercise the read-from-S3 path under fault. Small segments and fragments plus padded payloads force segments to roll, upload and trim within a short run; MinIO needs a KMS key for the plugin's SSE uploads (see `docker/docker-compose.yml`). The `--faults` option selects `s3-outage` and `s3-latency` (via Toxiproxy) and `trim` (periodic `evaluate_local_retention`, which trims uploaded segments locally so reads of older offsets fall to the S3 tier). A `:tiering` coverage checker scrapes the plugin's S3 counters before teardown and fails the run unless fragments were uploaded, and with `trim` that reads were served from S3, so a regression that silently stops using the remote tier fails rather than passing green.
+The storage-tier nemeses make data really tier to S3 and exercise the read-from-S3 path under fault. Small segments and fragments plus padded payloads force segments to roll, upload and trim within a short run; MinIO needs a KMS key for the plugin's SSE uploads (see `docker/docker-compose.yml`). The `--faults` option selects `s3-outage` and `s3-latency` (via Toxiproxy), `trim` (periodic `evaluate_local_retention`, which trims uploaded segments locally so reads of older offsets fall to the S3 tier), and `leader-move` (repeatedly transfer every stream's leader to a replica, relocating each writer and bumping the stream epoch so a deposed writer's in-flight upload must be fenced).
+
+Two extra checkers run alongside the kafka anomaly checkers. The `:tiering` coverage checker scrapes the plugin's S3 counters before teardown and fails the run unless fragments were uploaded, and with `trim` that reads were served from S3, and with `leader-move` that the epoch advanced; this keeps a run from passing green while silently not using the remote tier or not moving leaders. The `:durability` checker reads every stream end-to-end after the run and fails if any acknowledged write is lost or duplicated; it is authoritative under `leader-move`, where the kafka offset analyzers are downgraded to advisory (see "Why the Kafka workload").
 
 A run under `partition,s3-outage,s3-latency,trim` stays `:valid? true` while serving thousands of reads from the remote tier:
 
@@ -53,9 +57,18 @@ docker compose exec control \
     --faults partition,s3-outage,s3-latency,trim
 ```
 
+A run under `leader-move,trim` stays `:valid? true` with the durability checker confirming zero loss and zero duplication across epochs in the double digits:
+
+```sh
+docker compose exec control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit 150 --rate 50 --concurrency 10 \
+    --faults leader-move,trim
+```
+
 ## Planned
 
-- A `leader-move` nemesis (writer fencing) that relocates stream leaders mid-upload, with an authoritative durability checker
 - A bounded-durability checker for aggressive retention (a `force-trim` past the upload seam, with the checker scoped to `[f, n)`)
 - Super-streams (multi-partition)
 - CI (see `ci/`)

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -41,9 +41,21 @@ docker compose exec control \
 
 The partition nemesis runs against a 5-node cluster with the kafka anomaly checkers and retention wide. A run under partition faults reports `:valid? true`, with fault-induced failures correctly classified as indeterminate rather than lost or duplicate, and broker logs collected back to the control node.
 
+The storage-tier nemeses make data really tier to S3 and exercise the read-from-S3 path under fault. Small segments and fragments plus padded payloads force segments to roll, upload and trim within a short run; MinIO needs a KMS key for the plugin's SSE uploads (see `docker/docker-compose.yml`). The `--faults` option selects `s3-outage` and `s3-latency` (via Toxiproxy) and `trim` (periodic `evaluate_local_retention`, which trims uploaded segments locally so reads of older offsets fall to the S3 tier). A `:tiering` coverage checker scrapes the plugin's S3 counters before teardown and fails the run unless fragments were uploaded, and with `trim` that reads were served from S3, so a regression that silently stops using the remote tier fails rather than passing green.
+
+A run under `partition,s3-outage,s3-latency,trim` stays `:valid? true` while serving thousands of reads from the remote tier:
+
+```sh
+docker compose exec control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit 150 --rate 50 --concurrency 10 \
+    --faults partition,s3-outage,s3-latency,trim
+```
+
 ## Planned
 
-- Storage-tier nemeses: S3 outage and latency (via Toxiproxy), forced trim, and forced leader move
+- A `leader-move` nemesis (writer fencing) that relocates stream leaders mid-upload, with an authoritative durability checker
 - A bounded-durability checker for aggressive retention (a `force-trim` past the upload seam, with the checker scoped to `[f, n)`)
 - Super-streams (multi-partition)
 - CI (see `ci/`)

--- a/jepsen/ci/run-jepsen.sh
+++ b/jepsen/ci/run-jepsen.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # CI entry point: bring the cluster up and run one test, failing the build if
 # the checker reports anomalies. Intended to be called from a GitHub Actions
-# job (phase 5) after the broker tarball has been built/staged.
+# job after the broker tarball has been built/staged.
 #
 # Repo-topology note: `make package-generic-unix` is an *umbrella* target, so a
 # CI job needs the full server checkout (the plugin is developed standalone in
-# deps/rabbitmq_stream_s3 but built within the umbrella). The build job stages
-# the tarball; this script consumes it.
+# deps/rabbitmq_stream_s3 but built within the umbrella). `up.sh` builds the
+# tarball from the umbrella root that contains this checkout.
+#
+# Tunables (all overridable via the environment):
+#   TIME_LIMIT, RATE, CONCURRENCY  - workload size
+#   FAULTS                         - comma-separated nemeses to inject
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
@@ -15,6 +19,9 @@ docker_dir="$here/../docker"
 TIME_LIMIT="${TIME_LIMIT:-120}"
 RATE="${RATE:-100}"
 CONCURRENCY="${CONCURRENCY:-20}"
+# Which faults to inject. Override per CI matrix entry to cover the storage-tier
+# and writer-fencing scenarios separately.
+FAULTS="${FAULTS:-partition,s3-outage,s3-latency,trim}"
 
 "$docker_dir/up.sh"
 
@@ -22,7 +29,8 @@ set +e
 docker compose -f "$docker_dir/docker-compose.yml" exec -T control \
   lein run test --nodes-file /shared/nodes \
     --username root --ssh-private-key /shared/ssh_key \
-    --time-limit "$TIME_LIMIT" --rate "$RATE" --concurrency "$CONCURRENCY"
+    --time-limit "$TIME_LIMIT" --rate "$RATE" --concurrency "$CONCURRENCY" \
+    --faults "$FAULTS"
 status=$?
 set -e
 

--- a/jepsen/ci/run-jepsen.sh
+++ b/jepsen/ci/run-jepsen.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# CI entry point: bring the cluster up and run one test, failing the build if
+# the checker reports anomalies. Intended to be called from a GitHub Actions
+# job (phase 5) after the broker tarball has been built/staged.
+#
+# Repo-topology note: `make package-generic-unix` is an *umbrella* target, so a
+# CI job needs the full server checkout (the plugin is developed standalone in
+# deps/rabbitmq_stream_s3 but built within the umbrella). The build job stages
+# the tarball; this script consumes it.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+docker_dir="$here/../docker"
+
+TIME_LIMIT="${TIME_LIMIT:-120}"
+RATE="${RATE:-100}"
+CONCURRENCY="${CONCURRENCY:-20}"
+
+"$docker_dir/up.sh"
+
+set +e
+docker compose -f "$docker_dir/docker-compose.yml" exec -T control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit "$TIME_LIMIT" --rate "$RATE" --concurrency "$CONCURRENCY"
+status=$?
+set -e
+
+docker compose -f "$docker_dir/docker-compose.yml" down -v
+exit $status

--- a/jepsen/docker/Dockerfile-control
+++ b/jepsen/docker/Dockerfile-control
@@ -1,0 +1,11 @@
+# Jepsen control node: runs `lein run test ...` and drives the DB nodes over
+# SSH. Needs a JDK (for the Stream Java client + jepsen), leiningen, and an
+# SSH client.
+FROM clojure:temurin-21-lein
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git openssh-client sshpass iputils-ping dnsutils gnuplot graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-fetch deps so the first `lein run` inside the container is fast.
+WORKDIR /jepsen

--- a/jepsen/docker/Dockerfile-node
+++ b/jepsen/docker/Dockerfile-node
@@ -1,0 +1,19 @@
+# RabbitMQ broker node. Erlang 27 (matches the target OTP for main / 4.4.x)
+# plus the bits jepsen needs: sshd for control access and iptables/sudo for
+# the partition nemesis. The broker itself is installed at run time by db.clj
+# from /shared/rabbitmq.tar.xz (the generic-unix tarball).
+FROM erlang:27
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssh-server sudo iproute2 iptables procps ca-certificates \
+        net-tools logrotate curl \
+    && mkdir -p /var/run/sshd \
+    && echo 'root:root' | chpasswd \
+    && sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+EXPOSE 22
+# Install the jepsen control key (mounted at /shared/ssh_key.pub) as root's
+# authorized_keys at startup, then run sshd. Key auth is what lets jepsen scp
+# broker logs back to the control node.
+CMD ["bash", "-c", "mkdir -p /root/.ssh && chmod 700 /root/.ssh && cp /shared/ssh_key.pub /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys && exec /usr/sbin/sshd -D"]

--- a/jepsen/docker/docker-compose.yml
+++ b/jepsen/docker/docker-compose.yml
@@ -1,0 +1,102 @@
+# Docker topology for the rabbitmq_stream_s3 Jepsen test.
+#
+#   control            runs `lein run test ...`, SSHes into the nodes
+#   n1..n5             RabbitMQ broker nodes (Erlang 27 base, sshd)
+#   minio              S3-compatible store, HTTPS/443, virtual-host routing
+#   toxiproxy          L4 TLS passthrough in front of MinIO (fault injection);
+#                      carries the S3 vhost DNS aliases so the broker's
+#                      <bucket>.<endpoint> requests land here first
+#   minio-init         creates the `jepsen` bucket, then exits
+#
+# The broker reaches S3 as https://jepsen.s3.jepsen.local:443 -> toxiproxy:443
+# -> minio:443. The cert (gen-certs.sh) is valid for *.s3.jepsen.local and
+# s3.jepsen.local; nodes trust ./shared/ca.crt (laid in by db.clj).
+#
+# Bring up:  ./up.sh   (builds the broker tarball + certs, then compose up)
+
+x-node: &node
+  build:
+    context: .
+    dockerfile: Dockerfile-node
+  privileged: true          # jepsen needs to manipulate iptables for partitions
+  volumes:
+    - ./shared:/shared:ro
+  networks:
+    - jepsen
+
+services:
+  control:
+    build:
+      context: .
+      dockerfile: Dockerfile-control
+    volumes:
+      - ../jepsen.streams3:/jepsen
+      - ./shared:/shared:ro
+      # Persist lein's maven cache on the host so deps survive container
+      # recreation (and reuse the host's existing cache).
+      - ${HOME}/.m2:/root/.m2
+    working_dir: /jepsen
+    networks:
+      - jepsen
+    # The RabbitMQ stream client sizes its Netty/scheduler thread pools to the
+    # host's core count (64 here), so the JVM needs far more than the default
+    # 2048-pid cgroup limit. The host ulimit has ample headroom.
+    pids_limit: 32768
+    depends_on: [n1, n2, n3, n4, n5, minio-init]
+    command: ["sleep", "infinity"]
+
+  n1: {<<: *node, hostname: n1, container_name: n1}
+  n2: {<<: *node, hostname: n2, container_name: n2}
+  n3: {<<: *node, hostname: n3, container_name: n3}
+  n4: {<<: *node, hostname: n4, container_name: n4}
+  n5: {<<: *node, hostname: n5, container_name: n5}
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: jepsenjepsen
+      MINIO_ROOT_PASSWORD: jepsenjepsenjepsen
+      # Enable virtual-host-style addressing for <bucket>.s3.jepsen.local.
+      MINIO_DOMAIN: s3.jepsen.local
+    command: server /data --address ":443"
+    volumes:
+      - ./shared/certs:/root/.minio/certs:ro
+    networks:
+      jepsen:
+
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:latest
+    # The toxiproxy image is FROM scratch (no shell), so the passthrough proxy
+    # is declared in a config file loaded at startup rather than created by an
+    # init container. -host=0.0.0.0 exposes the admin API (8474) for S3 fault
+    # injection.
+    command: ["-host=0.0.0.0", "-config=/toxiproxy.json"]
+    volumes:
+      - ./toxiproxy.json:/toxiproxy.json:ro
+    networks:
+      jepsen:
+        # The broker resolves the S3 vhost names to Toxiproxy, which passes
+        # through to MinIO. This is what makes S3 faults injectable.
+        aliases:
+          - s3.jepsen.local
+          - jepsen.s3.jepsen.local
+    depends_on: [minio]
+
+  minio-init:
+    # Creates the bucket. mc is invoked directly (no shell): the MinIO endpoint
+    # comes from MC_HOST_j, and we talk path-style to minio:443 with --insecure
+    # (the cert is for *.s3.jepsen.local, not "minio"). restart: on-failure
+    # retries until MinIO is accepting connections, then exits 0.
+    image: minio/mc:latest
+    environment:
+      MC_HOST_j: "https://jepsenjepsen:jepsenjepsenjepsen@minio:443"
+    entrypoint: ["mc"]
+    command: ["mb", "--insecure", "--ignore-existing", "j/jepsen"]
+    restart: on-failure
+    networks:
+      jepsen:
+    depends_on: [minio]
+
+networks:
+  jepsen:
+    driver: bridge

--- a/jepsen/docker/docker-compose.yml
+++ b/jepsen/docker/docker-compose.yml
@@ -58,6 +58,10 @@ services:
       MINIO_ROOT_PASSWORD: jepsenjepsenjepsen
       # Enable virtual-host-style addressing for <bucket>.s3.jepsen.local.
       MINIO_DOMAIN: s3.jepsen.local
+      # The plugin requests SSE (x-amz-server-side-encryption: AES256) on every
+      # fragment PUT. MinIO rejects SSE with 501 unless a KMS backend exists, so
+      # configure a local KMS key. (Value is key-id:base64(32 bytes).)
+      MINIO_KMS_SECRET_KEY: "jepsen-key:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     command: server /data --address ":443"
     volumes:
       - ./shared/certs:/root/.minio/certs:ro

--- a/jepsen/docker/gen-certs.sh
+++ b/jepsen/docker/gen-certs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Generates a throwaway CA and a MinIO server certificate for the S3 endpoint.
+#
+# The broker's AWS backend connects with verify_peer against the system CA
+# store and uses virtual-hosted-style addressing (<bucket>.<endpoint>), so the
+# cert must be valid for both s3.jepsen.local and *.s3.jepsen.local, and the
+# nodes must trust the CA (db.clj copies shared/ca.crt into the system store).
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+out="$here/shared"
+certs="$out/certs"
+mkdir -p "$certs"
+
+if [[ -f "$out/ca.crt" && -f "$certs/public.crt" ]]; then
+  echo "certs already present in $out; delete them to regenerate"
+  exit 0
+fi
+
+# --- CA ---
+openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -keyout "$out/ca.key" -out "$out/ca.crt" \
+  -subj "/CN=jepsen-stream-s3-ca"
+
+# --- server cert (MinIO wants public.crt / private.key) ---
+openssl req -nodes -newkey rsa:2048 \
+  -keyout "$certs/private.key" -out "$certs/server.csr" \
+  -subj "/CN=s3.jepsen.local"
+
+openssl x509 -req -in "$certs/server.csr" \
+  -CA "$out/ca.crt" -CAkey "$out/ca.key" -CAcreateserial \
+  -days 3650 -out "$certs/public.crt" \
+  -extfile <(printf "subjectAltName=DNS:s3.jepsen.local,DNS:*.s3.jepsen.local")
+
+rm -f "$certs/server.csr"
+echo "wrote $out/ca.crt and $certs/{public.crt,private.key}"

--- a/jepsen/docker/toxiproxy.json
+++ b/jepsen/docker/toxiproxy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "s3",
+    "listen": "0.0.0.0:443",
+    "upstream": "minio:443",
+    "enabled": true
+  }
+]

--- a/jepsen/docker/up.sh
+++ b/jepsen/docker/up.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Builds everything the test needs and brings the cluster up.
+#
+#   1. builds the broker generic-unix tarball (make package-generic-unix) and
+#      stages it at shared/rabbitmq.tar.xz  (no release required)
+#   2. generates the throwaway S3 CA + server cert
+#   3. docker compose build + up
+#
+# After this, run the test:
+#   docker compose exec control lein run test \
+#     --nodes-file /shared/nodes --username root --password root \
+#     --time-limit 300 --rate 200 --concurrency 20
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+shared="$here/shared"
+# jepsen/docker -> jepsen -> rabbitmq_stream_s3 -> deps -> umbrella root
+umbrella="$(cd "$here/../../../.." && pwd)"
+
+mkdir -p "$shared"
+
+echo "==> building broker tarball (make package-generic-unix) in $umbrella"
+# Build serially: the rabbitmq_cli escript-zip step races under a parallel
+# make (parallel recursive appends to the runtime-deps list duplicate a dep,
+# so zip is handed the same ebin/dep_built twice -> "Duplicate filename on
+# disk"). -j1 here overrides any inherited MAKEFLAGS=--jobs=N.
+make -C "$umbrella" -j1 package-generic-unix
+tarball="$(ls -t "$umbrella"/PACKAGES/rabbitmq-server-generic-unix-*.tar.xz | head -n1)"
+cp "$tarball" "$shared/rabbitmq.tar.xz"
+echo "    staged $(basename "$tarball") -> shared/rabbitmq.tar.xz"
+
+echo "==> generating S3 certs"
+"$here/gen-certs.sh"
+
+echo "==> generating SSH key for control -> nodes"
+# jepsen runs commands and downloads logs (scp) over SSH; key auth makes both
+# work (password auth does not cover the scp log download). The node image
+# installs ssh_key.pub as root's authorized_keys at startup.
+if [ ! -f "$shared/ssh_key" ]; then
+  ssh-keygen -t ed25519 -N '' -C jepsen-streams3 -f "$shared/ssh_key" >/dev/null
+  chmod 600 "$shared/ssh_key"
+fi
+
+echo "==> writing nodes file"
+printf 'n1\nn2\nn3\nn4\nn5\n' > "$shared/nodes"
+
+echo "==> docker compose up"
+docker compose -f "$here/docker-compose.yml" build
+docker compose -f "$here/docker-compose.yml" up -d
+
+cat <<'EOF'
+
+Cluster is up. Run the test with:
+
+  docker compose -f docker-compose.yml exec control \
+    lein run test --nodes-file /shared/nodes \
+      --username root --ssh-private-key /shared/ssh_key \
+      --time-limit 300 --rate 200 --concurrency 20
+
+Results land under jepsen.streams3/store/ (mounted on the host).
+EOF

--- a/jepsen/jepsen.streams3/project.clj
+++ b/jepsen/jepsen.streams3/project.clj
@@ -1,0 +1,22 @@
+(defproject jepsen.streams3 "0.1.0-SNAPSHOT"
+  :description "Jepsen test for RabbitMQ streams with S3 tiered storage (rabbitmq_stream_s3)"
+  :url "https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/rabbitmq_stream_s3/jepsen"
+  :license {:name "Apache 2.0 License"
+            :url "https://www.apache.org/licenses/LICENSE-2.0.html"}
+  :main jepsen.streams3.core
+  :jvm-opts ["-Xmx8g"
+             "-Djava.awt.headless=true"]
+  :dependencies [[org.clojure/clojure "1.12.4"]
+                 ;; Jepsen brings in jepsen.tests.kafka (the log/queue workload and
+                 ;; its anomaly checkers) which we reuse for the ordered-log model.
+                 [jepsen "0.3.11"]
+                 ;; Official RabbitMQ Stream protocol client. The workload's :send/:poll
+                 ;; ops are driven through this via Clojure interop (see client.clj).
+                 [com.rabbitmq/stream-client "1.6.0"]
+                 ;; Pin slf4j-api to 2.x: jepsen's logback 1.5 needs it, but
+                 ;; transitive resolution otherwise pulls 1.7.36 and logging
+                 ;; init crashes (ClassNotFoundException LoggingEventAware).
+                 [org.slf4j/slf4j-api "2.0.12"]]
+  :exclusions [org.slf4j/log4j-over-slf4j
+               log4j/log4j]
+  :repl-options {:init-ns jepsen.streams3.core})

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
@@ -9,20 +9,25 @@
   plugin's S3 counters (scraped into db/tiering-stats before teardown) cleared
   the floor."
   (:require [jepsen.checker :as checker]
+            [jepsen.streams3.client :as sc]
             [jepsen.streams3.db :as db]
             [jepsen.streams3.nemesis :as nem]))
 
 (defn tiering-checker
   "Fails the test unless S3 was genuinely used: fragments must have uploaded,
-  and when `trim` is enabled (which forces reads off the local tier) reads must
-  have been served from S3."
+  when `trim` is enabled (which forces reads off the local tier) reads must have
+  been served from S3, and when `leader-move` is enabled the stream epoch must
+  have advanced past its initial 1 (proving a writer was actually fenced)."
   []
   (reify checker/Checker
     (check [_ test _history _opts]
-      (let [stats    @db/tiering-stats
-            uploads  (get stats "rabbitmq_stream_s3_transfers_completed" 0)
-            reads    (get stats "rabbitmq_stream_s3_get_range" 0)
-            trim?    (contains? (nem/faults test) "trim")
+      (let [stats        @db/tiering-stats
+            uploads      (get stats "rabbitmq_stream_s3_transfers_completed" 0)
+            reads        (get stats "rabbitmq_stream_s3_get_range" 0)
+            max-epoch    (get stats "max_epoch" 0)
+            fs           (nem/faults test)
+            trim?        (contains? fs "trim")
+            leader-move? (contains? fs "leader-move")
             problems (cond-> []
                        (empty? stats)
                        (conj :no-tiering-stats-collected)
@@ -31,7 +36,75 @@
                        (conj :no-fragments-uploaded-to-s3)
 
                        (and trim? (not (pos? reads)))
-                       (conj :no-reads-served-from-s3))]
+                       (conj :no-reads-served-from-s3)
+
+                       ;; The epoch starts at 1 and bumps on every leader move;
+                       ;; if it never rose, no leader moved and no writer was
+                       ;; ever fenced, so the path went unexercised.
+                       (and leader-move? (not (> max-epoch 1)))
+                       (conj :no-leader-moves))]
         {:valid?   (empty? problems)
          :stats    stats
          :problems problems}))))
+
+(defn- acked-sends-by-key
+  "Map of key -> set of acknowledged sent values, from the history."
+  [history]
+  (->> history
+       (filter #(and (= :ok (:type %)) (= :send (:f %))))
+       (reduce (fn [m op]
+                 (reduce (fn [m [_ k [_ v]]] (update m k (fnil conj #{}) v))
+                         m (:value op)))
+               {})))
+
+(defn durability-checker
+  "Authoritative no-loss / no-duplicate check, independent of send offsets.
+
+  The kafka workload derives loss from the offsets our client reports, but under
+  the leader-move nemesis those send offsets drift from the true offset (see
+  client.clj), which is unsound. This checker sidesteps that entirely: it
+  compares every acknowledged send in the history against an end-to-end read of
+  each stream captured after the run (db/log-files -> client/authoritative-reads),
+  which uses only true consumer offsets. It fails if any acknowledged value is
+  missing from its stream (lost) or appears more than once (duplicated) — the two
+  safety properties writer fencing must preserve."
+  []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [reads @sc/authoritative-reads
+            sent  (acked-sends-by-key history)
+            errs  (for [[k vs] sent
+                        :let [pairs   (get reads k)
+                              vals    (map second pairs)
+                              present (set vals)
+                              lost    (sort (remove present vs))
+                              dups    (->> vals frequencies
+                                           (keep (fn [[v c]] (when (> c 1) v)))
+                                           sort)]
+                        :when (or (nil? pairs) (seq lost) (seq dups))]
+                    (cond-> {:key k}
+                      (nil? pairs) (assoc :not-read true)
+                      (seq lost)   (assoc :lost lost)
+                      (seq dups)   (assoc :duplicated dups)))
+            problems (cond-> []
+                       (empty? reads) (conj :no-authoritative-reads)
+                       (seq errs)     (conj :acked-writes-lost-or-duplicated))]
+        {:valid?      (empty? problems)
+         :problems    problems
+         :keys-sent   (count sent)
+         :keys-read   (count reads)
+         :violations  (vec errs)}))))
+
+(defn downgrade-when
+  "Wraps a checker so that when (pred test) holds its result cannot invalidate
+  the run: anomalies are kept for inspection but :valid? is forced true. Used for
+  the kafka workload's offset analyzers under leader-move, where our client's send
+  offsets are known to be unsound; the durability checker carries the real safety
+  verdict there."
+  [pred inner]
+  (reify checker/Checker
+    (check [_ test history opts]
+      (let [r (checker/check inner test history opts)]
+        (if (pred test)
+          (assoc r :valid? true :downgraded-valid? (:valid? r))
+          r)))))

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
@@ -1,0 +1,37 @@
+(ns jepsen.streams3.checker
+  "Checks beyond correctness — that the S3 code paths were actually exercised.
+
+  The kafka workload checker validates correctness only; it cannot tell whether
+  a single byte reached S3. So a regression that silently no-ops tiering (a
+  rejected upload, a misbuilt endpoint, broken trimming, a soft-dependency
+  timeout swallowing everything) would leave all data local, keep correctness
+  intact, and still pass green. This checker closes that gap by asserting the
+  plugin's S3 counters (scraped into db/tiering-stats before teardown) cleared
+  the floor."
+  (:require [jepsen.checker :as checker]
+            [jepsen.streams3.db :as db]
+            [jepsen.streams3.nemesis :as nem]))
+
+(defn tiering-checker
+  "Fails the test unless S3 was genuinely used: fragments must have uploaded,
+  and when `trim` is enabled (which forces reads off the local tier) reads must
+  have been served from S3."
+  []
+  (reify checker/Checker
+    (check [_ test _history _opts]
+      (let [stats    @db/tiering-stats
+            uploads  (get stats "rabbitmq_stream_s3_transfers_completed" 0)
+            reads    (get stats "rabbitmq_stream_s3_get_range" 0)
+            trim?    (contains? (nem/faults test) "trim")
+            problems (cond-> []
+                       (empty? stats)
+                       (conj :no-tiering-stats-collected)
+
+                       (not (pos? uploads))
+                       (conj :no-fragments-uploaded-to-s3)
+
+                       (and trim? (not (pos? reads)))
+                       (conj :no-reads-served-from-s3))]
+        {:valid?   (empty? problems)
+         :stats    stats
+         :problems problems}))))

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
@@ -26,11 +26,24 @@
   (~cores-sized) thread pool meant to be shared, and one-per-client-per-reopen
   exhausts native threads."
   (:require [jepsen.client :as client])
-  (:import (com.rabbitmq.stream Environment OffsetSpecification)
+  (:import (com.rabbitmq.stream Environment OffsetSpecification ByteCapacity)
            (java.util.concurrent ConcurrentLinkedQueue CountDownLatch TimeUnit)
            (java.util.concurrent.atomic AtomicBoolean AtomicLong)))
 
 (def stream-port 5552)
+
+;; Message bodies are padded so the tiny integer values produce enough volume
+;; to fill stream segments and S3 fragments — otherwise nothing tiers to S3 and
+;; the S3 nemeses have no traffic to disrupt. The body is "<value>|<padding>";
+;; the consumer parses the value before the separator.
+(def ^:private msg-padding (apply str (repeat 1000 \x)))
+(defn- encode-value [v] (.getBytes (str v "|" msg-padding)))
+(defn- decode-value [^bytes body]
+  (let [s (String. body)] (Long/parseLong (subs s 0 (.indexOf s "|")))))
+
+;; Small stream segment size: segments roll over and, once tiered, get trimmed
+;; locally, forcing reads of older offsets to fall back to S3.
+(def ^:private segment-size (ByteCapacity/kB 16))
 
 ;; How long to retry a transient stream operation (create / producer / consumer
 ;; build) before giving up and letting the op fail as indeterminate. Kept short
@@ -84,7 +97,9 @@
 (defn ensure-stream! [env k]
   (when-not (contains? @declared-streams k)
     ;; create() is idempotent for a matching stream.
-    (with-retry #(-> env (.streamCreator) (.stream (stream-name k)) (.create)))
+    (with-retry #(-> env (.streamCreator) (.stream (stream-name k))
+                     (.maxSegmentSizeBytes segment-size)
+                     (.create)))
     (swap! declared-streams conj k)))
 
 (defn get-producer [env k]
@@ -118,7 +133,7 @@
                    (let [n   (.getAndIncrement counter)
                          msg (-> producer (.messageBuilder)
                                  (.publishingId n)
-                                 (.addData (.getBytes (str v)))
+                                 (.addData (encode-value v))
                                  (.build))]
                      (.send producer msg
                             (reify com.rabbitmq.stream.ConfirmationHandler
@@ -152,7 +167,7 @@
                            (reify com.rabbitmq.stream.MessageHandler
                              (handle [_ ctx msg]
                                (.add q [(.offset ctx)
-                                        (Long/parseLong (String. (.getBodyAsBinary msg)))]))))
+                                        (decode-value (.getBodyAsBinary msg))]))))
                          (.build)))]
             (swap! buffers assoc k q)
             (swap! consumers assoc k c)

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
@@ -4,15 +4,29 @@
   (`assign` model, :sub-via #{:assign} — like the reference Kafka/redpanda
   test, consumers read by position and there is no server-side offset commit).
 
-  Getting a real send offset. The kafka workload needs the *offset* of each
-  successful send (op->max-send-offsets ignores nil offsets, so poll-unseen
-  would never re-poll a key and its writes would all look :unseen). But a
-  stream publish confirm returns only a publishingId, not the offset. So we
-  publish each stream through ONE shared producer, set the publishingId from a
-  per-key counter, and serialize the send call under a per-key lock. With a
-  single writer to a stream that starts empty and sends issued in counter
-  order, the broker-assigned offset equals the publishingId — which is the
-  offset we return. (PublishingId dedup also makes retries idempotent.)
+  Send offsets. The kafka workload needs the *offset* of each successful send
+  (op->max-send-offsets ignores nil offsets, so the final-reads phase would not
+  learn a key's true tail and its un-polled writes would all look :unseen). A
+  stream publish confirm returns only a publishingId, not the committed offset
+  (ConfirmationStatus has no offset; the offset is knowable only by consuming
+  the message back). So we publish each stream through ONE shared producer, set
+  the publishingId from a per-key counter, and serialize the send call under a
+  per-key lock. With a single writer to a stream that starts empty and sends
+  issued in counter order, the broker-assigned offset equals the publishingId,
+  which is the offset we return. (PublishingId dedup also makes retries
+  idempotent.)
+
+  This equality holds only ABSENT a leader move: a leader move triggers producer
+  recovery, after which the publishingId drifts from the true offset (a failed
+  send still advances our counter), so under the leader-move nemesis our send
+  offsets are wrong. That breaks the kafka checker's offset-consistency
+  analyzers (a value appears at both its true offset and its drifted publishingId
+  => false duplicate / inconsistent-offset) but NOT its loss analyzers (the value
+  is still polled, just at two offsets). Under leader-move we therefore treat the
+  kafka offset analyzers as non-authoritative and rely on the durability checker
+  (checker.clj), which reads every stream end-to-end with a fresh Environment,
+  using only true consumer offsets, and asserts no acknowledged write is lost or
+  duplicated. See jepsen/README.md.
 
   Consumers. Persistent per key for a client's life, reading from the
   beginning into a per-key buffer; never rebuilt on re-assign (rebuilding
@@ -24,7 +38,21 @@
   Shared, long-lived objects (the Environment, producers, per-key counters)
   live in defonce atoms for the whole run: the Environment is a heavyweight
   (~cores-sized) thread pool meant to be shared, and one-per-client-per-reopen
-  exhausts native threads."
+  exhausts native threads.
+
+  Crash rebuilds the Environment. The kafka final-reads phase periodically
+  crashes the client to 'force a fresh one in case there's broken state inside
+  the client'. Sharing one Environment for the whole run would subvert that: a
+  topology-churning fault (the leader-move nemesis moves every stream's leader
+  repeatedly) can wedge the Environment's consumer connections so that even
+  freshly built consumers deliver nothing, and the final reads hang forever. So
+  a :crash discards the shared Environment (closing it to reclaim threads) and
+  the next open! builds a fresh one. A generation guard makes this idempotent
+  across the concurrent crashes the final phase issues, and :crash is only ever
+  emitted in the final phase, so live producers are never pulled out from under
+  a send. This cannot mask a real bug: genuinely unreadable data would defeat a
+  fresh Environment too, and the run would still hang (now bounded by the final
+  phase's time limit) and fail."
   (:require [jepsen.client :as client])
   (:import (com.rabbitmq.stream Environment OffsetSpecification ByteCapacity)
            (java.util.concurrent ConcurrentLinkedQueue CountDownLatch TimeUnit)
@@ -70,6 +98,7 @@
 (defonce ^:private declared-streams (atom #{}))    ; keys whose stream exists
 (defonce ^:private shared-producers (atom {}))     ; k -> Producer
 (defonce ^:private pub-counters (atom {}))         ; k -> AtomicLong (next publishingId)
+(defonce ^:private env-generation (atom 0))        ; bumped each Environment rebuild
 
 (defn with-retry
   "Calls thunk, retrying on any exception until op-retry-ms elapses, then
@@ -93,6 +122,22 @@
                   e (-> (Environment/builder) (.uris uris) (.build))]
               (reset! shared-env e)
               e)))))
+
+(defn reset-env!
+  "Discards the shared Environment (closing it to reclaim its thread pool) so
+  the next get-env builds a fresh one with clean connections, along with the
+  producers and counters bound to it. Idempotent across the concurrent crashes
+  the final-reads phase issues: only the caller whose captured generation `g`
+  still matches tears down; callers racing on an already-rebuilt Environment are
+  no-ops. So a wave of crashes triggers exactly one rebuild."
+  [g]
+  (locking shared-env
+    (when (= g @env-generation)
+      (when-let [e @shared-env] (try (.close e) (catch Exception _)))
+      (reset! shared-env nil)
+      (reset! shared-producers {})
+      (reset! pub-counters {})
+      (swap! env-generation inc))))
 
 (defn ensure-stream! [env k]
   (when-not (contains? @declared-streams k)
@@ -122,8 +167,11 @@
 
 (defn publish-at-offset!
   "Publishes v to stream k through its shared producer at the next publishingId
-  (== the stream offset). Serializes counter allocation and the send call per
-  key so offsets stay in order; awaits the confirm. Returns the offset."
+  (== the stream offset absent a leader move). Serializes counter allocation and
+  the send call per key so offsets stay in order; awaits the confirm. Returns the
+  offset. Under the leader-move nemesis the publishingId drifts from the true
+  offset, so the durability checker, not these send offsets, is authoritative for
+  loss (see the ns docstring)."
   [env k v]
   (let [producer (get-producer env k)
         counter  (get-counter k)
@@ -201,12 +249,80 @@
       (recur (conj acc item))
       acc)))
 
-(defrecord Client [node ^Environment env consumers buffers assigned]
+;; ---------------------------------------------------------------------------
+;; Authoritative end-to-end read (for the durability checker)
+;; ---------------------------------------------------------------------------
+
+;; Reading the whole history of ~90 streams, some served from S3, needs a far
+;; more generous quiescence wait than the steady-state catch-up above.
+(def auth-quiet-ms 3000)    ; deliveries idle this long => every stream at its tail
+(def auth-grace-ms 8000)    ; tolerate this long before any delivery (S3 warm-up)
+(def auth-cap-ms 180000)    ; hard cap so a genuinely stuck stream cannot hang
+
+;; The authoritative read of every jepsen stream, captured once after the run
+;; while the brokers are still up (db/log-files), for the durability checker:
+;; key -> vector of [offset value] in delivery order. Uses true consumer offsets
+;; only, so it is sound even when the leader-move nemesis has made our send
+;; offsets unreliable.
+(defonce authoritative-reads (atom {}))
+
+(defn- await-quiescent!
+  "Waits until the total buffered count across queues holds steady for
+  auth-quiet-ms (every stream reached its tail), bounded by auth-cap-ms, with an
+  auth-grace-ms grace before the first delivery for streams served from S3."
+  [queues]
+  (let [total (fn [] (reduce (fn [a ^java.util.Collection q] (+ a (.size q))) 0 queues))
+        start (System/currentTimeMillis)
+        deadline (+ start auth-cap-ms)]
+    (loop [last-total (total), last-change start]
+      (let [now (System/currentTimeMillis)
+            t   (total)]
+        (cond
+          (>= now deadline) nil
+          (not= t last-total) (do (Thread/sleep 100) (recur t now))
+          (and (> (- now last-change) auth-quiet-ms)
+               (or (pos? t) (> (- now start) auth-grace-ms))) nil
+          :else (do (Thread/sleep 100) (recur t last-change)))))))
+
+(defn read-streams-fully
+  "Authoritative end-to-end read of stream keys `ks` for the durability checker.
+  Builds a FRESH Environment (the run's shared one may be wedged from topology
+  churn), subscribes each stream from the beginning, waits for deliveries to go
+  quiet (every stream at its tail), and returns {key -> vector of [offset value]
+  in delivery order}. Closes the Environment before returning."
+  [test ks]
+  (let [uris (java.util.ArrayList.
+               (map #(str "rabbitmq-stream://guest:guest@" (name %) ":" stream-port)
+                    (:nodes test)))
+        env    (-> (Environment/builder) (.uris uris) (.build))
+        queues (reduce (fn [m k] (assoc m k (ConcurrentLinkedQueue.))) {} ks)]
+    (try
+      (doseq [[k q] queues]
+        (-> env (.consumerBuilder) (.stream (stream-name k))
+            (.offset (OffsetSpecification/first))
+            (.messageHandler
+              (reify com.rabbitmq.stream.MessageHandler
+                (handle [_ ctx msg]
+                  (.add q [(.offset ctx) (decode-value (.getBodyAsBinary msg))]))))
+            (.build)))
+      (await-quiescent! (vals queues))
+      (into {} (map (fn [[k q]] [k (drain! q)]) queues))
+      (finally (.close env)))))
+
+(defn capture-authoritative-reads!
+  "Reads keys `ks` end-to-end and stores the result in authoritative-reads."
+  [test ks]
+  (reset! authoritative-reads (read-streams-fully test ks)))
+
+(defrecord Client [node ^Environment env env-gen consumers buffers assigned]
   client/Client
   (open! [this test node]
     (assoc this
            :node node
            :env (get-env test)
+           ;; The Environment generation this client is bound to, so a crash
+           ;; rebuilds only the Environment it actually observed (see reset-env!).
+           :env-gen @env-generation
            :consumers (atom {})           ; k -> Consumer (persistent, per client)
            :buffers   (atom {})           ; k -> ConcurrentLinkedQueue of [off v]
            :assigned  (atom #{})))        ; currently-assigned keys
@@ -250,9 +366,12 @@
 
       ;; :crash must throw: jepsen only closes and reopens the client when
       ;; invoke! throws, and final-polls relies on a fresh client (fresh
-      ;; consumers re-reading each stream from the beginning).
+      ;; consumers re-reading each stream from the beginning). It also rebuilds
+      ;; the shared Environment so the fresh consumers get clean connections,
+      ;; not the wedged ones a topology-churning run can leave behind.
       :crash
-      (throw (ex-info "crash requested" {:type :crash}))))
+      (do (reset-env! env-gen)
+          (throw (ex-info "crash requested" {:type :crash})))))
 
   (teardown! [_ test])
 

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/client.clj
@@ -1,0 +1,248 @@
+(ns jepsen.streams3.client
+  "A jepsen client that drives RabbitMQ streams through the official Stream
+  protocol Java client, mapped onto the jepsen.tests.kafka op contract
+  (`assign` model, :sub-via #{:assign} — like the reference Kafka/redpanda
+  test, consumers read by position and there is no server-side offset commit).
+
+  Getting a real send offset. The kafka workload needs the *offset* of each
+  successful send (op->max-send-offsets ignores nil offsets, so poll-unseen
+  would never re-poll a key and its writes would all look :unseen). But a
+  stream publish confirm returns only a publishingId, not the offset. So we
+  publish each stream through ONE shared producer, set the publishingId from a
+  per-key counter, and serialize the send call under a per-key lock. With a
+  single writer to a stream that starts empty and sends issued in counter
+  order, the broker-assigned offset equals the publishingId — which is the
+  offset we return. (PublishingId dedup also makes retries idempotent.)
+
+  Consumers. Persistent per key for a client's life, reading from the
+  beginning into a per-key buffer; never rebuilt on re-assign (rebuilding
+  re-read buffered offsets => duplicate deliveries). :assign waits for newly
+  created consumers to catch up to the tail so the next poll returns their
+  data. On a fault crash jepsen opens a fresh client whose consumers re-read
+  from the beginning — a new process, so per-process monotonicity holds.
+
+  Shared, long-lived objects (the Environment, producers, per-key counters)
+  live in defonce atoms for the whole run: the Environment is a heavyweight
+  (~cores-sized) thread pool meant to be shared, and one-per-client-per-reopen
+  exhausts native threads."
+  (:require [jepsen.client :as client])
+  (:import (com.rabbitmq.stream Environment OffsetSpecification)
+           (java.util.concurrent ConcurrentLinkedQueue CountDownLatch TimeUnit)
+           (java.util.concurrent.atomic AtomicBoolean AtomicLong)))
+
+(def stream-port 5552)
+
+;; How long to retry a transient stream operation (create / producer / consumer
+;; build) before giving up and letting the op fail as indeterminate. Kept short
+;; so that ops fail reasonably fast during a partition rather than masking it.
+(def op-retry-ms 10000)
+
+;; The Stream consumer is push-based and delivers asynchronously; mimic Kafka's
+;; blocking poll(timeout) so a poll right after an :assign doesn't return empty.
+(def poll-wait-ms 500)
+
+;; :assign waits for freshly created consumers to catch up to their streams'
+;; tails before returning, so the following poll returns their data.
+(def catchup-max-ms 3000)   ; cap on waiting for a new consumer to reach the tail
+(def catchup-quiet-ms 300)  ; buffers steady this long => caught up to the tail
+(def catchup-grace-ms 1000) ; if buffers stay empty (empty stream), give up after this
+
+(defn stream-name [k] (str "jepsen-" k))
+
+;; ---------------------------------------------------------------------------
+;; Shared, run-scoped state (never closed; the lein process exits at run end)
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private shared-env (atom nil))
+(defonce ^:private declared-streams (atom #{}))    ; keys whose stream exists
+(defonce ^:private shared-producers (atom {}))     ; k -> Producer
+(defonce ^:private pub-counters (atom {}))         ; k -> AtomicLong (next publishingId)
+
+(defn with-retry
+  "Calls thunk, retrying on any exception until op-retry-ms elapses, then
+  rethrows. For transient 'leader/stream not available' errors right after
+  create or during a partition."
+  [thunk]
+  (let [deadline (+ (System/currentTimeMillis) op-retry-ms)]
+    (loop []
+      (let [r (try {:val (thunk)}
+                   (catch Exception e
+                     (if (< (System/currentTimeMillis) deadline) :retry (throw e))))]
+        (if (= r :retry) (do (Thread/sleep 250) (recur)) (:val r))))))
+
+(defn get-env ^Environment [test]
+  (or @shared-env
+      (locking shared-env
+        (or @shared-env
+            (let [uris (java.util.ArrayList.
+                         (map #(str "rabbitmq-stream://guest:guest@" (name %) ":" stream-port)
+                              (:nodes test)))
+                  e (-> (Environment/builder) (.uris uris) (.build))]
+              (reset! shared-env e)
+              e)))))
+
+(defn ensure-stream! [env k]
+  (when-not (contains? @declared-streams k)
+    ;; create() is idempotent for a matching stream.
+    (with-retry #(-> env (.streamCreator) (.stream (stream-name k)) (.create)))
+    (swap! declared-streams conj k)))
+
+(defn get-producer [env k]
+  (or (@shared-producers k)
+      (locking shared-producers
+        (or (@shared-producers k)
+            (do (ensure-stream! env k)
+                (let [p (with-retry
+                          #(-> env (.producerBuilder) (.stream (stream-name k)) (.build)))]
+                  (swap! shared-producers assoc k p)
+                  p))))))
+
+(defn ^AtomicLong get-counter [k]
+  (or (@pub-counters k)
+      (locking pub-counters
+        (or (@pub-counters k)
+            (let [c (AtomicLong. 0)]
+              (swap! pub-counters assoc k c)
+              c)))))
+
+(defn publish-at-offset!
+  "Publishes v to stream k through its shared producer at the next publishingId
+  (== the stream offset). Serializes counter allocation and the send call per
+  key so offsets stay in order; awaits the confirm. Returns the offset."
+  [env k v]
+  (let [producer (get-producer env k)
+        counter  (get-counter k)
+        latch    (CountDownLatch. 1)
+        ok       (AtomicBoolean. false)
+        n        (locking counter
+                   (let [n   (.getAndIncrement counter)
+                         msg (-> producer (.messageBuilder)
+                                 (.publishingId n)
+                                 (.addData (.getBytes (str v)))
+                                 (.build))]
+                     (.send producer msg
+                            (reify com.rabbitmq.stream.ConfirmationHandler
+                              (handle [_ status]
+                                (.set ok (.isConfirmed status))
+                                (.countDown latch))))
+                     n))]
+    (.await latch 30 TimeUnit/SECONDS)
+    (when-not (.get ok)
+      (throw (ex-info "send not confirmed" {:k k :v v})))
+    n))
+
+;; ---------------------------------------------------------------------------
+;; Per-client consumers
+;; ---------------------------------------------------------------------------
+
+(defn ensure-consumer!
+  "Creates the persistent consumer for key k (once per client). It reads from
+  the start of the stream and buffers [offset value] pairs into a per-key
+  queue."
+  [env consumers buffers k]
+  (or (get @consumers k)
+      (do (ensure-stream! env k)
+          (let [q (ConcurrentLinkedQueue.)
+                c (with-retry
+                    #(-> env
+                         (.consumerBuilder)
+                         (.stream (stream-name k))
+                         (.offset (OffsetSpecification/first))
+                         (.messageHandler
+                           (reify com.rabbitmq.stream.MessageHandler
+                             (handle [_ ctx msg]
+                               (.add q [(.offset ctx)
+                                        (Long/parseLong (String. (.getBodyAsBinary msg)))]))))
+                         (.build)))]
+            (swap! buffers assoc k q)
+            (swap! consumers assoc k c)
+            c))))
+
+(defn await-caught-up!
+  "Waits until the given consumer buffers have caught up to their streams'
+  tails: the total buffered count must grow and then hold steady for a quiet
+  period. Empty streams are handled by a grace timeout; bounded by
+  catchup-max-ms."
+  [queues]
+  (when (seq queues)
+    (let [total (fn [] (reduce (fn [a ^java.util.Collection q] (+ a (.size q))) 0 queues))
+          start (System/currentTimeMillis)
+          deadline (+ start catchup-max-ms)]
+      (loop [last-total (total), last-change start]
+        (let [now (System/currentTimeMillis)
+              t   (total)]
+          (cond
+            (>= now deadline) nil
+            (not= t last-total) (do (Thread/sleep 50) (recur t now))
+            (and (> (- now last-change) catchup-quiet-ms)
+                 (or (pos? t) (> (- now start) catchup-grace-ms))) nil
+            :else (do (Thread/sleep 50) (recur t last-change))))))))
+
+(defn drain!
+  "Drains all currently-buffered [offset value] pairs from queue q in order."
+  [q]
+  (loop [acc []]
+    (if-let [item (and q (.poll q))]
+      (recur (conj acc item))
+      acc)))
+
+(defrecord Client [node ^Environment env consumers buffers assigned]
+  client/Client
+  (open! [this test node]
+    (assoc this
+           :node node
+           :env (get-env test)
+           :consumers (atom {})           ; k -> Consumer (persistent, per client)
+           :buffers   (atom {})           ; k -> ConcurrentLinkedQueue of [off v]
+           :assigned  (atom #{})))        ; currently-assigned keys
+
+  (setup! [_ test])
+
+  (invoke! [this test op]
+    (case (:f op)
+      (:assign :subscribe)
+      (let [ks (:value op)
+            new-ks (remove #(contains? @consumers %) ks)]
+        (doseq [k ks] (ensure-consumer! env consumers buffers k))
+        (reset! assigned (set ks))
+        ;; Wait for the freshly created consumers to reach the tail so the next
+        ;; poll returns their data (otherwise the key looks empty and is never
+        ;; polled => :unseen).
+        (await-caught-up! (keep #(get @buffers %) new-ks))
+        (assoc op :type :ok))
+
+      :send
+      (let [results (mapv (fn [[_ k v]]
+                            [:send k [(publish-at-offset! env k v) v]])
+                          (:value op))]
+        (assoc op :type :ok :value results))
+
+      :poll
+      (let [drain-assigned (fn []
+                             (reduce (fn [m k]
+                                       (let [items (drain! (get @buffers k))]
+                                         (if (seq items) (assoc m k items) m)))
+                                     {} @assigned))
+            by-key (let [first-try (drain-assigned)]
+                     (if (seq first-try)
+                       first-try
+                       (do (Thread/sleep poll-wait-ms) (drain-assigned))))]
+        (assoc op :type :ok :value [[:poll by-key]]))
+
+      ;; final-polls queries partition state for debugging; just acknowledge.
+      :debug-topic-partitions
+      (assoc op :type :ok)
+
+      ;; :crash must throw: jepsen only closes and reopens the client when
+      ;; invoke! throws, and final-polls relies on a fresh client (fresh
+      ;; consumers re-reading each stream from the beginning).
+      :crash
+      (throw (ex-info "crash requested" {:type :crash}))))
+
+  (teardown! [_ test])
+
+  (close! [_ test]
+    ;; Close this client's consumers; the shared env/producers persist.
+    (doseq [[_ c] @consumers] (try (.close c) (catch Exception _)))))
+
+(defn client [] (map->Client {}))

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
@@ -1,0 +1,66 @@
+(ns jepsen.streams3.core
+  "Entry point and test assembly for the RabbitMQ stream_s3 Jepsen test.
+
+  Usage:
+    lein run test --nodes-file nodes --time-limit 300 --rate 200 --concurrency 20
+
+  See jepsen/README.md for the full docker-based run procedure."
+  (:require [jepsen [cli :as cli]
+                    [checker :as checker]
+                    [generator :as gen]
+                    [tests :as tests]]
+            [jepsen.checker.timeline :as timeline]
+            [jepsen.os.debian :as debian]
+            [jepsen.streams3.db :as db]
+            [jepsen.streams3.nemesis :as nem]
+            [jepsen.streams3.workload :as workload]))
+
+(def cli-opts
+  "Extra CLI options for this test."
+  [[nil "--rate HZ" "Approximate request rate, per second"
+    :default 200 :parse-fn read-string]
+   [nil "--key-count N" "Number of streams (topic-partitions)"
+    :default 8 :parse-fn parse-long]
+   [nil "--nemesis-interval SEC" "Seconds between fault transitions"
+    :default 15 :parse-fn parse-long]
+   [nil "--faults FAULTS" "Comma-separated faults (phase 1: partition)"
+    :default "partition"]])
+
+(defn streams3-test
+  [opts]
+  (let [wl (workload/workload opts)]
+    (merge
+      tests/noop-test
+      opts
+      ;; The kafka workload's generator/checker/client read these options from
+      ;; the *test map*. Merge only the scalar options — merging the whole
+      ;; workload map would drag in un-serializable generator Delays that break
+      ;; jepsen's fressian store.
+      (select-keys wl [:sub-via :txn? :crash-clients? :crash-client-interval])
+      {:name      "rabbitmq-stream-s3"
+       :os        debian/os
+       :db        (db/db)
+       :client    (:client wl)
+       :nemesis   (nem/full-nemesis)
+       :checker   (checker/compose
+                    {:perf     (checker/perf)
+                     :timeline (timeline/html)
+                     :workload (:checker wl)})
+       :generator (gen/phases
+                    ;; Main phase: workload ops + faults for the time limit.
+                    (->> (:generator wl)
+                         (gen/stagger (/ 1 (:rate opts)))
+                         (gen/nemesis (nem/nemesis-generator opts))
+                         (gen/time-limit (:time-limit opts)))
+                    ;; Heal, let things settle.
+                    (gen/nemesis (gen/once {:type :info :f :stop-partition}))
+                    (gen/sleep 15)
+                    ;; Final reads: the kafka workload drains everything written.
+                    (gen/clients (:final-generator wl)))})))
+
+(defn -main [& args]
+  (cli/run!
+    (merge (cli/single-test-cmd {:test-fn streams3-test
+                                 :opt-spec cli-opts})
+           (cli/serve-cmd))
+    args))

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
@@ -11,6 +11,7 @@
                     [tests :as tests]]
             [jepsen.checker.timeline :as timeline]
             [jepsen.os.debian :as debian]
+            [jepsen.streams3.checker :as s3-checker]
             [jepsen.streams3.db :as db]
             [jepsen.streams3.nemesis :as nem]
             [jepsen.streams3.workload :as workload]))
@@ -45,16 +46,29 @@
        :checker   (checker/compose
                     {:perf     (checker/perf)
                      :timeline (timeline/html)
-                     :workload (:checker wl)})
+                     :workload (:checker wl)
+                     ;; Fails the run unless S3 was actually exercised, so a
+                     ;; green result can't silently stop using the remote tier.
+                     :tiering  (s3-checker/tiering-checker)})
        :generator (gen/phases
                     ;; Main phase: workload ops + faults for the time limit.
                     (->> (:generator wl)
                          (gen/stagger (/ 1 (:rate opts)))
                          (gen/nemesis (nem/nemesis-generator opts))
                          (gen/time-limit (:time-limit opts)))
-                    ;; Heal, let things settle.
-                    (gen/nemesis (gen/once {:type :info :f :stop-partition}))
+                    ;; Heal every fault (the main phase may end mid-fault, and
+                    ;; the nemesis teardown runs only after analysis), then let
+                    ;; things settle before the final reads. The stop ops are
+                    ;; idempotent, so healing an inactive fault is harmless.
+                    (gen/nemesis [{:type :info :f :stop-partition}
+                                  {:type :info :f :stop-s3-outage}
+                                  {:type :info :f :stop-s3-latency}])
                     (gen/sleep 15)
+                    ;; With trimming enabled, trim once more after healing so the
+                    ;; final reads drain from the now-trimmed (S3-only) tier and
+                    ;; actually exercise the read-from-S3 path.
+                    (gen/nemesis (when (contains? (nem/faults opts) "trim")
+                                   {:type :info :f :trim-local}))
                     ;; Final reads: the kafka workload drains everything written.
                     (gen/clients (:final-generator wl)))})))
 

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
@@ -24,7 +24,11 @@
     :default 8 :parse-fn parse-long]
    [nil "--nemesis-interval SEC" "Seconds between fault transitions"
     :default 15 :parse-fn parse-long]
-   [nil "--faults FAULTS" "Comma-separated faults (phase 1: partition)"
+   [nil "--final-time-limit SEC"
+    "Cap on the final-reads phase (the kafka final-polls loop is unbounded)"
+    :default 180 :parse-fn parse-long]
+   [nil "--faults FAULTS"
+    "Comma-separated: partition, s3-outage, s3-latency, trim, leader-move"
     :default "partition"]])
 
 (defn streams3-test
@@ -46,7 +50,17 @@
        :checker   (checker/compose
                     {:perf     (checker/perf)
                      :timeline (timeline/html)
-                     :workload (:checker wl)
+                     ;; The kafka workload checker is authoritative on its own,
+                     ;; except under leader-move: there our send offsets drift
+                     ;; (see client.clj), so its offset-consistency analyzers go
+                     ;; red on artifacts. We downgrade it to advisory in that case
+                     ;; and let the durability checker carry the safety verdict.
+                     :workload (s3-checker/downgrade-when
+                                 (fn [t] (contains? (nem/faults t) "leader-move"))
+                                 (:checker wl))
+                     ;; Authoritative no-loss / no-duplicate via an end-to-end
+                     ;; read, sound even when send offsets are unreliable.
+                     :durability (s3-checker/durability-checker)
                      ;; Fails the run unless S3 was actually exercised, so a
                      ;; green result can't silently stop using the remote tier.
                      :tiering  (s3-checker/tiering-checker)})
@@ -70,7 +84,15 @@
                     (gen/nemesis (when (contains? (nem/faults opts) "trim")
                                    {:type :info :f :trim-local}))
                     ;; Final reads: the kafka workload drains everything written.
-                    (gen/clients (:final-generator wl)))})))
+                    ;; The kafka final-polls generator is unbounded by design —
+                    ;; it loops until every acknowledged offset is read back — so
+                    ;; bound it. If the data is readable this drains in seconds;
+                    ;; if a regression makes acknowledged data permanently
+                    ;; unreadable, this fails fast (the checker reports the
+                    ;; unseen writes) instead of hanging indefinitely.
+                    (gen/time-limit
+                      (:final-time-limit opts)
+                      (gen/clients (:final-generator wl))))})))
 
 (defn -main [& args]
   (cli/run!

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
@@ -35,12 +35,15 @@
 (def log-dir (str base-dir "/var/log/rabbitmq"))
 (def erlang-cookie "JEPSENSTREAMS3COOKIE")
 
-;; The S3 endpoint the broker talks to. region_endpoints maps the region name
-;; to this "TLD"; the AWS backend then forms <bucket>.<endpoint> and connects
-;; over TLS/443. docker-compose must give the Toxiproxy container the network
-;; aliases `s3.jepsen.local` and `jepsen.s3.jepsen.local`.
+;; The AWS backend builds the endpoint host the AWS way: `s3.<region>.<tld>`
+;; (cf. s3.us-east-1.amazonaws.com), where <tld> is the region_endpoints value.
+;; So region=jepsen + tld=local yields connection host `s3.jepsen.local` and
+;; per-request virtual-host `jepsen.s3.jepsen.local`. docker-compose aliases
+;; both `s3.jepsen.local` and `jepsen.s3.jepsen.local` to Toxiproxy, the cert
+;; covers them, and MINIO_DOMAIN=s3.jepsen.local routes the bucket. (Setting the
+;; tld to the full `s3.jepsen.local` would wrongly yield s3.jepsen.s3.jepsen.local.)
 (def s3-region   "jepsen")
-(def s3-endpoint "s3.jepsen.local")
+(def s3-region-tld "local")
 (def s3-bucket   "jepsen")
 (def s3-access-key "jepsenjepsen")
 (def s3-secret-key "jepsenjepsenjepsen")
@@ -77,13 +80,16 @@
          (:nodes test)))
      ;; --- S3 tier: point the AWS backend at MinIO via Toxiproxy ---
      (str "stream_s3.region = " s3-region)
-     (str "stream_s3.region_endpoints." s3-region " = " s3-endpoint)
+     (str "stream_s3.region_endpoints." s3-region " = " s3-region-tld)
      (str "stream_s3.access_key_id = " s3-access-key)
      (str "stream_s3.secret_key = " s3-secret-key)
      (str "stream_s3.bucket = " s3-bucket)
      ;; Small fragments + frequent persists so tiering and manifest replication
-     ;; actually happen within a short test run.
-     "stream_s3.fragment_target_size = 1MB"
+     ;; actually happen within a short test run. Combined with the small stream
+     ;; segment size and padded messages set by the client, this makes data
+     ;; really upload to S3 and local segments really trim, so the S3 nemeses
+     ;; have live traffic to disrupt and reads genuinely fall back to S3.
+     "stream_s3.fragment_target_size = 16KB"
      "stream_s3.persist_interval_ms = 500"
      "stream_s3.verbose_logging = true"
      ;; Keep transfers from saturating the link so S3-latency faults are visible.
@@ -122,6 +128,64 @@
 (defn rabbitmqctl [node & args]
   (apply c/exec :env (concat (env-args node)
                              [(str base-dir "/sbin/rabbitmqctl")] args)))
+
+;; One rabbitmqctl eval that, on the local node, triggers local-retention
+;; evaluation for every jepsen-<k> stream — looping in Erlang rather than
+;; spawning a slow CLI per stream. evaluate_local_retention no-ops where the
+;; node holds no running member, so running this on every node reaches each
+;; stream's writer.
+(def ^:private trim-eval
+  (str "Names = [element(4, amqqueue:get_name(Q)) "
+       "|| Q <- rabbit_amqqueue:list(<<\"/\">>)], "
+       "[catch rabbitmq_stream_s3_replica_reader:evaluate_local_retention(<<\"/\">>, N) "
+       "|| N <- Names, byte_size(N) >= 7, binary:part(N, 0, 7) =:= <<\"jepsen-\">>], ok."))
+
+(defn force-local-trim!
+  "Triggers local-retention evaluation for the jepsen streams on `node`, so
+  segments already uploaded to S3 are trimmed locally and reads of older
+  offsets fall back to the S3 tier. Runs in an SSH context (caller wraps with
+  c/on-nodes)."
+  [node]
+  (util/meh (rabbitmqctl node :eval trim-eval)))
+
+;; The plugin's read/write paths are instrumented, not logged, so these
+;; counters are how the test proves S3 was actually exercised (see the
+;; coverage checker). The management/Prometheus listener is on 15692.
+(def tiering-metrics
+  ["rabbitmq_stream_s3_transfers_completed"  ; fragments uploaded to S3
+   "rabbitmq_stream_s3_get_range"            ; range GETs (remote reads) from S3
+   "rabbitmq_stream_s3_read"                 ; remote_reader read calls
+   "rabbitmq_stream_s3_resolve"])            ; read-path offset resolutions
+
+(defn scrape-tiering-metrics
+  "Scrapes the plugin's Prometheus counters on `node`, returning a map of
+  metric name -> summed value (over all label sets). Runs in an SSH context."
+  [node]
+  (let [out   (try (c/exec :curl :-s "http://localhost:15692/metrics")
+                   (catch Exception _ ""))
+        lines (str/split-lines out)]
+    (into {}
+          (for [m tiering-metrics]
+            [m (->> lines
+                    (keep (fn [l]
+                            (when-let [[_ v] (re-find
+                                               (re-pattern
+                                                 (str "^" m "(?:\\{[^}]*\\})?\\s+([0-9.]+)"))
+                                               l)]
+                              (parse-double v))))
+                    (reduce + 0.0))]))))
+
+;; Cluster-wide S3 counter sums for the run, accumulated across nodes in
+;; log-files (which runs after the workload but before the checker, while the
+;; brokers are still up). The coverage checker reads this. Collecting it here
+;; rather than as a history op keeps it out of the kafka checker's analysis,
+;; which chokes on a trailing non-client op.
+(defonce tiering-stats (atom {}))
+
+(defn record-tiering-stats!
+  "Adds `node`'s S3 counters into the shared per-run totals."
+  [node]
+  (swap! tiering-stats #(merge-with + % (scrape-tiering-metrics node))))
 
 (defn start! [test node]
   (info node "starting broker")
@@ -170,6 +234,8 @@
   []
   (reify db/DB
     (setup! [_ test node]
+      ;; Clean slate for this run's coverage counters (idempotent across nodes).
+      (reset! tiering-stats {})
       (install! test node)
       (start! test node))
 
@@ -185,6 +251,9 @@
 
     db/LogFiles
     (log-files [_ test node]
+      ;; Scrape this node's S3 counters into the run totals (brokers are still
+      ;; up here, before teardown) so the coverage checker can read them.
+      (util/meh (record-tiering-stats! node))
       ;; Broker logs + the S3 plugin's status output for post-mortem.
       (util/meh
         (rabbitmqctl node :stream_s3_status

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
@@ -1,0 +1,195 @@
+(ns jepsen.streams3.db
+  "Installs, configures, starts and stops a RabbitMQ node with the
+  rabbitmq_stream_s3 plugin on each DB node.
+
+  The broker is installed from a *generic-unix* tarball produced by
+  `make package-generic-unix` at the umbrella root (it bundles every deps/
+  plugin, including rabbitmq_stream_s3 — no release is required). The tarball
+  is made available to every node at /shared/rabbitmq.tar.xz via a volume in
+  docker-compose; db setup installs it under /opt/rabbitmq.
+
+  The S3 tier points at the MinIO sidecar. The AWS backend
+  (rabbitmq_stream_s3_api_aws) is hardwired to TLS/443 with verify_peer and
+  uses virtual-hosted-style addressing (Host = <bucket>.<endpoint>), so:
+    * the node trusts the test CA (resources/ca.crt -> system store),
+    * region_endpoints.<region> resolves <bucket>.<endpoint> to Toxiproxy,
+      which L4-passes through to MinIO:443,
+    * static access_key_id/secret_key are configured so the IMDS/container
+      credential paths are never used."
+  (:require [clojure.tools.logging :refer [info]]
+            [clojure.string :as str]
+            [jepsen [control :as c]
+                    [db :as db]
+                    [util :as util]]
+            [jepsen.control.util :as cu]
+            [jepsen.os.debian :as debian]))
+
+(def base-dir "/opt/rabbitmq")
+(def tarball "file:///shared/rabbitmq.tar.xz")
+(def ca-cert "/shared/ca.crt")
+(def conf-file (str base-dir "/etc/rabbitmq/rabbitmq.conf"))
+;; RABBITMQ_CONFIG_FILE is given WITHOUT the .conf extension; the broker
+;; appends it. The file on disk is conf-file (with .conf).
+(def conf-file-base (str base-dir "/etc/rabbitmq/rabbitmq"))
+(def enabled-plugins-file (str base-dir "/etc/rabbitmq/enabled_plugins"))
+(def log-dir (str base-dir "/var/log/rabbitmq"))
+(def erlang-cookie "JEPSENSTREAMS3COOKIE")
+
+;; The S3 endpoint the broker talks to. region_endpoints maps the region name
+;; to this "TLD"; the AWS backend then forms <bucket>.<endpoint> and connects
+;; over TLS/443. docker-compose must give the Toxiproxy container the network
+;; aliases `s3.jepsen.local` and `jepsen.s3.jepsen.local`.
+(def s3-region   "jepsen")
+(def s3-endpoint "s3.jepsen.local")
+(def s3-bucket   "jepsen")
+(def s3-access-key "jepsenjepsen")
+(def s3-secret-key "jepsenjepsenjepsen")
+
+(defn enabled-plugins []
+  ;; enabled_plugins is an Erlang term: a LIST of plugin atoms.
+  "[rabbitmq_stream,rabbitmq_stream_management,rabbitmq_stream_s3].")
+
+(defn rabbitmq-conf
+  "Renders rabbitmq.conf. `nodes` is the full node list; node 0 is the seed.
+  Retention is intentionally generous: we want data to *tier to S3*
+  (small fragments + tiering) so reads exercise the remote tier, but we do NOT
+  want the local floor to trim past the upload seam, which would lose data the
+  plugin never promised to keep ([f,n) durability only — see docs/invariants.md).
+  Aggressive-retention scenarios are still to come, with a bounded-durability
+  checker."
+  [test node]
+  (str/join
+    "\n"
+    [;; --- listeners ---
+     "listeners.tcp.default = 5672"
+     "stream.listeners.tcp.default = 5552"
+     "management.tcp.port = 15672"
+     ;; The jepsen client connects as guest from the control node (a remote
+     ;; host), so lift the default loopback-only restriction on guest.
+     "loopback_users = none"
+     ;; --- clustering ---
+     "cluster_formation.peer_discovery_backend = classic_config"
+     (str/join
+       "\n"
+       (map-indexed
+         (fn [i n] (str "cluster_formation.classic_config.nodes." (inc i)
+                        " = rabbit@" (name n)))
+         (:nodes test)))
+     ;; --- S3 tier: point the AWS backend at MinIO via Toxiproxy ---
+     (str "stream_s3.region = " s3-region)
+     (str "stream_s3.region_endpoints." s3-region " = " s3-endpoint)
+     (str "stream_s3.access_key_id = " s3-access-key)
+     (str "stream_s3.secret_key = " s3-secret-key)
+     (str "stream_s3.bucket = " s3-bucket)
+     ;; Small fragments + frequent persists so tiering and manifest replication
+     ;; actually happen within a short test run.
+     "stream_s3.fragment_target_size = 1MB"
+     "stream_s3.persist_interval_ms = 500"
+     "stream_s3.verbose_logging = true"
+     ;; Keep transfers from saturating the link so S3-latency faults are visible.
+     "stream_s3.max_transfer_bytes_per_sec = 50MB"
+     ""]))
+
+(defn install!
+  [test node]
+  (info node "installing RabbitMQ + rabbitmq_stream_s3")
+  ;; Erlang 27 is provided by the node base image (erlang:27); we only need
+  ;; the CA tooling here to trust the test S3 CA.
+  (debian/install [:openssl :ca-certificates])
+  (cu/install-archive! tarball base-dir)
+  ;; Trust the test CA so verify_peer against MinIO's cert succeeds.
+  (c/su
+    (c/exec :cp ca-cert "/usr/local/share/ca-certificates/jepsen-s3-ca.crt")
+    (c/exec :update-ca-certificates))
+  (c/exec :mkdir :-p (str base-dir "/etc/rabbitmq") log-dir)
+  (cu/write-file! (enabled-plugins) enabled-plugins-file)
+  (cu/write-file! (rabbitmq-conf test node) conf-file)
+  ;; Shared Erlang cookie so nodes can cluster.
+  (cu/write-file! erlang-cookie "/root/.erlang.cookie")
+  (c/exec :chmod :600 "/root/.erlang.cookie"))
+
+(defn env-args
+  "Renders the broker environment as `VAR=value` args for `env`."
+  [node]
+  (map (fn [[k v]] (str (name k) "=" v))
+       {:RABBITMQ_BASE base-dir
+        :RABBITMQ_CONFIG_FILE conf-file-base
+        :RABBITMQ_ENABLED_PLUGINS_FILE enabled-plugins-file
+        :RABBITMQ_LOG_BASE log-dir
+        :RABBITMQ_NODENAME (str "rabbit@" (name node))
+        :HOME "/root"}))
+
+(defn rabbitmqctl [node & args]
+  (apply c/exec :env (concat (env-args node)
+                             [(str base-dir "/sbin/rabbitmqctl")] args)))
+
+(defn start! [test node]
+  (info node "starting broker")
+  (apply c/exec :env (concat (env-args node)
+                             [(str base-dir "/sbin/rabbitmq-server") :-detached]))
+  ;; rabbitmq-server -detached returns before the node is reachable (the beam
+  ;; needs a moment to register with epmd), and await_startup errors rather
+  ;; than waiting when it cannot connect. Poll it until the node is both
+  ;; reachable and fully started — which, with classic_config, also covers the
+  ;; window where this node is still joining the cluster.
+  (util/await-fn (fn [] (rabbitmqctl node :await_startup))
+                 {:retry-interval 1000
+                  :timeout 120000
+                  :log-message (str "Waiting for broker on " (name node))}))
+
+(defn stop! [test node]
+  (info node "stopping broker")
+  (util/meh (rabbitmqctl node :shutdown)))
+
+(def probe-stream-url
+  "http://localhost:15672/api/queues/%2F/jepsen-probe-stream")
+
+(defn await-stream-ready
+  "Waits until a stream can actually be created. Right after the cluster forms
+  the stream coordinator may still be electing a leader, so the workload's
+  first creates/producers/consumers would crash; this gates the workload on the
+  subsystem being ready by creating (and deleting) a probe stream via the
+  management API. Run once on the primary via setup-primary!."
+  [node]
+  (util/await-fn
+    (fn []
+      (let [code (c/exec :curl :-s :-o "/dev/null" :-w "%{http_code}"
+                         :-u "guest:guest" :-H "content-type: application/json"
+                         :-X "PUT" probe-stream-url
+                         :-d "{\"durable\":true,\"arguments\":{\"x-queue-type\":\"stream\"}}")]
+        (when-not (#{"201" "204"} code)
+          (throw (ex-info "stream subsystem not ready" {:http-code code})))))
+    {:retry-interval 1000
+     :timeout 120000
+     :log-message (str "Waiting for stream subsystem on " (name node))})
+  (util/meh
+    (c/exec :curl :-s :-o "/dev/null" :-u "guest:guest" :-X "DELETE" probe-stream-url)))
+
+(defn db
+  "RabbitMQ stream_s3 DB. One generic-unix tarball install per node."
+  []
+  (reify db/DB
+    (setup! [_ test node]
+      (install! test node)
+      (start! test node))
+
+    (teardown! [_ test node]
+      (stop! test node)
+      (c/su (c/exec :rm :-rf base-dir)))
+
+    db/Primary
+    (primaries [_ test] [(first (:nodes test))])
+    (setup-primary! [_ test node]
+      (info node "waiting for the stream subsystem to be ready")
+      (await-stream-ready node))
+
+    db/LogFiles
+    (log-files [_ test node]
+      ;; Broker logs + the S3 plugin's status output for post-mortem.
+      (util/meh
+        (rabbitmqctl node :stream_s3_status
+                     :> (str log-dir "/stream_s3_status.txt")))
+      ;; NB: cu/ls-full is broken in jepsen 0.3.11 (it calls assoc with two
+      ;; args), so use cu/ls with :full-path? directly.
+      (try (cu/ls log-dir {:full-path? true})
+           (catch Throwable _ [])))))

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
@@ -22,7 +22,8 @@
                     [db :as db]
                     [util :as util]]
             [jepsen.control.util :as cu]
-            [jepsen.os.debian :as debian]))
+            [jepsen.os.debian :as debian]
+            [jepsen.streams3.client :as sc]))
 
 (def base-dir "/opt/rabbitmq")
 (def tarball "file:///shared/rabbitmq.tar.xz")
@@ -148,6 +149,41 @@
   [node]
   (util/meh (rabbitmqctl node :eval trim-eval)))
 
+;; One rabbitmqctl eval that transfers every jepsen-<k> stream's leader to its
+;; first replica, moving each writer (and uploader) to a new node and bumping the
+;; stream's epoch. The stream coordinator is cluster-global, so this runs on a
+;; single node. transfer_leadership restarts the stream with the target preferred
+;; as leader; replica_nodes excludes the current leader, so the leader genuinely
+;; moves and the epoch increments.
+;;
+;; All streams at once, repeatedly: this maximizes the number of deposed-writer
+;; races, which is exactly what stresses writer fencing (an in-flight upload from
+;; an old epoch must be rejected, never overwrite the new leader's data). The
+;; resulting subscription churn wedges the push-based workload consumers, so the
+;; kafka workload's offset analyzers go red on artifacts — but that result is
+;; downgraded to advisory under leader-move, and correctness is verified by the
+;; durability checker, which reads each stream fresh after the run.
+(def ^:private leader-move-eval
+  (str "Names = [element(4, amqqueue:get_name(Q)) "
+       "|| Q <- rabbit_amqqueue:list(<<\"/\">>)], "
+       "Jeps = [N || N <- Names, byte_size(N) >= 7, binary:part(N, 0, 7) =:= <<\"jepsen-\">>], "
+       "[begin "
+       "Q = element(2, rabbit_amqqueue:lookup(rabbit_misc:r(<<\"/\">>, queue, N))), "
+       "case maps:get(replica_nodes, amqqueue:get_type_state(Q), []) of "
+       "[Target | _] -> catch rabbit_stream_queue:transfer_leadership(Q, Target); "
+       "[] -> ok "
+       "end "
+       "end || N <- Jeps], ok."))
+
+(defn force-leader-move!
+  "Transfers every jepsen stream's leader to its first replica, moving each
+  writer (and uploader) to a new node and bumping the stream's epoch. This fences
+  the deposed writers: a straggler upload carrying the old epoch must be rejected
+  (a manifest persist conflict), never overwrite the new leader's data. Run on a
+  single node (the coordinator is cluster-global). Runs in an SSH context."
+  [node]
+  (util/meh (rabbitmqctl node :eval leader-move-eval)))
+
 ;; The plugin's read/write paths are instrumented, not logged, so these
 ;; counters are how the test proves S3 was actually exercised (see the
 ;; coverage checker). The management/Prometheus listener is on 15692.
@@ -155,7 +191,13 @@
   ["rabbitmq_stream_s3_transfers_completed"  ; fragments uploaded to S3
    "rabbitmq_stream_s3_get_range"            ; range GETs (remote reads) from S3
    "rabbitmq_stream_s3_read"                 ; remote_reader read calls
-   "rabbitmq_stream_s3_resolve"])            ; read-path offset resolutions
+   "rabbitmq_stream_s3_resolve"              ; read-path offset resolutions
+   ;; Writer-fencing evidence: a deposed leader's straggler upload is rejected
+   ;; on a Khepri epoch conflict, and stale manifest syncs/resyncs are dropped
+   ;; or re-requested when the epoch moves under the leader-move nemesis.
+   "rabbitmq_stream_s3_persist_conflicts"
+   "rabbitmq_stream_s3_syncs_rejected"
+   "rabbitmq_stream_s3_resyncs_requested"])
 
 (defn scrape-tiering-metrics
   "Scrapes the plugin's Prometheus counters on `node`, returning a map of
@@ -175,6 +217,40 @@
                               (parse-double v))))
                     (reduce + 0.0))]))))
 
+;; The maximum stream coordinator epoch across the jepsen streams. The epoch
+;; starts at 1 and increments on every leader move, so it is how the coverage
+;; checker proves the writer-fencing (leader-move) path actually ran. It is a
+;; cluster-global value, so querying any one node suffices.
+(def ^:private max-epoch-eval
+  (str "Names = [element(4, amqqueue:get_name(Q)) "
+       "|| Q <- rabbit_amqqueue:list(<<\"/\">>)], "
+       "Jeps = [N || N <- Names, byte_size(N) >= 7, binary:part(N, 0, 7) =:= <<\"jepsen-\">>], "
+       "Epochs = [maps:get(epoch, amqqueue:get_type_state(element(2, "
+       "rabbit_amqqueue:lookup(rabbit_misc:r(<<\"/\">>, queue, N)))), 1) || N <- Jeps], "
+       "lists:max([1 | Epochs])."))
+
+(defn scrape-max-epoch
+  "Returns the maximum stream coordinator epoch across the jepsen streams on
+  `node` (a cluster-global value). Runs in an SSH context."
+  [node]
+  (let [out (try (rabbitmqctl node :eval max-epoch-eval) (catch Exception _ ""))]
+    (or (some-> (re-find #"\d+" (str out)) parse-long) 0)))
+
+;; Lists the integer keys of the jepsen-<k> streams that exist, so the
+;; durability checker reads exactly the streams the workload wrote to.
+(def ^:private jepsen-keys-eval
+  (str "Names = [element(4, amqqueue:get_name(Q)) "
+       "|| Q <- rabbit_amqqueue:list(<<\"/\">>)], "
+       "[binary_to_integer(binary:part(N, 7, byte_size(N) - 7)) "
+       "|| N <- Names, byte_size(N) >= 8, binary:part(N, 0, 7) =:= <<\"jepsen-\">>]."))
+
+(defn list-jepsen-keys
+  "Returns the integer keys of the jepsen streams on `node`. Runs in an SSH
+  context."
+  [node]
+  (let [out (try (rabbitmqctl node :eval jepsen-keys-eval) (catch Exception _ ""))]
+    (mapv parse-long (re-seq #"\d+" (str out)))))
+
 ;; Cluster-wide S3 counter sums for the run, accumulated across nodes in
 ;; log-files (which runs after the workload but before the checker, while the
 ;; brokers are still up). The coverage checker reads this. Collecting it here
@@ -183,9 +259,13 @@
 (defonce tiering-stats (atom {}))
 
 (defn record-tiering-stats!
-  "Adds `node`'s S3 counters into the shared per-run totals."
+  "Folds `node`'s S3 state into the shared per-run totals: counters are summed
+  across nodes, the epoch is maxed (it is cluster-global, so the max is exact)."
   [node]
-  (swap! tiering-stats #(merge-with + % (scrape-tiering-metrics node))))
+  (swap! tiering-stats
+         (fn [acc]
+           (-> (merge-with + acc (scrape-tiering-metrics node))
+               (update "max_epoch" (fnil max 0) (scrape-max-epoch node))))))
 
 (defn start! [test node]
   (info node "starting broker")
@@ -234,8 +314,10 @@
   []
   (reify db/DB
     (setup! [_ test node]
-      ;; Clean slate for this run's coverage counters (idempotent across nodes).
+      ;; Clean slate for this run's coverage counters and authoritative reads
+      ;; (idempotent across nodes).
       (reset! tiering-stats {})
+      (reset! sc/authoritative-reads {})
       (install! test node)
       (start! test node))
 
@@ -254,6 +336,11 @@
       ;; Scrape this node's S3 counters into the run totals (brokers are still
       ;; up here, before teardown) so the coverage checker can read them.
       (util/meh (record-tiering-stats! node))
+      ;; Authoritatively read every jepsen stream end-to-end for the durability
+      ;; checker, once (on the primary), while the brokers are still up. Uses the
+      ;; Stream client over a fresh Environment, so it needs no SSH context.
+      (when (= node (first (:nodes test)))
+        (util/meh (sc/capture-authoritative-reads! test (list-jepsen-keys node))))
       ;; Broker logs + the S3 plugin's status output for post-mortem.
       (util/meh
         (rabbitmqctl node :stream_s3_status

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
@@ -1,5 +1,5 @@
 (ns jepsen.streams3.nemesis
-  "Fault injection: network partitions plus the storage-tier
+  "Fault injection: network partitions plus the storage-tier and writer-fencing
   faults that are the whole point of testing this plugin. Currently:
 
     partition   - network partition (random halves)
@@ -9,9 +9,13 @@
                   already-tiered data failing then recovering
     s3-latency  - a Toxiproxy latency toxic on the S3 link: uploads fall behind
                   and manifests age while writes continue
+    leader-move - relocate every stream's leader to a replica mid-upload: the
+                  writer (and uploader) moves and the stream epoch bumps, fencing
+                  the deposed writer (its straggler uploads must be rejected on an
+                  epoch conflict, never overwrite the new leader's data)
 
   Still stubbed (see bottom): force-trim (needs the bounded-durability
-  checker) and leader-move (writer fencing)."
+  checker)."
   (:require [clojure.string :as str]
             [clojure.tools.logging :refer [info]]
             [jepsen [control :as c]
@@ -104,6 +108,20 @@
       (assoc op :value :trimmed))
     (teardown! [this _test] this)))
 
+(defn leader-move-nemesis
+  "Not a network fault: gracefully relocates every jepsen stream's leader to a
+  replica, moving the writer/uploader and bumping the stream epoch, which fences
+  the deposed writer. Run on one node only (the stream coordinator is cluster-
+  global), so each leadership transfer issues once rather than once per node."
+  []
+  (reify nemesis/Nemesis
+    (setup! [this _test] this)
+    (invoke! [_ test op]
+      (c/on-nodes test [(first (:nodes test))]
+                  (fn [_test node] (db/force-leader-move! node)))
+      (assoc op :value :leaders-moved))
+    (teardown! [this _test] this)))
+
 (defn full-nemesis
   "Composes all nemeses; the generator decides which faults actually fire."
   []
@@ -112,7 +130,8 @@
       :stop-partition  :stop}        (nemesis/partition-random-halves)
      #{:start-s3-outage :stop-s3-outage
        :start-s3-latency :stop-s3-latency} (s3-nemesis)
-     #{:trim-local}                  (trim-nemesis)}))
+     #{:trim-local}                  (trim-nemesis)
+     #{:move-leaders}                (leader-move-nemesis)}))
 
 ;; ---------------------------------------------------------------------------
 ;; Generator
@@ -123,24 +142,33 @@
    "s3-outage"  [:start-s3-outage :stop-s3-outage]
    "s3-latency" [:start-s3-latency :stop-s3-latency]})
 
+;; Background single-shot ops (not start/stop faults): a retention trim and a
+;; leader move. Each, when selected, runs steadily throughout the test — spread
+;; across the inter-fault gaps and, on its own, when no start/stop fault is
+;; enabled.
+(def ^:private fault->bg-op
+  {"trim"        {:type :info :f :trim-local}
+   "leader-move" {:type :info :f :move-leaders}})
+
 (defn nemesis-generator
-  "Rotates through the enabled faults one at a time, each led by a quiet
-  baseline period (so the workload establishes itself before the first fault,
-  and recovers between faults). When `trim` is selected (via --faults), a
-  steady local-retention trim runs throughout — between fault transitions and,
-  on its own, when no faults are enabled — so uploaded data is trimmed locally
-  and reads fall to the S3 tier. With nothing selected, an empty generator —
-  never a long sleep, which would deadlock a phase barrier on the nemesis."
+  "Rotates through the enabled start/stop faults one at a time, each led by a
+  quiet baseline period (so the workload establishes itself before the first
+  fault, and recovers between faults). Background single-shot ops selected via
+  --faults (`trim`, `leader-move`) run steadily throughout — between fault
+  transitions and, on their own, when no start/stop fault is enabled — so the
+  S3 read path and the writer-fencing path stay exercised. With nothing
+  selected, an empty generator — never a long sleep, which would deadlock a
+  phase barrier on the nemesis."
   [opts]
   (let [fs           (faults opts)
         interval     (or (:nemesis-interval opts) 15)
-        trim?        (contains? fs "trim")
-        fault-events (keep fault->events (sort (disj fs "trim")))
-        ;; One inter-fault gap: either a couple of trims spread across the
-        ;; interval, or just a quiet sleep.
-        spacer       (if trim?
-                       [(gen/sleep (/ interval 2)) {:type :info :f :trim-local}
-                        (gen/sleep (/ interval 2)) {:type :info :f :trim-local}]
+        bg-ops       (keep fault->bg-op (sort fs))
+        fault-events (keep fault->events (sort fs))
+        ;; One inter-fault gap: fire each background op twice across the
+        ;; interval, or, with no background op, just a quiet sleep.
+        spacer       (if (seq bg-ops)
+                       (let [gap (gen/sleep (/ interval (count bg-ops) 2))]
+                         (vec (mapcat (fn [op] [gap op gap op]) bg-ops)))
                        [(gen/sleep interval)])]
     (cond
       (seq fault-events)
@@ -149,8 +177,8 @@
                         spacer [{:type :info :f stop}]))
               (cycle fault-events))
 
-      trim?
-      (gen/stagger (/ interval 2) (repeat {:type :info :f :trim-local}))
+      (seq bg-ops)
+      (gen/stagger (/ interval 2) (cycle bg-ops))
 
       :else [])))
 
@@ -162,6 +190,3 @@
 ;;                n: drives reads to S3 (Tier overlap / Exactly-once) and, when
 ;;                pushed past un-uploaded data, Reset safety + bounded loss.
 ;;                Needs the bounded-durability checker first.
-;; leader-move  — relocate a stream leader mid-upload: deposed-writer uploads
-;;                must become GC orphans, never overwrite (key disjointness +
-;;                epoch monotonicity / writer fencing).

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
@@ -1,0 +1,62 @@
+(ns jepsen.streams3.nemesis
+  "Fault injection. Phase 1 ships the standard consensus-level faults
+  (partitions, broker kills). The storage-tier faults that are the whole point
+  of testing this plugin — S3 outage/latency via Toxiproxy, forced retention
+  trimming so reads must hit S3 / cross the seam, and forced leader moves to
+  exercise writer fencing — are stubbed here and land in phase 2."
+  (:require [clojure.string :as str]
+            [jepsen [nemesis :as nemesis]
+                    [generator :as gen]]))
+
+(defn faults
+  "The set of enabled faults, parsed from the --faults option."
+  [opts]
+  (set (remove str/blank? (str/split (or (:faults opts) "") #","))))
+
+;; ---------------------------------------------------------------------------
+;; Phase 1: partitions + kills
+;; ---------------------------------------------------------------------------
+
+(defn full-nemesis
+  "Composes the phase-1 nemeses. Each is addressed by its own :f so the
+  generator can target them independently. Phase 1 is partitions only; broker
+  kills and the storage-tier faults are added in phase 2 (see below)."
+  []
+  (nemesis/compose
+    {{:start-partition :start
+      :stop-partition  :stop} (nemesis/partition-random-halves)}))
+
+(defn nemesis-generator
+  "Alternates partitioning and healing on a fixed interval. Leads with a quiet
+  period (a sleep before the first fault) so the workload can create streams
+  and establish a baseline before anything is partitioned — otherwise the run
+  starts under a partition and never gets a clean footing. Phase 1 is
+  partitions only."
+  [opts]
+  (let [interval (or (:nemesis-interval opts) 15)]
+    (if (contains? (faults opts) "partition")
+      (cycle [(gen/sleep interval)
+              {:type :info :f :start-partition}
+              (gen/sleep interval)
+              {:type :info :f :stop-partition}])
+      ;; No faults selected: an empty generator that exhausts immediately, so
+      ;; the nemesis never holds up a phase barrier (a long sleep here would).
+      [])))
+
+;; ---------------------------------------------------------------------------
+;; Phase 2 (stubs): storage-tier faults
+;; ---------------------------------------------------------------------------
+;;
+;; s3-outage     — Toxiproxy: cut/timeout the broker->MinIO link mid-upload.
+;;                 Exercises "write availability never blocks on S3" + replica
+;;                 manifest staleness/resync.
+;; s3-latency    — Toxiproxy latency toxic; uploads fall behind, manifests age.
+;; force-trim    — drop a stream's local retention so f_local crosses the seam
+;;                 n: drives reads to S3 (Tier overlap / Exactly-once) and, when
+;;                 pushed past un-uploaded data, Reset safety + bounded loss.
+;; leader-move   — relocate a stream leader mid-upload: deposed-writer uploads
+;;                 must become GC orphans, never overwrite (key disjointness +
+;;                 epoch monotonicity / writer fencing).
+;;
+;; These compose with the phase-1 faults; the bounded-durability checker
+;; (phase 3) is required before running force-trim aggressively.

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/nemesis.clj
@@ -1,12 +1,28 @@
 (ns jepsen.streams3.nemesis
-  "Fault injection. Phase 1 ships the standard consensus-level faults
-  (partitions, broker kills). The storage-tier faults that are the whole point
-  of testing this plugin — S3 outage/latency via Toxiproxy, forced retention
-  trimming so reads must hit S3 / cross the seam, and forced leader moves to
-  exercise writer fencing — are stubbed here and land in phase 2."
+  "Fault injection: network partitions plus the storage-tier
+  faults that are the whole point of testing this plugin. Currently:
+
+    partition   - network partition (random halves)
+    s3-outage   - cut the broker->MinIO link (disable the Toxiproxy proxy):
+                  exercises 'write availability never blocks on S3', uploads
+                  falling behind, replica manifest staleness, and reads of
+                  already-tiered data failing then recovering
+    s3-latency  - a Toxiproxy latency toxic on the S3 link: uploads fall behind
+                  and manifests age while writes continue
+
+  Still stubbed (see bottom): force-trim (needs the bounded-durability
+  checker) and leader-move (writer fencing)."
   (:require [clojure.string :as str]
-            [jepsen [nemesis :as nemesis]
-                    [generator :as gen]]))
+            [clojure.tools.logging :refer [info]]
+            [jepsen [control :as c]
+                    [nemesis :as nemesis]
+                    [generator :as gen]]
+            [jepsen.streams3.db :as db])
+  (:import (java.net URI)
+           (java.net.http HttpClient
+                          HttpRequest
+                          HttpRequest$BodyPublishers
+                          HttpResponse$BodyHandlers)))
 
 (defn faults
   "The set of enabled faults, parsed from the --faults option."
@@ -14,49 +30,138 @@
   (set (remove str/blank? (str/split (or (:faults opts) "") #","))))
 
 ;; ---------------------------------------------------------------------------
-;; Phase 1: partitions + kills
+;; Toxiproxy admin API (reached from the control node at toxiproxy:8474)
 ;; ---------------------------------------------------------------------------
 
+(def ^:private toxiproxy-base "http://toxiproxy:8474")
+
+;; The S3 proxy as declared in docker/toxiproxy.json; re-sent in full when
+;; toggling `enabled`.
+(def ^:private s3-proxy
+  {:name "s3" :listen "0.0.0.0:443" :upstream "minio:443"})
+
+(defn- json [m]
+  (str "{" (str/join "," (map (fn [[k v]]
+                                (str \" (name k) "\":"
+                                     (cond (string? v) (str \" v \")
+                                           (map? v) (json v)
+                                           :else v)))
+                              m)) "}"))
+
+(defn- toxiproxy! [method path body]
+  (let [b (-> (HttpRequest/newBuilder (URI/create (str toxiproxy-base path)))
+              (.header "Content-Type" "application/json"))
+        req (-> (case method
+                  :post   (.POST b (HttpRequest$BodyPublishers/ofString (or body "")))
+                  :delete (.DELETE b)
+                  :get    (.GET b))
+                (.build))
+        resp (.send (HttpClient/newHttpClient) req (HttpResponse$BodyHandlers/ofString))]
+    {:status (.statusCode resp) :body (.body resp)}))
+
+(defn- set-s3-enabled! [enabled?]
+  (toxiproxy! :post "/proxies/s3" (json (assoc s3-proxy :enabled enabled?))))
+
+(defn- add-s3-latency! [ms jitter]
+  (toxiproxy! :post "/proxies/s3/toxics"
+              (json {:name "s3-latency" :type "latency" :stream "downstream"
+                     :attributes {:latency ms :jitter jitter}})))
+
+(defn- remove-s3-latency! []
+  (toxiproxy! :delete "/proxies/s3/toxics/s3-latency" nil))
+
+;; ---------------------------------------------------------------------------
+;; Nemeses
+;; ---------------------------------------------------------------------------
+
+(defn s3-nemesis
+  "Drives S3 faults through Toxiproxy. teardown! restores the link."
+  []
+  (reify nemesis/Nemesis
+    (setup! [this _test] this)
+    (invoke! [_ _test op]
+      (assoc op :value
+             (case (:f op)
+               :start-s3-outage  (do (info "S3 outage: disabling proxy") (set-s3-enabled! false))
+               :stop-s3-outage   (do (info "S3 outage: re-enabling proxy") (set-s3-enabled! true))
+               :start-s3-latency (do (info "S3 latency: adding toxic") (add-s3-latency! 2000 1000))
+               :stop-s3-latency  (do (info "S3 latency: removing toxic") (remove-s3-latency!)))))
+    (teardown! [this _test]
+      (try (set-s3-enabled! true) (catch Exception _))
+      (try (remove-s3-latency!) (catch Exception _))
+      this)))
+
+(defn trim-nemesis
+  "Not a fault: forces local-retention evaluation on every node so segments
+  already uploaded to S3 are trimmed locally and reads of older offsets fall
+  back to the S3 tier. Without this the workload's data stays local and the
+  read-from-S3 path is never exercised."
+  []
+  (reify nemesis/Nemesis
+    (setup! [this _test] this)
+    (invoke! [_ test op]
+      (c/on-nodes test (fn [_test node] (db/force-local-trim! node)))
+      (assoc op :value :trimmed))
+    (teardown! [this _test] this)))
+
 (defn full-nemesis
-  "Composes the phase-1 nemeses. Each is addressed by its own :f so the
-  generator can target them independently. Phase 1 is partitions only; broker
-  kills and the storage-tier faults are added in phase 2 (see below)."
+  "Composes all nemeses; the generator decides which faults actually fire."
   []
   (nemesis/compose
     {{:start-partition :start
-      :stop-partition  :stop} (nemesis/partition-random-halves)}))
+      :stop-partition  :stop}        (nemesis/partition-random-halves)
+     #{:start-s3-outage :stop-s3-outage
+       :start-s3-latency :stop-s3-latency} (s3-nemesis)
+     #{:trim-local}                  (trim-nemesis)}))
+
+;; ---------------------------------------------------------------------------
+;; Generator
+;; ---------------------------------------------------------------------------
+
+(def ^:private fault->events
+  {"partition"  [:start-partition :stop-partition]
+   "s3-outage"  [:start-s3-outage :stop-s3-outage]
+   "s3-latency" [:start-s3-latency :stop-s3-latency]})
 
 (defn nemesis-generator
-  "Alternates partitioning and healing on a fixed interval. Leads with a quiet
-  period (a sleep before the first fault) so the workload can create streams
-  and establish a baseline before anything is partitioned — otherwise the run
-  starts under a partition and never gets a clean footing. Phase 1 is
-  partitions only."
+  "Rotates through the enabled faults one at a time, each led by a quiet
+  baseline period (so the workload establishes itself before the first fault,
+  and recovers between faults). When `trim` is selected (via --faults), a
+  steady local-retention trim runs throughout — between fault transitions and,
+  on its own, when no faults are enabled — so uploaded data is trimmed locally
+  and reads fall to the S3 tier. With nothing selected, an empty generator —
+  never a long sleep, which would deadlock a phase barrier on the nemesis."
   [opts]
-  (let [interval (or (:nemesis-interval opts) 15)]
-    (if (contains? (faults opts) "partition")
-      (cycle [(gen/sleep interval)
-              {:type :info :f :start-partition}
-              (gen/sleep interval)
-              {:type :info :f :stop-partition}])
-      ;; No faults selected: an empty generator that exhausts immediately, so
-      ;; the nemesis never holds up a phase barrier (a long sleep here would).
-      [])))
+  (let [fs           (faults opts)
+        interval     (or (:nemesis-interval opts) 15)
+        trim?        (contains? fs "trim")
+        fault-events (keep fault->events (sort (disj fs "trim")))
+        ;; One inter-fault gap: either a couple of trims spread across the
+        ;; interval, or just a quiet sleep.
+        spacer       (if trim?
+                       [(gen/sleep (/ interval 2)) {:type :info :f :trim-local}
+                        (gen/sleep (/ interval 2)) {:type :info :f :trim-local}]
+                       [(gen/sleep interval)])]
+    (cond
+      (seq fault-events)
+      (mapcat (fn [[start stop]]
+                (concat spacer [{:type :info :f start}]
+                        spacer [{:type :info :f stop}]))
+              (cycle fault-events))
+
+      trim?
+      (gen/stagger (/ interval 2) (repeat {:type :info :f :trim-local}))
+
+      :else [])))
 
 ;; ---------------------------------------------------------------------------
-;; Phase 2 (stubs): storage-tier faults
+;; Still stubbed
 ;; ---------------------------------------------------------------------------
 ;;
-;; s3-outage     — Toxiproxy: cut/timeout the broker->MinIO link mid-upload.
-;;                 Exercises "write availability never blocks on S3" + replica
-;;                 manifest staleness/resync.
-;; s3-latency    — Toxiproxy latency toxic; uploads fall behind, manifests age.
-;; force-trim    — drop a stream's local retention so f_local crosses the seam
-;;                 n: drives reads to S3 (Tier overlap / Exactly-once) and, when
-;;                 pushed past un-uploaded data, Reset safety + bounded loss.
-;; leader-move   — relocate a stream leader mid-upload: deposed-writer uploads
-;;                 must become GC orphans, never overwrite (key disjointness +
-;;                 epoch monotonicity / writer fencing).
-;;
-;; These compose with the phase-1 faults; the bounded-durability checker
-;; (phase 3) is required before running force-trim aggressively.
+;; force-trim   — drop a stream's local retention so f_local crosses the seam
+;;                n: drives reads to S3 (Tier overlap / Exactly-once) and, when
+;;                pushed past un-uploaded data, Reset safety + bounded loss.
+;;                Needs the bounded-durability checker first.
+;; leader-move  — relocate a stream leader mid-upload: deposed-writer uploads
+;;                must become GC orphans, never overwrite (key disjointness +
+;;                epoch monotonicity / writer fencing).

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/workload.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/workload.clj
@@ -1,0 +1,23 @@
+(ns jepsen.streams3.workload
+  "Reuses the jepsen.tests.kafka ordered-log workload (generator + anomaly
+  checkers: lost writes, duplicates, offset monotonicity, consumer/producer
+  offset jumps, G0/G1c) and plugs in our Stream-protocol client.
+
+  We run NON-transactional send/poll only (streams have no cross-stream
+  transactions) with a single subscription mechanism, and rely on the stock
+  'no acknowledged write is lost' assertion being sound because retention is
+  configured wide (db.clj). A bounded-durability variant that only flags loss
+  inside the durable range [f,n) is still to come, alongside aggressive
+  retention faults."
+  (:require [jepsen.tests.kafka :as kafka]
+            [jepsen.streams3.client :as sc]))
+
+(defn workload
+  "Returns a Jepsen workload map {:client :generator :final-generator :checker}
+  for the kafka log model, backed by our Stream client."
+  [opts]
+  (assoc (kafka/workload (merge {:sub-via #{:assign}
+                                 :txn?   false
+                                 :crash-clients? false}
+                                opts))
+         :client (sc/client)))


### PR DESCRIPTION
This is an adaptation of the ra-kv Jepsen test done upstream. Jepsen is a black-box testing framework which injects faults and checks that the chosen guarantees are still satisfied. We can adapt the Kafka Jepsen checker and introduce additional nemeses to fault inject S3. We run MinIO as a local S3 and put it behind Toxiproxy to simulate transient network errors. Communication with the broker uses the official Java streams client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
