### PR TITLE
Add a P model of the anchor-before-first-fragment cleanup design

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -30,6 +30,7 @@ jobs:
       gc_reset_multinode: ${{ steps.filter.outputs.gc_reset_multinode }}
       gc_leading_group: ${{ steps.filter.outputs.gc_leading_group }}
       gc_reset_leading_group: ${{ steps.filter.outputs.gc_reset_leading_group }}
+      delete_stream_anchor: ${{ steps.filter.outputs.delete_stream_anchor }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
@@ -52,11 +53,13 @@ jobs:
           echo "gc_reset_multinode=false" >> "$GITHUB_OUTPUT"
           echo "gc_leading_group=false" >> "$GITHUB_OUTPUT"
           echo "gc_reset_leading_group=false" >> "$GITHUB_OUTPUT"
+          echo "delete_stream_anchor=false" >> "$GITHUB_OUTPUT"
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-reset-multinode/' && echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-leading-group/' && echo "gc_leading_group=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-reset-leading-group/' && echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/delete-stream-anchor/' && echo "delete_stream_anchor=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/trimmed-segment/' && echo "trimmed_segment=true" >> "$GITHUB_OUTPUT" || true
@@ -71,6 +74,7 @@ jobs:
             echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT"
+            echo "delete_stream_anchor=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
@@ -274,6 +278,59 @@ jobs:
           fi
           echo "Gate satisfied: the offset-only re-check deletes the live leading group."
           echo "::endgroup::"
+
+  delete-stream-anchor:
+    needs: changes
+    if: needs.changes.outputs.delete_stream_anchor == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/delete-stream-anchor
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/delete-stream-anchor
+          for tc in tcAnchorReclaimsAcrossCrash tcAnchorExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcAnchorExplore (PCT)"
+          p check -tc tcAnchorExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (a stale read or out-of-order anchor must reap live data)
+        run: |
+          cd p/delete-stream-anchor
+          # Both MUST fail with the NOREAPLIVE counterexample. A green here means
+          # the model no longer reaches the live-data reap, i.e. the consistent-read
+          # or anchor-before-fragment requirement is no longer load-bearing in the
+          # model and the by-construction result is not trustworthy.
+          for tc in tcAnchorStaleReadReapsLive tcAnchorOrderingViolated; do
+            rm -rf PCheckerOutput/
+            echo "::group::$tc (expect the live-reap counterexample)"
+            if p check -tc "$tc" -i 2000; then
+              echo "ERROR: $tc passed; the model no longer reaps live data."
+              echo "A stale anchor read (or a fragment written before the anchor) must reap a live"
+              echo "stream, otherwise the consistent-read / ordering requirement is not load-bearing."
+              exit 1
+            fi
+            if ! grep -rqF 'INV NOREAPLIVE violated' PCheckerOutput/BugFinding/; then
+              echo "ERROR: $tc failed, but not with the expected NOREAPLIVE counterexample."
+              exit 1
+            fi
+            echo "Gate satisfied: $tc reaps live data as expected."
+            echo "::endgroup::"
+          done
 
   read-resolution:
     needs: changes

--- a/p/delete-stream-anchor/PSpec/Monitors.p
+++ b/p/delete-stream-anchor/PSpec/Monitors.p
@@ -1,0 +1,47 @@
+/* Global safety monitors for the anchor-before-first-fragment design.
+
+   NoReapLive is the headline: a reap may happen only after the queue is deleted.
+   It catches both load-bearing failures - a stale anchor read and an
+   anchor-written-after-the-fragment ordering violation each cause the sweep to
+   reap a live stream, which trips here. EventuallyEmpty is the by-construction
+   reclaim: once the stream is deleted and sweeps quiesce, no object remains, even
+   across a crash mid-sweep. */
+
+/* A reap is legitimate only for a deleted stream. */
+spec NoReapLive observes eQueueDeleted, eObjReaped {
+  var queueDeleted: bool;
+
+  start state Watching {
+    on eQueueDeleted do {
+      queueDeleted = true;
+    }
+    on eObjReaped do (k: ObjKey) {
+      assert queueDeleted,
+        format("INV NOREAPLIVE violated: GC reaped object (offset={0}, uid={1}) while the stream's queue is still live (the anchor read was stale, or the anchor was written after the fragment)",
+          k.offset, k.uid);
+    }
+  }
+}
+
+/* Once the stream is deleted and sweeps quiesce, nothing is left under the prefix. */
+spec EventuallyEmpty observes eObjStored, eObjReaped, eSweepQuiesced {
+  var stored: map[ObjKey, bool];
+
+  start state Watching {
+    on eObjStored do (k: ObjKey) {
+      if (!(k in stored)) {
+        stored += (k, true);
+      }
+    }
+    on eObjReaped do (k: ObjKey) {
+      if (k in stored) {
+        stored -= (k);
+      }
+    }
+    on eSweepQuiesced do {
+      assert sizeof(stored) == 0,
+        format("INV RECLAIM violated: {0} object(s) left under the prefix after the stream was deleted and sweeps quiesced",
+          sizeof(stored));
+    }
+  }
+}

--- a/p/delete-stream-anchor/PSrc/Common.p
+++ b/p/delete-stream-anchor/PSrc/Common.p
@@ -1,0 +1,72 @@
+/* Shared types and events for the anchor-before-first-fragment cleanup design.
+
+   The design:
+
+     - Before the very first S3 fragment is written for a stream, the replica
+       reader writes a dedicated ANCHOR node in Khepri, keep_while'd to the queue,
+       as a BLOCKING step. The anchor's write must COMMIT strictly before the
+       first S3 PUT.
+     - Cleanup is driven by the anchor's ABSENCE, not by any record written at
+       deletion time. The keep_while removes the anchor in the same transaction
+       that deletes the queue, so "anchor absent" is produced atomically and is
+       permanent. A sweep classifies the prefix as junk iff objects are present
+       AND the anchor is absent.
+
+   This is correct by construction off one ordering invariant: an object exists
+   only after the anchor committed, and the anchor disappears only when the queue
+   does, so there is NO live state with objects-but-no-anchor. Two properties
+   fall out for free: a stream that never committed a manifest still has an
+   anchor (it predates the first fragment), and a crash anywhere in the deletion
+   path cannot lose the signal (the signal is the anchor's permanent absence, not
+   a write that can be dropped).
+
+   TWO things are load-bearing, and this model exists to prove both:
+
+     1. CONSISTENT READS. The sweep must read the anchor with a strongly-consistent
+        (committed) read. A stale local replica can report "anchor absent" for a
+        stream whose anchor just committed while S3 already shows its first
+        fragment, and a stale-read sweep then reaps LIVE data. (Same shape as the
+        gc-reset-multinode stale-floor finding.)
+
+     2. ORDERING. The anchor must commit BEFORE the first fragment PUT. If a
+        fragment can exist before the anchor commits, a sweep in that window sees
+        objects-but-no-anchor for a LIVE stream and reaps it, even with consistent
+        reads. */
+
+/* An S3 object under the stream's prefix, identified by (offset, uid). One
+   stream is modeled; every object here belongs to that stream's prefix. */
+type ObjKey = (offset: int, uid: int);
+
+/* S3 object store (the stream's prefix). */
+event eS3Put: (from: machine, key: ObjKey);
+event eS3DeleteAll: (from: machine);
+event eS3List: (from: machine);
+event eS3ListResult: int;
+event eS3Ack;
+
+/* Khepri: the committed truth (queue + anchor) plus a lagging local replica
+   cache. A consistent read returns the committed anchor; a local read returns the
+   cached anchor, which may be stale. */
+event eWriteAnchor: (from: machine);
+event eReplicate: (from: machine);
+event eDeleteQueue: (from: machine);
+event eReadAnchor: (from: machine, consistent: bool);
+event eAnchorResult: bool;
+event eKAck;
+
+/* Writer / replica reader: ensure the anchor, then PUT the first fragment.
+   anchorBeforeFragment selects whether the load-bearing ordering is honored. */
+event eEnsureAnchorThenPut: (from: machine, key: ObjKey, anchorBeforeFragment: bool);
+event eWriterDone;
+
+/* GC sweep: list the prefix, read the anchor, reap iff objects present and anchor
+   absent. consistent selects the read mode; crashBeforeDelete drops the reap to
+   model a crash mid-sweep (the next sweep must still be correct). */
+event eSweep: (from: machine, consistent: bool, crashBeforeDelete: bool);
+event eSweepDone;
+
+/* Spec events, delivered to monitors via announce. */
+event eObjStored: ObjKey;
+event eObjReaped: ObjKey;
+event eQueueDeleted;
+event eSweepQuiesced;

--- a/p/delete-stream-anchor/PSrc/GC.p
+++ b/p/delete-stream-anchor/PSrc/GC.p
@@ -1,0 +1,30 @@
+/* The GC sweep / reaper. It lists the prefix and reads the anchor, then reaps the
+   whole prefix iff objects are present AND the anchor is absent (the "should be
+   empty" classification). consistent selects the anchor read mode: a consistent
+   read sees the committed anchor, a local read can see a stale cache.
+   crashBeforeDelete drops the reap to model a crash after the decision; because
+   the anchor's absence is permanent, a later sweep is still correct. */
+machine GC {
+  var s3: machine;
+  var khepri: machine;
+
+  start state Serving {
+    entry (init: (s3: machine, khepri: machine)) {
+      s3 = init.s3;
+      khepri = init.khepri;
+    }
+    on eSweep do (p: (from: machine, consistent: bool, crashBeforeDelete: bool)) {
+      var n: int;
+      var anchorPresent: bool;
+      send s3, eS3List, (from = this,);
+      receive { case eS3ListResult: (c: int) { n = c; } }
+      send khepri, eReadAnchor, (from = this, consistent = p.consistent);
+      receive { case eAnchorResult: (b: bool) { anchorPresent = b; } }
+      if (n > 0 && !anchorPresent && !p.crashBeforeDelete) {
+        send s3, eS3DeleteAll, (from = this,);
+        receive { case eS3Ack: { } }
+      }
+      send p.from, eSweepDone;
+    }
+  }
+}

--- a/p/delete-stream-anchor/PSrc/Khepri.p
+++ b/p/delete-stream-anchor/PSrc/Khepri.p
@@ -1,0 +1,56 @@
+/* Khepri: the committed truth plus a lagging local replica cache.
+
+   committedAnchor / committedQueue are the durable, quorum-agreed state. A write
+   updates the committed state immediately but does NOT update the local cache;
+   eReplicate models the replica catching up. A consistent read returns the
+   committed anchor (what a quorum read sees); a local read returns the cached
+   anchor, which can lag.
+
+   The anchor is keep_while'd to the queue: deleting the queue removes the anchor
+   in the SAME committed transaction, which is why "anchor absent" is produced
+   atomically with deletion and is permanent. */
+machine Khepri {
+  var committedQueue: bool;
+  var committedAnchor: bool;
+  var cachedAnchor: bool;
+
+  start state Serving {
+    entry {
+      committedQueue = true;
+      committedAnchor = false;
+      cachedAnchor = false;
+    }
+
+    on eWriteAnchor do (p: (from: machine)) {
+      /* The anchor exists only while the queue does (keep_while). The local cache
+         is intentionally NOT updated here, so a local read lags until eReplicate. */
+      if (committedQueue) {
+        committedAnchor = true;
+      }
+      send p.from, eKAck;
+    }
+
+    on eReplicate do (p: (from: machine)) {
+      cachedAnchor = committedAnchor;
+      send p.from, eKAck;
+    }
+
+    on eDeleteQueue do (p: (from: machine)) {
+      /* keep_while removes the anchor in the same transaction as the queue. */
+      committedQueue = false;
+      committedAnchor = false;
+      announce eQueueDeleted;
+      send p.from, eKAck;
+    }
+
+    on eReadAnchor do (p: (from: machine, consistent: bool)) {
+      var present: bool;
+      if (p.consistent) {
+        present = committedAnchor;
+      } else {
+        present = cachedAnchor;
+      }
+      send p.from, eAnchorResult, present;
+    }
+  }
+}

--- a/p/delete-stream-anchor/PSrc/S3Store.p
+++ b/p/delete-stream-anchor/PSrc/S3Store.p
@@ -1,0 +1,31 @@
+/* The S3 object store for the stream's prefix. A LIST returns the current object
+   count; a reap deletes the whole prefix. Each store and each delete is announced
+   so the monitors can tell a live-stream reap from a legitimate junk reap. */
+machine S3Store {
+  var objects: map[ObjKey, bool];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, key: ObjKey)) {
+      if (!(p.key in objects)) {
+        objects += (p.key, true);
+      }
+      announce eObjStored, p.key;
+      send p.from, eS3Ack;
+    }
+    on eS3DeleteAll do (p: (from: machine)) {
+      var ks: seq[ObjKey];
+      var i: int;
+      ks = keys(objects);
+      i = 0;
+      while (i < sizeof(ks)) {
+        announce eObjReaped, ks[i];
+        i = i + 1;
+      }
+      objects = default(map[ObjKey, bool]);
+      send p.from, eS3Ack;
+    }
+    on eS3List do (p: (from: machine)) {
+      send p.from, eS3ListResult, sizeof(objects);
+    }
+  }
+}

--- a/p/delete-stream-anchor/PSrc/Writer.p
+++ b/p/delete-stream-anchor/PSrc/Writer.p
@@ -1,0 +1,29 @@
+/* The writer / replica reader. Before the first fragment it ensures the anchor is
+   committed, then PUTs the fragment. anchorBeforeFragment honors the load-bearing
+   ordering; with it false the writer PUTs first and writes the anchor late, which
+   the ordering-violation test uses to expose a live-stream reap. */
+machine Writer {
+  var s3: machine;
+  var khepri: machine;
+
+  start state Idle {
+    entry (init: (s3: machine, khepri: machine)) {
+      s3 = init.s3;
+      khepri = init.khepri;
+    }
+    on eEnsureAnchorThenPut do (p: (from: machine, key: ObjKey, anchorBeforeFragment: bool)) {
+      if (p.anchorBeforeFragment) {
+        send khepri, eWriteAnchor, (from = this,);
+        receive { case eKAck: { } }
+        send s3, eS3Put, (from = this, key = p.key);
+        receive { case eS3Ack: { } }
+      } else {
+        send s3, eS3Put, (from = this, key = p.key);
+        receive { case eS3Ack: { } }
+        send khepri, eWriteAnchor, (from = this,);
+        receive { case eKAck: { } }
+      }
+      send p.from, eWriterDone;
+    }
+  }
+}

--- a/p/delete-stream-anchor/PTst/TestDrivers.p
+++ b/p/delete-stream-anchor/PTst/TestDrivers.p
@@ -1,0 +1,168 @@
+/* Test drivers and declarations for the anchor-before-first-fragment design.
+
+   The model deliberately has NO manifest: objects are bare fragments and the
+   anchor is the only Khepri record, so every scenario is the never-committed case
+   - which the anchor design must handle by construction.
+
+   The validation gates are the two load-bearing failures:
+     - tcAnchorStaleReadReapsLive MUST FAIL: a local (stale) anchor read reaps a
+       LIVE stream whose anchor just committed
+     - tcAnchorOrderingViolated MUST FAIL: a fragment that exists before the anchor
+       commits is reaped while the stream is live, even with a consistent read
+   The correct design (consistent reads + anchor-before-fragment) holds, including
+   across a crash mid-sweep (tcAnchorReclaimsAcrossCrash, tcAnchorExplore). */
+
+machine DriverReclaimAcrossCrash {
+  start state Init {
+    entry {
+      var s3: machine;
+      var khepri: machine;
+      var writer: machine;
+      var gc: machine;
+
+      s3 = new S3Store();
+      khepri = new Khepri();
+      writer = new Writer((s3 = s3, khepri = khepri));
+      gc = new GC((s3 = s3, khepri = khepri));
+
+      /* Live stream: anchor committed before the first fragment, then replicated. */
+      send writer, eEnsureAnchorThenPut, (from = this, key = (offset = 10, uid = 1), anchorBeforeFragment = true);
+      receive { case eWriterDone: { } }
+      send khepri, eReplicate, (from = this,);
+      receive { case eKAck: { } }
+
+      /* Delete the queue: keep_while removes the anchor in the same transaction. */
+      send khepri, eDeleteQueue, (from = this,);
+      receive { case eKAck: { } }
+
+      /* A sweep decides to reap but crashes before deleting. */
+      send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = true);
+      receive { case eSweepDone: { } }
+      /* The anchor's absence is permanent, so the next sweep still reclaims. */
+      send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = false);
+      receive { case eSweepDone: { } }
+
+      announce eSweepQuiesced;
+    }
+  }
+}
+
+machine DriverStaleReadReapsLive {
+  start state Init {
+    entry {
+      var s3: machine;
+      var khepri: machine;
+      var writer: machine;
+      var gc: machine;
+
+      s3 = new S3Store();
+      khepri = new Khepri();
+      writer = new Writer((s3 = s3, khepri = khepri));
+      gc = new GC((s3 = s3, khepri = khepri));
+
+      /* Anchor committed before the fragment, but NOT replicated: the local cache
+         still reports the anchor absent. */
+      send writer, eEnsureAnchorThenPut, (from = this, key = (offset = 10, uid = 1), anchorBeforeFragment = true);
+      receive { case eWriterDone: { } }
+
+      /* The stream is LIVE (queue not deleted). A local (stale) read sees no
+         anchor and the sweep reaps the live stream's first fragment. */
+      send gc, eSweep, (from = this, consistent = false, crashBeforeDelete = false);
+      receive { case eSweepDone: { } }
+    }
+  }
+}
+
+machine DriverOrderingViolated {
+  start state Init {
+    entry {
+      var s3: machine;
+      var khepri: machine;
+      var gc: machine;
+
+      s3 = new S3Store();
+      khepri = new Khepri();
+      gc = new GC((s3 = s3, khepri = khepri));
+
+      /* Ordering VIOLATED: the fragment is PUT before the anchor is written. */
+      send s3, eS3Put, (from = this, key = (offset = 10, uid = 1));
+      receive { case eS3Ack: { } }
+
+      /* A sweep runs in the window before the anchor commits. Even a consistent
+         read sees no anchor, so it reaps the live stream's fragment. */
+      send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = false);
+      receive { case eSweepDone: { } }
+
+      /* The anchor is written too late. */
+      send khepri, eWriteAnchor, (from = this,);
+      receive { case eKAck: { } }
+    }
+  }
+}
+
+machine DriverExplore {
+  start state Init {
+    entry {
+      var s3: machine;
+      var khepri: machine;
+      var writer: machine;
+      var gc: machine;
+
+      s3 = new S3Store();
+      khepri = new Khepri();
+      writer = new Writer((s3 = s3, khepri = khepri));
+      gc = new GC((s3 = s3, khepri = khepri));
+
+      send writer, eEnsureAnchorThenPut, (from = this, key = (offset = 10, uid = 1), anchorBeforeFragment = true);
+      receive { case eWriterDone: { } }
+
+      /* A live-stream sweep (consistent) must NOT reap: the anchor is committed. */
+      send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = false);
+      receive { case eSweepDone: { } }
+
+      /* Replication may or may not have caught up; consistent reads ignore it. */
+      if ($) {
+        send khepri, eReplicate, (from = this,);
+        receive { case eKAck: { } }
+      }
+
+      send khepri, eDeleteQueue, (from = this,);
+      receive { case eKAck: { } }
+
+      /* The cleanup sweep may crash before deleting; a recovery sweep follows. */
+      if ($) {
+        send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = true);
+        receive { case eSweepDone: { } }
+      }
+      send gc, eSweep, (from = this, consistent = true, crashBeforeDelete = false);
+      receive { case eSweepDone: { } }
+
+      announce eSweepQuiesced;
+    }
+  }
+}
+
+/* The correct design - consistent reads, anchor before fragment - reclaims junk
+   even when a sweep crashes mid-reap. MUST HOLD. */
+test tcAnchorReclaimsAcrossCrash [main = DriverReclaimAcrossCrash]:
+  assert NoReapLive, EventuallyEmpty in
+  { DriverReclaimAcrossCrash, S3Store, Khepri, Writer, GC };
+
+/* GATE - a stale local anchor read reaps a LIVE stream: MUST FAIL. Proves the
+   consistent-read requirement is load-bearing. */
+test tcAnchorStaleReadReapsLive [main = DriverStaleReadReapsLive]:
+  assert NoReapLive, EventuallyEmpty in
+  { DriverStaleReadReapsLive, S3Store, Khepri, Writer, GC };
+
+/* GATE - a fragment that exists before the anchor commits is reaped while live:
+   MUST FAIL. Proves the anchor-before-fragment ordering is load-bearing, even
+   with a consistent read. */
+test tcAnchorOrderingViolated [main = DriverOrderingViolated]:
+  assert NoReapLive, EventuallyEmpty in
+  { DriverOrderingViolated, S3Store, Khepri, GC };
+
+/* Correct design across nondeterministic replication timing and a crash mid-sweep:
+   MUST HOLD. */
+test tcAnchorExplore [main = DriverExplore]:
+  assert NoReapLive, EventuallyEmpty in
+  { DriverExplore, S3Store, Khepri, Writer, GC };

--- a/p/delete-stream-anchor/README.md
+++ b/p/delete-stream-anchor/README.md
@@ -1,0 +1,48 @@
+# Anchor-before-first-fragment cleanup
+
+A model of a correct-by-construction design for reclaiming a stream's remote-tier objects when its queue is deleted. There is no orphan-GC fallback for a deleted stream: GC skips any prefix it has no live manifest for, so once the stream is gone its leftover objects can never be classified. The deletion path therefore has to reclaim everything, and it must never reap a stream that is still live.
+
+## The design
+
+Before the very first fragment is written for a stream, the replica reader writes a dedicated anchor node in Khepri, kept alive by a keep_while condition on the queue, as a blocking step whose write commits strictly before the first S3 PUT. A sweep classifies a prefix as junk when objects are present and the anchor is absent. The keep_while removes the anchor in the same transaction that deletes the queue, so the "anchor absent" signal is produced atomically and is permanent: there is no record written at deletion time that a crash could lose.
+
+This is correct by construction off one ordering invariant. An object exists only after the anchor committed, and the anchor disappears only when the queue does, so there is no live state with objects but no anchor. Two properties fall out for free:
+
+- a stream that never committed a manifest still has an anchor, because the anchor predates the first fragment
+- a crash anywhere in the deletion path cannot strand the objects, because the signal is the anchor's permanent absence rather than a write that could be dropped
+
+The model deliberately has no manifest. Objects are bare fragments and the anchor is the only Khepri record, so every scenario is the never-committed case.
+
+## The two load-bearing requirements
+
+Each is proven necessary by a gate that must fail when the requirement is dropped.
+
+| Requirement | If violated | Test |
+| --- | --- | --- |
+| Consistent reads: the sweep reads the anchor with a strongly consistent (committed) read, not a stale local replica | a stale read reports the anchor absent for a stream whose anchor just committed while S3 already shows its first fragment, and the sweep reaps live data | `tcAnchorStaleReadReapsLive` (must fail) |
+| Ordering: the anchor commits before the first fragment PUT | a fragment exists before the anchor commits, so a sweep in that window reaps a live stream even with a consistent read | `tcAnchorOrderingViolated` (must fail) |
+
+The stale-read gate is the same shape as the `../gc-reset-multinode` stale-floor finding: a local replica cache that lags committed Khepri defeats an otherwise sound guard.
+
+## Tests
+
+| Test case | Expectation |
+| --- | --- |
+| `tcAnchorReclaimsAcrossCrash` | holds: consistent reads and anchor-before-fragment reclaim the junk even when a sweep crashes mid-reap, because the absence signal is permanent |
+| `tcAnchorExplore` | holds across nondeterministic replication timing and a crash mid-sweep |
+| `tcAnchorStaleReadReapsLive` | fails with `INV NOREAPLIVE violated: GC reaped object ... while the stream's queue is still live` |
+| `tcAnchorOrderingViolated` | fails with the same counterexample, from the ordering violation |
+
+`NoReapLive` is the headline monitor: a reap may happen only after the queue is deleted, and both gates trip it. `EventuallyEmpty` is the reclaim property: once the stream is deleted and sweeps quiesce, nothing remains.
+
+```bash
+p compile
+p check -tc tcAnchorReclaimsAcrossCrash -i 2000   # 0 bugs (reclaims across a crash)
+p check -tc tcAnchorExplore             -i 5000   # 0 bugs, crash + replication explored
+p check -tc tcAnchorStaleReadReapsLive  -i 2000   # 1 bug: stale read reaps live data
+p check -tc tcAnchorOrderingViolated    -i 2000   # 1 bug: fragment before anchor reaps live data
+```
+
+## What the model does not cover
+
+The anchor's absence is a correct classifier but not a work-list. Finding the orphan prefixes still needs the deletion trigger for the prompt path (hung on the anchor node it fires for never-committed streams too) or a periodic S3-prefix scan as a backstop, which is now safe because the decision is by construction. Those provide discovery latency, not correctness.

--- a/p/delete-stream-anchor/delete-stream-anchor.pproj
+++ b/p/delete-stream-anchor/delete-stream-anchor.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>DeleteStreamAnchor</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>


### PR DESCRIPTION
When a stream queue is deleted its remote-tier objects must be reclaimed, and there is no orphan-GC fallback for a deleted stream: GC skips any prefix it has no live manifest for, so once the stream is gone its leftover objects can never be classified.

The model covers a design that is correct by construction. Before the first S3 fragment is written, the replica reader writes a dedicated anchor node in Khepri, kept alive by a keep_while condition on the queue, as a blocking step that commits before the first PUT. Cleanup is driven by the anchor's absence rather than a record written at deletion time: the keep_while removes the anchor in the same transaction that deletes the queue, so the signal is permanent and cannot be lost to a crash. A sweep reaps a prefix only when objects are present and the anchor is absent, and because an object exists only after the anchor committed, no live stream is ever in that state. A stream that never committed a manifest is covered too, since the anchor predates any manifest.

The model is crash-honest (the reap is interruptible, so it can reach the live-reap failure instead of going green hollow) and proves two requirements load-bearing with inverted gates: consistent reads, since a stale replica read reaps live data (tcAnchorStaleReadReapsLive), and anchor-before-fragment ordering (tcAnchorOrderingViolated). The correct design holds across a crash mid-sweep and replication timing (tcAnchorReclaimsAcrossCrash, tcAnchorExplore).

CI runs the must-hold cases under PCT and gates both must-fail cases on the NoReapLive counterexample.

*Issue #, if available:* connects https://github.com/amazon-mq/rabbitmq-stream-s3/issues/196

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
