### PR TITLE
Reclaim a deleted stream's straggler objects via a tombstone (#196)

### DIFF
--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -27,6 +27,17 @@ writer cannot make progress anymore.
 -include_lib("rabbit_common/include/resource.hrl").
 
 -define(PATH(StreamId), ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId])).
+%% Tombstone path for a deleted stream. Deliberately under a separate root from
+%% ?PATH/1 and with no keep-while condition, so it survives the keep-while
+%% removal of the stream entry (that removal is what fires the deletion trigger).
+%% A tombstone records that a stream's remote-tier prefix holds no live data and
+%% may be swept in full, the positive "stream deleted" signal that lets GC
+%% reclaim objects left by an upload that completed after the deletion sweep
+%% (issue #196). StreamIds embed a nanosecond timestamp, so a recreated stream
+%% gets a distinct id and cannot alias an existing tombstone.
+-define(TOMBSTONE_PATH(StreamId),
+    ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3_deleted, StreamId])
+).
 -define(STREAM_QUEUE_DELETION_TRIGGER_ID, rabbitmq_stream_s3_db_sq_deletion).
 %% Bounds a consistent read so it cannot block indefinitely waiting for a quorum
 %% that will not form (for example on a minority partition); timing out there
@@ -46,11 +57,16 @@ Zero indicates that the manifest has not been created yet.
     revision := revision()
 }.
 
--export_type([revision/0, entry/0]).
+%% Payload of a deletion tombstone. Carries whatever is useful for diagnosis or
+%% a future expiry policy; `deleted_at` is wall-clock milliseconds at deletion.
+-type tombstone() :: #{deleted_at := integer()}.
+
+-export_type([revision/0, entry/0, tombstone/0]).
 
 -export([setup/0]).
 
 -export([get/1, get_consistent/1, list/0, count/0, put/5, queue_path/1]).
+-export([write_tombstone/1, list_tombstones/0, delete_tombstone/1]).
 
 -define(C_SPROC_TRIGGERS, 1).
 -define(C_GETS, 2).
@@ -116,6 +132,13 @@ handle_queue_deletion(#{path := ?PATH(StreamId)}) ->
     %% Khepri leader node. This may not be the same node as the stream's writer
     %% process. And in larger clusters (5, 7, 9 nodes, etc..) this might not
     %% be a node of a replica either.
+    %%
+    %% The sproc runs synchronously inside the single khepri_event_handler
+    %% gen_server (Khepri dispatches triggered sprocs there via a mod_call
+    %% effect). A synchronous khepri:put from here would block that one handler
+    %% on its own Ra command and stall all trigger processing, so the tombstone
+    %% is written from the reaper's independent task process instead; see
+    %% rabbitmq_stream_s3_reaper:delete_stream/1.
     ok = rabbitmq_stream_s3_reaper:delete_stream(StreamId).
 
 -doc "Gets the latest-known manifest root UID and revision with a low-latency local read.".
@@ -169,6 +192,45 @@ list() ->
 -spec count() -> {ok, non_neg_integer()} | {error, any()}.
 count() ->
     rabbit_khepri:count(?PATH(#if_has_data{})).
+
+-doc """
+Write a tombstone marking a stream as deleted.
+
+Recorded by the queue-deletion trigger before the remote-tier sweep. The payload
+is a map of whatever is useful for diagnosis and a possible future expiry; for
+now the wall-clock deletion time. The tombstone is removed once the prefix is
+confirmed empty (by the reaper after its sweep, or by GC after reclaiming a
+straggler). See ?TOMBSTONE_PATH and issue #196.
+""".
+-spec write_tombstone(stream_id()) -> ok | {error, any()}.
+write_tombstone(StreamId) ->
+    Tombstone = #{deleted_at => erlang:system_time(millisecond)},
+    khepri:put(rabbit_khepri:get_store_id(), ?TOMBSTONE_PATH(StreamId), Tombstone).
+
+-doc "Lists the stream IDs that currently have a deletion tombstone.".
+-spec list_tombstones() -> {ok, #{stream_id() => tombstone()}} | {error, any()}.
+list_tombstones() ->
+    case rabbit_khepri:adv_get_many(?TOMBSTONE_PATH(#if_has_data{})) of
+        {ok, NodeProps} ->
+            Tombstones =
+                #{
+                    StreamId => Data
+                 || ?TOMBSTONE_PATH(StreamId) := #{data := Data} <- NodeProps
+                },
+            {ok, Tombstones};
+        {error, _} = Err ->
+            Err
+    end.
+
+-doc """
+Remove a stream's deletion tombstone.
+
+Called once the stream's remote-tier prefix is confirmed empty, so tombstones do
+not accumulate. Idempotent: deleting an absent tombstone is a no-op.
+""".
+-spec delete_tombstone(stream_id()) -> ok | {error, any()}.
+delete_tombstone(StreamId) ->
+    khepri:delete(rabbit_khepri:get_store_id(), ?TOMBSTONE_PATH(StreamId)).
 
 -doc """
 Sets the UID for the given stream ID if the current revision matches the given

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -42,7 +42,7 @@ signal without Khepri restructuring).
 
 -type mode() :: dry_run | delete.
 -type config() :: #{mode => mode(), writer_epoch => non_neg_integer()}.
--type reason() :: below_first_offset | stale_epoch.
+-type reason() :: below_first_offset | stale_epoch | stream_deleted.
 -type finding() :: #{stream_id := stream_id(), key := rabbitmq_stream_s3:key(), reason := reason()}.
 
 -export_type([mode/0, config/0, finding/0]).
@@ -59,8 +59,13 @@ run(Config) when is_map(Config) ->
     Mode = maps:get(mode, Config, dry_run),
     {ok, Streams} = rabbitmq_stream_s3_db:list(),
     Lookup = build_lookup(Streams),
+    Tombstones = load_tombstones(),
     Fun = make_handler(Mode),
-    Findings = list_and_classify(<<"rabbitmq/stream/">>, start, Lookup, Fun, []),
+    Findings = list_and_classify(<<"rabbitmq/stream/">>, start, Lookup, Tombstones, Fun, []),
+    %% Clear tombstones for deleted streams whose prefix this delete-mode sweep
+    %% fully reclaimed, so they do not accumulate. Only in delete mode (a dry run
+    %% removed nothing) and only when the prefix is now empty.
+    maybe_clear_swept_tombstones(Mode, Tombstones),
     ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
     {ok, Findings}.
 
@@ -77,7 +82,10 @@ run_stream(StreamId, Config) when is_binary(StreamId), is_map(Config) ->
         {ok, Lookup} ->
             Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
             Fun = make_handler(Mode),
-            Findings = list_and_classify(Prefix, start, Lookup, Fun, []),
+            %% The single-stream path runs against a live stream (the reset
+            %% recovery), so it carries no tombstones: a deleted stream has no
+            %% reader to invoke this. Pass an empty tombstone set.
+            Findings = list_and_classify(Prefix, start, Lookup, #{}, Fun, []),
             ?LOG_INFO(
                 "GC ~ts for stream ~ts complete: ~b dangling object(s)",
                 [Mode, StreamId, length(Findings)]
@@ -102,6 +110,40 @@ run_stream(VHost, QueueName, Config) when
         {error, _} = Err ->
             Err
     end.
+
+%% Load the set of deleted-stream tombstones. A failure to read them is not
+%% fatal to a sweep: treat it as no tombstones (the pre-existing behaviour of
+%% skipping unknown-stream prefixes), so GC stays conservative rather than
+%% deleting on a bad read.
+load_tombstones() ->
+    case rabbitmq_stream_s3_db:list_tombstones() of
+        {ok, Tombstones} ->
+            Tombstones;
+        {error, Reason} ->
+            ?LOG_INFO("GC: could not read deletion tombstones (~p); none applied", [Reason]),
+            #{}
+    end.
+
+%% After a delete-mode full sweep, drop the tombstone of any deleted stream whose
+%% prefix is now empty, so tombstones do not accumulate. A stream whose prefix
+%% still has objects (a delete that failed, or an upload still completing) keeps
+%% its tombstone for the next sweep.
+maybe_clear_swept_tombstones(delete, Tombstones) ->
+    maps:foreach(
+        fun(StreamId, _Data) ->
+            Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
+            case rabbitmq_stream_s3_api:list(Prefix, start) of
+                {ok, [], done} ->
+                    _ = rabbitmq_stream_s3_db:delete_tombstone(StreamId),
+                    ok;
+                _ ->
+                    ok
+            end
+        end,
+        Tombstones
+    );
+maybe_clear_swept_tombstones(_Mode, _Tombstones) ->
+    ok.
 
 make_handler(dry_run) ->
     fun(Finding, Acc) ->
@@ -146,6 +188,16 @@ make_handler(delete) ->
 -spec still_dangling(finding()) -> boolean().
 still_dangling(#{reason := stale_epoch}) ->
     true;
+still_dangling(#{reason := stream_deleted, stream_id := StreamId}) ->
+    %% The whole stream was deleted, so every object under its prefix is an
+    %% orphan. Re-validate that the tombstone is still present immediately
+    %% before deleting: a recreated stream gets a distinct id (its name embeds a
+    %% nanosecond timestamp), so a surviving tombstone for this exact id means
+    %% the stream is genuinely gone and nothing live can be under this prefix.
+    case rabbitmq_stream_s3_db:list_tombstones() of
+        {ok, Tombstones} -> is_map_key(StreamId, Tombstones);
+        {error, _} -> false
+    end;
 still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key}) ->
     case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
         #manifest{first_offset = FirstOffset} = Manifest ->
@@ -353,25 +405,25 @@ epoch_permits_sweep(CommittedEpoch, #{writer_epoch := WriterEpoch}) ->
 epoch_permits_sweep(_CommittedEpoch, _Config) ->
     true.
 
-list_and_classify(_Prefix, done, _Lookup, _Fun, Acc) ->
+list_and_classify(_Prefix, done, _Lookup, _Tombstones, _Fun, Acc) ->
     lists:reverse(Acc);
-list_and_classify(Prefix, Continuation, Lookup, Fun, Acc) ->
+list_and_classify(Prefix, Continuation, Lookup, Tombstones, Fun, Acc) ->
     case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
         {ok, [], done} ->
             lists:reverse(Acc);
         {ok, Keys, NextContinuation} ->
-            Orphans = classify_page(Keys, Lookup),
+            Orphans = classify_page(Keys, Lookup, Tombstones),
             NewAcc = lists:foldl(Fun, Acc, Orphans),
-            list_and_classify(Prefix, NextContinuation, Lookup, Fun, NewAcc);
+            list_and_classify(Prefix, NextContinuation, Lookup, Tombstones, Fun, NewAcc);
         {error, Reason} ->
             ?LOG_WARNING("GC: failed to list objects under ~ts: ~p", [Prefix, Reason]),
             lists:reverse(Acc)
     end.
 
-classify_page(Keys, Lookup) ->
+classify_page(Keys, Lookup, Tombstones) ->
     lists:filtermap(
         fun(Key) ->
-            case classify(Key, Lookup) of
+            case classify(Key, Lookup, Tombstones) of
                 {ok, Finding} -> {true, Finding};
                 skip -> false
             end
@@ -379,37 +431,75 @@ classify_page(Keys, Lookup) ->
         Keys
     ).
 
+-ifdef(TEST).
+%% classify/2 keeps the no-tombstone behaviour for the eunit tests that classify
+%% against the live lookup only. Equivalent to classify/3 with an empty tombstone
+%% set. Test-only: production always classifies with the tombstone set.
 -spec classify(rabbitmq_stream_s3:key(), map()) -> {ok, finding()} | skip.
 classify(Key, Lookup) ->
+    classify(Key, Lookup, #{}).
+-endif.
+
+-spec classify(rabbitmq_stream_s3:key(), map(), #{stream_id() => term()}) ->
+    {ok, finding()} | skip.
+classify(Key, Lookup, Tombstones) ->
     case parse_key(Key) of
         {data, StreamId, Offset} ->
             case Lookup of
-                #{StreamId := #{first_offset := FirstOffset}} when Offset < FirstOffset ->
-                    {ok, #{stream_id => StreamId, key => Key, reason => below_first_offset}};
+                #{StreamId := Info} ->
+                    classify_live(data, StreamId, Offset, Key, Info);
                 _ ->
-                    skip
+                    classify_against_tombstone(StreamId, Key, Tombstones)
             end;
         {group, StreamId, Offset} ->
             case Lookup of
-                #{StreamId := #{first_offset := FirstOffset} = Info} when Offset < FirstOffset ->
-                    classify_group(StreamId, Key, Info);
+                #{StreamId := Info} ->
+                    classify_live(group, StreamId, Offset, Key, Info);
                 _ ->
-                    skip
+                    classify_against_tombstone(StreamId, Key, Tombstones)
             end;
         {manifest, StreamId, Epoch} ->
             case Lookup of
-                #{StreamId := #{epoch := CurrentEpoch}} when Epoch < CurrentEpoch ->
-                    {ok, #{stream_id => StreamId, key => Key, reason => stale_epoch}};
+                #{StreamId := Info} ->
+                    classify_live(manifest, StreamId, Epoch, Key, Info);
                 _ ->
-                    skip
+                    classify_against_tombstone(StreamId, Key, Tombstones)
             end;
         unknown ->
-            %% Key belongs to a stream not in the lookup (either unknown to
-            %% Khepri or missing a local manifest replica). Not safe to delete
-            %% without a positive "stream deleted" signal. See #149 for the
-            %% planned Khepri restructuring that would make stream-prefix
-            %% sweep safe.
+            %% Key does not parse to a stream prefix (a stray object under
+            %% rabbitmq/stream/). Never delete it.
             skip
+    end.
+
+%% Classify a key whose stream IS present in the live lookup (Info is its lookup
+%% entry), by the normal offset/epoch rules. A tombstone is never consulted
+%% here: a live stream's objects are governed solely by its live manifest, so a
+%% stale tombstone for a still-present stream can never cause a live object to
+%% be deleted.
+classify_live(data, StreamId, Offset, Key, #{first_offset := FirstOffset}) when
+    Offset < FirstOffset
+->
+    {ok, #{stream_id => StreamId, key => Key, reason => below_first_offset}};
+classify_live(group, StreamId, Offset, Key, #{first_offset := FirstOffset} = Info) when
+    Offset < FirstOffset
+->
+    classify_group(StreamId, Key, Info);
+classify_live(manifest, StreamId, Epoch, Key, #{epoch := CurrentEpoch}) when
+    Epoch < CurrentEpoch
+->
+    {ok, #{stream_id => StreamId, key => Key, reason => stale_epoch}};
+classify_live(_Kind, _StreamId, _OffsetOrEpoch, _Key, _Info) ->
+    skip.
+
+%% A key whose stream is absent from the live lookup: delete it only if the
+%% stream has a deletion tombstone, the positive "stream deleted" signal. The
+%% stream entry is gone from Khepri after deletion, so without the tombstone a
+%% deleted stream's leftover object is indistinguishable from one belonging to a
+%% live stream this node merely cannot see, and must be skipped (issue #196).
+classify_against_tombstone(StreamId, Key, Tombstones) ->
+    case is_map_key(StreamId, Tombstones) of
+        true -> {ok, #{stream_id => StreamId, key => Key, reason => stream_deleted}};
+        false -> skip
     end.
 
 %% A group object below first_offset is an orphan and safe to delete unless it
@@ -667,10 +757,55 @@ classify_manifest_current_epoch_test() ->
     ?assertEqual(skip, classify(Key, Lookup)).
 
 classify_unknown_stream_skipped_test() ->
-    %% Stream not in lookup -> skip (not safe to delete).
+    %% Stream not in lookup and no tombstone -> skip (not safe to delete).
     Lookup = #{},
     Key = <<"rabbitmq/stream/unknown/data/00000000000000000100.deadbeef.fragment">>,
     ?assertEqual(skip, classify(Key, Lookup)).
+
+%% #196: a key whose stream is gone from the lookup but has a deletion tombstone
+%% is an orphan and is reclaimed. This is the leftover from an upload that
+%% completed after the deletion sweep listed the prefix.
+classify_tombstoned_stream_data_deletes_test() ->
+    StreamId = <<"gone">>,
+    Lookup = #{},
+    Tombstones = #{StreamId => #{deleted_at => 0}},
+    Key = <<"rabbitmq/stream/gone/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertMatch(
+        {ok, #{reason := stream_deleted}}, classify(Key, Lookup, Tombstones)
+    ).
+
+%% A tombstone covers every object kind under the deleted stream's prefix, not
+%% just fragments.
+classify_tombstoned_stream_metadata_deletes_test() ->
+    StreamId = <<"gone">>,
+    Tombstones = #{StreamId => #{deleted_at => 0}},
+    GroupKey = <<"rabbitmq/stream/gone/metadata/00000000000000000010.00000099.group">>,
+    ManifestKey = <<"rabbitmq/stream/gone/metadata/root.00000005.deadbeef.manifest">>,
+    ?assertMatch({ok, #{reason := stream_deleted}}, classify(GroupKey, #{}, Tombstones)),
+    ?assertMatch({ok, #{reason := stream_deleted}}, classify(ManifestKey, #{}, Tombstones)).
+
+%% A tombstone for one stream does not authorise deleting another unknown
+%% stream's objects: only the tombstoned prefix is swept.
+classify_tombstone_does_not_affect_other_streams_test() ->
+    Tombstones = #{<<"gone">> => #{deleted_at => 0}},
+    OtherKey = <<"rabbitmq/stream/other/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual(skip, classify(OtherKey, #{}, Tombstones)).
+
+%% A live stream (present in the lookup) is classified by the normal rules even
+%% if a stale tombstone somehow exists for its id: the lookup match wins, so a
+%% fragment at or above the live floor is kept.
+classify_live_stream_ignores_tombstone_test() ->
+    StreamId = <<"s">>,
+    Lookup = #{StreamId => #{first_offset => 100, epoch => 1}},
+    Tombstones = #{StreamId => #{deleted_at => 0}},
+    %% Above the floor: kept (not an orphan), despite the tombstone.
+    KeptKey = <<"rabbitmq/stream/s/data/00000000000000000150.0000002a.fragment">>,
+    ?assertEqual(skip, classify(KeptKey, Lookup, Tombstones)),
+    %% Below the floor: the normal below_first_offset rule still applies.
+    OrphanKey = <<"rabbitmq/stream/s/data/00000000000000000050.0000002a.fragment">>,
+    ?assertMatch(
+        {ok, #{reason := below_first_offset}}, classify(OrphanKey, Lookup, Tombstones)
+    ).
 
 %% A candidate deletion is re-validated against the live first_offset just before
 %% deleting. A remote-tier-ahead reset lowers first_offset and re-tiers live

--- a/src/rabbitmq_stream_s3_reaper.erl
+++ b/src/rabbitmq_stream_s3_reaper.erl
@@ -73,6 +73,11 @@ init([]) ->
 handle_batch(Ops, State) ->
     Keys = collect(Ops),
     _ = delete_batched(Keys),
+    %% Reply to any flush barrier in this batch only after the deletes above
+    %% have run. gen_batch_server processes a batch in order and a caller's
+    %% {delete, _} casts are enqueued before its flush call, so a returning
+    %% flush guarantees those deletes are complete (see list_and_delete/1).
+    _ = [gen:reply(From, ok) || {call, From, flush} <- Ops],
     {ok, State}.
 
 terminate(_Reason, _State) ->
@@ -125,11 +130,43 @@ delete_batch(Batch) ->
 
 list_and_delete(StreamId) ->
     Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
+    %% Record the tombstone before sweeping. This runs in the reaper's spawned
+    %% task (a normal process), not the Khepri trigger sproc, so it can write to
+    %% Khepri. The tombstone is the durable "stream deleted" signal that lets GC
+    %% reclaim a fragment whose upload completes after this one-shot sweep lists
+    %% the prefix (issue #196). Best effort: if it fails the sweep still runs,
+    %% and the worst case is the pre-existing leak this addresses.
+    _ = rabbitmq_stream_s3_db:write_tombstone(StreamId),
     Result = list_and_delete_loop(Prefix, start),
     case Result of
-        ok -> inc(?C_STREAMS_DELETED, 1);
-        _ -> ok
+        ok ->
+            inc(?C_STREAMS_DELETED, 1),
+            maybe_clear_tombstone(StreamId, Prefix);
+        _ ->
+            %% The sweep hit a LIST error and is incomplete; leave the tombstone
+            %% so GC reclaims whatever remains and clears it later.
+            ok
     end.
+
+%% After a clean sweep, confirm the prefix is empty and drop the tombstone so it
+%% does not accumulate. The deletes are async casts to this server, so flush
+%% first to ensure they have run, then re-LIST. If anything remains (an upload
+%% that completed after the sweep listed its page, the #196 race), keep the
+%% tombstone: GC will reclaim the straggler and clear the tombstone then.
+maybe_clear_tombstone(StreamId, Prefix) ->
+    _ = flush(),
+    case rabbitmq_stream_s3_api:list(Prefix, start) of
+        {ok, [], done} ->
+            _ = rabbitmq_stream_s3_db:delete_tombstone(StreamId),
+            ok;
+        _ ->
+            ok
+    end.
+
+%% Synchronous barrier: returns only after all delete casts enqueued before it
+%% have been processed by handle_batch/2.
+flush() ->
+    gen_batch_server:call(?MODULE, flush).
 
 list_and_delete_loop(_Prefix, done) ->
     ok;

--- a/test/broker_SUITE.erl
+++ b/test/broker_SUITE.erl
@@ -19,6 +19,7 @@ groups() ->
         {cluster_size_3, [shuffle], [
             publish_uploads_to_remote_tier,
             stream_deletion_cleans_remote_tier,
+            stream_deletion_straggler_reclaimed_by_gc,
             consumer_reads_across_tiers,
             leadership_transfer_continues_upload,
             plugin_disable_reenable,
@@ -112,6 +113,54 @@ stream_deletion_cleans_remote_tier(Config) ->
     amqp_channel:call(Ch, #'queue.delete'{queue = QName}),
 
     ?awaitMatch([], list_fragment_keys(Config, WriterNode, StreamId), 5000),
+    ok.
+
+%% #196: an upload that completes after the deletion sweep listed the prefix
+%% leaves a straggler object. Because the deletion records a tombstone, GC
+%% reclaims the straggler (the stream is gone from Khepri, so without the
+%% tombstone GC would skip it as an unknown-stream prefix) and clears the
+%% tombstone once the prefix is empty.
+%%
+%% The reaper's own fast path clears the tombstone as soon as its sweep drains
+%% the prefix, so a real deletion followed by a straggler is a timing race that
+%% does not reproduce deterministically. This test drives the GC path directly:
+%% a tombstone plus a straggler object for a stream that does not exist in
+%% Khepri (a distinct, never-created stream id), exactly the post-deletion
+%% state, and asserts GC reclaims the straggler and clears the tombstone.
+stream_deletion_straggler_reclaimed_by_gc(Config) ->
+    Node = hd(rabbit_ct_broker_helpers:get_node_configs(Config, nodename)),
+    %% A stream id that was never created, standing in for one already deleted
+    %% (and so absent from the Khepri lookup), with a unique suffix.
+    StreamId = <<"__gc_straggler_stream_1780000000000000000">>,
+
+    %% Record the deletion tombstone (as the reaper does on deletion) and leave a
+    %% straggler fragment under the prefix (the upload that finished after the
+    %% sweep).
+    ok = rabbit_ct_broker_helpers:rpc(
+        Config, Node, rabbitmq_stream_s3_db, write_tombstone, [StreamId]
+    ),
+    StragglerKey = rabbitmq_stream_s3:fragment_key(StreamId, 999, 16#deadbeef),
+    ok = rabbit_ct_broker_helpers:rpc(
+        Config, Node, rabbitmq_stream_s3_api, put, [StragglerKey, <<"orphan">>]
+    ),
+    ?assert(list_fragment_keys(Config, Node, StreamId) =/= []),
+
+    %% GC in delete mode reclaims the straggler via the tombstone, then clears
+    %% the tombstone because the prefix is now empty.
+    {ok, _} = rabbit_ct_broker_helpers:rpc(
+        Config, Node, rabbitmq_stream_s3_gc, run, [#{mode => delete}]
+    ),
+    ?awaitMatch([], list_fragment_keys(Config, Node, StreamId), 5000),
+    ?awaitMatch(
+        false,
+        begin
+            {ok, Ts} = rabbit_ct_broker_helpers:rpc(
+                Config, Node, rabbitmq_stream_s3_db, list_tombstones, []
+            ),
+            maps:is_key(StreamId, Ts)
+        end,
+        5000
+    ),
     ok.
 
 consumer_reads_across_tiers(Config) ->


### PR DESCRIPTION
Closes #196

## Problem

Stream deletion is a one-shot LIST-then-delete sweep. A fragment whose upload completes after the sweep has listed the prefix is missed, leaving a dangling S3 object. Orphan GC could not reclaim it either: after deletion the stream is gone from Khepri, so its leftover key classifies as an *unknown* stream, which GC deliberately skips (it cannot tell a deleted stream's prefix from a live stream this node merely cannot see). The object leaked indefinitely.

The earlier assumption that GC (#149/#204) would pick these up does not hold: #204 implemented GC for live streams only (offset-below-first-offset, stale-epoch), both of which require the stream to still exist in Khepri.

## Fix: a positive "stream deleted" signal

- **db**: write a tombstone at a separate Khepri root (`rabbitmq_stream_s3_deleted/<StreamId>`) with no keep-while, so it survives the keep-while removal of the stream entry that fires the deletion trigger. Payload carries the deletion time. Adds `write_tombstone/1`, `list_tombstones/0`, `delete_tombstone/1`. The tombstone is written by the reaper, **not** the trigger sproc: triggered sprocs run synchronously inside the single `khepri_event_handler` gen_server, where a synchronous `khepri:put` would block that handler on its own Ra command.

- **reaper**: write the tombstone before sweeping (from its own task process), then after the sweep flush the async delete casts (a new `gen_batch_server` call barrier) and re-LIST; if the prefix is empty, drop the tombstone. A straggler left by the race keeps the tombstone for GC.

- **gc**: classify an object whose stream is absent from the live lookup as an orphan when the stream is tombstoned (`reason => stream_deleted`), and clear the tombstone after a delete-mode sweep leaves the prefix empty. A tombstone is consulted **only** when the stream is absent from the lookup, so a live stream's objects are never deleted on the strength of a stale tombstone. `still_dangling` re-checks the tombstone immediately before deleting.

## StreamId aliasing

StreamIds embed a nanosecond timestamp, so a recreated stream gets a distinct id and cannot alias an existing tombstone.

## Tests

- gc eunit: tombstoned-stream reclaim, per-object-kind coverage, isolation between streams, and that a live stream ignores a tombstone (the last caught a real bug where a live stream's above-floor data would have been deleted).
- broker_SUITE: end-to-end GC reclaim of a straggler under a tombstone, asserting the tombstone is cleared; the existing clean-deletion test still passes.

Build clean, dialyzer clean.

## Verification notes

- The `gen_batch_server` flush barrier was verified against its source: it reverses the accumulated batch to arrival order, so the reaper's delete casts are processed before its flush reply.
- The trigger-sproc-cannot-write constraint was confirmed by reading the Khepri trigger dispatch (`khepri_machine` mod_call effect into `khepri_event_handler`).
- Cross-node correctness rests on Khepri replication of the tombstone (a deletion trigger fires on the Khepri leader; GC may run elsewhere), the same replicated-read mechanism the existing stream listing relies on.

## Follow-up

Tombstone cleanup happens on the reaper fast path or the next GC run. GC has no periodic trigger yet (it is CLI-only), so until one exists a straggler and its tombstone persist until a manual GC. Tracked in #309. This is still strictly better than the previous permanent leak with no recourse.