### PR TITLE
Add GC property tests and db:list_consistent/0

### DIFF
--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -72,7 +72,7 @@ Zero indicates that the manifest has not been created yet.
 
 -export([setup/0]).
 
--export([get/1, get_consistent/1, list/0, count/0, put/5, queue_path/1]).
+-export([get/1, get_consistent/1, list/0, list_consistent/0, count/0, put/5, queue_path/1]).
 -export([put_anchor/2, anchor_exists_consistent/1]).
 
 -define(C_SPROC_TRIGGERS, 1).
@@ -175,10 +175,23 @@ do_get(StreamId, Options) ->
             Err
     end.
 
--doc "Lists all streams known to the metadata store.".
+-doc "Lists all streams known to the metadata store with a low-latency local read.".
 -spec list() -> {ok, #{stream_id() => entry()}} | {error, any()}.
 list() ->
-    case rabbit_khepri:adv_get_many(?MANIFEST_PATH(?KHEPRI_WILDCARD_STAR)) of
+    do_list(#{}).
+
+-doc """
+Lists all streams known to the metadata store with a consistent read.
+
+A consistent read ensures that the query either reflects the latest possible
+information across the cluster, or fails.
+""".
+-spec list_consistent() -> {ok, #{stream_id() => entry()}} | {error, any()}.
+list_consistent() ->
+    do_list(#{favor => consistency, timeout => ?CONSISTENT_READ_TIMEOUT_MS}).
+
+do_list(Options) ->
+    case rabbit_khepri:adv_get_many(?MANIFEST_PATH(?KHEPRI_WILDCARD_STAR), Options) of
         {ok, NodeProps} ->
             Entries =
                 #{

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -24,18 +24,20 @@ floor a concurrent sweep already snapshotted. Three guards keep the sweep safe:
      if the floor has dropped to at or below its offset. The reset lowers the
      cached floor before it re-uploads, so a re-tiered fragment is always at or
      above the live floor by the time it exists.
-  2. The cross-stream sweep, like the single-stream path, gates each stream on a
-     strongly-consistent metadata read, so a partitioned or deposed node that
-     cannot reach a quorum fails closed and skips rather than deleting on a stale
-     local view.
-  3. That metadata read in build_lookup/2 is sampled once, up front. A reset that
-     commits *after* the snapshot, on a node whose manifest cache has not yet
-     applied the sync, leaves still_dangling/1 re-reading a stale-high floor while
-     the committed epoch has moved on, so guards 1 and 2 both pass. Each
-     offset-based deletion is therefore re-validated once more at the point of
-     deletion (see fresh_enough_to_delete/2): a fresh quorum read of the committed
-     epoch is compared against the cached epoch, and the delete is skipped when
-     they differ. A genuine orphan skipped here is reclaimed by a later sweep.
+  2. The cross-stream sweep gates on a single strongly-consistent wildcard read of
+     every stream's committed metadata (db:list_consistent/0, in run/1), and the
+     single-stream path on a per-stream consistent read, so a partitioned or
+     deposed node that cannot reach a quorum fails closed rather than deleting on a
+     stale local view.
+  3. That metadata read (the single wildcard quorum read in run/1) is sampled
+     once, up front. A reset that commits after the snapshot, on a node whose
+     manifest cache has not yet applied the sync, leaves still_dangling/1
+     re-reading a stale-high floor while the committed epoch has moved on, so
+     guards 1 and 2 both pass. Each offset-based deletion is therefore
+     re-validated once more at the point of deletion (see
+     `fresh_enough_to_delete/2`): a fresh quorum read of the committed epoch is
+     compared against the cached epoch, and the delete is skipped when they
+     differ. A orphan skipped here is reclaimed by a later sweep.
 
 For a stream that is in the committed lookup, objects are classified against its
 first_offset and epoch as above. For an object whose stream is NOT in the lookup
@@ -93,17 +95,30 @@ run() ->
 Run garbage collection. In `dry_run` mode, identifies and logs orphans without
 deleting. In `delete` mode, deletes identified orphans via the reaper.
 """.
--spec run(config()) -> {ok, [finding()]}.
+-spec run(config()) -> {ok, [finding()]} | {error, any()}.
 run(Config) when is_map(Config) ->
     Mode = maps:get(mode, Config, dry_run),
-    {ok, Streams} = rabbitmq_stream_s3_db:list(),
-    Lookup = build_lookup(Streams, Config),
-    Fun = make_handler(Mode),
-    Findings = list_and_classify(
-        <<"rabbitmq/stream/">>, start, Lookup, Fun, fun anchor_absent/1, []
-    ),
-    ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
-    {ok, Findings}.
+    %% One strongly-consistent wildcard read snapshots every stream's committed
+    %% metadata up front, so the whole sweep pays a single quorum round trip rather
+    %% than one per stream. A quorum failure (for example on a minority partition)
+    %% fails the entire sweep closed rather than deleting on a stale local view.
+    case rabbitmq_stream_s3_db:list_consistent() of
+        {ok, Streams} ->
+            Lookup = build_lookup(Streams, Config),
+            Fun = make_handler(Mode),
+            Findings = list_and_classify(
+                <<"rabbitmq/stream/">>, start, Lookup, Fun, fun anchor_absent/1, []
+            ),
+            ?LOG_INFO("GC ~ts complete: ~b dangling object(s)", [Mode, length(Findings)]),
+            {ok, Findings};
+        {error, Reason} ->
+            ?LOG_WARNING(
+                "GC ~ts aborted: could not read committed stream metadata with "
+                "quorum (~p); sweeping nothing",
+                [Mode, Reason]
+            ),
+            {error, Reason}
+    end.
 
 -doc """
 Run garbage collection scoped to a single stream. Only lists objects under the
@@ -308,21 +323,21 @@ live_leading_group(StreamId, Key, Manifest) ->
 -doc """
 Cross-stream sweep lookup.
 
-Gates each stream on a strongly-consistent metadata read so a partitioned or
-deposed node that cannot reach a quorum fails closed and skips, rather than
-deleting on a stale local view. The committed epoch from that read is also
-more authoritative than the local db:list/0 snapshot. The per-stream decision
-is shared with the single-stream path via stream_lookup_decision/5; here it
-runs with no empty-manifest allowance (an empty manifest has nothing in the
-remote tier to sweep against).
+Consumes the committed metadata snapshot taken by the single wildcard quorum read
+in run/1 (db:list_consistent/0): every stream's entry is already the committed
+authority, so no per-stream quorum read is done here. For each stream it reads the
+local replica cache (a direct ETS read) and runs the shared per-stream decision
+(stream_lookup_decision/5) with no empty-manifest allowance (an empty manifest has
+nothing in the remote tier to sweep against), which gates the cached floor against
+the committed epoch and fails closed when the cache lags.
 """.
 build_lookup(Streams, Config) ->
     maps:fold(
-        fun(StreamId, _LocalEntry, Acc) ->
-            Consistent = rabbitmq_stream_s3_db:get_consistent(StreamId),
+        fun(StreamId, Entry, Acc) ->
+            Consistent = {ok, Entry},
             CacheResult = read_cache_after(Consistent, StreamId),
             case stream_lookup_decision(StreamId, Consistent, CacheResult, Config, false) of
-                {ok, Entry} -> Acc#{StreamId => Entry};
+                {ok, LookupEntry} -> Acc#{StreamId => LookupEntry};
                 skip -> Acc
             end
         end,

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -28,7 +28,7 @@ floor a concurrent sweep already snapshotted. Three guards keep the sweep safe:
      strongly-consistent metadata read, so a partitioned or deposed node that
      cannot reach a quorum fails closed and skips rather than deleting on a stale
      local view.
-  3. That metadata read in build_lookup/1 is sampled once, up front. A reset that
+  3. That metadata read in build_lookup/2 is sampled once, up front. A reset that
      commits *after* the snapshot, on a node whose manifest cache has not yet
      applied the sync, leaves still_dangling/1 re-reading a stale-high floor while
      the committed epoch has moved on, so guards 1 and 2 both pass. Each
@@ -61,7 +61,30 @@ anchor absent and reap it.
 -type reason() :: below_first_offset | stale_epoch | no_anchor.
 -type finding() :: #{stream_id := stream_id(), key := rabbitmq_stream_s3:key(), reason := reason()}.
 
+%% The results of the two live reads the sweep depends on. The read-performing
+%% shells (build_lookup/2, build_stream_lookup/2, fresh_enough_to_delete/2,
+%% anchor_absent/1) hand these to pure decision functions, so every guard is a
+%% total function of read results, testable without a live db or replica cache.
+-type consistent_result() :: {ok, rabbitmq_stream_s3_db:entry()} | {error, term()}.
+-type cache_result() :: {#manifest{}, osiris:epoch() | undefined} | undefined.
+
 -export_type([mode/0, config/0, finding/0]).
+
+-ifdef(TEST).
+%% Exposed to prop_SUITE, which property-tests the pure reap decision against the
+%% same invariants the P models in p/ verify. These are the functional cores of
+%% the read-performing shells, taking read results as inputs.
+-export([
+    classify/2,
+    still_dangling/1,
+    lookup_entry/4,
+    stream_lookup_decision/5,
+    fresh_enough_decision/3,
+    anchor_decision/2,
+    cache_at_committed_epoch/2,
+    epoch_permits_sweep/2
+]).
+-endif.
 
 run() ->
     run(#{mode => dry_run}).
@@ -74,7 +97,7 @@ deleting. In `delete` mode, deletes identified orphans via the reaper.
 run(Config) when is_map(Config) ->
     Mode = maps:get(mode, Config, dry_run),
     {ok, Streams} = rabbitmq_stream_s3_db:list(),
-    Lookup = build_lookup(Streams),
+    Lookup = build_lookup(Streams, Config),
     Fun = make_handler(Mode),
     Findings = list_and_classify(
         <<"rabbitmq/stream/">>, start, Lookup, Fun, fun anchor_absent/1, []
@@ -156,7 +179,7 @@ make_handler(delete) ->
     end.
 
 %% Re-validate cache freshness against the committed epoch immediately before an
-%% offset-based deletion. build_lookup/1 (and build_stream_lookup/2) sampled the
+%% offset-based deletion. build_lookup/2 (and build_stream_lookup/2) sampled the
 %% committed epoch once, at the start of the sweep; a remote-tier-ahead reset that
 %% commits after that snapshot, on a node whose manifest cache has not yet applied
 %% the sync, leaves the cached floor stale-high at the old epoch while the
@@ -174,30 +197,35 @@ fresh_enough_to_delete(no_anchor, _StreamId) ->
     %% incarnation), so the absence is permanent.
     true;
 fresh_enough_to_delete(below_first_offset, StreamId) ->
-    case rabbitmq_stream_s3_db:get_consistent(StreamId) of
-        {ok, #{epoch := CommittedEpoch}} ->
-            CacheResult = rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId),
-            case cache_at_committed_epoch(CacheResult, CommittedEpoch) of
-                true ->
-                    true;
-                false ->
-                    ?LOG_INFO(
-                        "GC: not deleting under stream ~ts: local manifest cache "
-                        "epoch ~p does not match the committed epoch ~p; a reset "
-                        "committed after the sweep snapshot and this node has not "
-                        "applied it. A later sweep reclaims a genuine orphan.",
-                        [StreamId, cache_epoch(CacheResult), CommittedEpoch]
-                    ),
-                    false
-            end;
-        {error, Reason} ->
+    Consistent = rabbitmq_stream_s3_db:get_consistent(StreamId),
+    fresh_enough_decision(StreamId, Consistent, read_cache_after(Consistent, StreamId)).
+
+%% Pure decision for the offset-based freshness re-check: given the
+%% committed-epoch read and the cache read, delete only when the cache holds a
+%% manifest at exactly the committed epoch. A quorum-read failure or a cache
+%% that lags the committed epoch both fail closed.
+-spec fresh_enough_decision(stream_id(), consistent_result(), cache_result()) -> boolean().
+fresh_enough_decision(StreamId, {ok, #{epoch := CommittedEpoch}}, CacheResult) ->
+    case cache_at_committed_epoch(CacheResult, CommittedEpoch) of
+        true ->
+            true;
+        false ->
             ?LOG_INFO(
-                "GC: not deleting under stream ~ts: could not re-read the committed "
-                "epoch with quorum (~p); failing closed",
-                [StreamId, Reason]
+                "GC: not deleting under stream ~ts: local manifest cache "
+                "epoch ~p does not match the committed epoch ~p; a reset "
+                "committed after the sweep snapshot and this node has not "
+                "applied it. A later sweep reclaims a genuine orphan.",
+                [StreamId, cache_epoch(CacheResult), CommittedEpoch]
             ),
             false
-    end.
+    end;
+fresh_enough_decision(StreamId, {error, Reason}, _CacheResult) ->
+    ?LOG_INFO(
+        "GC: not deleting under stream ~ts: could not re-read the committed "
+        "epoch with quorum (~p); failing closed",
+        [StreamId, Reason]
+    ),
+    false.
 
 %% Pure decision for fresh_enough_to_delete/2: the cache must hold a manifest at
 %% exactly the committed epoch. A cache behind the committed epoch (the
@@ -277,59 +305,98 @@ live_leading_group(StreamId, Key, Manifest) ->
 %% Internal
 %% ------------------------------------------------------------------
 
-build_lookup(Streams) ->
+-doc """
+Cross-stream sweep lookup.
+
+Gates each stream on a strongly-consistent metadata read so a partitioned or
+deposed node that cannot reach a quorum fails closed and skips, rather than
+deleting on a stale local view. The committed epoch from that read is also
+more authoritative than the local db:list/0 snapshot. The per-stream decision
+is shared with the single-stream path via stream_lookup_decision/5; here it
+runs with no empty-manifest allowance (an empty manifest has nothing in the
+remote tier to sweep against).
+""".
+build_lookup(Streams, Config) ->
     maps:fold(
         fun(StreamId, _LocalEntry, Acc) ->
-            %% Like the single-stream path (build_stream_lookup/2), gate each
-            %% stream on a strongly-consistent metadata read so a partitioned or
-            %% deposed node that cannot reach a quorum fails closed and skips,
-            %% rather than deleting on a stale local view. The committed epoch
-            %% from this read is also more authoritative than the local db:list/0
-            %% snapshot. This makes a full sweep do one quorum read per stream,
-            %% which is acceptable for an infrequent operator-driven sweep.
-            case rabbitmq_stream_s3_db:get_consistent(StreamId) of
-                {ok, #{epoch := Epoch}} ->
-                    %% The floor comes from the local replica cache, but the
-                    %% committed epoch comes from the quorum read above. On a node
-                    %% that has not yet applied a floor-lowering reset's sync, the
-                    %% cache still holds the pre-reset high floor at the old epoch,
-                    %% and still_dangling/1 would re-read that same stale floor.
-                    %% Sweep only when the cached manifest's epoch matches the
-                    %% committed epoch; otherwise fail closed (the cache lags the
-                    %% committed reset). The `Epoch` in the matching clause is the
-                    %% committed epoch bound above, so the clause only matches an
-                    %% up-to-date cache.
-                    case rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId) of
-                        {#manifest{entries = <<>>}, _} ->
-                            %% Empty manifest: nothing in the remote tier to
-                            %% compare against (matches the prior get_range/1
-                            %% `empty` skip).
-                            Acc;
-                        {#manifest{first_offset = FirstOffset} = Manifest, Epoch} ->
-                            Acc#{StreamId => lookup_entry(StreamId, Epoch, FirstOffset, Manifest)};
-                        {#manifest{}, CacheEpoch} ->
-                            ?LOG_INFO(
-                                "GC for stream ~ts skipped: local manifest cache epoch ~p "
-                                "does not match the committed epoch ~p; the cache lags the "
-                                "committed reset, so its floor may be stale-high",
-                                [StreamId, CacheEpoch, Epoch]
-                            ),
-                            Acc;
-                        undefined ->
-                            Acc
-                    end;
-                {error, Reason} ->
-                    ?LOG_INFO(
-                        "GC for stream ~ts skipped: could not read committed "
-                        "metadata with quorum (~p); not sweeping",
-                        [StreamId, Reason]
-                    ),
-                    Acc
+            Consistent = rabbitmq_stream_s3_db:get_consistent(StreamId),
+            CacheResult = read_cache_after(Consistent, StreamId),
+            case stream_lookup_decision(StreamId, Consistent, CacheResult, Config, false) of
+                {ok, Entry} -> Acc#{StreamId => Entry};
+                skip -> Acc
             end
         end,
         #{},
         Streams
     ).
+
+%% Read the local replica cache only when the quorum read succeeded, mirroring
+%% the original control flow (a quorum failure fails closed before any cache
+%% read).
+-spec read_cache_after(consistent_result(), stream_id()) -> cache_result().
+read_cache_after({ok, _}, StreamId) ->
+    rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId);
+read_cache_after({error, _}, _StreamId) ->
+    undefined.
+
+%% Pure per-stream lookup decision shared by the cross-stream and
+%% single-stream sweeps. Given the committed-epoch read and the cache read, it
+%% yields the lookup entry to sweep against or skips (fails closed).
+%%
+%% The floor comes from the local replica cache but the committed epoch comes from
+%% the quorum read: on a node that has not applied a floor-lowering reset's sync,
+%% the cache still holds the pre-reset high floor at the old epoch, and
+%% still_dangling/1 would re-read that same stale floor. So the entry is built only
+%% when the cached manifest's epoch equals the committed epoch (the CommittedEpoch
+%% reused in the matching clause of stream_lookup_from_cache/4); otherwise the
+%% cache lags the committed reset and the stream is skipped.
+%%
+%% AllowEmpty distinguishes the callers: the cross-stream sweep skips an empty
+%% manifest, while the single-stream reset path keeps it (the reset installs an
+%% empty manifest whose first_offset is the floor the orphans sit below).
+-spec stream_lookup_decision(
+    stream_id(), consistent_result(), cache_result(), config(), boolean()
+) -> {ok, map()} | skip.
+stream_lookup_decision(StreamId, {ok, #{epoch := CommittedEpoch}}, CacheResult, Config, AllowEmpty) ->
+    case epoch_permits_sweep(CommittedEpoch, Config) of
+        true ->
+            stream_lookup_from_cache(StreamId, CommittedEpoch, CacheResult, AllowEmpty);
+        false ->
+            ?LOG_INFO(
+                "GC for stream ~ts skipped: writer epoch ~p is behind the "
+                "committed epoch ~p, this writer has been deposed",
+                [StreamId, maps:get(writer_epoch, Config, undefined), CommittedEpoch]
+            ),
+            skip
+    end;
+stream_lookup_decision(StreamId, {error, Reason}, _CacheResult, _Config, _AllowEmpty) ->
+    ?LOG_INFO(
+        "GC for stream ~ts skipped: could not read committed "
+        "metadata with quorum (~p); not sweeping",
+        [StreamId, Reason]
+    ),
+    skip.
+
+-spec stream_lookup_from_cache(stream_id(), osiris:epoch(), cache_result(), boolean()) ->
+    {ok, map()} | skip.
+stream_lookup_from_cache(_StreamId, _CommittedEpoch, {#manifest{entries = <<>>}, _}, false) ->
+    %% Cross-stream sweep: empty manifest, nothing in the remote tier to compare
+    %% against (matches the prior get_range/1 `empty` skip).
+    skip;
+stream_lookup_from_cache(
+    StreamId, CommittedEpoch, {#manifest{first_offset = FirstOffset} = Manifest, CommittedEpoch}, _
+) ->
+    {ok, lookup_entry(StreamId, CommittedEpoch, FirstOffset, Manifest)};
+stream_lookup_from_cache(StreamId, CommittedEpoch, {#manifest{}, CacheEpoch}, _AllowEmpty) ->
+    ?LOG_INFO(
+        "GC for stream ~ts skipped: local manifest cache epoch ~p "
+        "does not match the committed epoch ~p; the cache lags the "
+        "committed reset, so its floor may be stale-high",
+        [StreamId, CacheEpoch, CommittedEpoch]
+    ),
+    skip;
+stream_lookup_from_cache(_StreamId, _CommittedEpoch, undefined, _AllowEmpty) ->
+    skip.
 
 %% Build a per-stream lookup entry. Besides the epoch and first_offset used for
 %% the offset/epoch heuristics, it records the leading group's object key (the
@@ -378,66 +445,32 @@ leading_group_info(StreamId, #manifest{entries = Entries}) ->
             {none, true}
     end.
 
+-doc """
+Single-stream sweep lookup.
+
+Reads the committed epoch with a strongly consistent (quorum-requiring) read.
+the sweep deletes data objects below a floor taken from the local just-reset
+manifest, which sits above the committed floor, and a deposed writer that read
+stale local state would delete a successor's live fragments in that gap. The
+consistent read makes a deposed minority writer, which cannot reach a quorum,
+fail closed and skip; when the caller pins its own writer epoch,
+`epoch_permits_sweep/2` additionally makes a deposed writer that can still
+reach a quorum skip.
+
+Runs the shared decision with AllowEmpty = true: a manifest reset installs an
+empty manifest whose first_offset is the local floor the orphaned fragments sit
+below, and reading first_offset from that record (rather than via get_range/1,
+which reports `empty`) is precisely what lets this path reclaim them. On the
+reset path the writer's own cache was just updated synchronously at this epoch,
+so the cache-epoch gate is a no-op there; it fails closed for any caller
+reading a node whose cache lags the committed reset.
+""".
 build_stream_lookup(StreamId, Config) ->
-    %% Read the committed epoch with a strongly consistent (quorum-requiring)
-    %% read, not the default low-latency local read. The sweep deletes data
-    %% objects below a floor taken from the local just-reset manifest, which sits
-    %% above the committed floor. A deposed writer that read stale local state
-    %% would delete a successor's live fragments in that gap. A consistent read
-    %% makes a deposed minority writer, which cannot reach a quorum, fail closed
-    %% and skip. When the caller supplies its own writer epoch (the reset path),
-    %% additionally require the committed epoch to equal it, so a deposed writer
-    %% that can still reach a quorum also skips.
-    case rabbitmq_stream_s3_db:get_consistent(StreamId) of
-        {ok, #{epoch := CommittedEpoch}} ->
-            case epoch_permits_sweep(CommittedEpoch, Config) of
-                true ->
-                    %% Read first_offset from the manifest record directly rather
-                    %% than via get_range/1, which reports `empty` whenever the
-                    %% entries array is empty. A manifest reset (the caller of
-                    %% run_stream/2) installs exactly such an empty manifest with
-                    %% first_offset at the local floor, and that floor is precisely
-                    %% what the orphaned fragments sit below. Using get_range/1
-                    %% here would skip the stream and reclaim nothing.
-                    %% Sweep only against a cache at the committed epoch (see
-                    %% build_lookup/1). On the reset path the writer's own cache
-                    %% was just updated synchronously at this epoch, so this is a
-                    %% no-op there; it fails closed for any caller reading a node
-                    %% whose cache lags the committed reset. The matching clause
-                    %% reuses CommittedEpoch, so it only matches an up-to-date cache.
-                    case rabbitmq_stream_s3_manifest_replica:get_manifest_and_epoch(StreamId) of
-                        {#manifest{first_offset = FirstOffset} = Manifest, CommittedEpoch} ->
-                            {ok, #{
-                                StreamId => lookup_entry(
-                                    StreamId, CommittedEpoch, FirstOffset, Manifest
-                                )
-                            }};
-                        {#manifest{}, CacheEpoch} ->
-                            ?LOG_INFO(
-                                "GC for stream ~ts skipped: local manifest cache epoch ~p "
-                                "does not match the committed epoch ~p; the cache lags the "
-                                "committed reset, so its floor may be stale-high",
-                                [StreamId, CacheEpoch, CommittedEpoch]
-                            ),
-                            skip;
-                        undefined ->
-                            skip
-                    end;
-                false ->
-                    ?LOG_INFO(
-                        "GC for stream ~ts skipped: writer epoch ~p is behind the "
-                        "committed epoch ~p, this writer has been deposed",
-                        [StreamId, maps:get(writer_epoch, Config, undefined), CommittedEpoch]
-                    ),
-                    skip
-            end;
-        {error, Reason} ->
-            ?LOG_INFO(
-                "GC for stream ~ts skipped: could not read committed metadata "
-                "with quorum (~p); not sweeping",
-                [StreamId, Reason]
-            ),
-            skip
+    Consistent = rabbitmq_stream_s3_db:get_consistent(StreamId),
+    CacheResult = read_cache_after(Consistent, StreamId),
+    case stream_lookup_decision(StreamId, Consistent, CacheResult, Config, true) of
+        {ok, Entry} -> {ok, #{StreamId => Entry}};
+        skip -> skip
     end.
 
 %% On the reset path the caller pins its writer epoch, and the sweep is permitted
@@ -495,17 +528,22 @@ classify_page(Keys, Lookup, AnchorAbsent) ->
 %% a quorum fails closed (false), so a live or unverifiable stream is never reaped.
 -spec anchor_absent(stream_id()) -> boolean().
 anchor_absent(StreamId) ->
-    case rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId) of
-        {ok, Exists} ->
-            not Exists;
-        {error, Reason} ->
-            ?LOG_INFO(
-                "GC: not reaping the prefix of stream ~ts: could not read its anchor "
-                "with quorum (~p); failing closed",
-                [StreamId, Reason]
-            ),
-            false
-    end.
+    anchor_decision(StreamId, rabbitmq_stream_s3_db:anchor_exists_consistent(StreamId)).
+
+%% Pure decision for the no_anchor backstop: the anchor is "absent" (the stream is
+%% deleted, so its prefix is reapable) only on a consistent read that positively
+%% reports it gone. A present anchor, or any read that cannot reach a quorum, fails
+%% closed, so a live or unverifiable stream is never reaped.
+-spec anchor_decision(stream_id(), {ok, boolean()} | {error, term()}) -> boolean().
+anchor_decision(_StreamId, {ok, Exists}) ->
+    not Exists;
+anchor_decision(StreamId, {error, Reason}) ->
+    ?LOG_INFO(
+        "GC: not reaping the prefix of stream ~ts: could not read its anchor "
+        "with quorum (~p); failing closed",
+        [StreamId, Reason]
+    ),
+    false.
 
 %% A stream that is in the lookup is classified against its floor/epoch. A
 %% well-formed key whose stream is NOT in the lookup becomes a no_anchor

--- a/test/db_SUITE.erl
+++ b/test/db_SUITE.erl
@@ -19,6 +19,7 @@ all() ->
         update_with_correct_revision,
         conflict_on_stale_revision,
         epoch_fencing,
+        list_and_list_consistent,
         keep_while_deletes_on_queue_removal,
         put_anchor_present_and_absent,
         anchor_removed_on_queue_removal
@@ -80,6 +81,31 @@ epoch_fencing(_Config) ->
     ?assertMatch(
         {ok, _, _},
         rabbitmq_stream_s3_db:put(StreamId, StreamId, 2, Rev1, Uid3)
+    ).
+
+%% list/0 (local) and list_consistent/0 (quorum) return the same committed entry
+%% for every stream. list_consistent/0 lets the cross-stream GC sweep read all
+%% streams in a single quorum round trip instead of one per stream.
+list_and_list_consistent(_Config) ->
+    Ids = [<<"db_suite_list_a">>, <<"db_suite_list_b">>, <<"db_suite_list_c">>],
+    Expected = maps:from_list([
+        begin
+            Uid = rabbitmq_stream_s3:uid(),
+            {ok, undefined, Rev} = rabbitmq_stream_s3_db:put(Id, Id, 3, 0, Uid),
+            {Id, #{uid => Uid, epoch => 3, revision => Rev}}
+        end
+     || Id <- Ids
+    ]),
+    {ok, Consistent} = rabbitmq_stream_s3_db:list_consistent(),
+    {ok, Local} = rabbitmq_stream_s3_db:list(),
+    %% The store is shared across the suite, so assert on our streams rather than
+    %% the whole map: each appears with its committed entry in both views.
+    lists:foreach(
+        fun(Id) ->
+            ?assertEqual(maps:get(Id, Expected), maps:get(Id, Consistent)),
+            ?assertEqual(maps:get(Id, Expected), maps:get(Id, Local))
+        end,
+        Ids
     ).
 
 keep_while_deletes_on_queue_removal(_Config) ->

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -9,6 +9,8 @@ Covers:
 - Manifest edits (append, truncate, replace) preserve structural invariants
 - Fragment assembly metadata correctness
 - Fragment iterator traversal completeness and ordering
+- Garbage collection never reaps a live object and always reclaims a genuine
+  orphan (INV#2), the Erlang-level companion to the P models in p/
 """.
 
 -compile([export_all, nowarn_export_all]).
@@ -56,7 +58,16 @@ all() ->
         broadcast_edits_with_retention,
         %% Remote reader core
         remote_reader_core_no_crash,
-        remote_reader_core_reply_size_bounded
+        remote_reader_core_reply_size_bounded,
+        %% Garbage collection reap decision
+        gc_classify_never_reaps_live,
+        gc_classify_reclaims_orphans,
+        gc_still_dangling_respects_live_manifest,
+        gc_stream_lookup_epoch_gate,
+        gc_fresh_enough_fails_closed,
+        gc_anchor_decision_fails_closed,
+        gc_cache_epoch_gate,
+        gc_epoch_permits_sweep
     ].
 
 init_per_suite(Config) -> Config.
@@ -1754,3 +1765,460 @@ run_rrc_events([{retry} | Rest], State0) ->
 run_rrc_events([Event | Rest], State0) ->
     {State1, _} = rabbitmq_stream_s3_remote_reader_core:step(State0, Event),
     run_rrc_events(Rest, State1).
+
+%% =========================================================================
+%% Garbage collection reap-decision properties
+%%
+%% The Erlang-level companion to the P models in p/. The P models prove the GC
+%% invariants (chiefly INV#2, "GC never deletes a live object") across
+%% concurrent interleavings; these properties fuzz the input space of the pure
+%% reap-decision functions -- floors, epochs, UIDs, and leading-group shapes --
+%% which the hand-written eunit examples in rabbitmq_stream_s3_gc do not reach.
+%% The two axes are complementary: P covers the ordering, these cover the
+%% classification breadth.
+%% =========================================================================
+
+%% INV#2 at classification time: for any manifest and floor, classify/2 never
+%% marks a live-referenced object deletable. Live means a fragment or group at or
+%% above the floor, the current-epoch manifest, or the referenced leading group
+%% straddling the floor (partial expiry). A conservative skip-groups manifest
+%% (leading kilo-/mega-group) additionally protects every group below the floor.
+gc_classify_never_reaps_live(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_classify_never_reaps_live/0, [], 500).
+
+prop_gc_classify_never_reaps_live() ->
+    ?FORALL(
+        Scenario,
+        gen_gc_classify_scenario(),
+        begin
+            #{lookup := Lookup, live_keys := LiveKeys} = Scenario,
+            lists:all(
+                fun(Key) -> rabbitmq_stream_s3_gc:classify(Key, Lookup) =:= skip end,
+                LiveKeys
+            )
+        end
+    ).
+
+%% Anti-vacuity: a genuine orphan (fragment or non-leading group below the floor,
+%% or a stale-epoch manifest) is always classified deletable. Without this a
+%% classify/2 that skipped everything would pass the safety property vacuously.
+gc_classify_reclaims_orphans(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_classify_reclaims_orphans/0, [], 500).
+
+prop_gc_classify_reclaims_orphans() ->
+    ?FORALL(
+        Scenario,
+        gen_gc_classify_scenario(),
+        begin
+            #{lookup := Lookup, dead_keys := DeadKeys} = Scenario,
+            lists:all(
+                fun(Key) ->
+                    case rabbitmq_stream_s3_gc:classify(Key, Lookup) of
+                        {ok, _} -> true;
+                        skip -> false
+                    end
+                end,
+                DeadKeys
+            )
+        end
+    ).
+
+%% Build a single-stream GC scenario: a manifest whose leading entry is a
+%% fragment, group, or kilo-/mega-group, a floor above that leading entry
+%% (partial-expiry, so a leading group straddles the floor), an epoch, and the
+%% lookup entry the sweep would compute. LiveKeys must all classify to skip;
+%% DeadKeys must all classify to a finding.
+gen_gc_classify_scenario() ->
+    ?LET(
+        {LeadingKind, LeadingUid, Floor, Epoch, AboveOffs, BelowOffs, DeadGroupOffs, StaleEpochs},
+        {
+            oneof([fragment, group, kilo_group, mega_group]),
+            gc_uid(),
+            integer(2, 100000),
+            integer(1, 1000),
+            non_empty(list(non_neg_integer())),
+            non_empty(list(non_neg_integer())),
+            list(pos_integer()),
+            list(non_neg_integer())
+        },
+        begin
+            StreamId = <<"gc-prop-stream">>,
+            LeadingOffset = 0,
+            Kind = gc_leading_kind(LeadingKind),
+            %% leading_group_info reads only the first entry, so a single leading
+            %% entry is a faithful manifest for building the lookup.
+            Manifest = #manifest{
+                first_offset = Floor,
+                next_offset = Floor + 1,
+                entries = ?ENTRY(LeadingOffset, 0, 0, Kind, 0, LeadingUid)
+            },
+            Lookup = #{
+                StreamId => rabbitmq_stream_s3_gc:lookup_entry(StreamId, Epoch, Floor, Manifest)
+            },
+            SkipGroups = LeadingKind =:= kilo_group orelse LeadingKind =:= mega_group,
+            %% Fragments and groups at or above the floor are live.
+            LiveAbove =
+                [
+                    rabbitmq_stream_s3:fragment_key(StreamId, Floor + (O rem 1000), gc_uid_of(O))
+                 || O <- AboveOffs
+                ] ++
+                    [
+                        gc_group_key(StreamId, Floor + (O rem 1000), gc_uid_of(O + 1))
+                     || O <- AboveOffs
+                    ],
+            %% The current-epoch manifest is live.
+            LiveManifest = [
+                rabbitmq_stream_s3:manifest_key(StreamId, #manifest_ref{epoch = Epoch, uid = 7})
+            ],
+            %% The referenced leading group (a group straddling the floor) is
+            %% live; in skip-groups mode every group below the floor is protected.
+            LiveGroups =
+                case LeadingKind of
+                    group ->
+                        [gc_group_key(StreamId, LeadingOffset, LeadingUid)];
+                    _ when SkipGroups ->
+                        [
+                            gc_group_key(StreamId, gc_below(O, Floor), gc_uid_of(O))
+                         || O <- DeadGroupOffs
+                        ];
+                    _ ->
+                        []
+                end,
+            LiveKeys = LiveAbove ++ LiveManifest ++ LiveGroups,
+            %% Fragments below the floor are always dead, regardless of leading
+            %% kind.
+            DeadFragments = [
+                rabbitmq_stream_s3:fragment_key(StreamId, gc_below(O, Floor), gc_uid_of(O))
+             || O <- BelowOffs
+            ],
+            %% A manifest strictly below the current epoch is stale.
+            DeadManifests = [
+                rabbitmq_stream_s3:manifest_key(
+                    StreamId, #manifest_ref{epoch = E rem Epoch, uid = 9}
+                )
+             || E <- StaleEpochs, Epoch > 0
+            ],
+            %% Non-leading groups below the floor are dead only when not in
+            %% conservative skip-groups mode. Offset >= 1 keeps them clear of the
+            %% leading group at offset 0.
+            DeadGroups =
+                case SkipGroups of
+                    true ->
+                        [];
+                    false ->
+                        [
+                            gc_group_key(StreamId, 1 + (O rem (Floor - 1)), gc_uid_of(O + 3))
+                         || O <- DeadGroupOffs
+                        ]
+                end,
+            DeadKeys = DeadFragments ++ DeadManifests ++ DeadGroups,
+            #{lookup => Lookup, live_keys => LiveKeys, dead_keys => DeadKeys}
+        end
+    ).
+
+gc_leading_kind(fragment) -> ?MANIFEST_KIND_FRAGMENT;
+gc_leading_kind(group) -> ?MANIFEST_KIND_GROUP;
+gc_leading_kind(kilo_group) -> ?MANIFEST_KIND_KILO_GROUP;
+gc_leading_kind(mega_group) -> ?MANIFEST_KIND_MEGA_GROUP.
+
+gc_group_key(StreamId, Offset, Uid) ->
+    rabbitmq_stream_s3:group_key(
+        StreamId, #group_ref{offset = Offset, kind = ?MANIFEST_KIND_GROUP, uid = Uid}
+    ).
+
+%% Map an arbitrary non-negative integer to an offset strictly below the floor.
+gc_below(O, Floor) -> O rem Floor.
+
+gc_uid() -> integer(1, 16#FFFFFFFF).
+
+%% A deterministic, always-in-range UID derived from a generated integer, so keys
+%% vary without adding another generator dimension.
+gc_uid_of(O) -> 1 + (O rem 16#FFFFFFFF).
+
+%% Execute-time re-validation (still_dangling/1), guards B and C: an offset-based
+%% finding is deletable iff it is still below the *live* floor and, for a group,
+%% is not the live referenced leading group. This is the reset re-read: a
+%% re-tiered fragment at or above the live floor is protected, a genuine orphan
+%% below it is reclaimed, and the live leading group straddling the floor is
+%% protected while a stale object at the same offset (different UID) is reaped.
+gc_still_dangling_respects_live_manifest(_Config) ->
+    {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
+    unlink(Pid),
+    try
+        rabbit_ct_proper_helpers:run_proper(
+            fun prop_gc_still_dangling_respects_live_manifest/0, [], 300
+        )
+    after
+        gen_server:stop(Pid)
+    end.
+
+prop_gc_still_dangling_respects_live_manifest() ->
+    ?FORALL(
+        {LiveFloor, LeadingUid, DataOffs, GroupOffs},
+        {
+            integer(2, 100000),
+            gc_uid(),
+            non_empty(list(non_neg_integer())),
+            list(non_neg_integer())
+        },
+        begin
+            StreamId = <<"gc-still-dangling-prop-stream">>,
+            LeadingOffset = 0,
+            %% A live manifest whose leading group straddles the floor.
+            ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
+                StreamId,
+                #manifest{
+                    first_offset = LiveFloor,
+                    next_offset = LiveFloor + 1,
+                    entries = ?ENTRY(
+                        LeadingOffset, 0, 0, ?MANIFEST_KIND_GROUP, 0, LeadingUid
+                    )
+                }
+            ),
+            LeadingKey = gc_group_key(StreamId, LeadingOffset, LeadingUid),
+            %% The live leading group is below the floor but referenced: keep it.
+            LeadingChecks = [
+                not gc_still_dangling(StreamId, LeadingKey)
+            ],
+            %% A data fragment is deletable iff it is below the live floor.
+            DataChecks = [
+                begin
+                    Offset = O rem (LiveFloor * 2),
+                    Key = rabbitmq_stream_s3:fragment_key(StreamId, Offset, gc_uid_of(O)),
+                    gc_still_dangling(StreamId, Key) =:= (Offset < LiveFloor)
+                end
+             || O <- DataOffs
+            ],
+            %% A group at the leading offset with a *different* UID is a stale
+            %% orphan (below floor, not the live leading group): deletable. A
+            %% group at or above the floor is a re-tier: protected.
+            GroupChecks = [
+                begin
+                    StaleAtLeading = gc_group_key(
+                        StreamId, LeadingOffset, gc_other_uid(LeadingUid)
+                    ),
+                    Retier = gc_group_key(StreamId, LiveFloor + (O rem 1000), gc_uid_of(O)),
+                    gc_still_dangling(StreamId, StaleAtLeading) andalso
+                        not gc_still_dangling(StreamId, Retier)
+                end
+             || O <- GroupOffs
+            ],
+            %% Epoch-based findings are never re-checked (epoch is monotonic).
+            EpochChecks = [
+                gc_still_dangling_finding(#{
+                    stream_id => StreamId, key => <<"any">>, reason => stale_epoch
+                }),
+                gc_still_dangling_finding(#{
+                    stream_id => StreamId, key => <<"any">>, reason => no_anchor
+                })
+            ],
+            lists:all(
+                fun(B) -> B end,
+                LeadingChecks ++ DataChecks ++ GroupChecks ++ EpochChecks
+            )
+        end
+    ).
+
+gc_still_dangling(StreamId, Key) ->
+    gc_still_dangling_finding(#{
+        stream_id => StreamId, key => Key, reason => below_first_offset
+    }).
+
+gc_still_dangling_finding(Finding) ->
+    rabbitmq_stream_s3_gc:still_dangling(Finding).
+
+%% A UID distinct from the given one, staying in range.
+gc_other_uid(Uid) when Uid =:= 16#FFFFFFFF -> 1;
+gc_other_uid(Uid) -> Uid + 1.
+
+%% Guards A and D (cache-epoch gate): an offset-based delete is permitted only
+%% when the local manifest cache holds a manifest at exactly the committed epoch.
+%% A cache behind the committed epoch (the reset-after-snapshot window), a legacy
+%% entry with no epoch, or no manifest at all must all fail closed.
+gc_cache_epoch_gate(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_cache_epoch_gate/0, [], 500).
+
+prop_gc_cache_epoch_gate() ->
+    ?FORALL(
+        {CacheResult, Committed},
+        {
+            oneof([
+                {#manifest{}, integer(0, 1000)},
+                {#manifest{}, undefined},
+                undefined
+            ]),
+            integer(0, 1000)
+        },
+        begin
+            Result = rabbitmq_stream_s3_gc:cache_at_committed_epoch(CacheResult, Committed),
+            Expected =
+                case CacheResult of
+                    {#manifest{}, Committed} -> true;
+                    _ -> false
+                end,
+            Result =:= Expected
+        end
+    ).
+
+%% The reset-path epoch fence: with a pinned writer epoch the sweep is permitted
+%% only when the committed epoch equals it (a deposed or not-yet-committed writer
+%% skips); with no writer epoch pinned (the operator CLI path) the consistent
+%% read is the only guard and the sweep is always permitted.
+gc_epoch_permits_sweep(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_epoch_permits_sweep/0, [], 500).
+
+prop_gc_epoch_permits_sweep() ->
+    ?FORALL(
+        {Committed, MaybeWriter},
+        {integer(0, 1000), oneof([undefined, integer(0, 1000)])},
+        begin
+            Config =
+                case MaybeWriter of
+                    undefined -> #{mode => delete};
+                    W -> #{mode => delete, writer_epoch => W}
+                end,
+            Result = rabbitmq_stream_s3_gc:epoch_permits_sweep(Committed, Config),
+            Expected =
+                case MaybeWriter of
+                    undefined -> true;
+                    WriterEpoch -> Committed =:= WriterEpoch
+                end,
+            Result =:= Expected
+        end
+    ).
+
+%% Guard A (the cache-epoch gate) as a pure function of the two read results. The
+%% shared per-stream lookup decision yields an entry only when the quorum read
+%% succeeds, the writer-epoch fence permits the sweep, and the cache holds a
+%% manifest at exactly the committed epoch (with the cross-stream path also
+%% skipping an empty manifest). Every other combination fails closed. This is the
+%% functional core the read-performing shells (build_lookup/2, build_stream_lookup/2)
+%% delegate to, so it is exercised here without a live db or replica cache.
+gc_stream_lookup_epoch_gate(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_stream_lookup_epoch_gate/0, [], 500).
+
+prop_gc_stream_lookup_epoch_gate() ->
+    ?FORALL(
+        {Consistent, Cache, MaybeWriter, AllowEmpty},
+        {gc_consistent(), gc_cache(), oneof([undefined, integer(0, 10)]), boolean()},
+        begin
+            StreamId = <<"gc-lookup-prop-stream">>,
+            Config =
+                case MaybeWriter of
+                    undefined -> #{mode => delete};
+                    W -> #{mode => delete, writer_epoch => W}
+                end,
+            Result = rabbitmq_stream_s3_gc:stream_lookup_decision(
+                StreamId, Consistent, Cache, Config, AllowEmpty
+            ),
+            Expected = gc_expected_lookup(Consistent, Cache, MaybeWriter, AllowEmpty),
+            case {Result, Expected} of
+                {skip, skip} ->
+                    true;
+                {{ok, Entry}, {ok, CommittedEpoch, FirstOffset}} ->
+                    maps:get(epoch, Entry) =:= CommittedEpoch andalso
+                        maps:get(first_offset, Entry) =:= FirstOffset;
+                _ ->
+                    false
+            end
+        end
+    ).
+
+%% Independent oracle for stream_lookup_decision/5: skip | {ok, Epoch, FirstOffset}.
+gc_expected_lookup({error, _}, _Cache, _Writer, _AllowEmpty) ->
+    skip;
+gc_expected_lookup({ok, #{epoch := CommittedEpoch}}, Cache, Writer, AllowEmpty) ->
+    case Writer =:= undefined orelse Writer =:= CommittedEpoch of
+        false -> skip;
+        true -> gc_expected_from_cache(CommittedEpoch, Cache, AllowEmpty)
+    end.
+
+gc_expected_from_cache(_CommittedEpoch, undefined, _AllowEmpty) ->
+    skip;
+gc_expected_from_cache(_CommittedEpoch, {#manifest{entries = <<>>}, _}, false) ->
+    %% Cross-stream sweep skips an empty manifest regardless of its epoch.
+    skip;
+gc_expected_from_cache(CommittedEpoch, {#manifest{first_offset = FO}, CommittedEpoch}, _AllowEmpty) ->
+    {ok, CommittedEpoch, FO};
+gc_expected_from_cache(_CommittedEpoch, {#manifest{}, _CacheEpoch}, _AllowEmpty) ->
+    skip.
+
+%% Guard D (the execute-time freshness re-check) as a pure function of the read
+%% results: an offset-based delete is permitted only when the quorum read succeeds
+%% and the cache is at the committed epoch. A quorum failure or a lagging cache
+%% both fail closed.
+gc_fresh_enough_fails_closed(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_fresh_enough_fails_closed/0, [], 500).
+
+prop_gc_fresh_enough_fails_closed() ->
+    ?FORALL(
+        {Consistent, Cache},
+        {gc_consistent(), gc_cache()},
+        begin
+            StreamId = <<"gc-fresh-prop-stream">>,
+            Result = rabbitmq_stream_s3_gc:fresh_enough_decision(StreamId, Consistent, Cache),
+            Expected =
+                case Consistent of
+                    {error, _} ->
+                        false;
+                    {ok, #{epoch := CommittedEpoch}} ->
+                        case Cache of
+                            {#manifest{}, CommittedEpoch} -> true;
+                            _ -> false
+                        end
+                end,
+            Result =:= Expected
+        end
+    ).
+
+%% The no_anchor backstop as a pure function of the anchor read: reap only on a
+%% consistent read that positively reports the anchor gone; a present anchor or any
+%% read error fails closed.
+gc_anchor_decision_fails_closed(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_gc_anchor_decision_fails_closed/0, [], 500).
+
+prop_gc_anchor_decision_fails_closed() ->
+    ?FORALL(
+        Read,
+        oneof([{ok, boolean()}, {error, oneof([timeout, no_quorum, shutdown])}]),
+        begin
+            StreamId = <<"gc-anchor-prop-stream">>,
+            Result = rabbitmq_stream_s3_gc:anchor_decision(StreamId, Read),
+            Expected =
+                case Read of
+                    {ok, Exists} -> not Exists;
+                    {error, _} -> false
+                end,
+            Result =:= Expected
+        end
+    ).
+
+%% A committed-metadata quorum read result: an ok payload carrying the committed
+%% epoch, or a read error (partition, no quorum).
+gc_consistent() ->
+    oneof([
+        {ok, #{epoch => integer(0, 10)}},
+        {error, oneof([timeout, no_quorum, shutdown])}
+    ]).
+
+%% A local replica cache read result: a manifest tagged with its synced epoch
+%% (possibly a legacy undefined), or no cached manifest at all. The manifest is
+%% empty or carries a single leading fragment, at an arbitrary floor.
+gc_cache() ->
+    oneof([
+        undefined,
+        ?LET(
+            {Empty, Epoch, FirstOffset},
+            {boolean(), oneof([integer(0, 10), undefined]), integer(0, 100000)},
+            {gc_cache_manifest(Empty, FirstOffset), Epoch}
+        )
+    ]).
+
+gc_cache_manifest(true, FirstOffset) ->
+    #manifest{first_offset = FirstOffset, next_offset = FirstOffset};
+gc_cache_manifest(false, FirstOffset) ->
+    #manifest{
+        first_offset = FirstOffset,
+        next_offset = FirstOffset + 1,
+        entries = ?ENTRY(FirstOffset, 0, 0, ?MANIFEST_KIND_FRAGMENT, 0, 1)
+    }.


### PR DESCRIPTION
This is a few small improvements to the GC path: adding property tests based on the P models, and a new `rabbitmq_stream_s3_db:list_consistent/0` which reduces the number of consistent reads we need to send to Khepri in a full GC sweep. (Consistent reads are somewhat expensive.) Single stream deletion still uses the `get_consistent(StreamId)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
