### PR TITLE
Refresh past the current fragment's offset when it 404s (#173)

### DIFF
--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -369,19 +369,7 @@ try_serve(#state{pending = #pending{offset = Offset, bytes = Bytes}} = State) ->
             {State3, Effects} = maybe_start_requests(State2),
             {State3, [{observe, miss, State3#state.read_size} | Effects]};
         {not_found_check_range, State1} ->
-            %% Fragment was 404. Refresh iterator past it. If the iterator
-            %% is exhausted (last fragment in manifest was deleted), fall
-            %% back to refreshing past the current fragment's offset.
-            case next_fragment_offset(State1) of
-                {ok, NotFoundOffset} ->
-                    {State1, [{refresh_iterator, NotFoundOffset}]};
-                end_of_manifest ->
-                    {State1, [{refresh_iterator, current_fragment_offset(State1)}]};
-                group_fetch_failed ->
-                    %% Probing the next entry hit a transient group fetch
-                    %% error. Retry rather than becoming local.
-                    retry_group_fetch(State1)
-            end;
+            not_found_refresh(State1);
         {refresh_iterator, State1} ->
             %% Iterator exhausted. Refresh past current fragment.
             {State1, [{refresh_iterator, current_fragment_offset(State1)}]};
@@ -491,22 +479,46 @@ retry_group_fetch(
 %% Internal: fragment navigation
 %% ------------------------------------------------------------------
 
+%% Decide which offset to refresh the iterator past after a 404. Two paths
+%% reach `not_found_check_range`, and they 404'd different fragments, so they
+%% must refresh past different offsets:
+%%
+%%  1. `try_fragment_transition` matching `next = not_found`: the consumer read
+%%     past the current fragment and the prefetched *next* fragment 404'd. The
+%%     iterator still points at that 404'd next entry, so `next_fragment_offset`
+%%     returns its offset and we refresh past it. `current_not_found` is false.
+%%
+%%  2. `try_read` matching `current_not_found = true`: the *current* fragment
+%%     404'd. The iterator was advanced past the current entry at init, so it
+%%     points at the entry AFTER the 404'd one - a fragment that is still live.
+%%     Refreshing past *that* offset would silently skip the live fragment
+%%     (issue #173), so refresh past the current fragment's own offset instead.
+%%
+%% In both cases the shell's refresh_iterator/2 advances past anything at or
+%% below the given offset and resumes at the first surviving fragment, so
+%% passing the actually-404'd offset is what keeps a live fragment from being
+%% skipped.
+not_found_refresh(#state{current_not_found = true} = State) ->
+    %% Path 2: the current fragment 404'd. Refresh past its own offset.
+    {State, [{refresh_iterator, current_fragment_offset(State)}]};
+not_found_refresh(State) ->
+    %% Path 1: the prefetched next fragment 404'd. Refresh past it, falling
+    %% back to the current offset if the iterator is exhausted (the 404'd
+    %% next was the last entry in the manifest).
+    case next_fragment_offset(State) of
+        {ok, NotFoundOffset} ->
+            {State, [{refresh_iterator, NotFoundOffset}]};
+        end_of_manifest ->
+            {State, [{refresh_iterator, current_fragment_offset(State)}]};
+        group_fetch_failed ->
+            %% Probing the next entry hit a transient group fetch error. Retry
+            %% rather than becoming local.
+            retry_group_fetch(State)
+    end.
+
 %% Returns the offset of the next fragment in the iterator, or
-%% `end_of_manifest` if the iterator is exhausted. Called from the
-%% `not_found_check_range` branch of `try_serve`. There are two paths
-%% into that branch:
-%%
-%%  1. `try_fragment_transition` matching `next = not_found`: the consumer
-%%     read past the current fragment and the prefetched-next 404'd. The
-%%     iterator is positioned at the 404'd entry, so this returns the
-%%     404'd offset.
-%%
-%%  2. `try_read` matching `current_not_found = true`: the *current*
-%%     fragment 404'd while no read was pending; a later read wants bytes
-%%     past the partial buffer. The iterator was already advanced past
-%%     the current fragment, so it points at the entry AFTER the 404'd
-%%     one. If the current fragment was the last in the manifest, the
-%%     iterator is exhausted and this returns `end_of_manifest`.
+%% `end_of_manifest` if the iterator is exhausted (see not_found_refresh/1
+%% for the two paths that use this).
 next_fragment_offset(#state{iterator = Iterator}) ->
     case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
         {ok, #fragment_ref{offset = Offset}, _} -> {ok, Offset};

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -48,6 +48,7 @@ all() ->
         fragment_404_emits_refresh_iterator,
         last_fragment_404_no_pending_read_refreshes_past_current,
         current_fragment_404_no_pending_read_keeps_next_live_fragment,
+        current_and_next_404_read_past_current_keeps_surviving_fragment,
         observe_effects_emitted_for_hit_miss_and_transition,
         %% A retryable error drops only the failed fragment, not all in-flight
         retryable_error_preserves_co_pending_request,
@@ -334,6 +335,56 @@ current_fragment_404_no_pending_read_keeps_next_live_fragment(_Config) ->
         S2, {iterator_refreshed, RefreshedIterator}
     ),
     ?assertMatch([{reply, {next_fragment, 100}} | _], E2).
+
+%% Regression for #173, the subtle interleaving: the current fragment 404s
+%% (current_not_found = true) AND its prefetched next fragment also 404s
+%% (next = not_found) before any read, then the consumer reads PAST the current
+%% fragment. That read takes try_fragment_transition's `next = not_found` clause
+%% (the path-1 producer of not_found_check_range), but current_not_found is also
+%% set. The refresh must still target the current fragment's offset, not the
+%% next's, so a fragment that survived retention after both 404'd offsets is not
+%% skipped. Refreshing past the current (smaller) offset is always safe because
+%% refresh_iterator re-derives position from the live manifest and lands on the
+%% first surviving fragment greater than the target.
+current_and_next_404_read_past_current_keeps_surviving_fragment(_Config) ->
+    %% Fragments 0, 100, 200 live at init; the reader is on 0, iterator at 100.
+    Entries = [{0, 1_000_000, 1}, {100, 1_000_000, 2}, {200, 1_000_000, 3}],
+    FragRef = frag_ref(0, 1_000_000, 1),
+    Iterator = mock_iterator(Entries),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% Fill the current fragment's buffer so a read past it transitions rather
+    %% than awaiting more data for the current fragment.
+    Data = binary:copy(<<0>>, 1_000_000),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {data, make_ref(), 0, Data, done}
+    ),
+
+    %% Current fragment (0) 404s with no read pending: records current_not_found.
+    {S2, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {request_error, make_ref(), 0, not_found}
+    ),
+    %% The prefetched next fragment (100) also 404s: sets next = not_found. Now
+    %% both flags are set on the same state.
+    {S3, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {request_error, make_ref(), 100, not_found}
+    ),
+
+    %% Read past the end of the current fragment (>= 64 + 1_000_000). This takes
+    %% try_fragment_transition (next = not_found), but current_not_found is also
+    %% set, so the refresh must target the current offset (0), not 100.
+    {S4, E1} = rabbitmq_stream_s3_remote_reader_core:step(
+        S3, {read, 64 + 1_000_000, 100, chunk_boundary}
+    ),
+    ?assertMatch([{refresh_iterator, 0}], E1),
+
+    %% With 0 and 100 both gone from the tier, the refresh lands on the surviving
+    %% fragment 200 - not skipped, not become_local.
+    RefreshedIterator = mock_iterator([{0, 1_000_000, 1}, {200, 1_000_000, 3}]),
+    {_S5, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S4, {iterator_refreshed, RefreshedIterator}
+    ),
+    ?assertMatch([{reply, {next_fragment, 200}} | _], E2).
 
 %% ------------------------------------------------------------------
 %% AIMD and retry tests

--- a/test/remote_reader_core_SUITE.erl
+++ b/test/remote_reader_core_SUITE.erl
@@ -47,6 +47,7 @@ all() ->
         deadline_expired_resets_buffer_for_retry,
         fragment_404_emits_refresh_iterator,
         last_fragment_404_no_pending_read_refreshes_past_current,
+        current_fragment_404_no_pending_read_keeps_next_live_fragment,
         observe_effects_emitted_for_hit_miss_and_transition,
         %% A retryable error drops only the failed fragment, not all in-flight
         retryable_error_preserves_co_pending_request,
@@ -296,6 +297,43 @@ not_found_triggers_refresh_iterator(_Config) ->
         S2, {iterator_refreshed, end_of_manifest}
     ),
     ?assertMatch([{reply, {become_local, 0}}], E2).
+
+%% Regression for #173. When the CURRENT fragment 404s while no read is pending
+%% and the manifest has further live fragments, the refresh must advance past
+%% the current (404'd) fragment's own offset, not the next fragment's offset.
+%% The iterator is positioned past the current entry at init, so refreshing past
+%% the next entry's offset would silently skip a live fragment.
+current_fragment_404_no_pending_read_keeps_next_live_fragment(_Config) ->
+    %% Three live fragments. The reader is on the first (offset 0); the iterator
+    %% is positioned at the second (offset 100) after init advances past 0.
+    Entries = [{0, 1_000_000, 1}, {100, 1_000_000, 2}, {200, 1_000_000, 3}],
+    FragRef = frag_ref(0, 1_000_000, 1),
+    Iterator = mock_iterator(Entries),
+    {S0, _} = init(stream_id(), FragRef, 64, Iterator),
+
+    %% The current fragment 404s before any read is pending: no effect yet, the
+    %% reader just records current_not_found.
+    {S1, E0} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {request_error, make_ref(), 0, not_found}
+    ),
+    ?assertMatch([], E0),
+
+    %% A later read wants bytes past the (empty) buffer, taking the
+    %% current_not_found path. The refresh must target the current 404'd offset
+    %% (0), NOT the next live fragment's offset (100). Before the fix this was
+    %% {refresh_iterator, 100}, which made the shell skip fragment 100.
+    {S2, E1} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, 64, 100, chunk_boundary}
+    ),
+    ?assertMatch([{refresh_iterator, 0}], E1),
+
+    %% The shell refreshes past offset 0, leaving the iterator at the live
+    %% fragment 100. The reader resumes there rather than skipping to 200.
+    RefreshedIterator = mock_iterator(Entries),
+    {_S3, E2} = rabbitmq_stream_s3_remote_reader_core:step(
+        S2, {iterator_refreshed, RefreshedIterator}
+    ),
+    ?assertMatch([{reply, {next_fragment, 100}} | _], E2).
 
 %% ------------------------------------------------------------------
 %% AIMD and retry tests


### PR DESCRIPTION
Closes #173

## The bug (silent consumer data loss)

The `not_found_check_range` handler in `rabbitmq_stream_s3_remote_reader_core` refreshed the iterator past `next_fragment_offset` for both 404 paths, but the two paths leave the iterator pointing at different entries:

- When the prefetched *next* fragment 404s (`next = not_found`, via `try_fragment_transition`), the iterator points at that 404'd entry, so refreshing past it is correct.
- When the *current* fragment 404s with no read pending (`current_not_found = true`), the iterator was already advanced past the current entry at init, so it points at the *next* entry, which is still live. Refreshing past that offset made the shell's `refresh_iterator/2` (which advances past anything `=< NotFoundOffset`) skip the live fragment, silently dropping a contiguous block of consumer data with no error.

Concrete example with fragments at offsets [100, 200, 300] reading 100: 100 404s, the refresh was told `200`, and the reader resumed at `300`. Fragment 200 was live and silently skipped.

## The fix

Split the decision into `not_found_refresh/1`:

- `current_not_found = true` (current fragment 404'd): refresh past the current fragment's own offset, the one that actually 404'd, keeping the live next fragment.
- otherwise (prefetched next 404'd): unchanged, refresh past `next_fragment_offset` with the `end_of_manifest` / `group_fetch_failed` handling intact.

Refreshing past the current (smaller) offset is always safe: `refresh_iterator/2` re-derives position from the live manifest and lands on the first surviving fragment greater than the target, so a smaller target can never skip a live fragment. Passing the larger `next` offset was the only choice that could.

## Tests

Two regression tests, both confirmed to fail on the pre-fix code and pass with the fix:

- `current_fragment_404_no_pending_read_keeps_next_live_fragment`: the primary path, a multi-fragment manifest with the 404-before-read ordering that the existing single-fragment 404 tests never exercised.
- `current_and_next_404_read_past_current_keeps_surviving_fragment`: the subtle interleaving where the current fragment and its prefetched next both 404 before a read, then the consumer reads past the current fragment. Confirms the refresh still targets the current offset and the surviving fragment is not skipped.

`remote_reader_core_SUITE` and `read_resolution_SUITE` pass; dialyzer clean.

## Note on coverage

This is verified at the functional-core level (deterministic state-machine paths). It is not yet exercised end-to-end against live S3 retention; the integration suite cannot currently catch a retention-induced fragment skip because gap detection and active retention never overlap in a single test. That gap is tracked separately in #302.