### PR TITLE
Add exponential backoff and stalled-upload observability to the retry path (#212)

### DIFF
--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -27,6 +27,20 @@ For the concepts behind these scenarios, see [concepts.md](./concepts.md). For t
 
 ---
 
+## Upload retry strategy
+
+A failed fragment upload is always retried; the fragment is never abandoned, because dropping it would advance the manifest over a range that is not durable in S3 and leave a silent hole (issue #206). How the retry is paced depends on the error class.
+
+**Transient errors** (throttling, 5xx, timeouts, connection errors) are expected to clear quickly. The first retry is immediate, preserving responsiveness for a one-off blip. Successive consecutive failures of the same fragment back off exponentially from `stream_s3.task_retry_delay_constant` (10ms) by a factor of `stream_s3.task_retry_delay_exponent` (2), capped at `stream_s3.task_retry_delay_max_ms` (5s).
+
+**Non-transient errors** (a confirmed checksum mismatch, an unexpected 4xx) are unlikely to clear on a tight retry, so the pipeline stalls at the failed offset and retries with a backoff starting at `upload_retry_delay_ms` (1000ms), growing to `upload_retry_delay_max_ms` (30s). Local-tier cleanup also stalls at that offset, so the only durable copy is retained until the upload succeeds.
+
+Both profiles apply equal jitter (the delay is uniformly distributed in `[delay/2, delay]`) so that many streams stalled by a shared incident do not retry against S3 in lockstep. The per-fragment attempt counter resets once the fragment is durable.
+
+**Detection.** `rate(rabbitmq_stream_s3_transfer_retries[5m])` rising means uploads are not succeeding on the first try. `rate(rabbitmq_stream_s3_nontransient_transfer_retries[5m]) > 0` or `rabbitmq_stream_s3_upload_stalled_offset > 0` means a fragment is failing with a confirmed-fatal error and the pipeline is wedged at that offset; the accompanying WARNING log names the error and offset.
+
+---
+
 ## Leader election
 
 **Trigger.** Writer node fails or is shut down. A new writer is elected.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -163,12 +163,15 @@ Owned by `rabbitmq_stream_s3_replica_reader`. Each writer-node replica reader ow
 |-------------------------------------|---------|-------------------------------------------------------------------|
 | `rabbitmq_stream_s3_transfers_completed`               | counter | Fragment uploads that succeeded                                   |
 | `rabbitmq_stream_s3_transfers_failed`                  | counter | Fragment uploads that failed for any reason                       |
+| `rabbitmq_stream_s3_transfer_retries`                  | counter | Fragment upload retries scheduled (transient and non-transient errors) |
+| `rabbitmq_stream_s3_nontransient_transfer_retries`     | counter | Fragment upload retries for a confirmed-but-non-transient error (a checksum mismatch, an unexpected 4xx); the pipeline stalls at that offset until the fragment is durable |
 | `rabbitmq_stream_s3_bytes_transferred`                 | counter | Total payload bytes uploaded                                      |
 | `rabbitmq_stream_s3_groups_created`                    | counter | Group manifest objects uploaded                                   |
 | `rabbitmq_stream_s3_kilo_groups_created`               | counter | Kilo-group manifest objects uploaded                              |
 | `rabbitmq_stream_s3_mega_groups_created`               | counter | Mega-group manifest objects uploaded                              |
 | `rabbitmq_stream_s3_roots_created`                     | counter | Root manifest objects uploaded (one per successful persist)       |
 | `rabbitmq_stream_s3_transfers_in_flight`               | gauge   | Fragments cut and submitted that have not yet completed           |
+| `rabbitmq_stream_s3_upload_stalled_offset`             | gauge   | Offset at which the pipeline is stalled on a non-transient error, or 0 when not stalled |
 
 #### Pipeline (drain to persist)
 
@@ -372,6 +375,7 @@ The numbers below are starting points. Tune for your traffic patterns.
 - **Persistent transfer failures.** `rate(rabbitmq_stream_s3_transfers_failed[5m]) > 0` for more than ten minutes. Sustained failures usually mean S3 connectivity, throttling, or credentials problems.
 - **Persist conflicts.** `rate(rabbitmq_stream_s3_persist_conflicts[5m]) > 0`. A non-zero rate indicates competing writers, likely from a partition or a struggling leader election.
 - **Stuck uploads.** `rabbitmq_stream_s3_transfers_in_flight` non-zero and `rate(rabbitmq_stream_s3_transfers_completed[5m]) == 0` together. Drain loop is producing fragments but the governor is not flushing them.
+- **Stalled pipeline (non-transient error).** `rabbitmq_stream_s3_upload_stalled_offset > 0`, or `rate(rabbitmq_stream_s3_nontransient_transfer_retries[5m]) > 0`. A fragment is failing with a confirmed-fatal error (for example a persistent checksum mismatch or an unexpected 4xx) and the pipeline is stuck at that offset, retrying with a backoff. Inspect the accompanying WARNING log for the error and offset.
 - **Local log ahead recoveries.** `rate(rabbitmq_stream_s3_local_log_ahead_recoveries[1h]) > 0` for any stream. Indicates local retention is racing ahead of uploads. See [failure-modes.md](./failure-modes.md).
 - **Khepri conflicts.** `rate(rabbitmq_stream_s3_put_conflicts[5m]) > 0` matches `rabbitmq_stream_s3_persist_conflicts` above and surfaces the same problem from the metadata store side.
 - **S3 errors.** `rate(rabbitmq_stream_s3_response_500[5m]) > 0` or `rate(rabbitmq_stream_s3_response_503[5m]) > 0`. The plugin retries automatically; sustained high rates indicate an S3-side incident.

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -39,6 +39,7 @@ lives here. Callers use these functions instead of calling
     task_retry_delay_max_ms/0,
     task_retry_delay_constant/0,
     task_retry_delay_exponent/0,
+    upload_retry_delay_max_ms/0,
     verbose_logging/0,
     segment_upload_timeout/0,
     upload_retry_delay_ms/0,
@@ -193,12 +194,21 @@ verbose_logging() ->
 segment_upload_timeout() ->
     application:get_env(?APP, segment_upload_timeout, 45_000).
 
-%% Delay before retrying a fragment upload that failed with a non-transient
+%% Base delay before retrying a fragment upload that failed with a non-transient
 %% error. The upload pipeline stalls at the failed offset until the retry
-%% succeeds, so this bounds how often a persistently failing upload is retried.
+%% succeeds. Successive non-transient retries back off exponentially from this
+%% base (using task_retry_delay_exponent) up to upload_retry_delay_max_ms, so a
+%% persistently failing upload is not retried tightly.
 -spec upload_retry_delay_ms() -> non_neg_integer().
 upload_retry_delay_ms() ->
     application:get_env(?APP, upload_retry_delay_ms, 1000).
+
+%% Ceiling for the non-transient upload-retry backoff. A confirmed-fatal error
+%% (a checksum mismatch, an unexpected 4xx) is unlikely to clear on a tight
+%% retry, so the backoff is allowed to grow well beyond the transient ceiling.
+-spec upload_retry_delay_max_ms() -> non_neg_integer().
+upload_retry_delay_max_ms() ->
+    application:get_env(?APP, upload_retry_delay_max_ms, 30_000).
 
 %% Deadline for a submitted fragment transfer to report a result back to the
 %% replica reader. The reader submits each transfer to the per-node governor
@@ -280,6 +290,7 @@ defaults_test_() ->
         ?_assertEqual(false, verbose_logging()),
         ?_assertEqual(45_000, segment_upload_timeout()),
         ?_assertEqual(1000, upload_retry_delay_ms()),
+        ?_assertEqual(30_000, upload_retry_delay_max_ms()),
         ?_assertEqual(180_000, transfer_deadline_ms()),
         ?_assertEqual(60_000, retention_task_timeout()),
         ?_assertEqual(5000, tick_timeout_milliseconds()),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -98,19 +98,22 @@ returned by the functional core module.
 -define(C_REMOTE_TIER_RETENTION_FAILURES, 22).
 -define(C_MANIFEST_RESOLUTION_FAILURES, 23).
 -define(C_REMOTE_TIER_AHEAD_RECOVERIES, 24).
+-define(C_TRANSFER_RETRIES, 25).
+-define(C_NONTRANSIENT_TRANSFER_RETRIES, 26).
 %% Counters above; gauges below. The macro ?NODE_COUNTERS filters by
 %% type, and seshat requires counter indexes to be 1..N sequential. Add
 %% new counters before this divider and renumber the gauges that follow.
--define(C_TRANSFERS_IN_FLIGHT, 25).
--define(C_LAST_PERSIST_TIMESTAMP_MS, 26).
--define(C_MANIFEST_FIRST_OFFSET, 27).
--define(C_MANIFEST_NEXT_OFFSET, 28).
--define(C_MANIFEST_FIRST_TIMESTAMP_MS, 29).
--define(C_REMOTE_BYTES, 30).
--define(C_REMOTE_MESSAGES, 31).
--define(C_BYTES_IN_ASSEMBLY, 32).
--define(C_BYTES_IN_TRANSFER, 33).
--define(C_BYTES_IN_PERSIST, 34).
+-define(C_TRANSFERS_IN_FLIGHT, 27).
+-define(C_LAST_PERSIST_TIMESTAMP_MS, 28).
+-define(C_MANIFEST_FIRST_OFFSET, 29).
+-define(C_MANIFEST_NEXT_OFFSET, 30).
+-define(C_MANIFEST_FIRST_TIMESTAMP_MS, 31).
+-define(C_REMOTE_BYTES, 32).
+-define(C_REMOTE_MESSAGES, 33).
+-define(C_BYTES_IN_ASSEMBLY, 34).
+-define(C_BYTES_IN_TRANSFER, 35).
+-define(C_BYTES_IN_PERSIST, 36).
+-define(C_UPLOAD_STALLED_OFFSET, 37).
 
 -define(STREAM_COUNTERS, [
     {transfers_completed, ?C_TRANSFERS_COMPLETED, counter,
@@ -169,6 +172,14 @@ returned by the functional core module.
         "Number of times manifest resolution could not reach the metadata store or "
         "object store and scheduled a retry, rather than treating the remote tier as "
         "empty. A sustained non-zero rate means a stream cannot start tiering."},
+    {transfer_retries, ?C_TRANSFER_RETRIES, counter,
+        "Fragment upload retries scheduled (both transient and non-transient errors). "
+        "A sustained non-zero rate means uploads are not succeeding on the first try."},
+    {nontransient_transfer_retries, ?C_NONTRANSIENT_TRANSFER_RETRIES, counter,
+        "Fragment upload retries scheduled for a confirmed-but-non-transient error "
+        "(for example a checksum mismatch or an unexpected 4xx). The pipeline stalls "
+        "at the offset until the fragment is durable, so a sustained non-zero rate "
+        "means a stream's tiering is wedged."},
     {transfers_in_flight, ?C_TRANSFERS_IN_FLIGHT, gauge,
         "Fragments cut and submitted to the governor that have not yet completed"},
     {last_persist_timestamp_ms, ?C_LAST_PERSIST_TIMESTAMP_MS, gauge,
@@ -192,7 +203,11 @@ returned by the functional core module.
         "stage 2."},
     {bytes_in_persist, ?C_BYTES_IN_PERSIST, gauge,
         "Bytes in fragments uploaded to S3 whose manifest update has not yet "
-        "succeeded. Pipeline stage 3."}
+        "succeeded. Pipeline stage 3."},
+    {upload_stalled_offset, ?C_UPLOAD_STALLED_OFFSET, gauge,
+        "The offset at which the upload pipeline is currently stalled on a "
+        "non-transient error, or 0 when not stalled. The pipeline retries this "
+        "fragment with a backoff and makes no forward progress until it is durable."}
 ]).
 
 %% Node-level shadow counter set. Per-stream counters are dropped from
@@ -248,6 +263,12 @@ returned by the functional core module.
     %% completes. This eliminates the race where a reader sees a stale
     %% manifest pointing to already-deleted objects (issue #166).
     deferred_deletions = [] :: [#fragment_ref{} | #group_ref{}],
+    %% Fragments currently being retried after a non-transient (confirmed-fatal)
+    %% upload error, keyed by transfer Ref with their first offset. The pipeline
+    %% stalls head-of-line, but several fragments can each hit a non-transient
+    %% error, so this is a set; the upload_stalled_offset gauge reflects the
+    %% lowest (head) stalled offset, or 0 when empty.
+    stalled_transfers = #{} :: #{reference() => osiris:offset()},
     %% Set when the core asks to shut down (the stream's metadata node was
     %% deleted). The handler that executed the effect returns {stop, normal}.
     stopping = false :: boolean()
@@ -908,28 +929,43 @@ execute_effect({submit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} =
     StreamId = Cfg#cfg.stream,
     submit_upload(Ref, Dir, StreamId, Meta),
     on_transfer_submitted(Ref, maps:get(size, Meta), State0);
-execute_effect({resubmit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} = State0) ->
+execute_effect({resubmit_transfer, Ref, _StreamId, Dir, Meta, Attempt}, #state{cfg = Cfg} = State0) ->
     StreamId = Cfg#cfg.stream,
-    submit_upload(Ref, Dir, StreamId, Meta),
+    inc(State0, ?C_TRANSFER_RETRIES, 1),
+    Delay = transient_retry_delay(Attempt),
+    _ =
+        case Delay of
+            0 ->
+                %% First transient retry: resubmit immediately, preserving the
+                %% prior behaviour for a one-off blip.
+                submit_upload(Ref, Dir, StreamId, Meta);
+            _ ->
+                erlang:send_after(Delay, self(), {retry_transfer, Ref, Dir, Meta})
+        end,
     %% The failure already removed Ref from the model. Re-add it (a fresh slot
     %% with a new deadline token) so the eventual completion is accounted for.
     on_transfer_submitted(Ref, maps:get(size, Meta), State0);
 execute_effect(
-    {resubmit_transfer_delayed, Ref, _StreamId, Dir, Meta, Reason}, #state{cfg = Cfg} = State0
+    {resubmit_transfer_delayed, Ref, _StreamId, Dir, Meta, Reason, Attempt},
+    #state{cfg = Cfg} = State0
 ) ->
     StreamId = Cfg#cfg.stream,
-    Delay = rabbitmq_stream_s3_config:upload_retry_delay_ms(),
+    inc(State0, ?C_TRANSFER_RETRIES, 1),
+    inc(State0, ?C_NONTRANSIENT_TRANSFER_RETRIES, 1),
+    Offset = maps:get(first_offset, Meta),
+    State1 = mark_transfer_stalled(Ref, Offset, State0),
+    Delay = nontransient_retry_delay(Attempt),
     ?LOG_WARNING(
-        "~ts fragment upload at offset ~b failed with non-transient error ~p; "
-        "retrying in ~bms. The upload pipeline and local-tier cleanup are "
-        "stalled at this offset until the fragment is durable in S3.",
-        [StreamId, maps:get(first_offset, Meta), Reason, Delay]
+        "~ts fragment upload at offset ~b failed with non-transient error ~p "
+        "(attempt ~b); retrying in ~bms. The upload pipeline and local-tier "
+        "cleanup are stalled at this offset until the fragment is durable in S3.",
+        [StreamId, Offset, Reason, Attempt, Delay]
     ),
     erlang:send_after(Delay, self(), {retry_transfer, Ref, Dir, Meta}),
     %% The failure already removed Ref from the model. Re-add it now (the fragment
     %% is still pending and its bytes are still in the pipeline); the retry_transfer
     %% timer above triggers the actual re-upload after the backoff.
-    on_transfer_submitted(Ref, maps:get(size, Meta), State0);
+    on_transfer_submitted(Ref, maps:get(size, Meta), State1);
 execute_effect(
     {upload_group, StreamId, Kind, Entries, _Pos, _Len},
     #state{tasks = Tasks0, task_io = Io} = State0
@@ -1811,6 +1847,32 @@ dec(#state{metrics = Cnt}, Idx, N) when is_integer(N), N > 0 ->
 dec(_, _, _) ->
     ok.
 
+%% Backoff (with equal jitter) before resubmitting a transient upload failure.
+%% Attempt 1 retries immediately, preserving the prior behaviour for a one-off
+%% blip; attempts 2+ back off exponentially from task_retry_delay_constant up to
+%% task_retry_delay_max_ms.
+transient_retry_delay(1) ->
+    0;
+transient_retry_delay(Attempt) when Attempt > 1 ->
+    Base = rabbitmq_stream_s3_config:task_retry_delay_constant(),
+    Exp = rabbitmq_stream_s3_config:task_retry_delay_exponent(),
+    Max = rabbitmq_stream_s3_config:task_retry_delay_max_ms(),
+    %% Attempt - 1 so the first backed-off retry (attempt 2) uses Base.
+    rabbitmq_stream_s3_util:equal_jitter(
+        rabbitmq_stream_s3_util:backoff_delay(Attempt - 1, Base, Exp, Max)
+    ).
+
+%% Backoff (with equal jitter) before resubmitting a non-transient upload
+%% failure. A confirmed-fatal error is unlikely to clear on a tight retry, so
+%% the backoff starts at upload_retry_delay_ms and grows to a higher ceiling.
+nontransient_retry_delay(Attempt) when Attempt >= 1 ->
+    Base = rabbitmq_stream_s3_config:upload_retry_delay_ms(),
+    Exp = rabbitmq_stream_s3_config:task_retry_delay_exponent(),
+    Max = rabbitmq_stream_s3_config:upload_retry_delay_max_ms(),
+    rabbitmq_stream_s3_util:equal_jitter(
+        rabbitmq_stream_s3_util:backoff_delay(Attempt, Base, Exp, Max)
+    ).
+
 %% Submit a fragment upload to the governor. Shared by the initial submit
 %% and the immediate/delayed retry paths.
 submit_upload(Ref, Dir, StreamId, Meta) ->
@@ -1885,6 +1947,35 @@ derive_gauges(#state{tasks = Tasks} = State) ->
     ),
     State.
 
+%% Record a fragment as stalled on a non-transient error and republish the
+%% stalled-offset gauge (the lowest stalled offset is the head-of-line stall).
+mark_transfer_stalled(Ref, Offset, #state{stalled_transfers = Stalled} = State) ->
+    State1 = State#state{stalled_transfers = Stalled#{Ref => Offset}},
+    set_stalled_gauge(State1),
+    State1.
+
+%% Clear a fragment's stall once it is durable and republish the gauge. A Ref
+%% that was never stalled (the common case) is a no-op.
+clear_transfer_stalled(Ref, #state{stalled_transfers = Stalled} = State) ->
+    case maps:is_key(Ref, Stalled) of
+        false ->
+            State;
+        true ->
+            State1 = State#state{stalled_transfers = maps:remove(Ref, Stalled)},
+            set_stalled_gauge(State1),
+            State1
+    end.
+
+%% The gauge is the lowest stalled offset (the fragment blocking the pipeline
+%% head), or 0 when nothing is stalled.
+set_stalled_gauge(#state{stalled_transfers = Stalled} = State) ->
+    Offset =
+        case maps:values(Stalled) of
+            [] -> 0;
+            Offsets -> lists:min(Offsets)
+        end,
+    set(State, ?C_UPLOAD_STALLED_OFFSET, Offset).
+
 %% Carry out the transfer task model's decision. The transferred byte size is
 %% read before the step for the cumulative counter on success.
 apply_transfer_decisions(
@@ -1893,8 +1984,11 @@ apply_transfer_decisions(
     State1 = cancel_transfer_timer(Ref, State0),
     inc(State1, ?C_TRANSFERS_COMPLETED, 1),
     inc(State1, ?C_BYTES_TRANSFERRED, Size),
+    %% This fragment is durable; if it was being retried after a non-transient
+    %% error, clear its stall (the gauge falls to the next stalled offset, or 0).
+    State2 = clear_transfer_stalled(Ref, State1),
     {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, Uid, Core0),
-    {noreply, derive_gauges(execute_effects(Effects, State1#state{core = Core}))};
+    {noreply, derive_gauges(execute_effects(Effects, State2#state{core = Core}))};
 apply_transfer_decisions([{deliver, transfer_failed, {Ref, Reason}}], _Size, State0) ->
     handle_transfer_failure(Ref, Reason, State0);
 apply_transfer_decisions([{drop, _Reason}], _Size, State) ->
@@ -2029,6 +2123,9 @@ reset_for_recovery(
     #state{transfer_timers = Timers0, persist_timer = PersistTimer, tasks = Tasks0} = State0
 ) ->
     set(State0, ?C_BYTES_IN_ASSEMBLY, 0),
+    %% Recovery replaces the core, so no stalled fragment carries over; clear the
+    %% stall set and its gauge.
+    set(State0, ?C_UPLOAD_STALLED_OFFSET, 0),
     %% Cancel the per-transfer liveness deadline timers (a late deadline message
     %% is dropped by the model after recover clears the transfer map) and the
     %% persist tick (the core is about to be replaced).
@@ -2048,7 +2145,8 @@ reset_for_recovery(
         assembly = undefined,
         transfer_timers = #{},
         persist_timer = undefined,
-        deferred_deletions = []
+        deferred_deletions = [],
+        stalled_transfers = #{}
     }).
 
 %% Demonitor (flushing the queued 'DOWN') and kill the task process if its pid
@@ -2513,5 +2611,51 @@ reset_manifest_carries_floor_as_first_and_next_test() ->
     ?assertEqual(M#manifest.first_offset, M#manifest.next_offset),
     ?assertEqual(<<>>, M#manifest.entries),
     ?assertEqual(7, M#manifest.revision).
+
+%% The transient retry profile retries the first attempt immediately and backs
+%% off (within the configured ceiling, jitter included) on later attempts. The
+%% non-transient profile starts at its base delay even on the first attempt.
+retry_delay_profiles_test() ->
+    %% Use defaults: transient base 10ms, max 5000ms; non-transient base 1000ms,
+    %% max 30000ms; exponent 2.
+    ?assertEqual(0, transient_retry_delay(1)),
+    %% Attempt 2 uses the base (10ms) before jitter; equal jitter keeps it in
+    %% [base/2, base].
+    D2 = transient_retry_delay(2),
+    ?assert(D2 >= 5 andalso D2 =< 10),
+    %% A very high attempt is capped at the transient ceiling (5000ms), jitter
+    %% keeping it within [max/2, max].
+    DHigh = transient_retry_delay(100),
+    ?assert(DHigh >= 2500 andalso DHigh =< 5000),
+    %% Non-transient starts at its base (1000ms) on attempt 1, never immediate.
+    DN1 = nontransient_retry_delay(1),
+    ?assert(DN1 >= 500 andalso DN1 =< 1000),
+    DNHigh = nontransient_retry_delay(100),
+    ?assert(DNHigh >= 15000 andalso DNHigh =< 30000).
+
+%% The stalled-offset gauge reflects the lowest stalled offset (head-of-line),
+%% so an out-of-order completion of a later fragment does not prematurely clear
+%% it; only draining the head does.
+stalled_offset_gauge_tracks_head_of_line_test() ->
+    {ok, _} = application:ensure_all_started(seshat),
+    _ = seshat:new_group(rabbitmq_stream_s3),
+    Cnt = seshat:new(rabbitmq_stream_s3, {?MODULE, test_stalled}, ?STREAM_COUNTERS, #{}),
+    State0 = #state{cfg = #cfg{stream = <<"s">>}, metrics = Cnt},
+    Gauge = fun() -> counters:get(Cnt, ?C_UPLOAD_STALLED_OFFSET) end,
+    ?assertEqual(0, Gauge()),
+    RefA = make_ref(),
+    RefB = make_ref(),
+    %% Two fragments stall; the gauge tracks the lower offset.
+    State1 = mark_transfer_stalled(RefA, 100, State0),
+    ?assertEqual(100, Gauge()),
+    State2 = mark_transfer_stalled(RefB, 200, State1),
+    ?assertEqual(100, Gauge()),
+    %% The later fragment (B) becoming durable does not clear the head stall.
+    State3 = clear_transfer_stalled(RefB, State2),
+    ?assertEqual(100, Gauge()),
+    %% Only when the head (A) drains does the gauge fall to 0.
+    _State4 = clear_transfer_stalled(RefA, State3),
+    ?assertEqual(0, Gauge()),
+    seshat:delete(rabbitmq_stream_s3, {?MODULE, test_stalled}).
 
 -endif.

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -74,7 +74,11 @@ testable without mocks or timing.
     %% Whether a retention evaluation is currently in flight (async group download).
     retention_in_flight = false :: boolean(),
     %% All edits (appends, rebalance, retention) since last persist, in order.
-    edits_since_persist = [] :: [#edit{}]
+    edits_since_persist = [] :: [#edit{}],
+    %% Consecutive failed upload attempts per in-flight transfer, keyed by Ref.
+    %% Incremented on each transfer_failed and used to drive the resubmit
+    %% backoff; cleared when the transfer is drained (success) or on reinit.
+    transfer_attempts = #{} :: #{reference() => pos_integer()}
 }).
 
 -opaque state() :: #state{}.
@@ -94,8 +98,10 @@ testable without mocks or timing.
     | {reply_waiters, [{gen_server:from(), ok}]}
     | {start_persist_timer, non_neg_integer()}
     | cancel_persist_timer
-    | {resubmit_transfer, reference(), stream_id(), directory(), fragment_meta()}
-    | {resubmit_transfer_delayed, reference(), stream_id(), directory(), fragment_meta(), term()}
+    | {resubmit_transfer, reference(), stream_id(), directory(), fragment_meta(),
+        Attempt :: pos_integer()}
+    | {resubmit_transfer_delayed, reference(), stream_id(), directory(), fragment_meta(),
+        Reason :: term(), Attempt :: pos_integer()}
     | reinitialize
     %% Stop the reader: the stream's metadata node was deleted, so there is
     %% nothing left to persist to.
@@ -230,12 +236,18 @@ transfer_complete(Ref, Uid, #state{pending_completions = PC} = State0) ->
     drain_completions(State1).
 
 -spec transfer_failed(reference(), term(), state()) -> {state(), [core_effect()]}.
-transfer_failed(Ref, Reason, #state{cfg = Cfg} = State) ->
-    Meta = get_meta(Ref, State),
+transfer_failed(Ref, Reason, #state{cfg = Cfg, transfer_attempts = Attempts} = State0) ->
+    Meta = get_meta(Ref, State0),
+    %% Count this failure as the Nth consecutive attempt for the fragment. The
+    %% count survives resubmits (Ref is stable) and drives the backoff; it is
+    %% cleared when the fragment is drained on success, or on reinit.
+    Attempt = maps:get(Ref, Attempts, 0) + 1,
+    State = State0#state{transfer_attempts = Attempts#{Ref => Attempt}},
     case is_retriable(Reason) of
         true ->
-            %% Transient error. Retry immediately.
-            {State, [{resubmit_transfer, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta}]};
+            %% Transient error. Retry with a (jittered) backoff applied by the
+            %% shell from the attempt count.
+            {State, [{resubmit_transfer, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta, Attempt}]};
         false ->
             %% A confirmed fragment must never be abandoned. Dropping it would
             %% let drain_completions advance next_offset over the subsequent
@@ -246,7 +258,9 @@ transfer_failed(Ref, Reason, #state{cfg = Cfg} = State) ->
             %% in the middle of the stream (see issue #206). Instead, keep the
             %% fragment at its place in the queue and retry it with a backoff
             %% delay, stalling the pipeline until it is durable.
-            {State, [{resubmit_transfer_delayed, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta, Reason}]}
+            {State, [
+                {resubmit_transfer_delayed, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta, Reason, Attempt}
+            ]}
     end.
 
 -spec persist_complete(rabbitmq_stream_s3_db:revision(), state()) -> {state(), [core_effect()]}.
@@ -524,7 +538,10 @@ drain_completions(#state{in_flight = Q, pending_completions = PC} = State0) ->
                     State1 = apply_fragment(Uid, Meta, State0),
                     State2 = State1#state{
                         in_flight = queue:drop(State1#state.in_flight),
-                        pending_completions = maps:remove(Ref, State1#state.pending_completions)
+                        pending_completions = maps:remove(Ref, State1#state.pending_completions),
+                        %% The fragment is durable; forget its retry history so a
+                        %% later transfer reusing this Ref starts at attempt 1.
+                        transfer_attempts = maps:remove(Ref, State1#state.transfer_attempts)
                     },
                     %% Continue draining contiguous completions.
                     {State3, Effects} = drain_completions(State2),

--- a/src/rabbitmq_stream_s3_util.erl
+++ b/src/rabbitmq_stream_s3_util.erl
@@ -5,6 +5,7 @@
 -moduledoc "Shared utility functions.".
 
 -export([now/0, elapsed_ms/1, elapsed_ms/2]).
+-export([backoff_delay/4, equal_jitter/1]).
 
 -spec now() -> integer().
 now() ->
@@ -17,3 +18,87 @@ elapsed_ms(StartTs) ->
 -spec elapsed_ms(integer(), integer()) -> non_neg_integer().
 elapsed_ms(Now, StartTs) ->
     erlang:convert_time_unit(Now - StartTs, native, millisecond).
+
+-doc """
+Exponential backoff delay for a given attempt, capped at Max.
+
+`Attempt` is 1-based: the first retry uses `Base`, the second `Base * Exp`, and
+so on, growing as `Base * Exp^(Attempt - 1)` until it reaches `Max`. Pure and
+deterministic; apply equal_jitter/1 to the result where jitter is wanted.
+""".
+-spec backoff_delay(
+    Attempt :: pos_integer(),
+    Base :: non_neg_integer(),
+    Exp :: pos_integer(),
+    Max :: non_neg_integer()
+) -> non_neg_integer().
+backoff_delay(Attempt, Base, Exp, Max) when
+    is_integer(Attempt), Attempt >= 1, Base >= 0, Exp >= 1, Max >= 0
+->
+    %% Cap the exponent so Exp^(Attempt - 1) cannot overflow into a huge
+    %% bignum before min/2 clamps it; once Base * Exp^N reaches Max, further
+    %% growth is irrelevant.
+    Factor = pow_capped(Exp, Attempt - 1, Max, Base),
+    min(Max, Base * Factor).
+
+%% Integer power Exp^N, stopping early once Base * accumulator would exceed Cap.
+pow_capped(_Exp, 0, _Cap, _Base) ->
+    1;
+pow_capped(Exp, N, Cap, Base) when N > 0 ->
+    pow_capped(Exp, N, Cap, Base, 1).
+
+pow_capped(_Exp, 0, _Cap, _Base, Acc) ->
+    Acc;
+pow_capped(_Exp, _N, Cap, Base, Acc) when Base * Acc >= Cap, Base > 0 ->
+    Acc;
+pow_capped(Exp, N, Cap, Base, Acc) ->
+    pow_capped(Exp, N - 1, Cap, Base, Acc * Exp).
+
+-doc """
+Apply equal jitter to a delay: half the delay plus a random amount in
+`[0, half]`, so the result is uniformly distributed in `[Delay/2, Delay]`.
+
+This spreads retries that would otherwise fire in lockstep across many streams
+after a shared outage, without ever exceeding the backoff ceiling.
+""".
+-spec equal_jitter(non_neg_integer()) -> non_neg_integer().
+equal_jitter(0) ->
+    0;
+equal_jitter(Delay) when is_integer(Delay), Delay > 0 ->
+    Half = Delay div 2,
+    Half + rand:uniform(Delay - Half + 1) - 1.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+backoff_delay_grows_then_caps_test() ->
+    %% Base 10, exponent 2, cap 5000: 10, 20, 40, ... doubling each attempt.
+    ?assertEqual(10, backoff_delay(1, 10, 2, 5000)),
+    ?assertEqual(20, backoff_delay(2, 10, 2, 5000)),
+    ?assertEqual(40, backoff_delay(3, 10, 2, 5000)),
+    ?assertEqual(80, backoff_delay(4, 10, 2, 5000)),
+    %% Eventually clamps at the cap and never exceeds it, even for large attempts.
+    ?assertEqual(5000, backoff_delay(100, 10, 2, 5000)),
+    ?assertEqual(5000, backoff_delay(1000, 10, 2, 5000)).
+
+backoff_delay_first_attempt_is_base_test() ->
+    ?assertEqual(1000, backoff_delay(1, 1000, 2, 30000)),
+    ?assertEqual(2000, backoff_delay(2, 1000, 2, 30000)),
+    ?assertEqual(30000, backoff_delay(10, 1000, 2, 30000)).
+
+backoff_delay_base_above_cap_is_clamped_test() ->
+    ?assertEqual(500, backoff_delay(1, 1000, 2, 500)).
+
+equal_jitter_bounds_test() ->
+    Delay = 1000,
+    Half = Delay div 2,
+    [
+        begin
+            J = equal_jitter(Delay),
+            ?assert(J >= Half andalso J =< Delay)
+        end
+     || _ <- lists:seq(1, 1000)
+    ],
+    ?assertEqual(0, equal_jitter(0)).
+
+-endif.

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -36,6 +36,7 @@ all() ->
         transfer_failed_retriable_resubmits,
         transfer_failed_status_map_retriable_resubmits,
         transfer_failed_fatal_retries_no_gap,
+        transfer_failed_attempt_counter_escalates_and_resets,
         fatal_failure_does_not_drain_subsequent,
         fatal_failure_retry_then_complete_no_gap,
         fatal_failure_mid_sequence,
@@ -309,7 +310,7 @@ transfer_failed_retriable_resubmits(_Config) ->
     %% slow_down is the S3 API layer's term for a 503 (the real shape; the old
     %% {http, 503} term was never constructed by any code).
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, slow_down, S1),
-    ?assertMatch([{resubmit_transfer, Ref, _, _, _}], Effects).
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 1}], Effects).
 
 transfer_failed_status_map_retriable_resubmits(_Config) ->
     %% A non-special-cased transient status arrives as #{status => _}; a 5xx
@@ -319,7 +320,7 @@ transfer_failed_status_map_retriable_resubmits(_Config) ->
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
         Ref, #{status => 504, headers => []}, S1
     ),
-    ?assertMatch([{resubmit_transfer, Ref, _, _, _}], Effects).
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 1}], Effects).
 
 transfer_failed_fatal_retries_no_gap(_Config) ->
     %% A non-transient upload failure must NOT advance the manifest. The
@@ -331,13 +332,32 @@ transfer_failed_fatal_retries_no_gap(_Config) ->
         Ref, checksum_mismatch, S1
     ),
     ?assertMatch(
-        [{resubmit_transfer_delayed, Ref, _, _, _, checksum_mismatch}], Effects
+        [{resubmit_transfer_delayed, Ref, _, _, _, checksum_mismatch, 1}], Effects
     ),
     %% The manifest must not have advanced.
     ?assertEqual(0, manifest_next_offset(S2)),
     %% A subsequent successful retry of the same fragment applies it.
     {S3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, S2),
     ?assertEqual(100, manifest_next_offset(S3)).
+
+transfer_failed_attempt_counter_escalates_and_resets(_Config) ->
+    %% The per-fragment attempt counter increments across consecutive failures
+    %% (so the shell can back off), and resets once the fragment is durable.
+    {S0, _} = init_core(),
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, Effects1} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, slow_down, S1),
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 1}], Effects1),
+    {S3, Effects2} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, slow_down, S2),
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 2}], Effects2),
+    {S4, Effects3} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, slow_down, S3),
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 3}], Effects3),
+    %% Once the fragment succeeds and drains, its attempt history is cleared. A
+    %% subsequent fragment's first failure therefore starts again at attempt 1,
+    %% confirming the counter does not leak across fragments.
+    {S5, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, S4),
+    {S6, Ref2, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S5),
+    {_S7, Effects4} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref2, slow_down, S6),
+    ?assertMatch([{resubmit_transfer, Ref2, _, _, _, 1}], Effects4).
 
 fatal_failure_does_not_drain_subsequent(_Config) ->
     %% The previously buggy behavior: dropping a fatally-failed fragment and
@@ -372,7 +392,7 @@ fatal_failure_retry_then_complete_no_gap(_Config) ->
     {S5, BEffects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
         RefB, {open_failed, "seg", enoent}, S4
     ),
-    ?assertMatch([{resubmit_transfer_delayed, RefB, _, _, _, _}], BEffects),
+    ?assertMatch([{resubmit_transfer_delayed, RefB, _, _, _, _, _}], BEffects),
     ?assertEqual(100, manifest_next_offset(S5)),
     %% C completes but is buffered behind B; still no advance.
     {S6, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(RefC, 3003, S5),
@@ -562,7 +582,7 @@ fatal_failure_mid_sequence(_Config) ->
     ?assertEqual(100, manifest_next_offset(S7)),
     %% Fragment 2 fails fatally. 3 and 4 must NOT drain.
     {S8, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref2, enoent, S7),
-    ?assertMatch([{resubmit_transfer_delayed, Ref2, _, _, _, enoent}], Effects),
+    ?assertMatch([{resubmit_transfer_delayed, Ref2, _, _, _, enoent, _}], Effects),
     ?assertEqual(100, manifest_next_offset(S8)),
     %% Fragment 2's retry succeeds. Now 2, 3 and 4 drain to 400.
     {S9, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref2, 1002, S8),
@@ -609,7 +629,7 @@ fatal_only_transfer_retries_keeps_queue(_Config) ->
     {S0, _} = init_core(#{persist_threshold => 10}),
     {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
     {S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, enoent, S1),
-    ?assertMatch([{resubmit_transfer_delayed, Ref, _, _, _, enoent}], Effects),
+    ?assertMatch([{resubmit_transfer_delayed, Ref, _, _, _, enoent, _}], Effects),
     ?assertEqual(0, manifest_next_offset(S2)),
     %% The retry of the same fragment eventually succeeds and applies.
     {S3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, S2),


### PR DESCRIPTION
Addresses the two items left outstanding in #212 after the earlier error-classification and data-loss-safety work shipped:

- no exponential backoff or cap on either upload-retry path
- no distinct signal when the pipeline is wedged on a fragment

## Backoff

Both retry paths now back off exponentially with equal jitter, on separate profiles:

- **Transient errors** (throttling, 5xx, timeouts, connection errors) keep an immediate first retry, preserving responsiveness for a one-off blip, then back off from `task_retry_delay_constant` (10ms) by `task_retry_delay_exponent` (2) up to `task_retry_delay_max_ms` (5s). This wires in config keys that existed but were previously read nowhere.
- **Non-transient errors** (a confirmed checksum mismatch, an unexpected 4xx), where the pipeline intentionally stalls at the failed offset until the fragment is durable (the #206 safety), back off from `upload_retry_delay_ms` (1000ms) up to a new `upload_retry_delay_max_ms` (30s).

Equal jitter (delay uniformly distributed in `[delay/2, delay]`) spreads retries that would otherwise fire in lockstep across many streams after a shared incident.

A per-fragment attempt counter in the functional core drives the backoff; it survives resubmits (the Ref is stable) and is cleared once the fragment is durable or on reinit. The pure `backoff_delay/4` and `equal_jitter/1` helpers live in `rabbitmq_stream_s3_util` so the core stays deterministic and the formula is unit tested; jitter is applied in the shell.

## Observability

- `rabbitmq_stream_s3_transfer_retries` counter: all retries scheduled (transient and non-transient)
- `rabbitmq_stream_s3_nontransient_transfer_retries` counter: retries for a confirmed-fatal error (the pipeline stalls at that offset)
- `rabbitmq_stream_s3_upload_stalled_offset` gauge: the head-of-line offset the pipeline is stalled at, or 0 when healthy. It tracks the lowest stalled offset, so an out-of-order completion of a later fragment does not prematurely clear it, and it clears on recovery.

The WARNING log on a non-transient failure now includes the attempt number.

## Why no `rabbit_alarm`

Consistent with the bucket-accessibility work in #314: the only alarm primitive (`resource_limit`) flow-blocks all publishers on the node, which is the wrong response to a tiering-side stall. The loud-but-safe signal here is the metrics plus the WARNING log.

## Docs

`operations.md` gains the new metrics and a stalled-pipeline alerting rule; `failure-modes.md` gains an "Upload retry strategy" section describing the two profiles, jitter, and detection.

## Config

`upload_retry_delay_max_ms` (default 30000) is added. Like the other retry-tuning keys (`upload_retry_delay_ms`, `task_retry_delay_*`), it is an app-env-only advanced knob with no cuttlefish mapping, matching the existing convention.

## Testing

- eunit: full suite (170), the pure backoff/jitter helpers (growth, cap, base-above-cap, jitter bounds), the core attempt-counter lifecycle (escalates across failures, resets on durability and across fragments), and the shell stalled-offset gauge (head-of-line tracking, no premature clear on out-of-order completion)
- CT: full `broker_SUITE`, `replica_reader`, `replica_reader_core`, `replica_reader_tasks`
- `dialyze` and `xref` clean