### PR TITLE
Write anchors to the DB in order to identify dangling objects

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ Each stream on the writer node has exactly one replica reader. Its lifecycle:
 2. **Resolve manifest.** Fetches the current manifest state to determine where to resume uploading. If S3 is unreachable, retries with backoff. The writer is unaffected.
 3. **Open data reader.** Calls `osiris_writer:init_data_reader/3` starting at the manifest's `next_offset`.
 4. **Drain loop.** On each `{osiris_offset, ...}` notification, reads committed chunk headers via `osiris_log:read_header/1`. Accumulates metadata in the fragment assembly.
-5. **Cut.** When the assembly reaches the size target (default 64 MiB), the fragment is sealed. The core assigns a reference and returns a `{submit_transfer, ...}` effect.
+5. **Cut.** When the assembly reaches the size target (default 64 MiB), the fragment is sealed. The core assigns a reference and returns a `{submit_transfer, ...}` effect. On a brand-new stream the very first cut instead returns a `{write_anchor, ...}` effect and holds the fragment's submit: the shell writes the per-stream anchor to Khepri, and the core releases the held submits only once the anchor is durable, so no S3 object can exist under a prefix whose anchor is absent (this is what makes deleted-stream GC safe; see [operations.md](./operations.md#safety-guarantee-the-anchor)). A reader resuming an established stream already has the anchor and skips this step.
 6. **Submit.** The shell submits the transfer to the governor. The drain loop continues immediately without waiting for the upload to complete.
 7. **Transfer complete.** The governor reports completion. The core applies the completion in cut order (buffering out-of-order arrivals). When a contiguous prefix of completions is ready, they are applied to the in-memory manifest.
 8. **Durable persist.** When the persist threshold is reached (N fragments applied, or timer fires), the shell spawns a task that PUTs the manifest root to S3 and writes to Khepri (optimistic lock).
@@ -176,13 +176,13 @@ When the rate is configured as `unlimited` (the default), the governor imposes n
 
 When a stream queue is deleted:
 1. RabbitMQ removes the queue from `rabbit_db_queue` in Khepri.
-2. The plugin's keep-while condition on its Khepri entry fires, removing the entry.
+2. The plugin's keep-while condition on the per-stream container node fires, removing the container and the subtree below it (the manifest pointer and the anchor).
 3. The stored procedure `handle_queue_deletion` runs, calling `rabbitmq_stream_s3_reaper:delete_stream(StreamId)`.
 4. The reaper spawns a short-lived task that pages through `rabbitmq_stream_s3_api:list/2` on the stream's prefix.
 5. Each page of keys is sent back to the reaper as a delete cast.
 6. The reaper batches keys (up to 1000) and calls `rabbitmq_stream_s3_api:delete/1`.
 
-If the task crashes or S3 is unavailable, the orphan detection mechanism eventually cleans up.
+If the task crashes or S3 is unavailable, the objects are left behind, but the anchor is already gone (step 2 removed the whole subtree), so a later GC run reaps the prefix via the no-anchor path. See [operations.md](./operations.md#garbage-collection).
 
 ## Read path (consumer side)
 

--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -203,7 +203,7 @@ Committed data (offsets 76-100, confirmed to publishers) is lost. This requires 
 - Deposed replica reader uploaded a fragment that was never applied to the manifest.
 - Manifest truncation removed entries but object deletion failed or is pending.
 - Stream deletion cleanup was interrupted.
-- A node's data directory was wiped (e.g. during node replacement or disaster recovery) and RabbitMQ restarted. The Khepri database is recreated from scratch and any streams that existed before the wipe are gone from Khepri, but not via a delete operation, so the keep-while condition that triggers S3 cleanup never evaluates and the S3 objects remain.
+- A node's data directory was wiped (e.g. during node replacement or disaster recovery) and RabbitMQ restarted. The Khepri database is recreated from scratch and any streams that existed before the wipe are gone from Khepri, but not via a delete operation, so the keep-while condition that triggers S3 cleanup never evaluates and the S3 objects remain. The per-stream anchor is also gone with the wiped database, so a GC run reclaims these objects via the no-anchor path (see Resolution below).
 
 **Impact assessment.** Wasted S3 storage. No correctness impact. No impact on consumers or publishers.
 
@@ -216,7 +216,7 @@ Committed data (offsets 76-100, confirmed to publishers) is lost. This requires 
 aws s3 ls "s3://${BUCKET}/rabbitmq/stream/${STREAM_ID}/data/" --recursive
 ```
 
-**Mitigation.** None needed urgently. Orphans do not affect operation. For unbounded accumulation (typically only after data-directory resets), operators can manually delete S3 prefixes for streams that no longer exist in Khepri.
+**Mitigation.** None needed urgently. Orphans do not affect operation.
 
 **Resolution.** The `rabbitmq_stream_s3_gc` module identifies and optionally deletes orphaned objects. Run it via the CLI:
 
@@ -226,4 +226,4 @@ rabbitmq-streams stream_s3_gc --formatter json
 rabbitmq-streams stream_s3_gc --mode delete
 ```
 
-See [operations.md](./operations.md#garbage-collection) for details on the GC mechanism, its safety guarantees, and current scope limitations.
+Objects whose stream is still live are classified against its first_offset and epoch. Objects whose stream is gone from Khepri (a deleted stream, or one whose metadata was wiped) are classified against the per-stream anchor: with the stream gone the anchor is absent, so a GC run reaps them via the no-anchor path rather than requiring manual deletion. See [operations.md](./operations.md#garbage-collection) for details on the GC mechanism and its safety guarantees.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -69,6 +69,16 @@ Append, rebalance, and retention keep the remote tier a contiguous extension bel
 |---|---|---|
 | Reset safety | When `f_local > n`, the writer discards `M` and installs the empty manifest at the floor: `f := n := f_local` and `Frag := ∅`. Coverage and Durability hold vacuously, since `Cov = ∅ = [f, n)`; the step advances `n` over `[n, f_local)` only while emptying coverage, so it never claims durability it lacks. This is the inverse of the #206 hole, which advanced `n` while claiming coverage. `f` and `n` are non-decreasing, and the seam is restored at `f_local`, so Tier overlap holds again with the remote tier empty and the local segments covering `[f_local, T)`. The discarded range `[f, f_local)` is lost by design: it is the un-uploaded tail together with the now-disconnected durable prefix, which cannot be kept without a hole in `M`. | [architecture.md](./architecture.md) (Durability versus the local retention bound) |
 
+## Garbage collection
+
+GC reaps an S3 object only when it can prove the object is not live. For an object whose stream is still in the committed lookup that proof is the monotonic offset/epoch barrier. For an object whose stream is absent from the lookup (deleted, never committed, or missing a local replica) the proof is the per-stream anchor.
+
+| Invariant | Statement | Where |
+|---|---|---|
+| Anchor ordering | A stream's anchor is committed to Khepri before its first S3 object is written, so no object can exist under a prefix whose anchor is absent. The anchor's presence therefore witnesses a live stream, and its absence witnesses a prefix that is safe to reap. | [operations.md](./operations.md#safety-guarantee-the-anchor) |
+| Anchor removal | The anchor is kept alive by a `keep_while` on the stream queue, so it is removed in the same transaction that deletes the queue. The "stream deleted" signal is permanent and cannot be lost to a crash. | [operations.md](./operations.md#safety-guarantee-the-anchor) |
+| Anchor read | An object whose stream is absent from the lookup is reaped only when a strongly-consistent read reports its anchor absent; a present anchor or a non-quorum read fails closed. A stale local read could report a live stream's anchor absent, so the consistent read is load-bearing. Modeled in [PR #311](https://github.com/amazon-mq/rabbitmq-stream-s3/pull/311). | [operations.md](./operations.md#safety-guarantee-the-anchor) |
+
 ## Read path
 
 | Invariant | Statement | Where |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -636,28 +636,39 @@ curl http://node:15692/metrics/per-object | grep 'queue="my-stream"'
 
 ## Garbage collection
 
-Objects in S3 can become orphaned (not referenced by any manifest) in several scenarios: a deposed writer uploads a fragment but loses the Khepri race, a manifest persist fails or the process crashes before completion, or retention deletes entries from the manifest but the corresponding object deletion does not complete.
+Objects in S3 can become orphaned (not referenced by any manifest) in several scenarios: a deposed writer uploads a fragment but loses the Khepri race, a manifest persist fails or the process crashes before completion, retention deletes entries from the manifest but the corresponding object deletion does not complete, or a stream is deleted (or its Khepri metadata is wiped) and its objects outlive the metadata that referenced them.
 
 The GC mechanism identifies these orphans by listing S3 objects and comparing their keys against current authoritative state. It is invoked on demand via the CLI.
 
 ### Safety guarantee: monotonicity
 
-The correctness of GC depends on a single structural property: the values used as barriers (`first_offset`, `epoch`) only ever increase. This makes false positives (deleting a live object) structurally impossible, regardless of timing or consistency:
+For an object whose stream is still in the committed lookup, correctness rests on a structural property: the values used as barriers (`first_offset`, `epoch`) only ever increase. This makes false positives (deleting a live object) structurally impossible, regardless of timing or consistency:
 
 - `first_offset` advances monotonically as retention removes data from the front of the manifest. An object whose offset is below first_offset was already removed by retention. It can never become live again.
 - `epoch` advances monotonically with each new writer. A manifest root whose epoch is below the current epoch belongs to a deposed writer. The new writer's manifest is authoritative and the old root can never become active again.
 
 Eventually-consistent reads (from Khepri or the manifest replica ETS cache) can only return stale values that are lower than or equal to the true current value. A stale barrier is more conservative: it classifies fewer objects as garbage. The GC may miss orphans on a given run (false negatives) but can never delete live objects (false positives).
 
+### Safety guarantee: the anchor
+
+Monotonicity covers objects whose stream is still in the committed lookup. An object whose stream is absent from the lookup (a deleted stream, a stream that never committed a manifest, or one missing a local manifest replica) has no offset or epoch barrier to classify it against. These are resolved against the per-stream anchor instead.
+
+Before the first remote-tier fragment is uploaded, the replica reader writes an anchor node in Khepri, kept alive by a `keep_while` condition on the stream queue. Two properties make it a correct-by-construction signal:
+
+- Anchor-before-fragment ordering: no S3 object can exist under a stream's prefix unless that stream's anchor committed first. An object under a prefix with no anchor is therefore junk.
+- Atomic removal: the `keep_while` removes the anchor in the same transaction that deletes the queue, so the "stream deleted" signal is permanent and cannot be lost to a crash.
+
+An object whose stream is not in the lookup is reaped only when a strongly-consistent (quorum-requiring) read reports its anchor absent. A present anchor, or a read that cannot reach a quorum, fails closed and the object is skipped. The consistent read is load-bearing: a stale local read could report a live stream's anchor absent and reap it. This safety rests on ordering and consistency rather than on the monotonicity argument above, and it is what lets a deleted stream's objects be reclaimed automatically rather than by hand.
+
 ### Classifying garbage
 
 | Object type   | Key format                                                  | Condition for "garbage"
 |---            |---                                                          |---
-| Fragment      | `rabbitmq/stream/<id>/data/<offset>.<uid>.fragment`         | offset < manifest first_offset
-| Group         | `rabbitmq/stream/<id>/metadata/<offset>.<uid>.<kind>`       | offset < manifest first_offset
-| Manifest root | `rabbitmq/stream/<id>/metadata/root.<epoch>.<uid>.manifest` | epoch < current epoch according to Khepri
+| Fragment      | `rabbitmq/stream/<id>/data/<offset>.<uid>.fragment`         | offset < manifest first_offset, or the stream's anchor is absent
+| Group         | `rabbitmq/stream/<id>/metadata/<offset>.<uid>.<kind>`       | offset < manifest first_offset, or the stream's anchor is absent
+| Manifest root | `rabbitmq/stream/<id>/metadata/root.<epoch>.<uid>.manifest` | epoch < current epoch according to Khepri, or the stream's anchor is absent
 
-Note that objects belonging to an unknown stream ID are not currently considered garbage. Handling this case is planned.
+A well-formed key whose stream is not in the committed lookup is classified against the per-stream anchor, described under [Safety guarantee: the anchor](#safety-guarantee-the-anchor) above: it is reaped (reason `no_anchor`) only when a strongly-consistent read confirms the anchor absent, which reclaims the objects of a deleted stream. A key whose format is unrecognised is skipped outright.
 
 ### Modes
 
@@ -671,7 +682,8 @@ With `--formatter json`, the output is a JSON array of objects:
 ```json
 [
   {"stream_id": "...", "key": "rabbitmq/stream/.../00000000000000000042.abcd1234.fragment", "reason": "below_first_offset"},
-  {"stream_id": "...", "key": "rabbitmq/stream/.../metadata/root.1.deadbeef.manifest", "reason": "stale_epoch"}
+  {"stream_id": "...", "key": "rabbitmq/stream/.../metadata/root.1.deadbeef.manifest", "reason": "stale_epoch"},
+  {"stream_id": "...", "key": "rabbitmq/stream/.../00000000000000000042.abcd1234.fragment", "reason": "no_anchor"}
 ]
 ```
 

--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -5,10 +5,24 @@
 -moduledoc """
 Khepri-based database operations for tracking state with strong consistency.
 
-This plugin uses Khepri to store a minimal amount of information per-stream: we
-store a mapping between the `stream_id()` and the currently active manifest
-incarnation (`rabbitmq_stream_s3:uid()`) and the epoch of the writer who
-created that incarnation.
+This plugin uses Khepri to store a minimal amount of information per-stream. Each
+stream owns a small subtree under `[rabbitmq_stream_s3, StreamId]`:
+
+  * the per-stream node itself is a `container`, kept alive by a keep_while
+    condition on the stream queue. Its deletion (when the queue is removed) fires
+    the cleanup trigger and, because it is the subtree root, removes the children
+    below it.
+  * the `manifest` child maps to the currently active manifest incarnation
+    (`rabbitmq_stream_s3:uid()`) and the epoch of the writer who created that
+    incarnation. This is the optimistically-locked pointer.
+  * the `anchor` child (written by `put_anchor/2` before the first remote-tier
+    fragment) records, by its mere presence, that the stream's S3 prefix belongs
+    to a live stream. Its absence is the by-construction signal that a prefix is
+    junk. See `rabbitmq_stream_s3_gc`.
+
+Keeping the manifest pointer in a child rather than on the container node lets the
+anchor be written first (it only needs the container to exist) without disturbing
+the manifest pointer's optimistic-lock conditions.
 
 Two stream writers may exist, but the deposed writer would need to be
 partitioned and totally unaware of the new writer. This is possible but
@@ -26,7 +40,15 @@ writer cannot make progress anymore.
 -include_lib("rabbit/include/rabbit_khepri.hrl").
 -include_lib("rabbit_common/include/resource.hrl").
 
+%% The per-stream container node. Kept alive by a keep_while on the stream queue;
+%% its deletion fires the cleanup trigger and removes the subtree below it.
 -define(PATH(StreamId), ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId])).
+%% The optimistically-locked manifest pointer ({uid, epoch}).
+-define(MANIFEST_PATH(StreamId),
+    ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId, manifest])
+).
+%% Presence marks the stream's S3 prefix as live; absence marks it as junk.
+-define(ANCHOR_PATH(StreamId), ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId, anchor])).
 -define(STREAM_QUEUE_DELETION_TRIGGER_ID, rabbitmq_stream_s3_db_sq_deletion).
 %% Bounds a consistent read so it cannot block indefinitely waiting for a quorum
 %% that will not form (for example on a minority partition); timing out there
@@ -51,6 +73,7 @@ Zero indicates that the manifest has not been created yet.
 -export([setup/0]).
 
 -export([get/1, get_consistent/1, list/0, count/0, put/5, queue_path/1]).
+-export([put_anchor/2, anchor_exists_consistent/1]).
 
 -define(C_SPROC_TRIGGERS, 1).
 -define(C_GETS, 2).
@@ -78,10 +101,13 @@ setup() ->
     Cnt = seshat:new(rabbitmq_stream_s3, ?MODULE, ?COUNTERS, #{module => ?MODULE}),
     persistent_term:put(?COUNTER_KEY, Cnt),
     %% Register a stored procedure which is triggered on deletion of each
-    %% stream created with `put/5`. Streams created with `put/5` are
-    %% automatically deleted by keep-while conditions when a stream queue
-    %% is removed from `rabbit_db_queue` and that triggers a cleanup task which
-    %% deletes all objects belonging to the stream from the remote tier.
+    %% per-stream container node. The container is kept alive by a keep_while
+    %% condition on the stream queue, so when the queue is removed from
+    %% `rabbit_db_queue` the container (and its subtree) is automatically
+    %% deleted, which triggers a cleanup task that deletes all objects belonging
+    %% to the stream from the remote tier. The container is created by
+    %% `put_anchor/2` before the first fragment, or by `put/5` at the first
+    %% manifest commit, whichever comes first.
     StoredProcPath = ?RABBITMQ_KHEPRI_ROOT_PATH([
         stored_procedures,
         ?MODULE,
@@ -139,7 +165,7 @@ get_consistent(StreamId) ->
 
 do_get(StreamId, Options) ->
     counters:add(counter(), ?C_GETS, 1),
-    Path = ?PATH(StreamId),
+    Path = ?MANIFEST_PATH(StreamId),
     case rabbit_khepri:adv_get(Path, Options) of
         {ok, #{Path := #{data := {Uid, Epoch}, payload_version := Revision}}} ->
             {ok, #{uid => Uid, epoch => Epoch, revision => Revision}};
@@ -152,12 +178,12 @@ do_get(StreamId, Options) ->
 -doc "Lists all streams known to the metadata store.".
 -spec list() -> {ok, #{stream_id() => entry()}} | {error, any()}.
 list() ->
-    case rabbit_khepri:adv_get_many(?PATH(#if_has_data{})) of
+    case rabbit_khepri:adv_get_many(?MANIFEST_PATH(?KHEPRI_WILDCARD_STAR)) of
         {ok, NodeProps} ->
             Entries =
                 #{
                     StreamId => #{uid => Uid, epoch => Epoch, revision => Revision}
-                 || ?PATH(StreamId) := #{data := {Uid, Epoch}, payload_version := Revision} <-
+                 || ?MANIFEST_PATH(StreamId) := #{data := {Uid, Epoch}, payload_version := Revision} <-
                         NodeProps
                 },
             {ok, Entries};
@@ -168,7 +194,7 @@ list() ->
 -doc "Returns the count of streams known to the metadata store.".
 -spec count() -> {ok, non_neg_integer()} | {error, any()}.
 count() ->
-    rabbit_khepri:count(?PATH(#if_has_data{})).
+    rabbit_khepri:count(?MANIFEST_PATH(?KHEPRI_WILDCARD_STAR)).
 
 -doc """
 Sets the UID for the given stream ID if the current revision matches the given
@@ -197,17 +223,40 @@ modifications which would inconvenience the successor writer.
 put(StreamId, Reference, Epoch, ExpectedRevision, Uid) when
     is_binary(StreamId) andalso is_integer(ExpectedRevision) andalso is_integer(Uid)
 ->
-    do_put(StreamId, Epoch, ExpectedRevision, Uid, keep_while_options(Reference)).
+    do_put(StreamId, Reference, Epoch, ExpectedRevision, Uid).
 
--spec do_put(stream_id(), osiris:epoch(), revision(), rabbitmq_stream_s3:uid(), map()) ->
+-spec do_put(stream_id(), term(), osiris:epoch(), revision(), rabbitmq_stream_s3:uid()) ->
     {ok, {rabbitmq_stream_s3:uid(), osiris:epoch()} | undefined, revision()}
     | {error, {conflict, entry()}}
     | {error, not_found}
     | {error, any()}.
-do_put(StreamId, Epoch, ExpectedRevision, Uid, Options0) ->
+do_put(StreamId, Reference, Epoch, ExpectedRevision, Uid) ->
     Cnt = counter(),
     counters:add(Cnt, ?C_PUTS, 1),
-    Path = ?PATH(StreamId),
+    Path = ?MANIFEST_PATH(StreamId),
+    %% Ensure the per-stream container exists with the keep_while that drives
+    %% cleanup before creating the manifest child under it. The manifest child
+    %% itself needs no keep_while: deleting the container removes the subtree.
+    case ensure_container(StreamId, ExpectedRevision, Reference) of
+        ok ->
+            do_put_manifest(Cnt, Path, Epoch, ExpectedRevision, Uid);
+        {error, _} = Err ->
+            counters:add(Cnt, ?C_PUT_ERRORS, 1),
+            Err
+    end.
+
+%% Create the per-stream container with its keep_while when the manifest is first
+%% created (ExpectedRevision == 0); later commits find it already present. This is
+%% idempotent with put_anchor/2, which creates the same container before the first
+%% fragment. When the reference is not a queue resource (e.g. some tests) there is
+%% no keep_while, which is fine: those streams are not cleaned up by queue removal.
+-spec ensure_container(stream_id(), revision(), term()) -> ok | {error, any()}.
+ensure_container(StreamId, 0, Reference) ->
+    rabbit_khepri:put(?PATH(StreamId), StreamId, keep_while_options(Reference));
+ensure_container(_StreamId, _ExpectedRevision, _Reference) ->
+    ok.
+
+do_put_manifest(Cnt, Path, Epoch, ExpectedRevision, Uid) ->
     Conditions =
         case ExpectedRevision of
             0 ->
@@ -228,7 +277,9 @@ do_put(StreamId, Epoch, ExpectedRevision, Uid, Options0) ->
                 ]
         end,
     VersionedPath = khepri_path:combine_with_conditions(Path, Conditions),
-    case rabbit_khepri:adv_put(VersionedPath, {Uid, Epoch}, Options0) of
+    %% The container (not this manifest child) carries the keep_while, so no
+    %% keep_while option is needed here.
+    case rabbit_khepri:adv_put(VersionedPath, {Uid, Epoch}, #{}) of
         {ok, #{Path := #{payload_version := NewRevision, data := {OldUid, OldEpoch}}}} ->
             counters:add(Cnt, ?C_PUT_SUCCESSES, 1),
             {ok, {OldUid, OldEpoch}, NewRevision};
@@ -254,6 +305,48 @@ do_put(StreamId, Epoch, ExpectedRevision, Uid, Options0) ->
             {error, not_found};
         {error, _} = Err ->
             counters:add(Cnt, ?C_PUT_ERRORS, 1),
+            Err
+    end.
+
+-doc """
+Writes the per-stream anchor before the first remote-tier fragment is uploaded.
+
+Creates the per-stream container (kept alive by a keep_while on the stream queue)
+and the `anchor` child under it. The anchor's presence is the by-construction
+signal that the stream's S3 prefix belongs to a live stream; its absence (the
+keep_while removes it atomically with the queue) marks the prefix as junk. The
+caller must ensure this commits before the first fragment PUT, so that no object
+can exist under a prefix whose anchor is absent.
+""".
+-spec put_anchor(stream_id(), term()) -> ok | {error, any()}.
+put_anchor(StreamId, Reference) when is_binary(StreamId) ->
+    KeepWhile = keep_while_options(Reference),
+    case rabbit_khepri:put(?PATH(StreamId), StreamId, KeepWhile) of
+        ok ->
+            rabbit_khepri:put(?ANCHOR_PATH(StreamId), StreamId, KeepWhile);
+        {error, _} = Err ->
+            Err
+    end.
+
+-doc """
+Returns whether the stream's anchor exists, using a strongly consistent,
+quorum-requiring read.
+
+A consistent read is required: a stale local read can report the anchor absent
+for a stream whose anchor has just committed while its first fragment is already
+in S3, which would let a sweep reap live data. Fails when this node cannot reach a
+quorum, which a fail-closed caller treats as "do not reap".
+""".
+-spec anchor_exists_consistent(stream_id()) -> {ok, boolean()} | {error, any()}.
+anchor_exists_consistent(StreamId) when is_binary(StreamId) ->
+    Path = ?ANCHOR_PATH(StreamId),
+    Options = #{favor => consistency, timeout => ?CONSISTENT_READ_TIMEOUT_MS},
+    case rabbit_khepri:adv_get(Path, Options) of
+        {ok, #{Path := _NodeProps}} ->
+            {ok, true};
+        {error, ?khepri_error(node_not_found, _Props)} ->
+            {ok, false};
+        {error, _} = Err ->
             Err
     end.
 

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -17,7 +17,7 @@ less safe.
 The one break in that monotonicity is a remote-tier-ahead reset, which rebuilds
 the manifest from the local log floor after a timeline change and can *lower*
 first_offset, re-tiering live fragments (with fresh UIDs) at offsets below a
-floor a concurrent sweep already snapshotted. Two guards keep the sweep safe:
+floor a concurrent sweep already snapshotted. Three guards keep the sweep safe:
 
   1. Each candidate deletion is re-validated against the live first_offset
      immediately before the object is deleted (see still_dangling/1) and skipped
@@ -28,6 +28,14 @@ floor a concurrent sweep already snapshotted. Two guards keep the sweep safe:
      strongly-consistent metadata read, so a partitioned or deposed node that
      cannot reach a quorum fails closed and skips rather than deleting on a stale
      local view.
+  3. That metadata read in build_lookup/1 is sampled once, up front. A reset that
+     commits *after* the snapshot, on a node whose manifest cache has not yet
+     applied the sync, leaves still_dangling/1 re-reading a stale-high floor while
+     the committed epoch has moved on, so guards 1 and 2 both pass. Each
+     offset-based deletion is therefore re-validated once more at the point of
+     deletion (see fresh_enough_to_delete/2): a fresh quorum read of the committed
+     epoch is compared against the cached epoch, and the delete is skipped when
+     they differ. A genuine orphan skipped here is reclaimed by a later sweep.
 
 Streams with no local manifest replica are skipped (cannot verify first_offset).
 Unknown stream prefixes (stream not in Khepri) are skipped (no safe deletion
@@ -109,12 +117,23 @@ make_handler(dry_run) ->
         [Finding | Acc]
     end;
 make_handler(delete) ->
-    fun(#{stream_id := StreamId, key := Key} = Finding, Acc) ->
+    fun(#{stream_id := StreamId, key := Key, reason := Reason} = Finding, Acc) ->
         case still_dangling(Finding) of
             true ->
-                log_finding(Finding),
-                rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]),
-                [Finding | Acc];
+                %% still_dangling/1 passed against the live cache floor, but that
+                %% floor is trustworthy only if the cache is at the committed epoch
+                %% (a reset may have committed after the sweep snapshot). The
+                %% quorum read here runs only for an object already judged
+                %% deletable, so it is bounded by the number of orphans, not the
+                %% number of listed objects.
+                case fresh_enough_to_delete(Reason, StreamId) of
+                    true ->
+                        log_finding(Finding),
+                        rabbitmq_stream_s3_reaper:delete_objects(StreamId, [Key]),
+                        [Finding | Acc];
+                    false ->
+                        Acc
+                end;
             false ->
                 ?LOG_INFO(
                     "GC: not deleting ~ts (stream=~ts): it is no longer below the "
@@ -125,6 +144,64 @@ make_handler(delete) ->
                 Acc
         end
     end.
+
+%% Re-validate cache freshness against the committed epoch immediately before an
+%% offset-based deletion. build_lookup/1 (and build_stream_lookup/2) sampled the
+%% committed epoch once, at the start of the sweep; a remote-tier-ahead reset that
+%% commits after that snapshot, on a node whose manifest cache has not yet applied
+%% the sync, leaves the cached floor stale-high at the old epoch while the
+%% committed epoch has advanced. A fresh quorum read of the committed epoch
+%% compared against the cached epoch closes that window: delete only when the
+%% cache is at the committed epoch, otherwise fail closed (a later sweep reclaims a
+%% genuine orphan). Epoch-based (stale manifest) findings need no check: a higher
+%% committed epoch only confirms the manifest is stale.
+-spec fresh_enough_to_delete(reason(), stream_id()) -> boolean().
+fresh_enough_to_delete(stale_epoch, _StreamId) ->
+    true;
+fresh_enough_to_delete(below_first_offset, StreamId) ->
+    case rabbitmq_stream_s3_db:get_consistent(StreamId) of
+        {ok, #{epoch := CommittedEpoch}} ->
+            CacheResult = rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId),
+            case cache_at_committed_epoch(CacheResult, CommittedEpoch) of
+                true ->
+                    true;
+                false ->
+                    ?LOG_INFO(
+                        "GC: not deleting under stream ~ts: local manifest cache "
+                        "epoch ~p does not match the committed epoch ~p; a reset "
+                        "committed after the sweep snapshot and this node has not "
+                        "applied it. A later sweep reclaims a genuine orphan.",
+                        [StreamId, cache_epoch(CacheResult), CommittedEpoch]
+                    ),
+                    false
+            end;
+        {error, Reason} ->
+            ?LOG_INFO(
+                "GC: not deleting under stream ~ts: could not re-read the committed "
+                "epoch with quorum (~p); failing closed",
+                [StreamId, Reason]
+            ),
+            false
+    end.
+
+%% Pure decision for fresh_enough_to_delete/2: the cache must hold a manifest at
+%% exactly the committed epoch. A cache behind the committed epoch (the
+%% reset-after-snapshot window), a cache with no recorded epoch (a legacy
+%% put_manifest/2 entry), or no manifest at all all fail closed.
+-spec cache_at_committed_epoch(
+    {#manifest{}, osiris:epoch() | undefined} | undefined, osiris:epoch()
+) -> boolean().
+cache_at_committed_epoch({#manifest{}, CommittedEpoch}, CommittedEpoch) ->
+    true;
+cache_at_committed_epoch(_CacheResult, _CommittedEpoch) ->
+    false.
+
+-spec cache_epoch({#manifest{}, osiris:epoch() | undefined} | undefined) ->
+    osiris:epoch() | undefined.
+cache_epoch({#manifest{}, Epoch}) ->
+    Epoch;
+cache_epoch(undefined) ->
+    undefined.
 
 %% Re-validate an offset-based finding against the live manifest immediately
 %% before deleting it. The sweep's safety argument is that first_offset only
@@ -796,5 +873,31 @@ still_dangling_without_manifest_keeps_object_test_() ->
             },
             [?_assertNot(still_dangling(Finding))]
         end}.
+
+%% fresh_enough_to_delete/2 (see the moduledoc, guard 3): an offset-based finding
+%% is deletable only when the local manifest cache is at the committed epoch. A
+%% cache behind the committed epoch is the reset-after-snapshot window and must
+%% fail closed.
+cache_at_committed_epoch_matches_test() ->
+    ?assert(cache_at_committed_epoch({#manifest{first_offset = 100}, 7}, 7)).
+
+%% A cache behind the committed epoch (a reset committed after the sweep snapshot,
+%% sync not yet applied) fails closed.
+cache_at_committed_epoch_stale_test() ->
+    ?assertNot(cache_at_committed_epoch({#manifest{first_offset = 100}, 6}, 7)).
+
+%% A legacy put_manifest/2 entry has no recorded epoch: fail closed.
+cache_at_committed_epoch_undefined_epoch_test() ->
+    ?assertNot(cache_at_committed_epoch({#manifest{first_offset = 100}, undefined}, 7)).
+
+%% No manifest at all: fail closed.
+cache_at_committed_epoch_no_manifest_test() ->
+    ?assertNot(cache_at_committed_epoch(undefined, 7)).
+
+%% Stale-manifest (epoch-based) findings are not floor-based: a higher committed
+%% epoch only confirms staleness, so the freshness re-check is skipped and they
+%% remain deletable.
+fresh_enough_to_delete_stale_epoch_test() ->
+    ?assert(fresh_enough_to_delete(stale_epoch, <<"any-stream">>)).
 
 -endif.

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -37,9 +37,17 @@ floor a concurrent sweep already snapshotted. Three guards keep the sweep safe:
      epoch is compared against the cached epoch, and the delete is skipped when
      they differ. A genuine orphan skipped here is reclaimed by a later sweep.
 
-Streams with no local manifest replica are skipped (cannot verify first_offset).
-Unknown stream prefixes (stream not in Khepri) are skipped (no safe deletion
-signal without Khepri restructuring).
+For a stream that is in the committed lookup, objects are classified against its
+first_offset and epoch as above. For an object whose stream is NOT in the lookup
+(a deleted stream, a stream that never committed a manifest, or one missing a
+local manifest replica) the per-stream anchor decides: the anchor
+(rabbitmq_stream_s3_db, written before the first fragment, kept alive by a
+keep_while on the stream queue) is present for a live stream and absent only once
+the queue is gone. A strongly-consistent read of the anchor that returns absent is
+a positive "stream deleted" signal, so the object is reaped (reason no_anchor); a
+present anchor, or a read that cannot reach a quorum, fails closed and skips. The
+consistent read is load-bearing: a stale local read could report a live stream's
+anchor absent and reap it.
 """.
 
 -include("include/rabbitmq_stream_s3.hrl").
@@ -50,7 +58,7 @@ signal without Khepri restructuring).
 
 -type mode() :: dry_run | delete.
 -type config() :: #{mode => mode(), writer_epoch => non_neg_integer()}.
--type reason() :: below_first_offset | stale_epoch.
+-type reason() :: below_first_offset | stale_epoch | no_anchor.
 -type finding() :: #{stream_id := stream_id(), key := rabbitmq_stream_s3:key(), reason := reason()}.
 
 -export_type([mode/0, config/0, finding/0]).
@@ -68,7 +76,9 @@ run(Config) when is_map(Config) ->
     {ok, Streams} = rabbitmq_stream_s3_db:list(),
     Lookup = build_lookup(Streams),
     Fun = make_handler(Mode),
-    Findings = list_and_classify(<<"rabbitmq/stream/">>, start, Lookup, Fun, []),
+    Findings = list_and_classify(
+        <<"rabbitmq/stream/">>, start, Lookup, Fun, fun anchor_absent/1, []
+    ),
     ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
     {ok, Findings}.
 
@@ -85,7 +95,7 @@ run_stream(StreamId, Config) when is_binary(StreamId), is_map(Config) ->
         {ok, Lookup} ->
             Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
             Fun = make_handler(Mode),
-            Findings = list_and_classify(Prefix, start, Lookup, Fun, []),
+            Findings = list_and_classify(Prefix, start, Lookup, Fun, fun anchor_absent/1, []),
             ?LOG_INFO(
                 "GC ~ts for stream ~ts complete: ~b dangling object(s)",
                 [Mode, StreamId, length(Findings)]
@@ -158,6 +168,11 @@ make_handler(delete) ->
 -spec fresh_enough_to_delete(reason(), stream_id()) -> boolean().
 fresh_enough_to_delete(stale_epoch, _StreamId) ->
     true;
+fresh_enough_to_delete(no_anchor, _StreamId) ->
+    %% classify_page/3 already confirmed the anchor absent with a consistent read,
+    %% and a deleted stream's anchor never returns (stream_id is unique per
+    %% incarnation), so the absence is permanent.
+    true;
 fresh_enough_to_delete(below_first_offset, StreamId) ->
     case rabbitmq_stream_s3_db:get_consistent(StreamId) of
         {ok, #{epoch := CommittedEpoch}} ->
@@ -222,6 +237,10 @@ cache_epoch(undefined) ->
 %% carve-out from the live manifest closes that.
 -spec still_dangling(finding()) -> boolean().
 still_dangling(#{reason := stale_epoch}) ->
+    true;
+still_dangling(#{reason := no_anchor}) ->
+    %% The anchor was confirmed absent (consistent read) in classify_page/3 and
+    %% the absence is permanent, so there is nothing to re-validate.
     true;
 still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key}) ->
     case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
@@ -430,32 +449,68 @@ epoch_permits_sweep(CommittedEpoch, #{writer_epoch := WriterEpoch}) ->
 epoch_permits_sweep(_CommittedEpoch, _Config) ->
     true.
 
-list_and_classify(_Prefix, done, _Lookup, _Fun, Acc) ->
+list_and_classify(_Prefix, done, _Lookup, _Fun, _AnchorAbsent, Acc) ->
     lists:reverse(Acc);
-list_and_classify(Prefix, Continuation, Lookup, Fun, Acc) ->
+list_and_classify(Prefix, Continuation, Lookup, Fun, AnchorAbsent, Acc) ->
     case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
         {ok, [], done} ->
             lists:reverse(Acc);
         {ok, Keys, NextContinuation} ->
-            Orphans = classify_page(Keys, Lookup),
+            Orphans = classify_page(Keys, Lookup, AnchorAbsent),
             NewAcc = lists:foldl(Fun, Acc, Orphans),
-            list_and_classify(Prefix, NextContinuation, Lookup, Fun, NewAcc);
+            list_and_classify(Prefix, NextContinuation, Lookup, Fun, AnchorAbsent, NewAcc);
         {error, Reason} ->
             ?LOG_WARNING("GC: failed to list objects under ~ts: ~p", [Prefix, Reason]),
             lists:reverse(Acc)
     end.
 
-classify_page(Keys, Lookup) ->
-    lists:filtermap(
-        fun(Key) ->
+%% AnchorAbsent is fun((stream_id()) -> boolean()): true only on a strongly
+%% consistent read that confirms the anchor is absent (a deleted stream). A
+%% no_anchor candidate is kept only when its stream's anchor is confirmed absent;
+%% each distinct stream is checked once per page.
+-spec classify_page([rabbitmq_stream_s3:key()], map(), fun((stream_id()) -> boolean())) ->
+    [finding()].
+classify_page(Keys, Lookup, AnchorAbsent) ->
+    {Definite, Candidates} = lists:foldr(
+        fun(Key, {Def, Cand}) ->
             case classify(Key, Lookup) of
-                {ok, Finding} -> {true, Finding};
-                skip -> false
+                {ok, #{reason := no_anchor} = Finding} -> {Def, [Finding | Cand]};
+                {ok, Finding} -> {[Finding | Def], Cand};
+                skip -> {Def, Cand}
             end
         end,
+        {[], []},
         Keys
-    ).
+    ),
+    Streams = lists:usort([StreamId || #{stream_id := StreamId} <- Candidates]),
+    AbsentStreams = [StreamId || StreamId <- Streams, AnchorAbsent(StreamId)],
+    Confirmed = [
+        Finding
+     || #{stream_id := StreamId} = Finding <- Candidates, lists:member(StreamId, AbsentStreams)
+    ],
+    Definite ++ Confirmed.
 
+%% Strongly-consistent anchor read for the no_anchor backstop. True only when the
+%% read confirms the anchor is absent; a present anchor or a read that cannot reach
+%% a quorum fails closed (false), so a live or unverifiable stream is never reaped.
+-spec anchor_absent(stream_id()) -> boolean().
+anchor_absent(StreamId) ->
+    case rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId) of
+        {ok, Exists} ->
+            not Exists;
+        {error, Reason} ->
+            ?LOG_INFO(
+                "GC: not reaping the prefix of stream ~ts: could not read its anchor "
+                "with quorum (~p); failing closed",
+                [StreamId, Reason]
+            ),
+            false
+    end.
+
+%% A stream that is in the lookup is classified against its floor/epoch. A
+%% well-formed key whose stream is NOT in the lookup becomes a no_anchor
+%% CANDIDATE, resolved against the anchor in classify_page/3. Only an unrecognised
+%% key format is skipped outright.
 -spec classify(rabbitmq_stream_s3:key(), map()) -> {ok, finding()} | skip.
 classify(Key, Lookup) ->
     case parse_key(Key) of
@@ -463,31 +518,36 @@ classify(Key, Lookup) ->
             case Lookup of
                 #{StreamId := #{first_offset := FirstOffset}} when Offset < FirstOffset ->
                     {ok, #{stream_id => StreamId, key => Key, reason => below_first_offset}};
+                #{StreamId := _} ->
+                    skip;
                 _ ->
-                    skip
+                    no_anchor_candidate(StreamId, Key)
             end;
         {group, StreamId, Offset} ->
             case Lookup of
                 #{StreamId := #{first_offset := FirstOffset} = Info} when Offset < FirstOffset ->
                     classify_group(StreamId, Key, Info);
+                #{StreamId := _} ->
+                    skip;
                 _ ->
-                    skip
+                    no_anchor_candidate(StreamId, Key)
             end;
         {manifest, StreamId, Epoch} ->
             case Lookup of
                 #{StreamId := #{epoch := CurrentEpoch}} when Epoch < CurrentEpoch ->
                     {ok, #{stream_id => StreamId, key => Key, reason => stale_epoch}};
+                #{StreamId := _} ->
+                    skip;
                 _ ->
-                    skip
+                    no_anchor_candidate(StreamId, Key)
             end;
         unknown ->
-            %% Key belongs to a stream not in the lookup (either unknown to
-            %% Khepri or missing a local manifest replica). Not safe to delete
-            %% without a positive "stream deleted" signal. See #149 for the
-            %% planned Khepri restructuring that would make stream-prefix
-            %% sweep safe.
+            %% Unrecognised key format: nothing safe to do with it.
             skip
     end.
+
+no_anchor_candidate(StreamId, Key) ->
+    {ok, #{stream_id => StreamId, key => Key, reason => no_anchor}}.
 
 %% A group object below first_offset is an orphan and safe to delete unless it
 %% is the manifest's referenced leading group, or the stream is in conservative
@@ -743,11 +803,54 @@ classify_manifest_current_epoch_test() ->
     Key = <<"rabbitmq/stream/s/metadata/root.3.aabb0011.manifest">>,
     ?assertEqual(skip, classify(Key, Lookup)).
 
-classify_unknown_stream_skipped_test() ->
-    %% Stream not in lookup -> skip (not safe to delete).
+%% An unrecognised key format is skipped outright.
+classify_unrecognised_key_skipped_test() ->
+    ?assertEqual(skip, classify(<<"rabbitmq/stream/s/other/file">>, #{})),
+    ?assertEqual(skip, classify(<<"some/other/key">>, #{})).
+
+%% A well-formed key whose stream is not in the lookup becomes a no_anchor
+%% candidate, resolved against the anchor in classify_page/3.
+classify_unknown_stream_is_no_anchor_candidate_test() ->
     Lookup = #{},
-    Key = <<"rabbitmq/stream/unknown/data/00000000000000000100.deadbeef.fragment">>,
+    DataKey = <<"rabbitmq/stream/gone/data/00000000000000000100.deadbeef.fragment">>,
+    ?assertEqual(
+        {ok, #{stream_id => <<"gone">>, key => DataKey, reason => no_anchor}},
+        classify(DataKey, Lookup)
+    ),
+    GroupKey = <<"rabbitmq/stream/gone/metadata/00000000000000000500.aabbccdd.group">>,
+    ?assertMatch({ok, #{reason := no_anchor}}, classify(GroupKey, Lookup)),
+    ManifestKey = <<"rabbitmq/stream/gone/metadata/root.3.aabb0011.manifest">>,
+    ?assertMatch({ok, #{reason := no_anchor}}, classify(ManifestKey, Lookup)).
+
+%% An in-lookup object at or above the floor is live and skipped, not a candidate.
+classify_in_lookup_live_object_skipped_test() ->
+    Lookup = #{<<"s">> => #{epoch => 5, first_offset => 100}},
+    Key = <<"rabbitmq/stream/s/data/00000000000000000150.deadbeef.fragment">>,
     ?assertEqual(skip, classify(Key, Lookup)).
+
+%% classify_page keeps a no_anchor candidate only when its stream's anchor is
+%% confirmed absent, and checks each distinct stream exactly once.
+classify_page_no_anchor_resolution_test() ->
+    GoneKey1 = <<"rabbitmq/stream/gone/data/00000000000000000100.deadbeef.fragment">>,
+    GoneKey2 = <<"rabbitmq/stream/gone/data/00000000000000000200.deadbeef.fragment">>,
+    LiveKey = <<"rabbitmq/stream/live/data/00000000000000000100.deadbeef.fragment">>,
+    Self = self(),
+    AnchorAbsent = fun(StreamId) ->
+        Self ! {checked, StreamId},
+        StreamId =:= <<"gone">>
+    end,
+    Findings = classify_page([GoneKey1, GoneKey2, LiveKey], #{}, AnchorAbsent),
+    Keys = lists:sort([K || #{key := K} <- Findings]),
+    %% Both objects of the deleted stream are reaped; the live stream's object is kept.
+    ?assertEqual(lists:sort([GoneKey1, GoneKey2]), Keys),
+    %% Each distinct stream is checked once.
+    ?assertEqual(lists:sort([<<"gone">>, <<"live">>]), lists:sort(drain_checks([]))).
+
+drain_checks(Acc) ->
+    receive
+        {checked, StreamId} -> drain_checks([StreamId | Acc])
+    after 0 -> Acc
+    end.
 
 %% A candidate deletion is re-validated against the live first_offset just before
 %% deleting. A remote-tier-ahead reset lowers first_offset and re-tiers live

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -576,6 +576,24 @@ handle_info({persist_result, Gen, Result}, #state{tasks = Tasks0} = State0) ->
         {persist_result, Gen, Result}, Tasks0
     ),
     apply_persist_decisions(Decisions, PersistedBytes, State0#state{tasks = Tasks});
+handle_info({anchor_write_result, ok}, #state{core = Core0} = State0) ->
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(Core0),
+    {noreply, execute_effects(Effects, State0#state{core = Core})};
+handle_info(
+    {anchor_write_result, {error, Reason}},
+    #state{cfg = #cfg{stream = StreamId}} = State
+) ->
+    Delay = rabbitmq_stream_s3_config:upload_retry_delay_ms(),
+    ?LOG_WARNING(
+        "~ts anchor write failed (~p); retrying in ~bms. Fragment uploads are "
+        "held until the anchor is durable.",
+        [StreamId, Reason, Delay]
+    ),
+    erlang:send_after(Delay, self(), retry_anchor_write),
+    {noreply, State};
+handle_info(retry_anchor_write, #state{core = Core0} = State0) ->
+    {Core, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_failed(Core0),
+    {noreply, execute_effects(Effects, State0#state{core = Core})};
 handle_info({'DOWN', Mon, process, _Pid, Reason}, State) ->
     %% A monitored async task crashed. Its 'DOWN' carries the monitor ref, which
     %% identifies the family (and, via the model's slot, its generation): a crash
@@ -925,6 +943,23 @@ execute_effects([Effect | Rest], State0) ->
     State = execute_effect(Effect, State0),
     execute_effects(Rest, State).
 
+execute_effect({write_anchor, StreamId, Reference}, State) ->
+    %% Write the per-stream anchor asynchronously, then feed the result back into
+    %% the core. The core holds the fragments' submit_transfer effects until
+    %% anchor_write_complete is fed in, so the anchor commits before the first
+    %% fragment PUT. The spawned process always reports a result (failures included)
+    %% so the core is never left waiting.
+    Self = self(),
+    _ = spawn(fun() ->
+        Result =
+            try
+                rabbitmq_stream_s3_db:put_anchor(StreamId, Reference)
+            catch
+                Class:Reason -> {error, {Class, Reason}}
+            end,
+        Self ! {anchor_write_result, Result}
+    end),
+    State;
 execute_effect({submit_transfer, Ref, _StreamId, Dir, Meta}, #state{cfg = Cfg} = State0) ->
     StreamId = Cfg#cfg.stream,
     submit_upload(Ref, Dir, StreamId, Meta),

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -155,11 +155,20 @@ init(Manifest, Opts) ->
         last_persisted_manifest = Manifest,
         persisting_manifest = undefined,
         waiters = [],
-        %% Defaults to `pending`: the anchor is written before the first fragment.
-        %% Tests that exercise the steady-state pipeline pass `done`.
-        anchor = maps:get(anchor, Opts, pending)
+        %% A non-empty resolved manifest witnesses that a fragment was already
+        %% tiered, so the anchor already exists (it precedes the first fragment):
+        %% start `done` and skip re-writing it, e.g. on a reader restart. Only a
+        %% brand-new stream (empty manifest) starts `pending` and writes the anchor
+        %% on its genuine first fragment. Tests may override.
+        anchor = maps:get(anchor, Opts, initial_anchor(Manifest))
     },
     {State, []}.
+
+%% The anchor already exists iff the stream has already tiered a fragment, which a
+%% non-empty manifest witnesses. A re-write would be idempotent but adds a Khepri
+%% round-trip to the restart path, so skip it when the manifest already has data.
+initial_anchor(#manifest{entries = <<>>}) -> pending;
+initial_anchor(#manifest{}) -> done.
 
 -spec manifest(state()) -> #manifest{}.
 manifest(#state{manifest = Manifest}) ->

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -19,6 +19,8 @@ testable without mocks or timing.
     pending_prefix_rewrite/1,
     format_state/1,
     fragment_cut/2,
+    anchor_write_complete/1,
+    anchor_write_failed/1,
     transfer_complete/3,
     transfer_failed/3,
     group_upload_complete/2,
@@ -78,14 +80,22 @@ testable without mocks or timing.
     %% Consecutive failed upload attempts per in-flight transfer, keyed by Ref.
     %% Incremented on each transfer_failed and used to drive the resubmit
     %% backoff; cleared when the transfer is drained (success) or on reinit.
-    transfer_attempts = #{} :: #{reference() => pos_integer()}
+    transfer_attempts = #{} :: #{reference() => pos_integer()},
+    %% Whether the per-stream anchor (written before the first remote-tier
+    %% fragment) has been committed. Fragment uploads are held until it is `done`,
+    %% so no S3 object can exist under a prefix whose anchor is absent:
+    %%   pending  - no fragment cut yet, anchor not requested
+    %%   writing  - first fragment cut, write_anchor emitted, uploads held
+    %%   done     - anchor committed, uploads released and flowing normally
+    anchor = pending :: pending | writing | done
 }).
 
 -opaque state() :: #state{}.
 -type cfg() :: #cfg{}.
 
 -type core_effect() ::
-    {submit_transfer, reference(), stream_id(), directory(), fragment_meta()}
+    {write_anchor, stream_id(), term()}
+    | {submit_transfer, reference(), stream_id(), directory(), fragment_meta()}
     | {start_persist, #manifest{}, non_neg_integer(), term(), rabbitmq_stream_s3_db:revision(), [
         #edit{}
     ]}
@@ -144,7 +154,10 @@ init(Manifest, Opts) ->
         persist_in_flight = false,
         last_persisted_manifest = Manifest,
         persisting_manifest = undefined,
-        waiters = []
+        waiters = [],
+        %% Defaults to `pending`: the anchor is written before the first fragment.
+        %% Tests that exercise the steady-state pipeline pass `done`.
+        anchor = maps:get(anchor, Opts, pending)
     },
     {State, []}.
 
@@ -184,9 +197,11 @@ format_state(#state{
     persist_in_flight = PersistInFlight,
     rebalance_in_flight = RebalanceInFlight,
     retention_in_flight = RetentionInFlight,
-    waiters = Waiters
+    waiters = Waiters,
+    anchor = Anchor
 }) ->
     #{
+        anchor => Anchor,
         manifest_first_offset => FirstOff,
         manifest_next_offset => NextOff,
         manifest_total_size => TotalSize,
@@ -206,7 +221,23 @@ format_state(#state{
     }.
 
 -spec fragment_cut(fragment_meta(), state()) -> {state(), reference(), [core_effect()]}.
-fragment_cut(Meta, #state{cfg = Cfg, in_flight = Q, since_persist = 0} = State) ->
+fragment_cut(Meta, #state{anchor = done} = State) ->
+    fragment_cut_submit(Meta, State);
+fragment_cut(Meta, #state{anchor = AnchorStatus, cfg = Cfg} = State0) ->
+    %% The anchor must commit before the first fragment is uploaded. Track the
+    %% fragment in in_flight as usual, but hold its submit_transfer: it is
+    %% re-derived from in_flight in anchor_write_complete/1 once the anchor is
+    %% durable. On the very first fragment also emit the write_anchor effect.
+    {State1, Ref, Effects0} = fragment_cut_submit(Meta, State0),
+    Held = [E || E <- Effects0, not is_submit_transfer(E)],
+    AnchorEffect =
+        case AnchorStatus of
+            pending -> [{write_anchor, Cfg#cfg.stream, Cfg#cfg.reference}];
+            writing -> []
+        end,
+    {State1#state{anchor = writing}, Ref, AnchorEffect ++ Held}.
+
+fragment_cut_submit(Meta, #state{cfg = Cfg, in_flight = Q, since_persist = 0} = State) ->
     case queue:is_empty(Q) of
         true ->
             %% First fragment since last persist. Start the timer.
@@ -220,8 +251,36 @@ fragment_cut(Meta, #state{cfg = Cfg, in_flight = Q, since_persist = 0} = State) 
         false ->
             do_fragment_cut(Meta, State)
     end;
-fragment_cut(Meta, State) ->
+fragment_cut_submit(Meta, State) ->
     do_fragment_cut(Meta, State).
+
+is_submit_transfer({submit_transfer, _Ref, _Stream, _Dir, _Meta}) -> true;
+is_submit_transfer(_) -> false.
+
+-doc """
+The per-stream anchor has been durably written. Release the fragment uploads that
+were held while it was being written: each is in in_flight (in cut order) but was
+never submitted. Subsequent fragments are submitted as they are cut.
+""".
+-spec anchor_write_complete(state()) -> {state(), [core_effect()]}.
+anchor_write_complete(#state{anchor = writing, cfg = Cfg, in_flight = Q} = State) ->
+    Effects = [
+        {submit_transfer, Ref, Cfg#cfg.stream, Cfg#cfg.dir, Meta}
+     || {Ref, Meta} <- queue:to_list(Q)
+    ],
+    {State#state{anchor = done}, Effects};
+anchor_write_complete(State) ->
+    {State, []}.
+
+-doc """
+The per-stream anchor write failed. Re-emit the write_anchor effect so the shell
+retries it; uploads stay held until the anchor commits.
+""".
+-spec anchor_write_failed(state()) -> {state(), [core_effect()]}.
+anchor_write_failed(#state{anchor = writing, cfg = Cfg} = State) ->
+    {State, [{write_anchor, Cfg#cfg.stream, Cfg#cfg.reference}]};
+anchor_write_failed(State) ->
+    {State, []}.
 
 do_fragment_cut(Meta, #state{cfg = Cfg, in_flight = Q} = State) ->
     Ref = make_ref(),

--- a/test/db_SUITE.erl
+++ b/test/db_SUITE.erl
@@ -19,7 +19,9 @@ all() ->
         update_with_correct_revision,
         conflict_on_stale_revision,
         epoch_fencing,
-        keep_while_deletes_on_queue_removal
+        keep_while_deletes_on_queue_removal,
+        put_anchor_present_and_absent,
+        anchor_removed_on_queue_removal
     ].
 
 init_per_suite(Config) ->
@@ -92,3 +94,33 @@ keep_while_deletes_on_queue_removal(_Config) ->
     %% Delete the queue node. Khepri should automatically remove our entry.
     ok = khepri:delete(rabbitmq_metadata, rabbitmq_stream_s3_db:queue_path(QueueRef)),
     ?awaitMatch({error, not_found}, rabbitmq_stream_s3_db:get(StreamId), 1000).
+
+put_anchor_present_and_absent(_Config) ->
+    StreamId = <<"db_suite_anchor">>,
+    %% No anchor yet.
+    ?assertEqual({ok, false}, rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId)),
+    ok = rabbitmq_stream_s3_db:put_anchor(StreamId, StreamId),
+    ?assertEqual({ok, true}, rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId)),
+    %% An unrelated stream still has no anchor.
+    ?assertEqual(
+        {ok, false}, rabbitmq_stream_s3_db:anchor_exists_consistent(<<"db_suite_anchor_other">>)
+    ).
+
+%% A never-committed stream (anchor written, no manifest pointer) is still cleaned
+%% up when its queue is removed: the keep_while on the container removes the whole
+%% subtree, anchor included. This is the window the anchor closes.
+anchor_removed_on_queue_removal(_Config) ->
+    StreamId = <<"db_suite_anchor_kw">>,
+    QueueRef = #resource{
+        virtual_host = <<"/">>, kind = queue, name = <<"test-queue-anchor-kw">>
+    },
+    ok = khepri:put(rabbitmq_metadata, rabbitmq_stream_s3_db:queue_path(QueueRef), queue_exists),
+    ok = rabbitmq_stream_s3_db:put_anchor(StreamId, QueueRef),
+    ?assertEqual({ok, true}, rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId)),
+    %% Never committed: the anchor exists but there is no manifest pointer.
+    ?assertEqual({error, not_found}, rabbitmq_stream_s3_db:get(StreamId)),
+    %% Removing the queue removes the container subtree and the anchor with it.
+    ok = khepri:delete(rabbitmq_metadata, rabbitmq_stream_s3_db:queue_path(QueueRef)),
+    ?awaitMatch(
+        {ok, false}, rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId), 1000
+    ).

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -84,7 +84,14 @@ all() ->
         retention_complete_rechecks_deferred_rebalance,
         retention_failed_rechecks_deferred_rebalance,
         retention_deletes_all_entries,
-        new_fragment_after_empty_manifest
+        new_fragment_after_empty_manifest,
+        %% Anchor before first fragment
+        anchor_first_cut_emits_write_anchor_holds_submit,
+        anchor_complete_releases_held_submit,
+        anchor_holds_multiple_then_releases_in_order,
+        anchor_failed_reemits_write_anchor_keeps_holding,
+        anchor_done_cuts_submit_normally,
+        no_submit_transfer_before_anchor_complete
     ].
 
 init_per_suite(Config) -> Config.
@@ -1540,6 +1547,77 @@ new_fragment_after_empty_manifest(_Config) ->
     ?assertEqual(300, M2#manifest.next_offset).
 
 %% ------------------------------------------------------------------
+%% Anchor before first fragment
+%%
+%% The anchor must commit before the first fragment is uploaded, so no S3 object
+%% can exist under a prefix whose anchor is absent. In the core this means no
+%% submit_transfer is emitted before anchor_write_complete/1.
+%% ------------------------------------------------------------------
+
+%% The first fragment requests the anchor and holds its upload; the persist timer
+%% still starts.
+anchor_first_cut_emits_write_anchor_holds_submit(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {_S1, _Ref, Effects} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    ?assertMatch([{write_anchor, <<"stream">>, test_ref} | _], Effects),
+    ?assertEqual([], submit_refs(Effects)),
+    ?assertMatch([{start_persist_timer, _}], [E || {start_persist_timer, _} = E <- Effects]).
+
+%% Once the anchor is durable, the held upload is released.
+anchor_complete_releases_held_submit(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(S1),
+    ?assertMatch([{submit_transfer, Ref, <<"stream">>, <<"/dir">>, _}], Effects).
+
+%% Every fragment cut while the anchor is being written is held, then released in
+%% cut order, with write_anchor emitted exactly once.
+anchor_holds_multiple_then_releases_in_order(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {S1, Ref1, E1} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, Ref2, E2} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
+    {S3, Ref3, E3} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(200, 300), S2),
+    ?assertEqual([], submit_refs(E1 ++ E2 ++ E3)),
+    ?assertEqual(1, length([E || {write_anchor, _, _} = E <- E1 ++ E2 ++ E3])),
+    {_S4, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(S3),
+    ?assertEqual([Ref1, Ref2, Ref3], submit_refs(Effects)).
+
+%% A failed anchor write re-emits write_anchor and keeps the uploads held.
+anchor_failed_reemits_write_anchor_keeps_holding(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, FailEffects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_failed(S1),
+    ?assertEqual([{write_anchor, <<"stream">>, test_ref}], FailEffects),
+    {_S3, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(S2),
+    ?assertMatch([{submit_transfer, Ref, _, _, _}], Effects).
+
+%% After the anchor is done, later cuts submit immediately with no write_anchor.
+anchor_done_cuts_submit_normally(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {S1, _Ref1, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, _} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(S1),
+    {_S3, Ref2, Effects} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S2),
+    ?assertMatch([{submit_transfer, Ref2, _, _, _} | _], Effects),
+    ?assertEqual([], [E || {write_anchor, _, _} = E <- Effects]).
+
+%% The invariant as a small deterministic harness: across cuts and a failed anchor
+%% write, no submit_transfer is emitted until anchor_write_complete; then all held
+%% fragments are released.
+no_submit_transfer_before_anchor_complete(_Config) ->
+    {S0, _} = init_core(#{anchor => pending}),
+    {S1, _, E1} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {S2, _, E2} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(100, 200), S1),
+    {S3, _, E3} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(200, 300), S2),
+    {S4, E4} = rabbitmq_stream_s3_replica_reader_core:anchor_write_failed(S3),
+    {S5, _, E5} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(300, 400), S4),
+    ?assertEqual([], submit_refs(E1 ++ E2 ++ E3 ++ E4 ++ E5)),
+    {_S6, Effects} = rabbitmq_stream_s3_replica_reader_core:anchor_write_complete(S5),
+    ?assertEqual(4, length(submit_refs(Effects))).
+
+submit_refs(Effects) ->
+    [Ref || {submit_transfer, Ref, _Stream, _Dir, _Meta} <- Effects].
+
+%% ------------------------------------------------------------------
 %% Helpers
 %% ------------------------------------------------------------------
 
@@ -1561,7 +1639,10 @@ init_core_with_manifest(Manifest, Overrides) ->
             reference => test_ref,
             persist_threshold => 5,
             persist_interval_ms => 2000,
-            rebalance_threshold => 1024
+            rebalance_threshold => 1024,
+            %% Default to the post-anchor steady state so the pipeline tests are
+            %% unaffected by the anchor gate; the anchor tests override to pending.
+            anchor => done
         },
         Overrides
     ),

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -91,7 +91,9 @@ all() ->
         anchor_holds_multiple_then_releases_in_order,
         anchor_failed_reemits_write_anchor_keeps_holding,
         anchor_done_cuts_submit_normally,
-        no_submit_transfer_before_anchor_complete
+        no_submit_transfer_before_anchor_complete,
+        anchor_pending_for_empty_manifest,
+        anchor_done_for_non_empty_manifest
     ].
 
 init_per_suite(Config) -> Config.
@@ -1616,6 +1618,38 @@ no_submit_transfer_before_anchor_complete(_Config) ->
 
 submit_refs(Effects) ->
     [Ref || {submit_transfer, Ref, _Stream, _Dir, _Meta} <- Effects].
+
+%% A brand-new stream (empty resolved manifest) starts pending: the first fragment
+%% requests the anchor and holds the upload.
+anchor_pending_for_empty_manifest(_Config) ->
+    {S0, _} = rabbitmq_stream_s3_replica_reader_core:init(#manifest{}, base_opts()),
+    {_S1, _Ref, Effects} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    ?assertMatch([{write_anchor, _, _} | _], Effects),
+    ?assertEqual([], submit_refs(Effects)).
+
+%% A reader resuming an established stream (non-empty resolved manifest) starts
+%% done: the anchor already exists, so the first fragment submits immediately with
+%% no write_anchor and no hold. This keeps the restart path off the Khepri round-trip.
+anchor_done_for_non_empty_manifest(_Config) ->
+    Entry = ?ENTRY(0, 0, 0, ?MANIFEST_KIND_FRAGMENT, 1000, 1),
+    NonEmpty = #manifest{entries = Entry, first_offset = 0, next_offset = 1},
+    {S0, _} = rabbitmq_stream_s3_replica_reader_core:init(NonEmpty, base_opts()),
+    {_S1, Ref, Effects} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(1, 100), S0),
+    ?assertMatch([{submit_transfer, Ref, _, _, _} | _], Effects),
+    ?assertEqual([], [E || {write_anchor, _, _} = E <- Effects]).
+
+%% Base init opts WITHOUT an anchor override, so init derives the anchor state
+%% from the manifest.
+base_opts() ->
+    #{
+        stream => <<"stream">>,
+        dir => <<"/dir">>,
+        epoch => 1,
+        reference => test_ref,
+        persist_threshold => 5,
+        persist_interval_ms => 2000,
+        rebalance_threshold => 1024
+    }.
 
 %% ------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
*Issue #, if available:* fixes https://github.com/amazon-mq/rabbitmq-stream-s3/issues/196 from a behavior / GC aspect. But a full fix of that issue would also need https://github.com/amazon-mq/rabbitmq-stream-s3/issues/309

*Description of changes:* This changes the Khepri layout a bit to have the manifest pointer under one branch for the stream and an anchor node under the other. The anchor gives us strong ordering that we can use to nearly guarantee that we can correctly identify garbage. This is the implementation of the design in https://github.com/amazon-mq/rabbitmq-stream-s3/pull/311.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
