### PR TITLE
Evaluate local retention when a manifest is resolved or synced (#75)

### DIFF
--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -491,8 +491,36 @@ maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs) ->
         false ->
             write_manifest(StreamId, Manifest, Epoch),
             seed_first_offset_counter(StreamId, Manifest, Ctxs),
+            %% Evaluate local retention once against the freshly synced manifest.
+            %% On a replica, retention is otherwise only driven by edits that
+            %% advance next_offset; a replica that was offline (an upgrade, say),
+            %% receives a full sync on rejoin, and whose stream then stops
+            %% publishing would never reclaim the local segments already durable
+            %% in the remote tier. This one-shot pass reclaims them. It is a no-op
+            %% for an empty manifest or a stream with no registered context here
+            %% (issue #75).
+            maybe_evaluate_retention_on_sync(StreamId, Manifest, Ctxs),
             Seqs#{StreamId => {Seq, Epoch, WriterNode}}
     end.
+
+%% Run local retention against a just-synced manifest, guarding on the same
+%% conditions run_local_retention requires: a registered replica context on this
+%% node and a non-empty manifest (next_offset > 0, so the first_timestamp
+%% sentinel never reaches the counters). Unlike the edit-driven
+%% maybe_evaluate_retention/4 this does not require next_offset to have advanced,
+%% because a sync establishes the manifest wholesale rather than moving it
+%% forward.
+maybe_evaluate_retention_on_sync(StreamId, #manifest{next_offset = Next} = Manifest, Ctxs) when
+    Next > 0
+->
+    case maps:get(StreamId, Ctxs, undefined) of
+        #replica_ctx{} = Ctx ->
+            run_local_retention(StreamId, Manifest, Ctx);
+        undefined ->
+            ok
+    end;
+maybe_evaluate_retention_on_sync(_StreamId, #manifest{}, _Ctxs) ->
+    ok.
 
 %% A sync is stale only when an entry is already recorded and the incoming
 %% (epoch, seq) is strictly older. Epoch dominates sequence so a higher epoch is

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -2256,6 +2256,16 @@ on_manifest_resolved(
     counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, ManifestFirst)),
     LocalFirstTs = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP),
     counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, min(LocalFirstTs, ManifestFirstTs)),
+    %% Evaluate local retention once against the just-resolved manifest. Local
+    %% retention is otherwise only triggered by a persist (which a new publish
+    %% drives), so a stream that resolves a non-empty manifest and then stays
+    %% idle - for example a replica that was offline for an upgrade, caught up
+    %% from the writer, and whose stream then stopped publishing - would never
+    %% reclaim the local segments already durable in the remote tier. This
+    %% one-shot pass reclaims them. It only deletes segments fully below the
+    %% manifest's next_offset, which is where the reader opens, so it cannot
+    %% trim data the reader is about to read (issue #75).
+    maybe_evaluate_retention(Manifest, State),
     State.
 
 on_remote_retention_deleted(Refs, StreamId, State) ->

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -44,6 +44,7 @@ have a way to form a barrier. To assert the results of retention we use the
     start_replica_reader/3,
     flush_writer/1,
     seed_log/2,
+    build_manifest/1,
     await_offset/2,
     list_fragment_offsets/1,
     list_segment_offsets/1,
@@ -69,6 +70,7 @@ groups() ->
             fragment_spans_segment_boundary,
             range_advances_monotonically,
             retention_reclaims_uploaded_segments,
+            sync_triggers_local_retention_on_idle_replica,
             message_count_reflects_remote_tier,
             resumes_after_restart,
             lost_transfer_result_recovered_by_deadline,
@@ -421,6 +423,54 @@ retention_reclaims_uploaded_segments(Config) ->
 
     %% Retention will eventually reclaim everything but the current segment.
     ?awaitMatch([_], list_segment_offsets(Config), 1_000).
+
+sync_triggers_local_retention_on_idle_replica(Config) ->
+    %% #75 (replica node, the scenario the issue describes). A replica that was
+    %% offline, rejoins and receives a full manifest sync, then sees its stream
+    %% go idle, must reclaim the local segments already durable in the remote
+    %% tier. On a replica, retention is otherwise only driven by edits that
+    %% advance next_offset; a sync establishes the manifest wholesale and so
+    %% never triggered retention before this fix.
+    StreamId = ?config(stream_id, Config),
+
+    %% Seed a real multi-segment local log: three older segments plus an active
+    %% one. seed_log writes directly to disk, bypassing the writer.
+    #{next_offset := NextOffset} = seed_log(Config, [
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]},
+        {segment, [{chunk, #{records => 5, size => 600}}]}
+    ]),
+    ?assert(length(list_segment_offsets(Config)) > 1),
+
+    %% Register a replica context for this stream pointing at the seeded log,
+    %% as the acceptor hook does on a replica node.
+    WriterCfg = ?config(writer_cfg, Config),
+    OsirisDir = ?config(osiris_dir, Config),
+    Dir = filename:join(OsirisDir, maps:get(name, WriterCfg)),
+    Shared = osiris_log_shared:new(),
+    Counter = counters:new(5, []),
+    Member = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    ok = rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        StreamId, Member, Dir, Shared, Counter
+    ),
+
+    %% Build a manifest covering all the seeded data (next_offset = end of log)
+    %% and sync it, as a writer would to a rejoining replica. No edits follow.
+    {Manifest, _} = build_manifest([
+        {fragment, #{offset => 0, size => 1000}}
+    ]),
+    Covering = Manifest#manifest{next_offset = NextOffset},
+    ok = rabbitmq_stream_s3_manifest_replica:sync(StreamId, 0, 1, Covering),
+
+    %% The sync alone (no edits, no new writes) reclaims the older local
+    %% segments: only the active segment remains.
+    ?awaitMatch([_], list_segment_offsets(Config), 5000),
+    exit(Member, kill).
 
 message_count_reflects_remote_tier(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
Closes #75

## Problem

Local retention reclaims local segments whose data is already durable in the remote tier. It was only ever triggered by a manifest persist, which a new publish drives. So a stream that learns about the remote tier and then stays idle never reclaimed its redundant local data.

This is the scenario in #75: a replica that was offline (an upgrade, for example), rejoins and catches up from the writer, and whose stream then stops publishing. It replicates all the data but never cleans up the local copies already in S3.

## Fix

Two paths learn about the remote tier without a publish following, and neither evaluated retention:

- **Replica node** (the case #75 describes): `manifest_replica:maybe_apply_sync` applies a full sync but did not evaluate retention; only edits that advance `next_offset` did. A returning replica receives a full *sync*, not incremental edits, so retention never ran. Now a one-shot local retention pass runs after a non-stale sync, guarded on a registered replica context and a non-empty manifest.

- **Writer node**: `replica_reader:on_manifest_resolved` seeds counters on resolution but did not evaluate retention. Add the same one-shot pass so a reader that resolves a non-empty manifest and then stays idle reclaims too. This is defensive: on the writer node the persist-driven pass normally runs first, so this rarely has work to do, but it closes the same gap on that side.

Both reuse the existing local-retention evaluation, which only deletes segments fully below the manifest's `next_offset` (which is where the reader opens), so it cannot trim data a reader is about to read.

## Test

`sync_triggers_local_retention_on_idle_replica` seeds a real multi-segment local log, registers a replica context pointing at it, and syncs a manifest covering all the data, with no edits and no new writes. The older segments are reclaimed by the sync alone. The test fails without the fix (the await times out because the segments are never reclaimed) and passes with it.

The writer-side path calls the same `maybe_evaluate_retention` already exercised by `retention_reclaims_uploaded_segments` and the CLI `evaluate_local_retention`. A dedicated writer-side test was not added: on the writer node the persist-driven retention runs during the initial upload, so constructing uploaded-but-untrimmed local segments at resolve time requires fragile state-forging for a defensive path; the replica-side test covers the substantive scenario end to end.

Full `replica_reader_SUITE` and `manifest_replica_SUITE` pass; dialyzer clean.

## Note

The issue's framing pointed at the writer side, but the substantive gap turned out to be the replica sync path. This was a touch larger than the `E-small` label suggested; closer to `E-medium`.