### PR TITLE
Add an integrated P model of the GC reap decision

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -30,6 +30,7 @@ jobs:
       gc_reset_multinode: ${{ steps.filter.outputs.gc_reset_multinode }}
       gc_leading_group: ${{ steps.filter.outputs.gc_leading_group }}
       gc_reset_leading_group: ${{ steps.filter.outputs.gc_reset_leading_group }}
+      gc_decision: ${{ steps.filter.outputs.gc_decision }}
       delete_stream_anchor: ${{ steps.filter.outputs.delete_stream_anchor }}
       read_resolution: ${{ steps.filter.outputs.read_resolution }}
       trimmed_segment: ${{ steps.filter.outputs.trimmed_segment }}
@@ -53,12 +54,14 @@ jobs:
           echo "gc_reset_multinode=false" >> "$GITHUB_OUTPUT"
           echo "gc_leading_group=false" >> "$GITHUB_OUTPUT"
           echo "gc_reset_leading_group=false" >> "$GITHUB_OUTPUT"
+          echo "gc_decision=false" >> "$GITHUB_OUTPUT"
           echo "delete_stream_anchor=false" >> "$GITHUB_OUTPUT"
           echo "read_resolution=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/gc-reset/' && echo "gc_reset=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-reset-multinode/' && echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-leading-group/' && echo "gc_leading_group=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/gc-reset-leading-group/' && echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT" || true
+          echo "$CHANGED" | grep -q '^p/gc-decision/' && echo "gc_decision=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/delete-stream-anchor/' && echo "delete_stream_anchor=true" >> "$GITHUB_OUTPUT" || true
           echo "$CHANGED" | grep -q '^p/read-resolution/' && echo "read_resolution=true" >> "$GITHUB_OUTPUT" || true
           echo "trimmed_segment=false" >> "$GITHUB_OUTPUT"
@@ -74,6 +77,7 @@ jobs:
             echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT"
             echo "gc_leading_group=true" >> "$GITHUB_OUTPUT"
             echo "gc_reset_leading_group=true" >> "$GITHUB_OUTPUT"
+            echo "gc_decision=true" >> "$GITHUB_OUTPUT"
             echo "delete_stream_anchor=true" >> "$GITHUB_OUTPUT"
             echo "read_resolution=true" >> "$GITHUB_OUTPUT"
             echo "trimmed_segment=true" >> "$GITHUB_OUTPUT"
@@ -277,6 +281,93 @@ jobs:
             exit 1
           fi
           echo "Gate satisfied: the offset-only re-check deletes the live leading group."
+          echo "::endgroup::"
+
+  gc-decision:
+    needs: changes
+    if: needs.changes.outputs.gc_decision == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/gc-decision
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/gc-decision
+          for tc in tcGcBasicReclaim tcGcCrossNodeStaleGuarded tcGcCrossNodeSynced \
+                    tcGcResetRereadHolds tcGcLeadingGroupHolds tcGcResetAfterSnapshotGuarded \
+                    tcGcExploreGuarded; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcGcExploreGuarded (PCT)"
+          p check -tc tcGcExploreGuarded --sch-pct 20 -i 6000
+          echo "::endgroup::"
+      - name: Validation gate (each shipped guard is load-bearing)
+        run: |
+          cd p/gc-decision
+          # Each gate removes one shipped guard and must reproduce a live deletion
+          # with the specific counterexample object, otherwise the guarded result
+          # is not trustworthy.
+          check_gate() {
+            tc="$1"; expected="$2"
+            rm -rf PCheckerOutput/
+            echo "::group::$tc (expect $expected)"
+            if p check -tc "$tc" -i 2000; then
+              echo "ERROR: $tc passed; the model no longer reaps live data with this guard removed."
+              exit 1
+            fi
+            if ! grep -rqF "$expected" PCheckerOutput/BugFinding/; then
+              echo "ERROR: $tc failed, but not with the expected counterexample: $expected"
+              exit 1
+            fi
+            echo "Gate satisfied: $tc reaps live data as expected."
+            echo "::endgroup::"
+          }
+          check_gate tcGcCrossNodeStaleUnguarded 'INV#2 violated: GC deleted live object (kind=0, offset=850, uid=2, epoch=0)'
+          check_gate tcGcNoReread 'INV#2 violated: GC deleted live object (kind=0, offset=80, uid=3, epoch=0)'
+          check_gate tcGcNoLeadingReread 'INV#2 violated: GC deleted live object (kind=1, offset=80, uid=820, epoch=0)'
+      - name: Validation gate (the reset-after-snapshot gap, shipped guards only)
+        run: |
+          cd p/gc-decision
+          # With all three shipped guards on, a reset that commits after the sweep
+          # snapshots still reaps the live re-tier: the epoch gate was already
+          # sampled and still_dangling re-reads the same stale floor. The proposed
+          # GUARD D (tcGcResetAfterSnapshotGuarded above) closes it; these must fail.
+          rm -rf PCheckerOutput/
+          echo "::group::tcGcResetAfterSnapshotStale (expect the reset-after-snapshot counterexample)"
+          if p check -tc tcGcResetAfterSnapshotStale -i 2000; then
+            echo "ERROR: tcGcResetAfterSnapshotStale passed; the shipped-guard gap is no longer reproduced."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object (kind=0, offset=80, uid=3, epoch=0)' PCheckerOutput/BugFinding/; then
+            echo "ERROR: the run failed, but not with the expected (offset=80, uid=3) counterexample."
+            exit 1
+          fi
+          echo "Gate satisfied: reset-after-snapshot reaps the live re-tier under shipped guards."
+          echo "::endgroup::"
+          rm -rf PCheckerOutput/
+          echo "::group::tcGcExploreShipped (PCT, expect the same gap)"
+          if p check -tc tcGcExploreShipped --sch-pct 20 -i 6000; then
+            echo "ERROR: tcGcExploreShipped passed; PCT no longer reaches the reset-after-snapshot gap."
+            exit 1
+          fi
+          if ! grep -rqF 'INV#2 violated: GC deleted live object' PCheckerOutput/BugFinding/; then
+            echo "ERROR: tcGcExploreShipped failed, but not via the INV#2 dangling reference."
+            exit 1
+          fi
+          echo "Gate satisfied: PCT reaches the reset-after-snapshot live deletion."
           echo "::endgroup::"
 
   delete-stream-anchor:

--- a/p/README.md
+++ b/p/README.md
@@ -20,7 +20,7 @@ The models target five global invariants of the tiered-storage design:
 | Invariant | Property | Model |
 | --- | --- | --- |
 | INV#1 | no lost acked data | `gc-reset/` |
-| INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/`, `gc-leading-group/` |
+| INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/`, `gc-leading-group/`, `gc-decision/` |
 | INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
 | INV#4 | tier resolution total / gap-free | `read-resolution/`, `tier-routing/` |
 | INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
@@ -46,6 +46,18 @@ protects the one leading group that straddles `first_offset` (retention advanced
 the floor into it on partial expiry) while deleting other groups below the floor.
 Verifies that removing the `referenced_group_key` carve-out deletes a live group.
 See [`gc-leading-group/README.md`](gc-leading-group/README.md).
+
+### `gc-decision/`
+
+The whole `rabbitmq_stream_s3_gc` reap decision in one state space: build_lookup,
+classify, and still_dangling composed, with all three classify reasons (data and
+group below the floor, stale-epoch manifest) and the guards interacting rather
+than isolated. Re-proves each shipped guard load-bearing in the composed decision,
+and surfaces a gap the single-axis models miss: a reset that commits after the
+sweep snapshots, on a node whose cache has not applied the sync, reaps a live
+re-tier even with every shipped guard on (the epoch gate is sampled once and
+still_dangling re-reads only the floor). Models a proposed execute-time epoch
+re-validation that closes it. See [`gc-decision/README.md`](gc-decision/README.md).
 
 ### `read-resolution/`
 

--- a/p/gc-decision/PSpec/Monitors.p
+++ b/p/gc-decision/PSpec/Monitors.p
@@ -1,0 +1,29 @@
+/* Global safety monitor for the integrated GC decision. It observes the
+   AUTHORITATIVE committed manifest state announced by the writer and drivers and
+   asserts GC never deletes a currently-referenced object. The lagging cache is
+   never a source of these events, so "referenced" always means what the committed
+   manifest references, regardless of which node's cache the sweep read.
+
+   This is INV#2 (no dangling-reference deletion) generalized over all three object
+   kinds at once: a data fragment at or above the live floor, a manifest at the
+   committed epoch, and the referenced leading group below the floor are all live
+   and all protected by the same assertion. */
+spec NoDanglingReference observes eObjectReferenced, eObjectUnreferenced, eGcDelete {
+  var live: set[Obj];
+
+  start state Watching {
+    on eObjectReferenced do (o: Obj) {
+      live += (o);
+    }
+    on eObjectUnreferenced do (o: Obj) {
+      if (o in live) {
+        live -= (o);
+      }
+    }
+    on eGcDelete do (o: Obj) {
+      assert !(o in live),
+        format("INV#2 violated: GC deleted live object (kind={0}, offset={1}, uid={2}, epoch={3}) still referenced by the committed manifest",
+          o.kind, o.offset, o.uid, o.epoch);
+    }
+  }
+}

--- a/p/gc-decision/PSrc/Common.p
+++ b/p/gc-decision/PSrc/Common.p
@@ -1,0 +1,121 @@
+/* Shared types and events for the integrated GC reap-decision model.
+
+   The single-axis GC models each prove one guard in isolation: ../gc-reset
+   (still_dangling re-reads the live floor), ../gc-reset-multinode (build_lookup
+   gates on cache epoch == committed epoch), ../gc-leading-group and
+   ../gc-reset-leading-group (the leading-group carve-out, snapshot and live).
+   Each collapses the other axes into a constant. This model composes the WHOLE
+   rabbitmq_stream_s3_gc decision into one state space so the guards can interact:
+   all three classify reasons and all three guards, two stores with independent
+   freshness, and a sweep a reset can interleave into.
+
+   The pipeline mirrors the code exactly:
+
+     1. build_lookup / build_stream_lookup - read the committed epoch with a
+        QUORUM read (rabbitmq_stream_s3_db:get_consistent) and read the floor plus
+        the leading-group carve-out from the LOCAL manifest_replica cache
+        (get_manifest_and_epoch). GUARD A (epoch gate): proceed only when the
+        cache epoch equals the committed epoch, else fail closed and skip. The
+        snapshot uses the committed epoch and the cached floor/carve-out.
+
+     2. classify - against the SNAPSHOT: a data object is an orphan iff its offset
+        is below the snapshot floor (reason below_first_offset); a group object
+        iff below the floor AND not the snapshot referenced leading group AND not
+        in conservative skip-groups mode; a manifest object iff its epoch is below
+        the committed epoch (reason stale_epoch).
+
+     3. still_dangling - re-validate each candidate immediately before deleting.
+        A stale_epoch candidate is deleted with no re-check (epoch is monotonic;
+        its safety rests on the ../writer-fencing guarantee). A below_first_offset
+        candidate re-reads the LIVE cache: GUARD B (re-read) compares the offset
+        to the live floor rather than the snapshot floor; GUARD C (live carve-out)
+        re-derives the leading group from the live manifest rather than the
+        snapshot. Either re-read returning undefined keeps the object.
+
+   The committed manifest truth is carried only by the authoritative
+   eObjectReferenced / eObjectUnreferenced announcements (as in ../gc-reset-multinode):
+   the cache is the single materialized copy GC reads, and it may lag. A reap is
+   a bug iff it deletes a currently-referenced object. */
+
+/* An S3 object: a data fragment, a metadata group, or a root manifest. For data
+   and group objects epoch is unused (0); for manifest objects offset is unused
+   (0). Identified by all four fields, so a stale UID and a freshly re-tiered one
+   at the same offset are distinct objects. */
+enum ObjKind { DATA, GROUP, MANIFEST }
+type Obj = (kind: ObjKind, offset: int, uid: int, epoch: int);
+
+/* Why classify/2 flagged an object. */
+enum Reason { BELOW_FLOOR, STALE_EPOCH }
+type Candidate = (obj: Obj, reason: Reason);
+
+/* Khepri (rabbitmq_stream_s3_db): the committed epoch, answered by a
+   strongly-consistent quorum read. Monotonic; the reset bumps it. */
+event eGetConsistent: (from: machine);
+event eEpochResult: (ok: bool, epoch: int);
+event eSetCommittedEpoch: (from: machine, epoch: int);
+event eDbAck;
+
+/* The local manifest_replica cache. A ManifestView is the cached manifest the
+   reads return: present is false when the cache has no usable manifest (the
+   get_manifest undefined case and the build_lookup empty-entries skip); floor is
+   first_offset; epoch is the epoch the cache was synced at; (leadOff, leadUid,
+   leadPresent) is the referenced leading group below the floor; skipGroups is the
+   conservative leading kilo-/mega-group mode. eMRSync is the fire-and-forget
+   propagation from the writer, applied only when the incoming epoch is not behind
+   the cached one (is_stale_sync). */
+type ManifestView = (present: bool, floor: int, epoch: int,
+                     leadOff: int, leadUid: int, leadPresent: bool, skipGroups: bool);
+event eMRSync: (from: machine, view: ManifestView);
+/* get_manifest_and_epoch: the epoch-aware read build_lookup uses (GUARD A). */
+event eMRGetFull: (from: machine);
+event eMRFullResult: ManifestView;
+/* get_manifest: the live read still_dangling re-uses. The real read drops the
+   epoch; this model ignores the epoch field of the result there. */
+event eMRGetLive: (from: machine);
+event eMRLiveResult: ManifestView;
+
+/* S3 object store. */
+event eS3Put: (from: machine, obj: Obj);
+event eS3Delete: (from: machine, obj: Obj);
+event eS3List: (from: machine);
+event eS3ListResult: set[Obj];
+event eS3Has: (from: machine, obj: Obj);
+event eS3HasResult: bool;
+event eS3Ack;
+
+/* Writer / reset orchestrator (rabbitmq_stream_s3_replica_reader). The reset is a
+   committed remote-tier-ahead reset: it bumps the committed epoch, lowers the
+   floor, and re-tiers a live fragment with a fresh UID below the old floor. It
+   announces the authoritative new floor and the re-tiered live (offset, uid). It
+   does NOT touch the cache - the cache learns of it only via eMRSync, which the
+   driver controls. */
+event eDoReset: (from: machine, newFloor: int, newEpoch: int, retierOffset: int, retierUid: int);
+event eResetDone;
+
+/* GC sweep steps, driven explicitly so a driver can force an exact interleaving
+   (e.g. snapshot, then a reset, then classify, then execute). */
+event eGcSnapshot;
+event eGcSnapshotDone;
+event eGcClassify;
+event eGcClassifyDone;
+event eGcExecute;
+event eGcExecuteDone;
+
+/* Spec events, delivered to monitors via announce. The AUTHORITATIVE committed
+   manifest drives them; the lagging cache is never their source. */
+event eObjectReferenced: Obj;
+event eObjectUnreferenced: Obj;
+event eGcDelete: Obj;
+
+/* Whether a group object is protected by a (snapshot or live) leading-group
+   carve-out: the stream is in conservative skip-groups mode, or the object is the
+   referenced leading group. Mirrors classify_group/3 and live_leading_group/3. */
+fun groupProtected(o: Obj, leadOff: int, leadUid: int, leadPresent: bool, skipGroups: bool): bool {
+  if (skipGroups) {
+    return true;
+  }
+  if (leadPresent && o.offset == leadOff && o.uid == leadUid) {
+    return true;
+  }
+  return false;
+}

--- a/p/gc-decision/PSrc/GC.p
+++ b/p/gc-decision/PSrc/GC.p
@@ -1,0 +1,198 @@
+/* The orphan GC sweep (rabbitmq_stream_s3_gc), the whole decision in one machine.
+   Split into the three steps the code performs, driven explicitly so a driver can
+   interleave a reset between them:
+
+     1. eGcSnapshot  - build_lookup/build_stream_lookup: quorum-read the committed
+                       epoch, read the cached manifest view, apply the epoch gate,
+                       and form the snapshot (committed epoch + cached floor and
+                       carve-out).
+     2. eGcClassify  - LIST S3 and classify/2 each object against the snapshot.
+     3. eGcExecute   - for each candidate apply still_dangling/1 (re-read the live
+                       cache) and delete.
+
+   Three independent guards, each the fix one single-axis model proved load-bearing:
+
+     - epochGate    (GUARD A, build_lookup): skip the stream unless the cache
+                    epoch equals the committed epoch. Without it a node that has
+                    not applied a reset sweeps against a stale-high floor.
+     - reread       (GUARD B, still_dangling): compare to the LIVE cache floor, not
+                    the snapshot floor. Without it a reset that lowers the floor
+                    between snapshot and execute lets a stale-high snapshot reap a
+                    re-tiered live object.
+     - leadingReread(GUARD C, still_dangling): re-derive the leading-group carve-out
+                    from the LIVE manifest, not the snapshot. Without it a reset
+                    plus forward retention that installs a new referenced leading
+                    group below the live floor is deleted by the stale snapshot
+                    carve-out.
+
+     - epochRecheck (GUARD D, still_dangling): PROPOSED, not shipped. Re-read the
+                    committed epoch and the cache epoch at execute time and fail
+                    closed when they differ. GUARD A samples the committed epoch
+                    once, in build_lookup; still_dangling re-reads only the floor
+                    (get_manifest drops the epoch). A reset that commits AFTER the
+                    snapshot, on a node whose cache has not applied the sync,
+                    therefore passes the (already-sampled) epoch gate and the live
+                    re-read sees the same stale-high floor. GUARD D closes that by
+                    re-validating freshness at the point of deletion; it requires
+                    still_dangling to use the epoch-aware read (get_manifest_and_epoch)
+                    plus a fresh get_consistent. */
+machine GC {
+  var epochGate: bool;
+  var reread: bool;
+  var leadingReread: bool;
+  var epochRecheck: bool;
+  var db: machine;
+  var cache: machine;
+  var s3: machine;
+  var driver: machine;
+
+  /* Snapshot taken at build_lookup time. */
+  var snapEpoch: int;
+  var snap: ManifestView;
+  var skipped: bool;
+  var candidates: seq[Candidate];
+
+  start state Idle {
+    entry (init: (epochGate: bool, reread: bool, leadingReread: bool, epochRecheck: bool,
+                  db: machine, cache: machine, s3: machine, driver: machine)) {
+      epochGate = init.epochGate;
+      reread = init.reread;
+      leadingReread = init.leadingReread;
+      epochRecheck = init.epochRecheck;
+      db = init.db;
+      cache = init.cache;
+      s3 = init.s3;
+      driver = init.driver;
+      skipped = false;
+    }
+
+    on eGcSnapshot do {
+      var committedEpoch: int;
+      var v: ManifestView;
+      /* Quorum read of the committed epoch (get_consistent). */
+      send db, eGetConsistent, (from = this,);
+      receive { case eEpochResult: (r: (ok: bool, epoch: int)) { committedEpoch = r.epoch; } }
+      /* Cached manifest view (get_manifest_and_epoch): floor and carve-out from
+         the local replica, plus the epoch it was synced at. */
+      send cache, eMRGetFull, (from = this,);
+      receive { case eMRFullResult: (x: ManifestView) { v = x; } }
+      snapEpoch = committedEpoch;
+      snap = v;
+      /* No usable cached manifest (undefined or empty entries): skip the stream. */
+      if (!v.present) {
+        skipped = true;
+      }
+      /* GUARD A: a cache behind the committed epoch has a floor that predates the
+         committed reset, so its floor may be stale-high. Fail closed and skip. */
+      if (epochGate && v.epoch != committedEpoch) {
+        skipped = true;
+      }
+      send driver, eGcSnapshotDone;
+    }
+
+    on eGcClassify do {
+      var objs: set[Obj];
+      var o: Obj;
+      candidates = default(seq[Candidate]);
+      if (!skipped) {
+        send s3, eS3List, (from = this,);
+        receive { case eS3ListResult: (lst: set[Obj]) { objs = lst; } }
+        foreach (o in objs) {
+          if (o.kind == DATA) {
+            /* A fragment below the snapshot floor is an orphan. */
+            if (o.offset < snap.floor) {
+              candidates += (sizeof(candidates), (obj = o, reason = BELOW_FLOOR));
+            }
+          } else if (o.kind == GROUP) {
+            /* A group below the floor is an orphan unless protected by the
+               snapshot carve-out (referenced leading group / skip-groups). */
+            if (o.offset < snap.floor &&
+                !groupProtected(o, snap.leadOff, snap.leadUid, snap.leadPresent, snap.skipGroups)) {
+              candidates += (sizeof(candidates), (obj = o, reason = BELOW_FLOOR));
+            }
+          } else {
+            /* A manifest below the committed epoch is stale. */
+            if (o.epoch < snapEpoch) {
+              candidates += (sizeof(candidates), (obj = o, reason = STALE_EPOCH));
+            }
+          }
+        }
+      }
+      send driver, eGcClassifyDone;
+    }
+
+    on eGcExecute do {
+      var i: int;
+      var c: Candidate;
+      i = 0;
+      while (i < sizeof(candidates)) {
+        c = candidates[i];
+        if (stillDangling(c)) {
+          send s3, eS3Delete, (from = this, obj = c.obj);
+          receive { case eS3Ack: { } }
+          announce eGcDelete, c.obj;
+        }
+        i = i + 1;
+      }
+      send driver, eGcExecuteDone;
+    }
+  }
+
+  /* still_dangling/1. A stale_epoch candidate is deleted with no re-check (epoch
+     is monotonic; safety rests on ../writer-fencing). A below_first_offset
+     candidate re-reads the live cache: GUARD B picks the live floor over the
+     snapshot floor, GUARD C re-derives the carve-out from the live view. A live
+     read with no usable manifest keeps the object (a later sweep reclaims it). */
+  fun stillDangling(c: Candidate): bool {
+    var live: ManifestView;
+    var committedNow: int;
+    var effFloor: int;
+    var leadOff: int;
+    var leadUid: int;
+    var leadPresent: bool;
+    var skipGroups: bool;
+
+    if (c.reason == STALE_EPOCH) {
+      return true;
+    }
+
+    send cache, eMRGetLive, (from = this,);
+    receive { case eMRLiveResult: (x: ManifestView) { live = x; } }
+    if (!live.present) {
+      return false;
+    }
+
+    /* GUARD D (proposed): re-validate the committed epoch against the cache epoch
+       at execute time. A reset committed after the snapshot leaves the cache
+       behind the committed epoch; fail closed rather than delete against a floor
+       that predates it. */
+    if (epochRecheck) {
+      send db, eGetConsistent, (from = this,);
+      receive { case eEpochResult: (r: (ok: bool, epoch: int)) { committedNow = r.epoch; } }
+      if (live.epoch != committedNow) {
+        return false;
+      }
+    }
+
+    if (reread) {
+      effFloor = live.floor;
+    } else {
+      effFloor = snap.floor;
+    }
+
+    if (c.obj.kind == DATA) {
+      return c.obj.offset < effFloor;
+    }
+
+    /* GROUP: re-validate the offset and the carve-out. */
+    if (leadingReread) {
+      leadOff = live.leadOff; leadUid = live.leadUid;
+      leadPresent = live.leadPresent; skipGroups = live.skipGroups;
+    } else {
+      leadOff = snap.leadOff; leadUid = snap.leadUid;
+      leadPresent = snap.leadPresent; skipGroups = snap.skipGroups;
+    }
+    return c.obj.offset < effFloor &&
+           !groupProtected(c.obj, leadOff, leadUid, leadPresent, skipGroups);
+  }
+}

--- a/p/gc-decision/PSrc/KhepriDB.p
+++ b/p/gc-decision/PSrc/KhepriDB.p
@@ -1,0 +1,21 @@
+/* Durable consensus layer (rabbitmq_stream_s3_db). Holds the committed epoch and
+   answers strongly-consistent reads. The committed epoch is monotonic and is the
+   authoritative truth a quorum read returns; the per-node manifest cache may lag
+   it. The reset commits the new (higher) epoch here BEFORE the sync that updates
+   the lagging cache, which is exactly why the cache can be behind. */
+machine KhepriDB {
+  var committedEpoch: int;
+
+  start state Serving {
+    entry (init: (epoch: int)) {
+      committedEpoch = init.epoch;
+    }
+    on eGetConsistent do (p: (from: machine)) {
+      send p.from, eEpochResult, (ok = true, epoch = committedEpoch);
+    }
+    on eSetCommittedEpoch do (p: (from: machine, epoch: int)) {
+      committedEpoch = p.epoch;
+      send p.from, eDbAck;
+    }
+  }
+}

--- a/p/gc-decision/PSrc/ManifestReplica.p
+++ b/p/gc-decision/PSrc/ManifestReplica.p
@@ -1,0 +1,39 @@
+/* A single per-node manifest replica cache (rabbitmq_stream_s3_manifest_replica),
+   the lagging non-writer node an operator CLI sweep happens to target. It holds
+   the cached manifest view: floor, the epoch that view was synced at, and the
+   leading-group carve-out (referenced leading group and the conservative
+   skip-groups flag) that build_lookup's lookup_entry derives from the manifest.
+
+   The cache learns of a committed change only via eMRSync, a fire-and-forget
+   cast applied only when the incoming epoch is not behind the cached epoch
+   (is_stale_sync, where epoch dominates). When the sync is never delivered the
+   cache keeps its stale view at its old epoch. The cache never announces to the
+   monitors: it is a possibly-stale view, not the source of truth.
+
+   get_manifest_and_epoch (eMRGetFull) returns the view WITH its epoch, the read
+   build_lookup uses for the epoch gate. get_manifest (eMRGetLive) is the read
+   still_dangling re-uses; the real function drops the epoch, so callers there
+   must not depend on the returned epoch field. */
+machine ManifestReplica {
+  var view: ManifestView;
+
+  start state Serving {
+    entry (init: (view: ManifestView)) {
+      view = init.view;
+    }
+
+    on eMRSync do (p: (from: machine, view: ManifestView)) {
+      if (p.view.epoch >= view.epoch) {
+        view = p.view;
+      }
+    }
+
+    on eMRGetFull do (p: (from: machine)) {
+      send p.from, eMRFullResult, view;
+    }
+
+    on eMRGetLive do (p: (from: machine)) {
+      send p.from, eMRLiveResult, view;
+    }
+  }
+}

--- a/p/gc-decision/PSrc/S3Store.p
+++ b/p/gc-decision/PSrc/S3Store.p
@@ -1,0 +1,27 @@
+/* The S3 object store. Objects are identified by all of (kind, offset, uid,
+   epoch). LIST returns whatever is present at the moment of the call. The
+   committed reset has already put any re-tiered live object here (the durable
+   side of the reset is done); what the model explores is whether the lagging
+   cache the sweep reads knows about the lowered floor. */
+machine S3Store {
+  var objects: set[Obj];
+
+  start state Serving {
+    on eS3Put do (p: (from: machine, obj: Obj)) {
+      objects += (p.obj);
+      send p.from, eS3Ack;
+    }
+    on eS3Delete do (p: (from: machine, obj: Obj)) {
+      if (p.obj in objects) {
+        objects -= (p.obj);
+      }
+      send p.from, eS3Ack;
+    }
+    on eS3Has do (p: (from: machine, obj: Obj)) {
+      send p.from, eS3HasResult, (p.obj in objects);
+    }
+    on eS3List do (p: (from: machine)) {
+      send p.from, eS3ListResult, objects;
+    }
+  }
+}

--- a/p/gc-decision/PSrc/Writer.p
+++ b/p/gc-decision/PSrc/Writer.p
@@ -1,0 +1,34 @@
+/* The writer / reset orchestrator (rabbitmq_stream_s3_replica_reader). By the
+   time the dangerous CLI sweep runs, the committed remote-tier-ahead reset is
+   durable: the new (higher) epoch is committed in Khepri, the floor is lowered in
+   the authoritative manifest, and the live fragment is re-tiered to S3 with a
+   fresh UID below the old floor.
+
+   The writer announces the AUTHORITATIVE manifest state to the monitors: the
+   re-tiered live (offset, uid) becomes referenced. The only modeled uncertainty
+   is whether the lagging cache the sweep reads has learned of the reset; that
+   propagation (eMRSync) is driven by the test driver, never by the writer. */
+machine Writer {
+  var db: machine;
+  var s3: machine;
+  var driver: machine;
+
+  start state Idle {
+    entry (init: (db: machine, s3: machine, driver: machine)) {
+      db = init.db;
+      s3 = init.s3;
+      driver = init.driver;
+    }
+    on eDoReset do (p: (from: machine, newFloor: int, newEpoch: int, retierOffset: int, retierUid: int)) {
+      /* Commit the new epoch (the quorum truth a sweep's get_consistent sees). */
+      send db, eSetCommittedEpoch, (from = this, epoch = p.newEpoch);
+      receive { case eDbAck: { } }
+      /* Re-tier the live fragment below the lowered floor with a fresh UID, and
+         announce it as referenced by the committed manifest. */
+      announce eObjectReferenced, (kind = DATA, offset = p.retierOffset, uid = p.retierUid, epoch = 0);
+      send s3, eS3Put, (from = this, obj = (kind = DATA, offset = p.retierOffset, uid = p.retierUid, epoch = 0));
+      receive { case eS3Ack: { } }
+      send driver, eResetDone;
+    }
+  }
+}

--- a/p/gc-decision/PTst/TestDrivers.p
+++ b/p/gc-decision/PTst/TestDrivers.p
@@ -1,0 +1,371 @@
+/* Test drivers for the integrated GC reap-decision model.
+
+   The holds exercise the whole decision with every guard on; each gate turns one
+   guard off and must reproduce a live deletion, proving that guard load-bearing
+   inside the composed model rather than in isolation:
+
+     - tcGcBasicReclaim        - data + manifest orphans reclaimed, live preserved
+     - tcGcCrossNodeStaleGuarded / ...Unguarded - GUARD A (build_lookup epoch gate)
+     - tcGcNoReread            - GUARD B (still_dangling live-floor re-read)
+     - tcGcNoLeadingReread     - GUARD C (still_dangling live carve-out re-derivation)
+
+   tcGcResetAfterSnapshotStale and tcGcExplore probe an interaction no single-axis
+   model covers: a reset that commits AFTER build_lookup's get_consistent. The
+   epoch gate samples the committed epoch once, at snapshot; still_dangling never
+   re-checks it. If a lagging node's sweep snapshots epoch N, a reset to N+1 then
+   commits and re-tiers, and the cache has not applied the sync, the live re-read
+   still sees the stale-high floor. These two tests are OBSERVATIONS: they assert
+   the same safety property and report whether that window is reachable. */
+
+fun dataObj(off: int, uid: int): Obj { return (kind = DATA, offset = off, uid = uid, epoch = 0); }
+fun groupObj(off: int, uid: int): Obj { return (kind = GROUP, offset = off, uid = uid, epoch = 0); }
+fun manifestObj(ep: int, uid: int): Obj { return (kind = MANIFEST, offset = 0, uid = uid, epoch = ep); }
+
+fun mkView(present: bool, floor: int, epoch: int,
+           leadOff: int, leadUid: int, leadPresent: bool, skip: bool): ManifestView {
+  return (present = present, floor = floor, epoch = epoch,
+          leadOff = leadOff, leadUid = leadUid, leadPresent = leadPresent, skipGroups = skip);
+}
+
+fun S3Put(self: machine, s3: machine, o: Obj) {
+  send s3, eS3Put, (from = self, obj = o);
+  receive { case eS3Ack: { } }
+}
+
+fun S3Has(self: machine, s3: machine, o: Obj): bool {
+  var present: bool;
+  send s3, eS3Has, (from = self, obj = o);
+  receive { case eS3HasResult: (b: bool) { present = b; } }
+  return present;
+}
+
+fun GcSnapshot(self: machine, gc: machine) {
+  send gc, eGcSnapshot;
+  receive { case eGcSnapshotDone: { } }
+}
+fun GcClassify(self: machine, gc: machine) {
+  send gc, eGcClassify;
+  receive { case eGcClassifyDone: { } }
+}
+fun GcExecute(self: machine, gc: machine) {
+  send gc, eGcExecute;
+  receive { case eGcExecuteDone: { } }
+}
+fun Sweep3(self: machine, gc: machine) {
+  GcSnapshot(self, gc);
+  GcClassify(self, gc);
+  GcExecute(self, gc);
+}
+
+/* Single node, cache in sync. A data orphan below the floor and a stale-epoch
+   manifest are reclaimed; the live fragment above the floor and the current
+   manifest are preserved. Exercises the data and manifest reasons together. */
+fun ScenarioBasic(self: machine) {
+  var db: machine; var s3: machine; var cache: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 100, 1, 0, 0, false, false),));
+  gc = new GC((epochGate = true, reread = true, leadingReread = true, epochRecheck = false,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, dataObj(150, 2);
+  announce eObjectReferenced, manifestObj(1, 8);
+
+  S3Put(self, s3, dataObj(50, 1));
+  S3Put(self, s3, dataObj(150, 2));
+  S3Put(self, s3, manifestObj(0, 9));
+  S3Put(self, s3, manifestObj(1, 8));
+
+  Sweep3(self, gc);
+
+  assert !S3Has(self, s3, dataObj(50, 1)),
+    "basic: data orphan below the floor was not reclaimed";
+  assert !S3Has(self, s3, manifestObj(0, 9)),
+    "basic: stale-epoch manifest was not reclaimed";
+  assert S3Has(self, s3, dataObj(150, 2)),
+    "basic: live fragment above the floor was deleted";
+  assert S3Has(self, s3, manifestObj(1, 8)),
+    "basic: current manifest was deleted";
+}
+
+/* Cross-node (../gc-reset-multinode integrated): a committed reset lowers the
+   floor and re-tiers a live fragment below the lagging cache's stale-high floor.
+   The reset commits BEFORE the sweep snapshots, so get_consistent returns the new
+   epoch and the epoch gate can catch the lag. epochGate off + sync dropped reaps
+   the live (850, 2); epochGate on fails closed; sync delivered reclaims the deep
+   orphan and preserves the live re-tier. */
+fun ScenarioCrossNode(self: machine, epochGate: bool, deliverSync: bool) {
+  var db: machine; var s3: machine; var cache: machine; var writer: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 1000, 1, 0, 0, false, false),));
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((epochGate = epochGate, reread = true, leadingReread = true, epochRecheck = false,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, dataObj(1000, 10);
+  S3Put(self, s3, dataObj(1000, 10));
+  S3Put(self, s3, dataObj(850, 1));
+  S3Put(self, s3, dataObj(500, 0));
+
+  /* Reset commits (epoch 2, floor 850, re-tier (850, 2)) before the snapshot. */
+  send writer, eDoReset, (from = self, newFloor = 850, newEpoch = 2, retierOffset = 850, retierUid = 2);
+  receive { case eResetDone: { } }
+
+  if (deliverSync) {
+    send cache, eMRSync, (from = self, view = mkView(true, 850, 2, 0, 0, false, false));
+  }
+
+  Sweep3(self, gc);
+
+  if (deliverSync) {
+    assert !S3Has(self, s3, dataObj(500, 0)),
+      "cross-node synced: genuine deep orphan (500, 0) was not reclaimed";
+    assert S3Has(self, s3, dataObj(850, 2)),
+      "cross-node synced: live re-tiered (850, 2) was deleted";
+    assert S3Has(self, s3, dataObj(1000, 10)),
+      "cross-node synced: live (1000, 10) was deleted";
+  }
+}
+
+/* Single node, snapshot-then-reset (../gc-reset integrated): the sweep snapshots
+   the high floor, then a reset lowers the floor and re-tiers a live fragment, and
+   the cache catches up before execute. GUARD B (live-floor re-read) preserves the
+   re-tier; without it the stale-high snapshot floor reaps the live (80, 3). */
+fun ScenarioResetReread(self: machine, reread: bool) {
+  var db: machine; var s3: machine; var cache: machine; var writer: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 100, 1, 0, 0, false, false),));
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((epochGate = true, reread = reread, leadingReread = true, epochRecheck = false,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, dataObj(150, 2);
+  S3Put(self, s3, dataObj(150, 2));
+  S3Put(self, s3, dataObj(40, 1));
+
+  /* Snapshot the high floor (100), THEN the reset lands and the cache catches up. */
+  GcSnapshot(self, gc);
+  send writer, eDoReset, (from = self, newFloor = 60, newEpoch = 2, retierOffset = 80, retierUid = 3);
+  receive { case eResetDone: { } }
+  send cache, eMRSync, (from = self, view = mkView(true, 60, 2, 0, 0, false, false));
+
+  GcClassify(self, gc);
+  GcExecute(self, gc);
+
+  if (reread) {
+    assert !S3Has(self, s3, dataObj(40, 1)),
+      "reset-reread: genuine orphan (40, 1) was not reclaimed";
+    assert S3Has(self, s3, dataObj(80, 3)),
+      "reset-reread: live re-tiered (80, 3) was deleted";
+    assert S3Has(self, s3, dataObj(150, 2)),
+      "reset-reread: live (150, 2) was deleted";
+  }
+}
+
+/* Single node, snapshot-then-reset-plus-retention (../gc-reset-leading-group
+   integrated): the snapshot carve-out protects the OLD leading group (50, 510);
+   then retention advances the floor and promotes a NEW referenced leading group
+   (80, 820) below the live floor. GUARD C (live carve-out re-derivation) preserves
+   it; without it the stale snapshot carve-out reaps the live leading group. */
+fun ScenarioLeadingGroup(self: machine, leadingReread: bool) {
+  var db: machine; var s3: machine; var cache: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 100, 1, 50, 510, true, false),));
+  gc = new GC((epochGate = true, reread = true, leadingReread = leadingReread, epochRecheck = false,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, groupObj(50, 510);
+  announce eObjectReferenced, dataObj(150, 2);
+  S3Put(self, s3, groupObj(50, 510));
+  S3Put(self, s3, groupObj(80, 820));
+  S3Put(self, s3, groupObj(30, 300));
+  S3Put(self, s3, dataObj(150, 2));
+
+  /* Snapshot the carve-out at (50, 510), THEN retention advances the floor and
+     promotes (80, 820) to the referenced leading group; the cache catches up. */
+  GcSnapshot(self, gc);
+  announce eObjectUnreferenced, groupObj(50, 510);
+  announce eObjectReferenced, groupObj(80, 820);
+  send cache, eMRSync, (from = self, view = mkView(true, 120, 1, 80, 820, true, false));
+
+  GcClassify(self, gc);
+  GcExecute(self, gc);
+
+  if (leadingReread) {
+    assert !S3Has(self, s3, groupObj(30, 300)),
+      "leading-group: deep orphan group (30, 300) was not reclaimed";
+    assert S3Has(self, s3, groupObj(80, 820)),
+      "leading-group: live referenced leading group (80, 820) was deleted";
+    assert S3Has(self, s3, dataObj(150, 2)),
+      "leading-group: live (150, 2) was deleted";
+  }
+}
+
+/* A reset that commits AFTER the sweep snapshots, on a node whose cache never
+   applies the sync. GUARDS A/B/C are on: get_consistent returned the old epoch,
+   so the epoch gate passed; the reset then lowers the floor and re-tiers (80, 3);
+   the live re-read still sees the stale-high cached floor. epochRecheck toggles
+   the proposed GUARD D. Off (shipped) reaps the live re-tier; on closes it. */
+fun ScenarioResetAfterSnapshotStale(self: machine, epochRecheck: bool) {
+  var db: machine; var s3: machine; var cache: machine; var writer: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 100, 1, 0, 0, false, false),));
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((epochGate = true, reread = true, leadingReread = true, epochRecheck = epochRecheck,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, dataObj(150, 2);
+  S3Put(self, s3, dataObj(150, 2));
+  S3Put(self, s3, dataObj(40, 1));
+
+  /* Snapshot first: get_consistent sees epoch 1, cache epoch 1, gate passes. */
+  GcSnapshot(self, gc);
+
+  /* Reset commits epoch 2, lowers the floor to 60, re-tiers a live (80, 3). The
+     sync is NOT delivered: the cache keeps its stale-high floor 100 at epoch 1. */
+  send writer, eDoReset, (from = self, newFloor = 60, newEpoch = 2, retierOffset = 80, retierUid = 3);
+  receive { case eResetDone: { } }
+
+  GcClassify(self, gc);
+  GcExecute(self, gc);
+
+  if (epochRecheck) {
+    assert S3Has(self, s3, dataObj(80, 3)),
+      "reset-after-snapshot guarded: GUARD D failed to preserve the live re-tier (80, 3)";
+  }
+}
+
+/* PCT exploration. A reset may commit before or after the snapshot, and its sync
+   may or may not be delivered. epochRecheck toggles the proposed GUARD D: with it
+   off (shipped) the reset-after-snapshot branch reaps live; with it on no
+   interleaving violates safety. */
+fun ScenarioExplore(self: machine, epochRecheck: bool) {
+  var db: machine; var s3: machine; var cache: machine; var writer: machine; var gc: machine;
+
+  db = new KhepriDB((epoch = 1,));
+  s3 = new S3Store();
+  cache = new ManifestReplica((view = mkView(true, 100, 1, 0, 0, false, false),));
+  writer = new Writer((db = db, s3 = s3, driver = self));
+  gc = new GC((epochGate = true, reread = true, leadingReread = true, epochRecheck = epochRecheck,
+               db = db, cache = cache, s3 = s3, driver = self));
+
+  announce eObjectReferenced, dataObj(150, 2);
+  S3Put(self, s3, dataObj(150, 2));
+  S3Put(self, s3, dataObj(40, 1));
+
+  if ($) {
+    /* Reset before the snapshot: get_consistent sees the new epoch. */
+    send writer, eDoReset, (from = self, newFloor = 60, newEpoch = 2, retierOffset = 80, retierUid = 3);
+    receive { case eResetDone: { } }
+    if ($) {
+      send cache, eMRSync, (from = self, view = mkView(true, 60, 2, 0, 0, false, false));
+    }
+    Sweep3(self, gc);
+  } else {
+    /* Reset after the snapshot: get_consistent saw the old epoch. */
+    GcSnapshot(self, gc);
+    send writer, eDoReset, (from = self, newFloor = 60, newEpoch = 2, retierOffset = 80, retierUid = 3);
+    receive { case eResetDone: { } }
+    if ($) {
+      send cache, eMRSync, (from = self, view = mkView(true, 60, 2, 0, 0, false, false));
+    }
+    GcClassify(self, gc);
+    GcExecute(self, gc);
+  }
+}
+
+machine DriverBasic { start state Init { entry { ScenarioBasic(this); } } }
+machine DriverCrossNodeStaleUnguarded { start state Init { entry { ScenarioCrossNode(this, false, false); } } }
+machine DriverCrossNodeStaleGuarded { start state Init { entry { ScenarioCrossNode(this, true, false); } } }
+machine DriverCrossNodeSynced { start state Init { entry { ScenarioCrossNode(this, true, true); } } }
+machine DriverResetRereadHolds { start state Init { entry { ScenarioResetReread(this, true); } } }
+machine DriverNoReread { start state Init { entry { ScenarioResetReread(this, false); } } }
+machine DriverLeadingGroupHolds { start state Init { entry { ScenarioLeadingGroup(this, true); } } }
+machine DriverNoLeadingReread { start state Init { entry { ScenarioLeadingGroup(this, false); } } }
+machine DriverResetAfterSnapshotStale { start state Init { entry { ScenarioResetAfterSnapshotStale(this, false); } } }
+machine DriverResetAfterSnapshotGuarded { start state Init { entry { ScenarioResetAfterSnapshotStale(this, true); } } }
+machine DriverExploreShipped { start state Init { entry { ScenarioExplore(this, false); } } }
+machine DriverExploreGuarded { start state Init { entry { ScenarioExplore(this, true); } } }
+
+/* HOLD: data + manifest reasons reclaimed, live preserved, every guard on. */
+test tcGcBasicReclaim [main = DriverBasic]:
+  assert NoDanglingReference in
+  { DriverBasic, KhepriDB, S3Store, ManifestReplica, GC };
+
+/* GATE (MUST fail): GUARD A off, sync dropped. The shipped live re-read re-reads
+   the same stale cache, so the re-tiered live (850, 2) is deleted. */
+test tcGcCrossNodeStaleUnguarded [main = DriverCrossNodeStaleUnguarded]:
+  assert NoDanglingReference in
+  { DriverCrossNodeStaleUnguarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD: GUARD A on, sync dropped. The cache epoch lags the committed epoch, so
+   build_lookup fails closed and deletes nothing. */
+test tcGcCrossNodeStaleGuarded [main = DriverCrossNodeStaleGuarded]:
+  assert NoDanglingReference in
+  { DriverCrossNodeStaleGuarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD + anti-vacuity: GUARD A on, sync delivered. The caught-up cache lets the
+   sweep proceed, reclaim the deep orphan, and preserve the live re-tier. */
+test tcGcCrossNodeSynced [main = DriverCrossNodeSynced]:
+  assert NoDanglingReference in
+  { DriverCrossNodeSynced, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD + anti-vacuity: GUARD B on. The live-floor re-read preserves the re-tier
+   and still reclaims the genuine orphan. */
+test tcGcResetRereadHolds [main = DriverResetRereadHolds]:
+  assert NoDanglingReference in
+  { DriverResetRereadHolds, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* GATE (MUST fail): GUARD B off. The stale-high snapshot floor reaps the live
+   re-tiered (80, 3). */
+test tcGcNoReread [main = DriverNoReread]:
+  assert NoDanglingReference in
+  { DriverNoReread, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD + anti-vacuity: GUARD C on. The live carve-out re-derivation preserves the
+   newly promoted leading group and still reclaims the deep orphan group. */
+test tcGcLeadingGroupHolds [main = DriverLeadingGroupHolds]:
+  assert NoDanglingReference in
+  { DriverLeadingGroupHolds, KhepriDB, S3Store, ManifestReplica, GC };
+
+/* GATE (MUST fail): GUARD C off. The stale snapshot carve-out reaps the live
+   referenced leading group (80, 820). */
+test tcGcNoLeadingReread [main = DriverNoLeadingReread]:
+  assert NoDanglingReference in
+  { DriverNoLeadingReread, KhepriDB, S3Store, ManifestReplica, GC };
+
+/* GATE for GUARD D (MUST fail): the three shipped guards are on, but a reset
+   commits after the snapshot and the cache never applies the sync. The epoch gate
+   was already sampled, the live re-read sees the stale-high floor, and the live
+   re-tier (80, 3) is deleted. This is the gap the integrated model surfaces that
+   no single-axis model covers. */
+test tcGcResetAfterSnapshotStale [main = DriverResetAfterSnapshotStale]:
+  assert NoDanglingReference in
+  { DriverResetAfterSnapshotStale, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD + anti-vacuity: the proposed GUARD D re-validates the committed epoch at
+   execute time and fails closed, preserving the live re-tier. */
+test tcGcResetAfterSnapshotGuarded [main = DriverResetAfterSnapshotGuarded]:
+  assert NoDanglingReference in
+  { DriverResetAfterSnapshotGuarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* GATE (MUST fail): PCT exploration with shipped guards only reaches the
+   reset-after-snapshot deletion. */
+test tcGcExploreShipped [main = DriverExploreShipped]:
+  assert NoDanglingReference in
+  { DriverExploreShipped, KhepriDB, S3Store, ManifestReplica, Writer, GC };
+
+/* HOLD: PCT exploration with GUARD D on. No interleaving of reset timing and sync
+   delivery violates safety. */
+test tcGcExploreGuarded [main = DriverExploreGuarded]:
+  assert NoDanglingReference in
+  { DriverExploreGuarded, KhepriDB, S3Store, ManifestReplica, Writer, GC };

--- a/p/gc-decision/README.md
+++ b/p/gc-decision/README.md
@@ -1,0 +1,67 @@
+# Integrated GC reap-decision
+
+A model of the whole rabbitmq_stream_s3_gc decision in one state space. The other GC models each prove a single guard in isolation and collapse the remaining axes into a constant: gc-reset proves still_dangling re-reads the live floor, gc-reset-multinode proves build_lookup gates on the cache epoch, gc-leading-group and gc-reset-leading-group prove the leading-group carve-out. This model composes all three classify reasons and all the guards together so they can interact, with two stores that lag independently and a sweep a reset can interleave into. The point is the interactions, not re-proving each guard.
+
+## The decision, as the code runs it
+
+The sweep is three phases, each reading a different store, mirrored from the module:
+
+1. build_lookup reads the committed epoch with a quorum read (db:get_consistent) and reads the floor and the leading-group carve-out from the local manifest_replica cache (get_manifest_and_epoch). It proceeds only when the cache epoch equals the committed epoch, and snapshots the committed epoch together with the cached floor and carve-out.
+2. classify flags an object against that snapshot: a data fragment below the snapshot floor, a group below the floor that is neither the referenced leading group nor in skip-groups mode, or a manifest below the committed epoch.
+3. still_dangling re-validates each candidate immediately before deleting it. A stale-epoch candidate is deleted with no re-check because the epoch is monotonic. A below-floor candidate re-reads the live cache: it compares the offset to the live floor (get_manifest) and re-derives the leading-group carve-out from the live manifest.
+
+The committed manifest truth is carried only by the authoritative referenced and unreferenced announcements, exactly as in gc-reset-multinode. The cache is the single materialized copy the sweep reads, and it may lag. A reap is a bug only when it deletes a currently referenced object.
+
+## The four guards
+
+Three are shipped. Each gate turns one off and reproduces a live deletion, so the model proves it load-bearing in the composed decision rather than in isolation.
+
+| Guard | Where | If removed | Gate |
+| --- | --- | --- | --- |
+| A epoch gate | build_lookup: skip unless cache epoch equals committed epoch | a node that has not applied a reset sweeps against a stale-high floor and the live re-read confirms it | `tcGcCrossNodeStaleUnguarded` |
+| B live-floor re-read | still_dangling: compare to the live floor, not the snapshot floor | a reset that lowers the floor between snapshot and execute lets the stale-high snapshot reap a re-tiered live fragment | `tcGcNoReread` |
+| C live carve-out | still_dangling: re-derive the leading group from the live manifest | a reset plus forward retention installs a new referenced leading group below the live floor that the stale snapshot carve-out deletes | `tcGcNoLeadingReread` |
+
+The fourth guard is proposed, not shipped, and is the result the model exists to surface.
+
+## The gap the integration surfaces
+
+With all three shipped guards on, the model still reaches a live deletion when a reset commits after the sweep has snapshotted. build_lookup samples the committed epoch once, at the start. still_dangling re-reads only the floor (get_manifest drops the epoch), so it never notices that the committed epoch has moved. On a node whose cache has not applied the reset sync, the sweep snapshots epoch N with a matching cache and an honest floor, a reset to N+1 then commits and re-tiers a live fragment below the old floor, and the live re-read returns the same stale-high floor. The epoch gate has already passed and the floor re-read defends nothing. The sweep deletes the re-tiered live fragment.
+
+gc-reset-multinode closed the mirror image of this, where the reset commits before the snapshot so get_consistent returns the new epoch and the gate skips. Its single scenario fixed the reset-before-snapshot ordering and did not exercise reset-after-snapshot. The dangerous path is the operator CLI full sweep (run/1 to build_lookup), which pins no writer epoch and relies on the consistent read and the cache-epoch gate, both sampled once.
+
+The proposed guard D re-validates freshness at the point of deletion: still_dangling re-reads the committed epoch and the cache epoch and fails closed when they differ. This requires still_dangling to use the epoch-aware read (get_manifest_and_epoch) plus a fresh get_consistent. Where that re-check lands in real code (per candidate, per list page, or once per stream before execute) is an implementation choice; the model proves only that the logical re-validation closes the window. With guard D on the model holds across the reset timing and sync delivery; with it off the shipped behavior reaps the live fragment.
+
+## Tests
+
+| Test case | Expectation |
+| --- | --- |
+| `tcGcBasicReclaim` | holds: data and stale-manifest orphans reclaimed, live fragment and current manifest preserved |
+| `tcGcCrossNodeStaleGuarded` | holds: guard A fails closed when the cache epoch lags |
+| `tcGcCrossNodeSynced` | holds: caught-up cache reclaims the deep orphan and preserves the live re-tier |
+| `tcGcResetRereadHolds` | holds: guard B preserves the re-tier and still reclaims a genuine orphan |
+| `tcGcLeadingGroupHolds` | holds: guard C preserves the newly promoted leading group and reclaims a deep orphan group |
+| `tcGcResetAfterSnapshotGuarded` | holds: guard D preserves the re-tier when the reset commits after the snapshot |
+| `tcGcExploreGuarded` | holds under PCT over reset timing and sync delivery, guard D on |
+| `tcGcCrossNodeStaleUnguarded` | fails: guard A off reaps the live re-tier |
+| `tcGcNoReread` | fails: guard B off reaps the live re-tier |
+| `tcGcNoLeadingReread` | fails: guard C off reaps the live leading group |
+| `tcGcResetAfterSnapshotStale` | fails: shipped guards only, reset after snapshot reaps the live re-tier |
+| `tcGcExploreShipped` | fails: PCT with shipped guards only reaches the same deletion |
+
+`NoDanglingReference` is the single monitor: it observes the authoritative committed manifest and asserts GC never deletes a currently referenced object, across data, manifest, and leading-group objects at once.
+
+```bash
+p compile
+p check -tc tcGcBasicReclaim              -i 2000   # 0 bugs
+p check -tc tcGcResetAfterSnapshotGuarded -i 2000   # 0 bugs (guard D closes the gap)
+p check -tc tcGcExploreGuarded            -i 6000 --sch-pct 20   # 0 bugs
+p check -tc tcGcResetAfterSnapshotStale   -i 2000   # 1 bug (the shipped gap)
+p check -tc tcGcNoReread                  -i 2000   # 1 bug
+p check -tc tcGcNoLeadingReread           -i 2000   # 1 bug
+p check -tc tcGcCrossNodeStaleUnguarded   -i 2000   # 1 bug
+```
+
+## What the model does not cover
+
+The stale-epoch reap path deletes with no re-check, and its safety rests on epoch monotonicity, which is the subject of the writer-fencing model rather than this one. The model is one stream and one sweeping node, with the rest of the cluster represented by the committed-truth announcements and the lagging cache. The fail-closed-on-quorum-error path (a partitioned node that cannot reach a quorum) is covered by gc-reset-multinode and is not repeated here.

--- a/p/gc-decision/gc-decision.pproj
+++ b/p/gc-decision/gc-decision.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>GcDecision</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>


### PR DESCRIPTION
The existing GC models each prove one guard in isolation and collapse the other axes into a constant. This model composes the whole rabbitmq_stream_s3_gc decision (build_lookup, classify, still_dangling) into one state space: all three classify reasons and the guards interacting, two independently-lagging stores (committed epoch via quorum, manifest replica cache), and a two-phase sweep a reset can interleave into.

It re-proves each shipped guard load-bearing in the composed decision and surfaces a gap the single-axis models cannot reach. With all three shipped guards on, a remote-tier-ahead reset that commits after the sweep snapshots, on a node whose cache has not applied the sync, reaps a live re-tier: build_lookup samples the committed epoch once, and still_dangling re-reads only the floor (get_manifest drops the epoch), so the already-passed epoch gate and the stale-high cached floor both defend nothing. gc-reset-multinode closed the mirror case (reset before the snapshot); this leaves reset after the snapshot open. A proposed execute-time epoch re-validation closes it in the model.

Adds the gc-decision CI job mirroring the other models, with a validation gate per shipped guard and a gate for the reset-after-snapshot window.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
