### PR TITLE
manifest replica: Gate sync on a live reader context

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -37,6 +37,7 @@ jobs:
       orphan_leak: ${{ steps.filter.outputs.orphan_leak }}
       tier_routing: ${{ steps.filter.outputs.tier_routing }}
       writer_fencing: ${{ steps.filter.outputs.writer_fencing }}
+      manifest_replica_lifecycle: ${{ steps.filter.outputs.manifest_replica_lifecycle }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -72,6 +73,8 @@ jobs:
           echo "$CHANGED" | grep -q '^p/tier-routing/' && echo "tier_routing=true" >> "$GITHUB_OUTPUT" || true
           echo "writer_fencing=false" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | grep -q '^p/writer-fencing/' && echo "writer_fencing=true" >> "$GITHUB_OUTPUT" || true
+          echo "manifest_replica_lifecycle=false" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" | grep -q '^p/manifest-replica-lifecycle/' && echo "manifest_replica_lifecycle=true" >> "$GITHUB_OUTPUT" || true
           if echo "$CHANGED" | grep -q '^\.github/workflows/p-model-check\.yaml'; then
             echo "gc_reset=true" >> "$GITHUB_OUTPUT"
             echo "gc_reset_multinode=true" >> "$GITHUB_OUTPUT"
@@ -84,6 +87,7 @@ jobs:
             echo "orphan_leak=true" >> "$GITHUB_OUTPUT"
             echo "tier_routing=true" >> "$GITHUB_OUTPUT"
             echo "writer_fencing=true" >> "$GITHUB_OUTPUT"
+            echo "manifest_replica_lifecycle=true" >> "$GITHUB_OUTPUT"
           fi
 
   gc-reset:
@@ -369,6 +373,74 @@ jobs:
           fi
           echo "Gate satisfied: PCT reaches the reset-after-snapshot live deletion."
           echo "::endgroup::"
+
+  manifest-replica-lifecycle:
+    needs: changes
+    if: needs.changes.outputs.manifest_replica_lifecycle == 'true' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install the P checker
+        run: |
+          dotnet tool install --global P --version 3.1.0 --configfile "$GITHUB_WORKSPACE/p/NuGet.config"
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Compile
+        run: |
+          cd p/manifest-replica-lifecycle
+          p compile
+      - name: Tests that must hold
+        run: |
+          cd p/manifest-replica-lifecycle
+          for tc in tcCleanupGuarded tcStaleSyncGuarded tcReregisterGuarded \
+                    tcConvergenceGuarded tcForgetReleasesWriterRow tcSyncAfterExitFixed \
+                    tcStartupRaceContextFirst tcReconcileRaceResync tcExplore; do
+            echo "::group::$tc (expect hold)"
+            p check -tc "$tc" -i 5000
+            echo "::endgroup::"
+          done
+          # PCT surfaces rare interleavings the random strategy misses.
+          echo "::group::tcExplore (PCT)"
+          p check -tc tcExplore --sch-pct 10 -i 5000
+          echo "::endgroup::"
+      - name: Validation gate (each guard is load-bearing)
+        run: |
+          cd p/manifest-replica-lifecycle
+          # Each gate removes one guard and must reproduce its specific failure,
+          # otherwise the guarded results above are not trustworthy. A gate that
+          # passes means the guard is no longer load-bearing, or the model rotted.
+          check_gate() {
+            tc="$1"; expected="$2"
+            rm -rf PCheckerOutput/
+            echo "::group::$tc (expect failure: $expected)"
+            if p check -tc "$tc" -i 2000; then
+              echo "ERROR: $tc passed with the guard removed; the model no longer reproduces the failure."
+              exit 1
+            fi
+            if ! grep -rqF "$expected" PCheckerOutput/BugFinding/; then
+              echo "ERROR: $tc failed, but not with the expected counterexample: $expected"
+              exit 1
+            fi
+            echo "Gate satisfied: $tc reproduces the failure as expected."
+            echo "::endgroup::"
+          }
+          # The three shipped guards: member-DOWN cleanup, stale-sync ordering,
+          # and the re-registration monitor repoint.
+          check_gate tcCleanupUnguarded 'NOLEAK violated: replica holds per-node state for stream 0 with no live reader'
+          check_gate tcStaleSyncUnguarded 'STALEFLOOR violated: cache for stream 0 regressed to (epoch=1, sn=1) below already-applied (epoch=2, sn=2)'
+          check_gate tcReregisterUnguarded 'RETAIN violated: replica dropped per-node state for stream 0 that still has a live reader (a superseded member DOWN evicted the live context)'
+          # The gap this model surfaces: a sync after a member DOWN re-strands the
+          # row (the shipped-in-this-branch A2 guard closes it in tcSyncAfterExitFixed).
+          check_gate tcSyncAfterExitStrands 'NOLEAK violated: replica holds per-node state for stream 0 with no live reader'
+          # Liveness: syncs dropped forever (tcConvergenceStuck), and the two
+          # startup triggers that starve the cache without recovery - the
+          # WriterFirst acceptor race (A1 fixes it) and the writer-driven reconcile
+          # race (only A1' can, since the node's attach ordering cannot reach it).
+          check_gate tcConvergenceStuck "ReplicaConverges detected liveness bug in hot state 'Lagging'"
+          check_gate tcStartupRaceWriterFirst "ReplicaConverges detected liveness bug in hot state 'Lagging'"
+          check_gate tcReconcileRaceNoResync "ReplicaConverges detected liveness bug in hot state 'Lagging'"
 
   delete-stream-anchor:
     needs: changes

--- a/p/README.md
+++ b/p/README.md
@@ -21,9 +21,10 @@ The models target five global invariants of the tiered-storage design:
 | --- | --- | --- |
 | INV#1 | no lost acked data | `gc-reset/` |
 | INV#2 | no dangling reference (GC never deletes a live object) | `gc-reset/`, `gc-leading-group/`, `gc-decision/` |
-| INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/` |
+| INV#3 | no unbounded orphan leak (liveness) | `orphan-leak/`, `manifest-replica-lifecycle/` |
 | INV#4 | tier resolution total / gap-free | `read-resolution/`, `tier-routing/` |
 | INV#5 | monotonic frontier except a labeled reset | `gc-reset/`, `trimmed-segment/` |
+| (lifecycle) | per-node replica state is released when a reader exits | `manifest-replica-lifecycle/` |
 | (foundation) | epoch monotonicity / split-brain safety | `writer-fencing/` |
 
 The last row is the mechanism the others assume: `writer-fencing/` proves the
@@ -99,6 +100,29 @@ failures by leaving unconfirmed objects for orphan GC. Verifies that GC's
 re-sweep eventually reclaims a transiently-failed delete rather than leaking it
 forever. A *liveness* property (`hot`-state monitor). See
 [`orphan-leak/README.md`](orphan-leak/README.md).
+
+### `manifest-replica-lifecycle/`
+
+The per-node manifest replica's lifecycle: registration and cleanup when a reader
+(osiris member) exits, verifying the design behind commit `cc50092`. osiris has no
+terminate hook, so the replica monitors the registering member and releases its
+context, gap sequence, and cached row on `'DOWN'`. Proves three shipped guards
+load-bearing — the member-`DOWN` cleanup (no metadata leak), `is_stale_sync` (no
+stale floor served), and the re-registration monitor repoint (no eviction of a
+live reader) — plus a `hot`-state convergence property. Surfaces a gap the
+single-axis view misses: with every shipped guard on, a sync that arrives after
+the `DOWN` re-strands a cache row with no monitor to reclaim it, and models a
+proposed `syncRequiresContext` guard (A2) that closes it. Adds an attach-ordering
+axis that proves the guard is **unsafe in isolation**: with the shipped writer-first
+attach order a startup sync that beats the local context registration is dropped
+and never re-sent (the cache stays empty — a convergence violation). A1
+(register-context-before-writer) closes that for the acceptor-reply sync, but a
+second axis models the **writer-driven reconcile path** — a member-visible sync
+independent of `register_acceptor` that A1 cannot reach — and a proposed
+**A1′ resync-on-register** toggle. The gates show A1′ recovers *both* startup
+triggers (acceptor reply and reconcile) and **subsumes A1**, so the minimal sound
+fix is **A2 + A1′**, not A2 + A1 + A1′.
+See [`manifest-replica-lifecycle/README.md`](manifest-replica-lifecycle/README.md).
 
 ## Running
 

--- a/p/manifest-replica-lifecycle/PSpec/Monitors.p
+++ b/p/manifest-replica-lifecycle/PSpec/Monitors.p
@@ -1,0 +1,132 @@
+/* Global invariant monitors for the manifest-replica lifecycle seam.
+
+   ReplicaStateMatchesReaders (safety, INV: no leak / no premature loss). At a
+   quiesce checkpoint, the set of streams the replica still holds state for must
+   equal the set of streams with a live reader. Two directions, each tied to a
+   guard:
+     - held => live  (no leak): a stranded entry for an exited reader trips this.
+       Proves the member-DOWN cleanup (G1) load-bearing, and surfaces the
+       sync-after-exit gap (a sync re-creates a row after cleanup released it).
+     - live => held  (no loss): evicting a live reader's state trips this. Proves
+       the re-registration monitor repoint (G3) load-bearing.
+
+   NoStaleFloorServed (safety, INV: no stale floor). Read-side analogue of the
+   ../gc-reset-multinode finding. The cache's applied (epoch, sn) must be
+   monotonically non-decreasing and must only ever hold a committed floor, so a
+   replica never serves a floor that a newer write already superseded. Proves
+   is_stale_sync (G2) load-bearing.
+
+   ReplicaConverges (liveness, hot state). Once the writer has committed a floor,
+   a replica that keeps receiving syncs must eventually catch up to the latest
+   committed (epoch, sn). A run that ends with the cache permanently behind is a
+   liveness violation. */
+
+/* held(stream) == (live readers for stream > 0), checked at quiesce. */
+spec ReplicaStateMatchesReaders
+  observes eReaderUp, eReaderDown, eQuiesceBegin, eHeld, eQuiesceEnd {
+  var liveReaders: map[StreamId, int];
+  var held: set[StreamId];
+
+  start state Watching {
+    on eReaderUp do (s: StreamId) {
+      if (s in liveReaders) {
+        liveReaders[s] = liveReaders[s] + 1;
+      } else {
+        liveReaders[s] = 1;
+      }
+    }
+    on eReaderDown do (s: StreamId) {
+      if (s in liveReaders) {
+        liveReaders[s] = liveReaders[s] - 1;
+        if (liveReaders[s] == 0) {
+          liveReaders -= (s);
+        }
+      }
+    }
+    on eQuiesceBegin do {
+      held = default(set[StreamId]);
+    }
+    on eHeld do (s: StreamId) {
+      held += (s);
+    }
+    on eQuiesceEnd do {
+      var s: StreamId;
+      /* No leak: every held stream must still have a live reader. */
+      foreach (s in held) {
+        assert s in liveReaders,
+          format("NOLEAK violated: replica holds per-node state for stream {0} with no live reader (an exited reader was not cleaned up, or a sync re-stranded the row after cleanup)",
+            s);
+      }
+      /* No loss: every live reader's stream must still be held. */
+      foreach (s in keys(liveReaders)) {
+        assert s in held,
+          format("RETAIN violated: replica dropped per-node state for stream {0} that still has a live reader (a superseded member DOWN evicted the live context)",
+            s);
+      }
+    }
+  }
+}
+
+/* The cache may only ever hold a committed floor, and its applied (epoch, sn)
+   must never regress - the read-side stale-floor guard. */
+spec NoStaleFloorServed observes eFloorCommitted, eCacheUpdated {
+  var committed: set[(floor: int, epoch: int, sn: int)];
+  var maxApplied: map[StreamId, (epoch: int, sn: int)];
+
+  start state Watching {
+    on eFloorCommitted do (p: (floor: int, epoch: int, sn: int)) {
+      committed += ((floor = p.floor, epoch = p.epoch, sn = p.sn));
+    }
+    on eCacheUpdated do (p: (stream: StreamId, floor: int, epoch: int, sn: int)) {
+      var prev: (epoch: int, sn: int);
+      assert (floor = p.floor, epoch = p.epoch, sn = p.sn) in committed,
+        format("STALEFLOOR violated: replica cached an uncommitted floor for stream {0} (floor={1}, epoch={2}, sn={3})",
+          p.stream, p.floor, p.epoch, p.sn);
+      if (p.stream in maxApplied) {
+        prev = maxApplied[p.stream];
+        assert !StaleLex(p.epoch, p.sn, prev.epoch, prev.sn),
+          format("STALEFLOOR violated: cache for stream {0} regressed to (epoch={1}, sn={2}) below already-applied (epoch={3}, sn={4}) - a stale sync rolled the floor backward",
+            p.stream, p.epoch, p.sn, prev.epoch, prev.sn);
+      }
+      maxApplied[p.stream] = (epoch = p.epoch, sn = p.sn);
+    }
+  }
+}
+
+/* Liveness: a single tracked stream's cache must eventually reach the latest
+   committed (epoch, sn). Lagging is hot: a terminal state with the cache behind
+   the committed floor is a violation. */
+spec ReplicaConverges observes eFloorCommitted, eCacheUpdated {
+  var committedEpoch: int;
+  var committedSeq: int;
+  var cacheEpoch: int;
+  var cacheSeq: int;
+
+  start state Caught {
+    on eFloorCommitted do (p: (floor: int, epoch: int, sn: int)) {
+      committedEpoch = p.epoch;
+      committedSeq = p.sn;
+      if (StaleLex(cacheEpoch, cacheSeq, committedEpoch, committedSeq)) {
+        goto Lagging;
+      }
+    }
+    on eCacheUpdated do (p: (stream: StreamId, floor: int, epoch: int, sn: int)) {
+      cacheEpoch = p.epoch;
+      cacheSeq = p.sn;
+    }
+  }
+
+  hot state Lagging {
+    on eFloorCommitted do (p: (floor: int, epoch: int, sn: int)) {
+      committedEpoch = p.epoch;
+      committedSeq = p.sn;
+    }
+    on eCacheUpdated do (p: (stream: StreamId, floor: int, epoch: int, sn: int)) {
+      cacheEpoch = p.epoch;
+      cacheSeq = p.sn;
+      if (!StaleLex(cacheEpoch, cacheSeq, committedEpoch, committedSeq)) {
+        goto Caught;
+      }
+    }
+  }
+}

--- a/p/manifest-replica-lifecycle/PSrc/Common.p
+++ b/p/manifest-replica-lifecycle/PSrc/Common.p
@@ -1,0 +1,156 @@
+/* Shared types and events for the manifest-replica lifecycle seam.
+
+   This model verifies the per-node manifest replica process
+   (rabbitmq_stream_s3_manifest_replica) and, specifically, the cleanup-on-
+   reader-exit logic landed in commit cc50092 ("manifest replica: Clean up when
+   a replica (reader) exits").
+
+   The replica process holds three kinds of per-stream state in lockstep:
+
+     - contexts : the osiris log context, registered by the acceptor hook when a
+                  reader (osiris member) starts. The member pid is monitored.
+     - seqs     : the last-applied {sn, epoch, writer_node} used for gap
+                  detection on the broadcast sync stream.
+     - cache    : the ETS row {manifest/floor, epoch} that GC and consumers read.
+
+   osiris has NO terminate/delete hook, so the replica MONITORS the member that
+   registered a context and, on its DOWN, releases all three (release_stream/2).
+   This is the only thing that reclaims per-node state when a replica moves off
+   the node or the stream is deleted; without it the metadata accretes forever
+   (the bug cc50092 set out to fix).
+
+   The model abstracts the osiris member to its MONITOR REFERENCE (an int mref):
+   the replica's only handle on a member IS the monitor it holds, so this is
+   faithful. The driver plays "the world that starts and kills members": a
+   register returns the mref the replica assigned, and the driver later signals a
+   member exit by delivering eMemberDown with that mref (the modeled DOWN).
+
+   Syncs from the writer are fire-and-forget casts (eMRSync) that the scheduler
+   may drop, delay, or reorder relative to a member exit - the same multi-node
+   stale-cache substrate as ../gc-reset-multinode. is_stale_sync gates them:
+   epoch dominates sequence, so a delayed lower-epoch sync is rejected. */
+
+/* A stream id (small ints). */
+type StreamId = int;
+
+/* ---- Manifest replica (the system under test) ---- */
+
+/* register_replica_context/5: the acceptor hook registers an osiris member's
+   context. Synchronous call; the reply carries the assigned monitor ref. */
+event eRegister: (from: machine, stream: StreamId);
+event eRegisterAck: (mref: int);
+
+/* The modeled member DOWN: the osiris member that owned a context exited. The
+   replica releases the stream iff the mref is still live in its reverse index
+   (a superseded mref - from a member that re-registered - is ignored, modeling
+   demonitor(OldRef, [flush])). Acked so a driver can sequence a post-exit sync. */
+event eMemberDown: (from: machine, mref: int);
+event eDownAck;
+
+/* sync/5: a full-manifest sync from the writer, fire-and-forget (cast). Carries
+   the writer's epoch and sequence; applied only if not is_stale_sync. */
+event eMRSync: (stream: StreamId, floor: int, epoch: int, sn: int, writerNode: int);
+
+/* put_manifest/3: the WRITER node writes its own cache row directly (no osiris
+   member to monitor); released explicitly by forget/1. Synchronous. */
+event ePutManifest: (from: machine, stream: StreamId, floor: int, epoch: int, sn: int);
+event ePutAck;
+
+/* forget/1: explicit release of all per-stream state (writer-node teardown). */
+event eForget: (from: machine, stream: StreamId);
+event eForgetAck;
+
+/* Quiesce barrier and held-state query. eBarrierPing flushes the writer->replica
+   FIFO so all in-flight syncs are applied before the checkpoint reads state. */
+event eBarrierPing: (from: machine);
+event eBarrierPong;
+event eQueryHeld: (from: machine);
+event eHeldResult: set[StreamId];
+
+/* ---- Writer / replica_reader (authoritative source) ---- */
+
+/* Commit a new authoritative floor at (epoch, sn) for a stream; announces it to
+   the monitors as committed truth AND records it as the writer's persisted floor
+   for that stream, so a later reconcile/resync can re-send it (persisted_manifest).
+   The writer is the only source of committed floors. */
+event eDoCommit: (from: machine, stream: StreamId, floor: int, epoch: int, sn: int);
+event eCommitAck;
+
+/* Emit a sync (cast) to a replica for a chosen committed (floor, epoch, sn).
+   Routing it through the writer models rabbitmq_stream_s3_replica_reader as the
+   broadcaster; the driver can replay an OLD committed tuple to reorder. */
+event eEmitSync: (from: machine, target: machine, stream: StreamId,
+                  floor: int, epoch: int, sn: int);
+event eEmitAck;
+
+/* Synchronous barrier through the writer: flushes prior writer->replica casts. */
+event eBarrier: (from: machine, target: machine);
+event eBarrierAck;
+
+/* register_acceptor: the acceptor hook tells the writer's replica reader to
+   register this node (rabbitmq_stream_s3_hooks: gen_server:cast({register_acceptor,
+   node()})). The writer responds by IMMEDIATELY emitting a startup sync of the
+   persisted manifest (rabbitmq_stream_s3_replica_reader handle_cast
+   {register_acceptor, Node} -> sync_manifest, :435,:771). A fire-and-forget cast:
+   no ack, modeling attach decoupling #1 - a sync can be in flight to a node
+   BEFORE that node's local manifest_replica context exists. */
+event eRegisterAcceptor: (replica: machine, stream: StreamId, floor: int, epoch: int, sn: int);
+
+/* reconcile_replicas: the SECOND, writer-driven startup sync trigger
+   (rabbitmq_stream_s3_replica_reader.erl handle_cast(reconcile_replicas,...),
+   ~:467-487). The periodic reconciler discovers replica NODES from
+   osiris_writer:query_replication_state and syncs each via register_replica/2
+   (~:719-737, which calls sync_manifest with persisted_manifest). This is driven
+   by the osiris MEMBER becoming visible to the writer, NOT by the node's
+   register_acceptor and NOT by whether the node's local manifest-replica CONTEXT
+   has registered yet. So a reconcile sync can arrive at a node BEFORE its local
+   context exists, and unlike the acceptor-reply sync this trigger is on the WRITER
+   side, so the node's own attach ordering (A1) cannot prevent it. A fire-and-forget
+   cast to a target replica; the writer re-sends its persisted committed floor. */
+event eReconcile: (target: machine, stream: StreamId);
+
+/* request_resync/2 (rabbitmq_stream_s3_manifest_replica.erl:508): the replica
+   casts {resync, node()} to the writer's replica reader (via the registry),
+   which answers with a fresh sync of persisted_manifest (the {resync, Node}
+   handler, rabbitmq_stream_s3_replica_reader.erl:455-466 -> sync_manifest). A1'
+   (resyncOnRegister) wires this into context registration: when the manifest
+   replica registers a context, it requests a resync, so the writer re-sends the
+   manifest even if an earlier premature (reconcile or acceptor-reply) sync was
+   dropped. from is the requesting replica (the sync target). */
+event eResync: (from: machine, stream: StreamId);
+
+/* The attach node signals the driver it finished registering, carrying the
+   context's monitor ref so the driver can later deliver the member DOWN. */
+event eAttachDone: (mref: int);
+
+/* Internal yield token. After registering with the writer (WriterFirst order),
+   the attach node relinquishes control via a self-send + receive, so the
+   scheduler MAY run the writer and deliver its startup sync to the replica
+   before the local context registration - the modeled startup race. */
+event eProceed;
+
+/* ---- Spec events (announced to monitors) ---- */
+
+/* A reader (osiris member) the driver considers live came up / exited. */
+event eReaderUp: StreamId;
+event eReaderDown: StreamId;
+
+/* The replica wrote a cache row at (floor, epoch, sn). */
+event eCacheUpdated: (stream: StreamId, floor: int, epoch: int, sn: int);
+
+/* The writer committed an authoritative floor at (floor, epoch, sn). */
+event eFloorCommitted: (floor: int, epoch: int, sn: int);
+
+/* Quiesce checkpoint: the held-state snapshot is bracketed by begin/end and one
+   eHeld per stream the replica still holds any state for. */
+event eQuiesceBegin;
+event eHeld: StreamId;
+event eQuiesceEnd;
+
+/* Lexicographic staleness: (epoch, sn) strictly older than (epoch0, seq0).
+   Mirrors is_stale_sync/3: epoch dominates so a higher epoch is never stale. */
+fun StaleLex(epoch: int, sn: int, epoch0: int, seq0: int): bool {
+  if (epoch < epoch0) { return true; }
+  if (epoch > epoch0) { return false; }
+  return sn < seq0;
+}

--- a/p/manifest-replica-lifecycle/PSrc/ManifestReplica.p
+++ b/p/manifest-replica-lifecycle/PSrc/ManifestReplica.p
@@ -1,0 +1,175 @@
+/* The per-node manifest replica process (rabbitmq_stream_s3_manifest_replica),
+   the system under test. Holds three per-stream maps in lockstep:
+
+     contexts : stream -> mref      (the registered osiris member's monitor ref)
+     seqs     : stream -> {epoch, sn, writerNode}   (gap detection)
+     cache    : stream -> {floor, epoch, sn}        (the ETS row GC/consumers read)
+
+   plus a reverse index monitors : mref -> stream so a DOWN can find the stream
+   to release, exactly as the shipped #state{} carries.
+
+   Four toggles let the validation-gate tests remove one guard at a time:
+
+     cleanupEnabled            : G1. On a member DOWN, release_stream/2 drops all
+                                 per-stream state. OFF models the pre-cc50092 code
+                                 that never monitored or released, so an exited
+                                 reader's metadata accretes forever.
+     staleSyncGuardEnabled     : G2. is_stale_sync/3 - drop a sync whose (epoch,
+                                 sn) is older than what is recorded. OFF lets a
+                                 reordered older sync roll the cache backward.
+     repointEnabled            : G3. On re-registration (member restart) drop the
+                                 previous monitor first, so the old incarnation's
+                                 DOWN cannot evict the new context. OFF leaves the
+                                 stale mref in the reverse index, so the old DOWN
+                                 releases the LIVE new context.
+     syncRequiresContextEnabled: A2. A PROPOSED (not shipped) fix for the gap this
+                                 model surfaces: ignore a sync for a stream with
+                                 no registered context, so a sync that arrives
+                                 after the member DOWN cannot re-strand a row.
+                                 OFF (the shipped behaviour) re-creates the row.
+     resyncOnRegisterEnabled   : A1'. The PROPOSED writer-independent recovery for
+                                 A2: on registering a context, request a resync
+                                 from the writer (request_resync/2), so the writer
+                                 re-sends the manifest even if an earlier premature
+                                 sync - from the acceptor reply OR the writer-driven
+                                 reconcile path - was dropped by A2. Unlike the A1
+                                 attach-ordering fix, this covers the reconcile
+                                 trigger, which A1 cannot reach. */
+machine ManifestReplica {
+  var contexts: map[StreamId, int];
+  var seqs: map[StreamId, (epoch: int, sn: int, writerNode: int)];
+  var cache: map[StreamId, (floor: int, epoch: int, sn: int)];
+  var monitors: map[int, StreamId];
+  var mrefCounter: int;
+
+  var cleanupEnabled: bool;
+  var staleSyncGuardEnabled: bool;
+  var repointEnabled: bool;
+  var syncRequiresContextEnabled: bool;
+  var resyncOnRegisterEnabled: bool;
+
+  /* The writer's replica reader for this replica's streams. In the shipped code
+     the replica resolves it per (stream, writer_node) via the registry when it
+     casts {resync, node()}; every driver here has a single writer, so we carry
+     one handle. Only used when resyncOnRegisterEnabled (A1'). */
+  var writer: machine;
+
+  /* release_stream/2: drop the context (and its monitor), the gap-detection
+     sequence, and the cached row for a stream. Used by both the member DOWN
+     handler and the explicit forget/1. */
+  fun ReleaseStream(stream: StreamId) {
+    if (stream in contexts) {
+      monitors -= (contexts[stream]);
+      contexts -= (stream);
+    }
+    if (stream in seqs) { seqs -= (stream); }
+    if (stream in cache) { cache -= (stream); }
+  }
+
+  /* The set of streams the replica still holds ANY state for. Cleanup must drive
+     this to exclude every stream whose last reader has exited. */
+  fun HeldStreams(): set[StreamId] {
+    var held: set[StreamId];
+    var s: StreamId;
+    held = default(set[StreamId]);
+    foreach (s in keys(contexts)) { held += (s); }
+    foreach (s in keys(seqs)) { held += (s); }
+    foreach (s in keys(cache)) { held += (s); }
+    return held;
+  }
+
+  start state Serving {
+    entry (init: (cleanupEnabled: bool, staleSyncGuardEnabled: bool,
+                  repointEnabled: bool, syncRequiresContextEnabled: bool,
+                  resyncOnRegisterEnabled: bool, writer: machine)) {
+      cleanupEnabled = init.cleanupEnabled;
+      staleSyncGuardEnabled = init.staleSyncGuardEnabled;
+      repointEnabled = init.repointEnabled;
+      syncRequiresContextEnabled = init.syncRequiresContextEnabled;
+      resyncOnRegisterEnabled = init.resyncOnRegisterEnabled;
+      writer = init.writer;
+      mrefCounter = 0;
+    }
+
+    /* register_replica_context/5: monitor the member and record the context.
+       A re-registration for a stream already registered repoints the monitor:
+       drop the previous mref from the reverse index first (G3). */
+    on eRegister do (p: (from: machine, stream: StreamId)) {
+      var newMref: int;
+      if (repointEnabled && p.stream in contexts) {
+        monitors -= (contexts[p.stream]);
+      }
+      mrefCounter = mrefCounter + 1;
+      newMref = mrefCounter;
+      contexts[p.stream] = newMref;
+      monitors[newMref] = p.stream;
+      /* A1' (resyncOnRegister): now that a context exists, ask the writer to
+         re-send the manifest. This recovers a premature sync (acceptor-reply or
+         reconcile-path) that A2 dropped before this context existed. The resync
+         reply lands on the now-live context. */
+      if (resyncOnRegisterEnabled) {
+        send writer, eResync, (from = this, stream = p.stream);
+      }
+      send p.from, eRegisterAck, (mref = newMref,);
+    }
+
+    /* handle_info({'DOWN', MRef, ...}): a monitored member exited. Release its
+       stream iff the mref is still live in the reverse index. An mref absent
+       from the map belongs to a superseded registration and is ignored. With
+       cleanup disabled the replica never monitored, so a DOWN does nothing. */
+    on eMemberDown do (p: (from: machine, mref: int)) {
+      if (cleanupEnabled && p.mref in monitors) {
+        ReleaseStream(monitors[p.mref]);
+      }
+      send p.from, eDownAck;
+    }
+
+    /* maybe_apply_sync/7: a fire-and-forget full-manifest sync from the writer.
+       Drop it when is_stale_sync (the recorded (epoch, sn) is at least as new).
+       Otherwise write the cache row, update the gap sequence, and announce the
+       new cached floor to the monitors. */
+    on eMRSync do (p: (stream: StreamId, floor: int, epoch: int, sn: int, writerNode: int)) {
+      var stale: bool;
+      var rec: (epoch: int, sn: int, writerNode: int);
+      stale = false;
+      if (staleSyncGuardEnabled && p.stream in seqs) {
+        rec = seqs[p.stream];
+        stale = StaleLex(p.epoch, p.sn, rec.epoch, rec.sn);
+      }
+      if (!stale) {
+        /* PROPOSED gap fix: ignore a sync for a stream with no live context, so
+           a sync racing/after a member DOWN cannot re-strand a cache row. The
+           shipped code does NOT do this (syncRequiresContextEnabled == false). */
+        if (syncRequiresContextEnabled && !(p.stream in contexts)) {
+          return;
+        }
+        cache[p.stream] = (floor = p.floor, epoch = p.epoch, sn = p.sn);
+        seqs[p.stream] = (epoch = p.epoch, sn = p.sn, writerNode = p.writerNode);
+        announce eCacheUpdated, (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
+      }
+    }
+
+    /* put_manifest/3: the writer node writes its own cache row (no member). */
+    on ePutManifest do (p: (from: machine, stream: StreamId, floor: int, epoch: int, sn: int)) {
+      cache[p.stream] = (floor = p.floor, epoch = p.epoch, sn = p.sn);
+      announce eCacheUpdated, (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
+      send p.from, ePutAck;
+    }
+
+    /* forget/1: explicit release (writer-node reader teardown). */
+    on eForget do (p: (from: machine, stream: StreamId)) {
+      ReleaseStream(p.stream);
+      send p.from, eForgetAck;
+    }
+
+    /* Quiesce barrier: a no-op call that, by FIFO from the writer, is processed
+       only after every prior writer->replica sync cast. */
+    on eBarrierPing do (p: (from: machine)) {
+      send p.from, eBarrierPong;
+    }
+
+    on eQueryHeld do (p: (from: machine)) {
+      send p.from, eHeldResult, HeldStreams();
+    }
+  }
+}

--- a/p/manifest-replica-lifecycle/PSrc/Writer.p
+++ b/p/manifest-replica-lifecycle/PSrc/Writer.p
@@ -1,0 +1,74 @@
+/* The writer-side broadcaster (rabbitmq_stream_s3_replica_reader). It is the
+   authoritative source of committed floors: every floor a replica may legitimately
+   serve was committed here first. Floors advance under a monotonic (epoch, sn)
+   stamp - the stream's Khepri payload_version and writer epoch - exactly as the
+   shipped sequence numbering works.
+
+   Syncs to a replica are fire-and-forget casts. Routing the emission through the
+   writer (rather than the driver) models the broadcaster and lets a test replay
+   an OLD committed (floor, epoch, sn) to reorder a sync behind a newer one. The
+   writer NEVER updates a replica's cache directly; that propagation is the
+   modeled uncertainty (dropped, delayed, or raced against a member exit). */
+machine Writer {
+  /* The writer's persisted floor per stream (persisted_manifest(Core)): the tuple
+     a reconcile or resync re-sends. Recorded on every commit. */
+  var committed: map[StreamId, (floor: int, epoch: int, sn: int)];
+
+  start state Serving {
+    on eDoCommit do (p: (from: machine, stream: StreamId, floor: int, epoch: int, sn: int)) {
+      committed[p.stream] = (floor = p.floor, epoch = p.epoch, sn = p.sn);
+      announce eFloorCommitted, (floor = p.floor, epoch = p.epoch, sn = p.sn);
+      send p.from, eCommitAck;
+    }
+
+    /* reconcile_replicas: the writer discovers a visible member and syncs the
+       node with its persisted floor, INDEPENDENT of register_acceptor. This
+       cast can be delivered to the replica before that node's context exists. */
+    on eReconcile do (p: (target: machine, stream: StreamId)) {
+      var c: (floor: int, epoch: int, sn: int);
+      if (p.stream in committed) {
+        c = committed[p.stream];
+        send p.target, eMRSync,
+          (stream = p.stream, floor = c.floor, epoch = c.epoch, sn = c.sn, writerNode = 0);
+      }
+    }
+
+    /* {resync, Node}: a replica requested a fresh sync; re-send the persisted
+       floor. This is how A1' recovers a dropped premature sync. */
+    on eResync do (p: (from: machine, stream: StreamId)) {
+      var c: (floor: int, epoch: int, sn: int);
+      if (p.stream in committed) {
+        c = committed[p.stream];
+        send p.from, eMRSync,
+          (stream = p.stream, floor = c.floor, epoch = c.epoch, sn = c.sn, writerNode = 0);
+      }
+    }
+
+    on eEmitSync do (p: (from: machine, target: machine, stream: StreamId,
+                         floor: int, epoch: int, sn: int)) {
+      send p.target, eMRSync,
+        (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn, writerNode = 0);
+      send p.from, eEmitAck;
+    }
+
+    /* Synchronous barrier: flush prior writer->target sync casts by riding the
+       FIFO behind them, then confirm to the caller. */
+    on eBarrier do (p: (from: machine, target: machine)) {
+      send p.target, eBarrierPing, (from = this,);
+      receive { case eBarrierPong: { } }
+      send p.from, eBarrierAck;
+    }
+
+    /* register_acceptor cast: the replica reader registers the node and,
+       in the same handler, broadcasts the persisted manifest back as a startup
+       sync (sync_manifest on {register_acceptor, Node}). The cast carries the
+       committed (floor, epoch, sn) the driver wrote, modeling persisted_manifest
+       at register time. No ack: this is the writer-originated sync that races the
+       node's local context registration. */
+    on eRegisterAcceptor do (p: (replica: machine, stream: StreamId,
+                                 floor: int, epoch: int, sn: int)) {
+      send p.replica, eMRSync,
+        (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn, writerNode = 0);
+    }
+  }
+}

--- a/p/manifest-replica-lifecycle/PTst/TestDrivers.p
+++ b/p/manifest-replica-lifecycle/PTst/TestDrivers.p
@@ -1,0 +1,512 @@
+/* Test drivers for the manifest-replica lifecycle seam.
+
+   Each load-bearing guard ships two test cases: a guarded one that MUST HOLD and
+   an unguarded one that MUST FAIL with a named counterexample. The failing runs
+   are the proof the monitors have teeth.
+
+     G1  member-DOWN cleanup     tcCleanupGuarded   / tcCleanupUnguarded   (NOLEAK)
+     G2  is_stale_sync           tcStaleSyncGuarded / tcStaleSyncUnguarded (STALEFLOOR)
+     G3  re-register repoint      tcReregisterGuarded/ tcReregisterUnguarded(RETAIN)
+     liveness  convergence       tcConvergenceGuarded/tcConvergenceStuck   (ReplicaConverges)
+
+   tcForgetReleasesWriterRow exercises the writer-node forget/1 path. tcExplore
+   races register/sync/restart/exit across two streams with every guard on.
+
+   GAP (headline finding): with every SHIPPED guard on, a sync that arrives after
+   a member DOWN re-creates a cache row for a stream the cleanup already released,
+   stranding it forever (no monitor will ever fire again). tcSyncAfterExitStrands
+   demonstrates it; tcSyncAfterExitFixed shows a proposed guard closing it. */
+
+fun Register(self: machine, replica: machine, stream: StreamId): int {
+  var mref: int;
+  send replica, eRegister, (from = self, stream = stream);
+  receive { case eRegisterAck: (r: (mref: int)) { mref = r.mref; } }
+  announce eReaderUp, stream;
+  return mref;
+}
+
+fun MemberDown(self: machine, replica: machine, stream: StreamId, mref: int) {
+  announce eReaderDown, stream;
+  send replica, eMemberDown, (from = self, mref = mref);
+  receive { case eDownAck: { } }
+}
+
+fun Commit(self: machine, writer: machine, stream: StreamId, floor: int, epoch: int, sn: int) {
+  send writer, eDoCommit, (from = self, stream = stream, floor = floor, epoch = epoch, sn = sn);
+  receive { case eCommitAck: { } }
+}
+
+/* Emit a sync cast (not yet applied); call Barrier to flush it. */
+fun EmitSync(self: machine, writer: machine, replica: machine,
+             stream: StreamId, floor: int, epoch: int, sn: int) {
+  send writer, eEmitSync,
+    (from = self, target = replica, stream = stream, floor = floor, epoch = epoch, sn = sn);
+  receive { case eEmitAck: { } }
+}
+
+fun Barrier(self: machine, writer: machine, replica: machine) {
+  send writer, eBarrier, (from = self, target = replica);
+  receive { case eBarrierAck: { } }
+}
+
+fun PutManifest(self: machine, replica: machine, stream: StreamId, floor: int, epoch: int, sn: int) {
+  send replica, ePutManifest, (from = self, stream = stream, floor = floor, epoch = epoch, sn = sn);
+  receive { case ePutAck: { } }
+}
+
+fun Forget(self: machine, replica: machine, stream: StreamId) {
+  send replica, eForget, (from = self, stream = stream);
+  receive { case eForgetAck: { } }
+}
+
+/* Quiesce checkpoint: flush is the caller's responsibility (Barrier first). Snap
+   the replica's held set and bracket it with begin/end for the monitor. */
+fun Quiesce(self: machine, replica: machine) {
+  var held: set[StreamId];
+  var s: StreamId;
+  send replica, eQueryHeld, (from = self,);
+  receive { case eHeldResult: (h: set[StreamId]) { held = h; } }
+  announce eQuiesceBegin;
+  foreach (s in held) { announce eHeld, s; }
+  announce eQuiesceEnd;
+}
+
+fun NewReplica(cleanup: bool, stale: bool, repoint: bool, gapFix: bool,
+               resync: bool, writer: machine): machine {
+  return new ManifestReplica((cleanupEnabled = cleanup, staleSyncGuardEnabled = stale,
+                              repointEnabled = repoint, syncRequiresContextEnabled = gapFix,
+                              resyncOnRegisterEnabled = resync, writer = writer));
+}
+
+/* ---- G1: member-DOWN cleanup ---- */
+
+/* A reader registers, syncs, then exits. With cleanup on the replica holds
+   nothing afterwards; with it off the entry is stranded. */
+fun RunCleanup(self: machine, cleanup: bool) {
+  var replica: machine;
+  var writer: machine;
+  var mref: int;
+  writer = new Writer();
+  replica = NewReplica(cleanup, true, true, false, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  mref = Register(self, replica, 0);
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  MemberDown(self, replica, 0, mref);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverCleanupGuarded { start state Init { entry { RunCleanup(this, true); } } }
+machine DriverCleanupUnguarded { start state Init { entry { RunCleanup(this, false); } } }
+
+/* ---- G2: is_stale_sync ---- */
+
+/* Apply the reset (epoch 2), then a delayed earlier-epoch sync arrives. With the
+   guard on it is dropped; with it off it rolls the cache backward. */
+fun RunStaleSync(self: machine, stale: bool) {
+  var replica: machine;
+  var writer: machine;
+  var mref: int;
+  writer = new Writer();
+  replica = NewReplica(true, stale, true, false, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  Commit(self, writer, 0, 850, 2, 2);
+  mref = Register(self, replica, 0);
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  EmitSync(self, writer, replica, 0, 850, 2, 2);
+  Barrier(self, writer, replica);
+  /* The delayed, reordered sync from the deposed lower epoch. */
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  MemberDown(self, replica, 0, mref);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverStaleGuarded { start state Init { entry { RunStaleSync(this, true); } } }
+machine DriverStaleUnguarded { start state Init { entry { RunStaleSync(this, false); } } }
+
+/* ---- G3: re-register repoint ---- */
+
+/* A member restart re-registers the stream, then the OLD member exits. With the
+   repoint on its DOWN is ignored; with it off the old DOWN evicts the live
+   context registered by the new member. */
+fun RunReregister(self: machine, repoint: bool) {
+  var replica: machine;
+  var writer: machine;
+  var mrefOld: int;
+  var mrefNew: int;
+  writer = new Writer();
+  replica = NewReplica(true, true, repoint, false, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  mrefOld = Register(self, replica, 0);
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  /* Member restart: re-register the same stream with a new incarnation. */
+  mrefNew = Register(self, replica, 0);
+  /* The old incarnation's DOWN must not evict the live new context. */
+  MemberDown(self, replica, 0, mrefOld);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverReregisterGuarded { start state Init { entry { RunReregister(this, true); } } }
+machine DriverReregisterUnguarded { start state Init { entry { RunReregister(this, false); } } }
+
+/* ---- liveness: convergence ---- */
+
+/* A live replica receives every sync and catches up to the latest committed
+   floor. The hot Lagging state is entered on each commit and left on each sync. */
+machine DriverConvergenceGuarded {
+  start state Init {
+    entry {
+      var replica: machine;
+      var writer: machine;
+      var mref: int;
+      writer = new Writer();
+      replica = NewReplica(true, true, true, false, false, writer);
+      mref = Register(this, replica, 0);
+      Commit(this, writer, 0, 1000, 1, 1);
+      EmitSync(this, writer, replica, 0, 1000, 1, 1);
+      Barrier(this, writer, replica);
+      Commit(this, writer, 0, 850, 2, 2);
+      EmitSync(this, writer, replica, 0, 850, 2, 2);
+      Barrier(this, writer, replica);
+    }
+  }
+}
+
+/* The sync is never delivered, so the replica stays behind the committed floor:
+   the hot Lagging state is never left - a liveness violation. */
+machine DriverConvergenceStuck {
+  start state Init {
+    entry {
+      var replica: machine;
+      var writer: machine;
+      var mref: int;
+      writer = new Writer();
+      replica = NewReplica(true, true, true, false, false, writer);
+      mref = Register(this, replica, 0);
+      Commit(this, writer, 0, 1000, 1, 1);
+    }
+  }
+}
+
+/* ---- writer-node forget/1 path ---- */
+
+/* The writer node writes its own cache row with put_manifest (no member to
+   monitor) and releases it explicitly via forget/1 on teardown. */
+machine DriverForget {
+  start state Init {
+    entry {
+      var replica: machine;
+      var writer: machine;
+      writer = new Writer();
+      replica = NewReplica(true, true, true, false, false, writer);
+      Commit(this, writer, 0, 1000, 1, 1);
+      PutManifest(this, replica, 0, 1000, 1, 1);
+      Forget(this, replica, 0);
+      Quiesce(this, replica);
+    }
+  }
+}
+
+/* ---- GAP: sync after exit ---- */
+
+/* Every shipped guard on. A sync delivered AFTER the member DOWN (causally after
+   the cleanup released the stream) re-creates the cache row and gap sequence -
+   with no context, so no monitor will ever clean it up. gapFix selects the
+   proposed guard: ignore a sync for a stream with no live context. */
+fun RunSyncAfterExit(self: machine, gapFix: bool) {
+  var replica: machine;
+  var writer: machine;
+  var mref: int;
+  writer = new Writer();
+  replica = NewReplica(true, true, true, gapFix, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  mref = Register(self, replica, 0);
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  /* Synchronous: the cleanup has fully released the stream before we proceed. */
+  MemberDown(self, replica, 0, mref);
+  /* The straggler sync, now strictly after the release. */
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverSyncAfterExitStrands { start state Init { entry { RunSyncAfterExit(this, false); } } }
+machine DriverSyncAfterExitFixed { start state Init { entry { RunSyncAfterExit(this, true); } } }
+
+/* ---- STARTUP RACE: attach ordering vs the syncRequiresContext guard ---- */
+
+/* The acceptor attach node (rabbitmq_stream_s3_hooks on_init(acceptor, ...)).
+   It performs two registrations whose ORDER is the new axis:
+
+     - register the LOCAL manifest-replica context (eRegister), and
+     - register the node with the WRITER (eRegisterAcceptor), which makes the
+       writer immediately broadcast a startup sync back to the replica.
+
+   contextFirst selects the order:
+
+     ContextFirst (A1 fix, the discovery path attach_replica/1 order, hooks.erl
+       :350-358): register the context BEFORE the writer, so the context exists
+       before any sync can be emitted - the startup sync always lands on a live
+       context.
+     WriterFirst (the SHIPPED acceptor order, hooks.erl:83-95): register with the
+       writer FIRST, then yield, then register the local context. The writer's
+       startup sync can be delivered to the replica BEFORE the local context
+       exists - the modeled race. Paired with the syncRequiresContext guard, that
+       sync is DROPPED and (the writer's register is idempotent, so it never
+       re-syncs) the cache may stay empty forever.
+
+   A barrier from THIS machine (the same sender as the eRegisterAcceptor cast, so
+   FIFO orders the ping behind the startup sync) flushes the sync before the node
+   reports done, so the driver observes a settled cache. */
+machine AttachNode {
+  start state Init {
+    entry (p: (parent: machine, writer: machine, replica: machine, stream: StreamId,
+               floor: int, epoch: int, sn: int, contextFirst: bool)) {
+      var mref: int;
+      if (p.contextFirst) {
+        send p.replica, eRegister, (from = this, stream = p.stream);
+        receive { case eRegisterAck: (r: (mref: int)) { mref = r.mref; } }
+        announce eReaderUp, p.stream;
+        send p.writer, eRegisterAcceptor,
+          (replica = p.replica, stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
+      } else {
+        send p.writer, eRegisterAcceptor,
+          (replica = p.replica, stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
+        /* Yield so the writer may emit (and the replica may apply/drop) the
+           startup sync before the local context registration below. */
+        send this, eProceed;
+        receive { case eProceed: { } }
+        send p.replica, eRegister, (from = this, stream = p.stream);
+        receive { case eRegisterAck: (r: (mref: int)) { mref = r.mref; } }
+        announce eReaderUp, p.stream;
+      }
+      send p.writer, eBarrier, (from = this, target = p.replica);
+      receive { case eBarrierAck: { } }
+      send p.parent, eAttachDone, (mref = mref,);
+    }
+  }
+}
+
+/* Commit a floor, attach a node with the chosen ordering (every shipped guard
+   AND the syncRequiresContext guard on), then move the member off the node and
+   let a straggler sync arrive after the DOWN (decoupling #2: the writer keeps
+   broadcasting). With ContextFirst the startup sync always lands so the cache
+   converges and nothing strands; with WriterFirst the guard can drop the startup
+   sync, leaving the cache permanently empty - a convergence violation. */
+fun RunStartupRace(self: machine, contextFirst: bool) {
+  var replica: machine;
+  var writer: machine;
+  var attach: machine;
+  var mref: int;
+  writer = new Writer();
+  replica = NewReplica(true, true, true, true, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  attach = new AttachNode((parent = self, writer = writer, replica = replica,
+                           stream = 0, floor = 1000, epoch = 1, sn = 1,
+                           contextFirst = contextFirst));
+  receive { case eAttachDone: (r: (mref: int)) { mref = r.mref; } }
+  /* The member moves off this node; the writer keeps targeting it (singleton
+     still live), so a straggler sync arrives after the DOWN. */
+  MemberDown(self, replica, 0, mref);
+  EmitSync(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverStartupRaceWriterFirst { start state Init { entry { RunStartupRace(this, false); } } }
+machine DriverStartupRaceContextFirst { start state Init { entry { RunStartupRace(this, true); } } }
+
+/* ---- RECONCILE PATH: the writer-driven startup sync trigger ---- */
+
+/* The node's local context registration in isolation - a clean, context-first
+   (A1-consistent) event with NO register_acceptor. It races the writer's
+   reconcile-path sync, which is delivered to the replica from a different sender
+   (the writer), so the scheduler may process either first. */
+machine ContextRegistrar {
+  start state Init {
+    entry (p: (parent: machine, replica: machine, stream: StreamId)) {
+      var mref: int;
+      send p.replica, eRegister, (from = this, stream = p.stream);
+      receive { case eRegisterAck: (r: (mref: int)) { mref = r.mref; } }
+      announce eReaderUp, p.stream;
+      send p.parent, eAttachDone, (mref = mref,);
+    }
+  }
+}
+
+/* Every shipped guard AND A2 (syncRequiresContext) on. The reconcile-path sync
+   (writer-driven, triggered by the member becoming visible) races the node's
+   local context registration: the eReconcile cast makes the writer send an eMRSync
+   to the replica, WHILE a ContextRegistrar concurrently sends eRegister to the same
+   replica. The two arrive from different senders, so the scheduler interleaves them
+   BOTH ways - a genuine race the reconcile sync can win (sync before register).
+   This is the trigger the attach-ordering fix (A1) CANNOT reach: it is on the
+   writer side, unordered w.r.t. context registration.
+
+   resync selects A1' (resyncOnRegister). OFF: when the reconcile sync wins the
+   race it is dropped by A2 (no context yet) and never re-sent, so the cache stays
+   empty forever - a ReplicaConverges violation, proving A1 is insufficient for the
+   writer-driven trigger. ON: registering the context requests a resync, so the
+   writer re-sends the manifest and the cache converges. */
+fun RunReconcileRace(self: machine, resync: bool) {
+  var replica: machine;
+  var writer: machine;
+  var reg: machine;
+  var mref: int;
+  writer = new Writer();
+  Commit(self, writer, 0, 1000, 1, 1);
+  replica = NewReplica(true, true, true, true, resync, writer);
+  /* Context registration and the reconcile-path sync are launched unordered. */
+  reg = new ContextRegistrar((parent = self, replica = replica, stream = 0));
+  send writer, eReconcile, (target = replica, stream = 0);
+  receive { case eAttachDone: (r: (mref: int)) { mref = r.mref; } }
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverReconcileRaceNoResync { start state Init { entry { RunReconcileRace(this, false); } } }
+machine DriverReconcileRaceResync   { start state Init { entry { RunReconcileRace(this, true); } } }
+
+/* ---- exploration ---- */
+
+/* Race register / sync / restart / exit across two streams with every guard and
+   the gap fix on. A sync may be in flight when a member exits; no interleaving
+   may leave the replica's held set out of step with the live readers. */
+machine DriverExplore {
+  var replica: machine;
+  var writer: machine;
+  start state Init {
+    entry {
+      writer = new Writer();
+      replica = NewReplica(true, true, true, true, false, writer);
+      /* Commit each stream's floors up front so syncs replay committed tuples. */
+      Commit(this, writer, 0, 1010, 1, 1);
+      Commit(this, writer, 0, 1005, 2, 2);
+      Commit(this, writer, 1, 2010, 1, 1);
+      Commit(this, writer, 1, 2005, 2, 2);
+      ChurnStream(0, 1010, 1005);
+      ChurnStream(1, 2010, 2005);
+      Barrier(this, writer, replica);
+      Quiesce(this, replica);
+    }
+  }
+
+  fun ChurnStream(stream: StreamId, floorA: int, floorB: int) {
+    var mref: int;
+    var mref2: int;
+    mref = Register(this, replica, stream);
+    if ($) {
+      /* A sync may be in flight when the member exits (no Barrier here). */
+      EmitSync(this, writer, replica, stream, floorA, 1, 1);
+    }
+    if ($) {
+      /* Member restart: re-register, retiring the old incarnation. */
+      mref2 = Register(this, replica, stream);
+      MemberDown(this, replica, stream, mref);
+      if ($) {
+        EmitSync(this, writer, replica, stream, floorB, 2, 2);
+      }
+      if ($) {
+        MemberDown(this, replica, stream, mref2);
+      }
+    } else {
+      if ($) {
+        /* Possibly-reordered second sync; the stale guard must drop a stale one. */
+        EmitSync(this, writer, replica, stream, floorB, 2, 2);
+      }
+      if ($) {
+        MemberDown(this, replica, stream, mref);
+      }
+    }
+  }
+}
+
+/* ---- test declarations ---- */
+
+test tcCleanupGuarded [main = DriverCleanupGuarded]:
+  assert ReplicaStateMatchesReaders, NoStaleFloorServed in
+  { DriverCleanupGuarded, ManifestReplica, Writer };
+
+test tcCleanupUnguarded [main = DriverCleanupUnguarded]:
+  assert ReplicaStateMatchesReaders in
+  { DriverCleanupUnguarded, ManifestReplica, Writer };
+
+test tcStaleSyncGuarded [main = DriverStaleGuarded]:
+  assert NoStaleFloorServed, ReplicaStateMatchesReaders in
+  { DriverStaleGuarded, ManifestReplica, Writer };
+
+test tcStaleSyncUnguarded [main = DriverStaleUnguarded]:
+  assert NoStaleFloorServed in
+  { DriverStaleUnguarded, ManifestReplica, Writer };
+
+test tcReregisterGuarded [main = DriverReregisterGuarded]:
+  assert ReplicaStateMatchesReaders in
+  { DriverReregisterGuarded, ManifestReplica, Writer };
+
+test tcReregisterUnguarded [main = DriverReregisterUnguarded]:
+  assert ReplicaStateMatchesReaders in
+  { DriverReregisterUnguarded, ManifestReplica, Writer };
+
+test tcConvergenceGuarded [main = DriverConvergenceGuarded]:
+  assert ReplicaConverges in
+  { DriverConvergenceGuarded, ManifestReplica, Writer };
+
+test tcConvergenceStuck [main = DriverConvergenceStuck]:
+  assert ReplicaConverges in
+  { DriverConvergenceStuck, ManifestReplica, Writer };
+
+test tcForgetReleasesWriterRow [main = DriverForget]:
+  assert ReplicaStateMatchesReaders, NoStaleFloorServed in
+  { DriverForget, ManifestReplica, Writer };
+
+test tcSyncAfterExitStrands [main = DriverSyncAfterExitStrands]:
+  assert ReplicaStateMatchesReaders in
+  { DriverSyncAfterExitStrands, ManifestReplica, Writer };
+
+test tcSyncAfterExitFixed [main = DriverSyncAfterExitFixed]:
+  assert ReplicaStateMatchesReaders in
+  { DriverSyncAfterExitFixed, ManifestReplica, Writer };
+
+test tcExplore [main = DriverExplore]:
+  assert ReplicaStateMatchesReaders, NoStaleFloorServed in
+  { DriverExplore, ManifestReplica, Writer };
+
+/* Headline new gate: the syncRequiresContext guard ALONE (with the shipped
+   writer-first attach order) is UNSAFE. A startup sync that beats the local
+   context registration is dropped and never re-sent, so the cache stays empty -
+   a ReplicaConverges violation - even though no state leaks (ReplicaStateMatchesReaders
+   stays green). MUST FAIL on convergence. */
+test tcStartupRaceWriterFirst [main = DriverStartupRaceWriterFirst]:
+  assert ReplicaConverges, ReplicaStateMatchesReaders in
+  { DriverStartupRaceWriterFirst, AttachNode, ManifestReplica, Writer };
+
+/* The coordinated fix: A1 attach-ordering (context before writer) + A2
+   syncRequiresContext guard. The startup sync always lands on a live context so
+   the cache converges, and the post-DOWN straggler is dropped so nothing strands.
+   All monitors HOLD. */
+test tcStartupRaceContextFirst [main = DriverStartupRaceContextFirst]:
+  assert ReplicaConverges, ReplicaStateMatchesReaders, NoStaleFloorServed in
+  { DriverStartupRaceContextFirst, AttachNode, ManifestReplica, Writer };
+
+/* Headline second-trigger gate: A1 does NOT cover the writer-driven reconcile
+   path. Context registration is clean (A1-consistent) and A2 is on, but the
+   reconcile-path sync races ahead of the context registration, is dropped, and
+   (resyncOnRegister OFF) is never recovered - the cache stays empty. MUST FAIL on
+   convergence, proving the attach-ordering fix is insufficient for this trigger. */
+test tcReconcileRaceNoResync [main = DriverReconcileRaceNoResync]:
+  assert ReplicaConverges, ReplicaStateMatchesReaders in
+  { DriverReconcileRaceNoResync, ContextRegistrar, ManifestReplica, Writer };
+
+/* A2 + A1' covers the reconcile trigger: registering the context requests a
+   resync, so the writer re-sends the manifest even when the reconcile sync won
+   the race and was dropped. All monitors HOLD. */
+test tcReconcileRaceResync [main = DriverReconcileRaceResync]:
+  assert ReplicaConverges, ReplicaStateMatchesReaders, NoStaleFloorServed in
+  { DriverReconcileRaceResync, ContextRegistrar, ManifestReplica, Writer };

--- a/p/manifest-replica-lifecycle/README.md
+++ b/p/manifest-replica-lifecycle/README.md
@@ -1,0 +1,96 @@
+# Manifest-replica lifecycle: registration and cleanup-on-reader-exit
+
+A model of the per-node manifest replica (`rabbitmq_stream_s3_manifest_replica`) and the cleanup-on-reader-exit landed in `cc50092`. It shares the multi-node stale-cache substrate of [`../gc-reset-multinode`](../gc-reset-multinode) (fire-and-forget, droppable, reorderable syncs gated by `is_stale_sync`) but targets the lifecycle of the replica's per-node state, not a GC sweep that reads it.
+
+It complements the [`tla/manifest-replication`](../../tla/manifest-replication) TLA+ model without overlapping it. TLA+ verifies data-prefix consistency of sequenced edits under loss and resync (`SeqBounded`, `ReplicaConsistent`) over full edit histories; this model verifies resource-lifecycle correctness, that every cache row is owned by a live monitor and no sync races context registration, over a manifest abstracted to a floor/epoch/seq. The strand and startup-race gates below are invisible to TLA+ (it has no monitor/context coupling), and prefix-consistency is inexpressible here (there are no edit histories).
+
+## The seam
+
+The replica holds three per-stream maps in lockstep plus a reverse monitor index:
+
+- `contexts`, the osiris log context, registered by the acceptor hook when a member starts; the member pid is monitored
+- `seqs`, the last-applied `{seq, epoch, writer_node}` for gap detection
+- the ETS cache row `{manifest, epoch}` that GC and consumers read directly
+- `monitors`, an `mref -> stream` index so a member `DOWN` finds the stream to release
+
+osiris has no terminate or delete hook, so a member `DOWN` (via `monitor/2`) is the only thing that reclaims this state: it runs `release_stream/2` to drop all four. Before `cc50092` there was no cleanup and the metadata accreted forever. The writer node's own row (written by `put_manifest/3`, with no member to monitor) is released explicitly by `forget/1` from the reader's `terminate/2`.
+
+The model abstracts a member to its monitor reference: the replica's only handle on a member is the monitor it holds. The driver starts and kills members; a kill is `eMemberDown` with that mref (the modeled `'DOWN'`).
+
+## The gap: a contextless sync strands the cache
+
+With every shipped guard on, cleanup is not airtight. A sync arriving after a member `DOWN`, when cleanup has already released the stream, falls through `maybe_apply_sync` with `Recorded == undefined`, so `is_stale_sync` returns `false` and `write_manifest` re-inserts the ETS row and `seqs` with no context and no monitor: nothing will ever `'DOWN'` to reclaim it. It lingers rather than being a narrow window because the writer keeps broadcasting to a departed node (decoupling 2 below). It re-introduces exactly the accretion `cc50092` killed. `tcSyncAfterExitStrands` reproduces it (NOLEAK).
+
+## The fix: A2 + A1', and why the guard alone is unsafe
+
+Dropping a contextless sync (A2, `syncRequiresContext`) closes the strand, but three decoupled lifecycles make it unsafe on its own:
+
+1. Attach ordering. The acceptor hook (`hooks.erl:83-95`) registers with the writer first (`{register_acceptor}`, which makes the writer reply with a sync, `replica_reader.erl:435,:771`) and registers the local context second, so a sync can beat the context.
+2. Writer targeting monitors the remote node's `manifest_replica` singleton (`replica_reader.erl:435,:542-549`), not the osiris member, so after a member moves off the writer keeps syncing that node.
+3. Reconcile (`hooks.erl:234-256`, the 60s tick) re-registers a context only for a node that still hosts a member, and the writer's `register_acceptor` and `register_replica` are idempotent, so neither side self-heals a dropped sync.
+
+So with A2 on, a startup sync that beats registration is dropped and never re-sent, leaving the cache empty forever, a `ReplicaConverges` liveness violation even though nothing leaks. The guard alone is a hollow fix.
+
+There are two writer-side sync triggers, and they need different treatment. The acceptor reply (the node's own attach) is closable by reordering the attach to register the context first, the A1 fix. The reconcile path (`replica_reader.erl:467-487`, member-visible-driven, independent of `register_acceptor`) is not: A1 cannot reach it, because the trigger fires on the writer side, unordered with the node's registration.
+
+A1' (resync-on-register) covers both: on registering a context the replica requests a resync (the existing `request_resync/2`; the writer re-sends its persisted floor), so a premature drop from either trigger is recovered. The model proves A1' is load-bearing for the reconcile trigger that A1 cannot reach: `tcReconcileRaceNoResync` starves without it and `tcReconcileRaceResync` converges with it. Because A1' fires on registration regardless of which premature sync was dropped, the same mechanism recovers the acceptor-reply drop, so A1 (attach reorder) is not required and the minimal sound fix is A2 + A1'. The acceptor starve itself is shown by `tcStartupRaceWriterFirst`, and A1 fixing it by `tcStartupRaceContextFirst`; the reconcile pair is what shows why A1 alone is insufficient and A1' is the general fix. A possible A3 (the writer prunes its target on member departure rather than singleton death, removing the orphan-feeding at the source) is noted but not modeled.
+
+### Machines (`PSrc/`)
+
+- `ManifestReplica`, the system under test: the three maps and reverse index, with a toggle per guard so each gate can remove one (`cleanupEnabled`, `staleSyncGuardEnabled`, `repointEnabled`, `syncRequiresContextEnabled`, `resyncOnRegisterEnabled`)
+- `Writer`, the writer-side broadcaster (`rabbitmq_stream_s3_replica_reader`): the authoritative source of committed floors and the emitter of fire-and-forget syncs, answering two triggers from its persisted floor, `eReconcile` (member-visible-driven, independent of `register_acceptor`) and `eResync` (a replica's `request_resync`)
+- `AttachNode` and `ContextRegistrar`, which drive the attach order (the `contextFirst` axis) and the concurrent reconcile race, so a startup sync can be scheduled before or after context registration
+
+### Monitors (`PSpec/`)
+
+- `ReplicaStateMatchesReaders` (safety): the streams the replica holds state for must equal the streams with a live reader. The held-implies-live direction (NOLEAK) proves the `cc50092` cleanup and surfaces the strand; the live-implies-held direction (RETAIN) proves the re-registration monitor repoint.
+- `NoStaleFloorServed` (safety): the cache may only hold a committed floor, and its `(epoch, seq)` never regresses, so a replica never serves a floor a newer write already superseded. This is the read-side analogue of the `../gc-reset-multinode` stale-floor finding (it proves `is_stale_sync/3`).
+- `ReplicaConverges` (liveness, `hot`): a replica fed syncs must eventually reach the latest committed floor; the empty-cache strand trips it.
+
+## Tests (`PTst/`) and the validation gate
+
+| Test case | Expectation |
+| --- | --- |
+| `tcCleanupGuarded` | holds: reader registers, syncs, exits; cleanup releases everything |
+| `tcCleanupUnguarded` | fails: cleanup off, so the exited reader's state is stranded: `NOLEAK violated: replica holds per-node state for stream 0 with no live reader` |
+| `tcStaleSyncGuarded` | holds: a delayed lower-epoch sync is dropped; the cache stays at the reset floor |
+| `tcStaleSyncUnguarded` | fails: guard off; `STALEFLOOR violated: cache for stream 0 regressed to (epoch=1, sn=1) below already-applied (epoch=2, sn=2)` |
+| `tcReregisterGuarded` | holds: a member restart repoints the monitor; the old `DOWN` is ignored, the new context survives |
+| `tcReregisterUnguarded` | fails: repoint off; `RETAIN violated: replica dropped per-node state for stream 0 that still has a live reader (a superseded member DOWN evicted the live context)` |
+| `tcConvergenceGuarded` | holds: every sync delivered; the replica reaches the latest committed floor |
+| `tcConvergenceStuck` | fails: syncs dropped forever; `ReplicaConverges detected liveness bug in hot state 'Lagging' at the end of program execution` |
+| `tcForgetReleasesWriterRow` | holds: the writer-node `put_manifest` row is released by `forget/1` |
+| `tcSyncAfterExitStrands` | fails: all shipped guards on, and a sync after the `DOWN` re-strands the row: the same `NOLEAK` counterexample, the gap |
+| `tcSyncAfterExitFixed` | holds: the `syncRequiresContext` guard (A2) ignores the post-exit sync |
+| `tcStartupRaceWriterFirst` | fails: A2 on plus the shipped writer-first attach; a startup sync beats context registration, is dropped, and is never re-sent: `ReplicaConverges detected liveness bug in hot state 'Lagging' at the end of program execution` (the cache stays empty and NOLEAK stays green, so the guard alone is unsafe) |
+| `tcStartupRaceContextFirst` | holds: A1 attach-ordering (context before writer) plus A2; the startup sync always lands and the post-`DOWN` straggler is dropped (convergence and NOLEAK) |
+| `tcReconcileRaceNoResync` | fails: A1-consistent registration plus A2 with A1' off; the writer-driven reconcile sync races ahead of the context, is dropped, and is never re-sent: `ReplicaConverges detected liveness bug in hot state 'Lagging' at the end of program execution` (A1 cannot cover the writer-side trigger) |
+| `tcReconcileRaceResync` | holds: A2 plus A1'; registering the context requests a resync that refills the cache (convergence, NOLEAK, and stale-floor) |
+| `tcExplore` | holds: register, sync, restart, and exit raced across two streams with every guard and the fix on |
+
+The four unguarded gates, the strand test, and the two startup/reconcile must-fails (`tcStartupRaceWriterFirst`, `tcReconcileRaceNoResync`) are expected to fail: those counterexamples are the proof the monitors have teeth, so the guarded results are meaningful. CI inverts them, so a passing buggy run means the model rotted.
+
+```bash
+p compile
+p check -tc tcCleanupGuarded        -i 2000   # 0 bugs
+p check -tc tcStaleSyncGuarded      -i 2000   # 0 bugs
+p check -tc tcReregisterGuarded     -i 2000   # 0 bugs
+p check -tc tcConvergenceGuarded    -i 2000   # 0 bugs
+p check -tc tcForgetReleasesWriterRow -i 2000 # 0 bugs
+p check -tc tcSyncAfterExitFixed    -i 2000   # 0 bugs (A2 closes the strand)
+p check -tc tcStartupRaceContextFirst -i 2000 # 0 bugs (A1 + A2)
+p check -tc tcReconcileRaceResync   -i 2000   # 0 bugs (A2 + A1' covers reconcile)
+p check -tc tcExplore               -i 5000   # 0 bugs
+p check -tc tcExplore --sch-pct 10  -i 5000   # 0 bugs (PCT)
+p check -tc tcCleanupUnguarded      -i 2000   # 1 bug: NOLEAK
+p check -tc tcStaleSyncUnguarded    -i 2000   # 1 bug: STALEFLOOR
+p check -tc tcReregisterUnguarded   -i 2000   # 1 bug: RETAIN
+p check -tc tcSyncAfterExitStrands  -i 2000   # 1 bug: NOLEAK (the gap)
+p check -tc tcConvergenceStuck      -i 2000   # 1 bug: liveness (hot Lagging)
+p check -tc tcStartupRaceWriterFirst -i 2000  # 1 bug: liveness (guard alone unsafe)
+p check -tc tcReconcileRaceNoResync -i 2000   # 1 bug: liveness (A1 misses reconcile)
+```
+
+## Corresponding code fix
+
+A2 and A1' are implemented in `rabbitmq_stream_s3_manifest_replica`. `maybe_apply_sync/8` drops a sync for a stream with no registered context (counted as `syncs_dropped_no_context`) and records the writer node the sync carried in a new `pending_resync` map; `register_replica_context` consumes that entry to `request_resync/2` from the writer once a monitored context can own the row. Sourcing the writer node from the dropped sync, which carries it, covers both the acceptor-reply and reconcile-path syncs without threading a leader lookup into registration. A1 (attach reorder) and A3 are not implemented: A1' is trigger-agnostic (it fires on registration regardless of which premature sync was dropped), so it recovers the acceptor-reply drop that A1 would reorder around as well as the reconcile drop A1 cannot reach, and A3 is unnecessary once the receiver refuses the orphan row. The suite's tests that drove `sync/4` without a context now register one first; `make ct-manifest_replica`, `make xref`, and `make dialyze` are green.

--- a/p/manifest-replica-lifecycle/manifest-replica-lifecycle.pproj
+++ b/p/manifest-replica-lifecycle/manifest-replica-lifecycle.pproj
@@ -1,0 +1,9 @@
+<Project>
+  <ProjectName>ManifestReplicaLifecycle</ProjectName>
+  <InputFiles>
+    <PFile>./PSrc/</PFile>
+    <PFile>./PSpec/</PFile>
+    <PFile>./PTst/</PFile>
+  </InputFiles>
+  <OutputDir>./PGenerated</OutputDir>
+</Project>

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -34,6 +34,12 @@ No heartbeat or reconnection mechanism is needed because:
   which re-registers with the writer, triggering a fresh sync.
 - An inactive stream (no writes) cannot grow disk regardless of
   whether the replica's manifest is stale.
+
+A sync is applied only for a stream that has a registered reader context, so a
+sync can never create a cached row that no member monitor would ever reclaim. A
+sync that races ahead of registration (or arrives after the context is released)
+is dropped; registering the context then requests a re-sync from that writer, so
+the drop is recovered rather than leaving the cache empty.
 """.
 
 -behaviour(gen_server).
@@ -46,11 +52,14 @@ No heartbeat or reconnection mechanism is needed because:
 
 -define(C_RESYNCS_REQUESTED, 1).
 -define(C_SYNCS_REJECTED, 2).
+-define(C_SYNCS_DROPPED_NO_CONTEXT, 3).
 -define(COUNTERS, [
     {resyncs_requested, ?C_RESYNCS_REQUESTED, counter,
         "Re-syncs a manifest replica requested after a broadcast gap or epoch mismatch"},
     {syncs_rejected, ?C_SYNCS_REJECTED, counter,
-        "Syncs a manifest replica dropped because they were older than the cached epoch or sequence"}
+        "Syncs a manifest replica dropped because they were older than the cached epoch or sequence"},
+    {syncs_dropped_no_context, ?C_SYNCS_DROPPED_NO_CONTEXT, counter,
+        "Syncs a manifest replica dropped because no live reader context owned the stream on this node"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -97,7 +106,12 @@ No heartbeat or reconnection mechanism is needed because:
     seqs = #{} :: #{stream_id() => {non_neg_integer(), non_neg_integer(), node()}},
     %% Reverse index from a member monitor ref to its stream, so a DOWN can find
     %% which stream to release. Kept in lockstep with the mref in each context.
-    monitors = #{} :: #{reference() => stream_id()}
+    monitors = #{} :: #{reference() => stream_id()},
+    %% Streams whose sync was dropped for lack of a context, mapped to the writer
+    %% node the dropped sync came from. When a context later registers we request
+    %% a re-sync from that node, so a sync that raced ahead of registration is
+    %% recovered rather than leaving the cache empty. See maybe_apply_sync/8.
+    pending_resync = #{} :: #{stream_id() => node()}
 }).
 
 %% ------------------------------------------------------------------
@@ -242,10 +256,12 @@ handle_call({put_manifest, StreamId, Manifest, Epoch}, _From, State) ->
 handle_call(
     {sync, StreamId, Seq, Epoch, Manifest, WriterNode},
     _From,
-    #state{seqs = Seqs, contexts = Ctxs} = State
+    #state{seqs = Seqs, contexts = Ctxs, pending_resync = Pending} = State
 ) ->
-    Seqs1 = maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs),
-    {reply, ok, State#state{seqs = Seqs1}};
+    {Seqs1, Pending1} = maybe_apply_sync(
+        StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs, Pending
+    ),
+    {reply, ok, State#state{seqs = Seqs1, pending_resync = Pending1}};
 handle_call(
     {apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, _From, #state{seqs = Seqs} = State
 ) ->
@@ -290,7 +306,7 @@ handle_call({apply_edit, StreamId, Edit}, _From, State) ->
 handle_call(
     {register_replica_context, StreamId, MemberPid, Dir, Shared, Counter},
     _From,
-    #state{contexts = Ctxs, monitors = Mons0} = State
+    #state{contexts = Ctxs, monitors = Mons0, pending_resync = Pending0} = State
 ) ->
     %% Replace any previous registration's monitor first: a member restart
     %% re-registers, and the old incarnation's DOWN must not evict the new
@@ -305,9 +321,13 @@ handle_call(
         end,
     MRef = monitor(process, MemberPid),
     Ctx = #replica_ctx{dir = Dir, shared = Shared, counter = Counter, mref = MRef},
+    %% If a sync for this stream was dropped before this context existed, ask its
+    %% writer to re-send it now that a monitored context can own the cached row.
+    Pending1 = maybe_request_resync(StreamId, Pending0),
     {reply, ok, State#state{
         contexts = Ctxs#{StreamId => Ctx},
-        monitors = Mons1#{MRef => StreamId}
+        monitors = Mons1#{MRef => StreamId},
+        pending_resync = Pending1
     }};
 handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = State) ->
     {reply, maps:is_key(StreamId, Ctxs), State};
@@ -359,10 +379,12 @@ handle_cast({apply_edit, StreamId, Edit}, State) ->
     {noreply, State};
 handle_cast(
     {sync, StreamId, Seq, Epoch, Manifest, WriterNode},
-    #state{seqs = Seqs, contexts = Ctxs} = State
+    #state{seqs = Seqs, contexts = Ctxs, pending_resync = Pending} = State
 ) ->
-    Seqs1 = maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs),
-    {noreply, State#state{seqs = Seqs1}};
+    {Seqs1, Pending1} = maybe_apply_sync(
+        StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs, Pending
+    ),
+    {noreply, State#state{seqs = Seqs1, pending_resync = Pending1}};
 handle_cast({apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, #state{seqs = Seqs} = State) ->
     case maps:get(StreamId, Seqs, undefined) of
         {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
@@ -423,7 +445,10 @@ write_manifest(StreamId, Manifest, Epoch) ->
 %% Drop all per-node state for a stream: its context (and member monitor), its
 %% gap-detection sequence, and its cached manifest row. Used by both the member
 %% DOWN handler and the explicit forget/1 (writer reader teardown).
-release_stream(StreamId, #state{contexts = Ctxs, seqs = Seqs, monitors = Mons} = State) ->
+release_stream(
+    StreamId,
+    #state{contexts = Ctxs, seqs = Seqs, monitors = Mons, pending_resync = Pending} = State
+) ->
     Mons1 =
         case maps:get(StreamId, Ctxs, undefined) of
             #replica_ctx{mref = MRef} ->
@@ -436,7 +461,8 @@ release_stream(StreamId, #state{contexts = Ctxs, seqs = Seqs, monitors = Mons} =
     State#state{
         contexts = maps:remove(StreamId, Ctxs),
         seqs = maps:remove(StreamId, Seqs),
-        monitors = Mons1
+        monitors = Mons1,
+        pending_resync = maps:remove(StreamId, Pending)
     }.
 
 %% Apply a batch of edits, catching any failure from apply_edit/2. apply_edit/2
@@ -475,32 +501,54 @@ apply_edits_catching(StreamId, Edits, Manifest0) ->
 %% next gap triggers a re-sync. Drop any sync that is not at least as new as
 %% what is recorded, comparing epoch first and then sequence so a higher epoch
 %% always wins regardless of where its sequence restarted.
-maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs) ->
-    Recorded = maps:get(StreamId, Seqs, undefined),
-    case is_stale_sync(Epoch, Seq, Recorded) of
-        true ->
-            {Seq0, Epoch0, _} = Recorded,
-            inc(?C_SYNCS_REJECTED, 1),
+maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs, Pending) ->
+    case maps:is_key(StreamId, Ctxs) of
+        false ->
+            %% No live reader context owns this stream on this node: the member
+            %% has gone down (release_stream/2 already dropped its state) or has
+            %% not registered yet. Applying the sync would re-insert an ETS row
+            %% and sequence with no monitor to ever reclaim them. Drop it, and
+            %% remember the writer so registering a context can request a re-sync
+            %% (a sync that raced ahead of registration is then recovered rather
+            %% than leaving the cache empty).
+            inc(?C_SYNCS_DROPPED_NO_CONTEXT, 1),
             ?LOG_INFO(
-                "Manifest replica for stream ~ts dropped a stale sync "
-                "(epoch ~b seq ~b from node ~p) behind the cached epoch ~b seq ~b",
-                [StreamId, Epoch, Seq, WriterNode, Epoch0, Seq0],
+                "Manifest replica for stream ~ts dropped a sync "
+                "(epoch ~b seq ~b from node ~p) with no live reader context",
+                [StreamId, Epoch, Seq, WriterNode],
                 #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
             ),
-            Seqs;
-        false ->
-            write_manifest(StreamId, Manifest, Epoch),
-            seed_first_offset_counter(StreamId, Manifest, Ctxs),
-            %% Evaluate local retention once against the freshly synced manifest.
-            %% On a replica, retention is otherwise only driven by edits that
-            %% advance next_offset; a replica that was offline (an upgrade, say),
-            %% receives a full sync on rejoin, and whose stream then stops
-            %% publishing would never reclaim the local segments already durable
-            %% in the remote tier. This one-shot pass reclaims them. It is a no-op
-            %% for an empty manifest or a stream with no registered context here
-            %% (issue #75).
-            maybe_evaluate_retention_on_sync(StreamId, Manifest, Ctxs),
-            Seqs#{StreamId => {Seq, Epoch, WriterNode}}
+            {Seqs, Pending#{StreamId => WriterNode}};
+        true ->
+            Recorded = maps:get(StreamId, Seqs, undefined),
+            case is_stale_sync(Epoch, Seq, Recorded) of
+                true ->
+                    {Seq0, Epoch0, _} = Recorded,
+                    inc(?C_SYNCS_REJECTED, 1),
+                    ?LOG_INFO(
+                        "Manifest replica for stream ~ts dropped a stale sync "
+                        "(epoch ~b seq ~b from node ~p) behind the cached epoch ~b seq ~b",
+                        [StreamId, Epoch, Seq, WriterNode, Epoch0, Seq0],
+                        #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+                    ),
+                    {Seqs, Pending};
+                false ->
+                    write_manifest(StreamId, Manifest, Epoch),
+                    seed_first_offset_counter(StreamId, Manifest, Ctxs),
+                    %% Evaluate local retention once against the freshly synced
+                    %% manifest. On a replica, retention is otherwise only driven
+                    %% by edits that advance next_offset; a replica that was
+                    %% offline (an upgrade, say), receives a full sync on rejoin,
+                    %% and whose stream then stops publishing would never reclaim
+                    %% the local segments already durable in the remote tier. This
+                    %% one-shot pass reclaims them. It is a no-op for an empty
+                    %% manifest or a stream with no registered context here
+                    %% (issue #75).
+                    maybe_evaluate_retention_on_sync(StreamId, Manifest, Ctxs),
+                    %% The sync landed, so any pending re-sync for this stream is
+                    %% satisfied.
+                    {Seqs#{StreamId => {Seq, Epoch, WriterNode}}, maps:remove(StreamId, Pending)}
+            end
     end.
 
 %% Run local retention against a just-synced manifest, guarding on the same
@@ -534,13 +582,36 @@ is_stale_sync(Epoch, Seq, {Seq0, Epoch0, _}) ->
     {Epoch, Seq} < {Epoch0, Seq0}.
 
 request_resync(StreamId, WriterNode) ->
-    inc(?C_RESYNCS_REQUESTED, 1),
     ?LOG_INFO(
         "Manifest replica for stream ~ts detected a broadcast gap or epoch "
         "mismatch; requesting a re-sync from writer node ~p",
         [StreamId, WriterNode],
         #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
     ),
+    send_resync(StreamId, WriterNode).
+
+%% Request a re-sync from the writer whose sync was dropped for lack of a context
+%% (recorded in pending_resync), now that a context has registered to own the
+%% cached row. Without this, a sync that raced ahead of registration is dropped
+%% and never re-sent (the writer's register is idempotent), leaving the cache
+%% empty. See maybe_apply_sync/8.
+maybe_request_resync(StreamId, Pending) ->
+    case maps:take(StreamId, Pending) of
+        {WriterNode, Pending1} ->
+            ?LOG_INFO(
+                "Manifest replica for stream ~ts registered a context with a "
+                "sync pending; requesting a re-sync from writer node ~p",
+                [StreamId, WriterNode],
+                #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+            ),
+            send_resync(StreamId, WriterNode),
+            Pending1;
+        error ->
+            Pending
+    end.
+
+send_resync(StreamId, WriterNode) ->
+    inc(?C_RESYNCS_REQUESTED, 1),
     gen_server:cast(
         {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
         {resync, node()}

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -29,7 +29,9 @@ all() ->
         retention_evaluated_floors_first_offset_and_timestamp,
         member_down_releases_state,
         forget_releases_writer_row,
-        reregister_repoints_monitor
+        reregister_repoints_monitor,
+        sync_without_context_dropped,
+        register_after_dropped_sync_requests_resync
     ].
 
 init_per_suite(Config) ->
@@ -127,6 +129,63 @@ reregister_repoints_monitor(_Config) ->
     exit(New, kill),
     ok = await(fun() -> not Replica:is_context_registered(Stream) end).
 
+%% A sync for a stream with no registered reader context is dropped rather than
+%% caching a row that no member monitor would ever reclaim (the pre-registration
+%% / post-DOWN strand). get_manifest stays undefined: nothing was cached.
+sync_without_context_dropped(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"no-context-stream">>,
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+    ok = Replica:sync(Stream, 0, 1, Manifest),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)).
+
+%% Registering a context for a stream whose sync was dropped requests a re-sync
+%% from the writer the dropped sync came from, so a sync that raced ahead of
+%% registration is recovered rather than leaving the cache empty.
+register_after_dropped_sync_requests_resync(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"resync-on-register-stream">>,
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+
+    %% A fake writer registered under {Stream, node()} receives the resync cast.
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer(Self) end),
+    yes = rabbitmq_stream_s3_registry:register_name({Stream, node()}, WriterPid),
+
+    %% The sync arrives before any context: it is dropped and its writer node is
+    %% remembered.
+    ok = Replica:sync(Stream, 0, 1, Manifest),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)),
+
+    %% Registering the context now requests a resync from that writer.
+    Member = register_context(Stream),
+    receive
+        {resync_received, Node} -> ?assertEqual(node(), Node)
+    after 1000 -> ct:fail("resync request not received after context registration")
+    end,
+
+    rabbitmq_stream_s3_registry:unregister_name({Stream, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill),
+    exit(Member, kill).
+
+%% Register a live reader context so syncs for the stream are accepted (a sync
+%% for a stream with no context is dropped). Returns the member pid; it is left
+%% alive for the duration of the test.
+register_context(Stream) ->
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    Member = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    ok = rabbitmq_stream_s3_manifest_replica:register_replica_context(
+        Stream, Member, <<"/tmp/s">>, Shared, Counter
+    ),
+    Member.
+
 await(Fun) ->
     await(Fun, 2000).
 
@@ -151,6 +210,7 @@ unknown_stream(_Config) ->
 cached_epoch_reflects_writer_epoch(_Config) ->
     Replica = rabbitmq_stream_s3_manifest_replica,
     StreamId = <<"epoch-stream">>,
+    _ = register_context(StreamId),
     {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
 
     %% put_manifest/3 (the writer's local update) records its epoch.
@@ -258,6 +318,7 @@ range_updates_on_edit(_Config) ->
 
 sequenced_edits_applied_in_order(_Config) ->
     StreamId = <<"stream-seq">>,
+    _ = register_context(StreamId),
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}}
     ]),
@@ -299,6 +360,7 @@ sequenced_edits_applied_in_order(_Config) ->
 
 gap_triggers_resync(_Config) ->
     StreamId = <<"stream-gap">>,
+    _ = register_context(StreamId),
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}}
     ]),
@@ -341,6 +403,7 @@ gap_triggers_resync(_Config) ->
 
 rapid_edits_with_gap_then_resync(_Config) ->
     StreamId = <<"stream-rapid">>,
+    _ = register_context(StreamId),
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}}
     ]),
@@ -395,6 +458,7 @@ rapid_edits_with_gap_then_resync(_Config) ->
 
 stale_edit_after_resync_ignored(_Config) ->
     StreamId = <<"stream-stale">>,
+    _ = register_context(StreamId),
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000}}
     ]),
@@ -438,6 +502,7 @@ stale_edit_after_resync_ignored(_Config) ->
 
 retention_and_append_in_same_broadcast(_Config) ->
     StreamId = <<"stream-mixed">>,
+    _ = register_context(StreamId),
     {Manifest0, _} = build_manifest([
         {fragment, #{offset => 0, size => 1000, uid => 1}},
         {fragment, #{offset => 50, size => 2000, uid => 2}},
@@ -526,6 +591,7 @@ sync_live_manifest_then_broadcast_double_applies(_Config) ->
     %% Correct (fixed) writer: sync the *persisted* manifest at seq 0, then the
     %% broadcast delivers Edit at seq 1. The replica converges on LiveManifest.
     Good = <<"stream-c1-good">>,
+    _ = register_context(Good),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Good, 0, 1, Manifest0),
     ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Good, [Edit], 1, 1),
     ?assertEqual(LiveManifest, rabbitmq_stream_s3_manifest_replica:get_manifest(Good)),
@@ -542,6 +608,7 @@ sync_live_manifest_then_broadcast_double_applies(_Config) ->
     Self = self(),
     WriterPid = spawn_link(fun() -> fake_writer(Self) end),
     Bad = <<"stream-c1-bad">>,
+    _ = register_context(Bad),
     yes = rabbitmq_stream_s3_registry:register_name({Bad, node()}, WriterPid),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Bad, 0, 1, LiveManifest),
     ?assertEqual(
@@ -608,6 +675,7 @@ manifest_reset_requires_resync(_Config) ->
     Self = self(),
     WriterPid = spawn_link(fun() -> fake_writer(Self) end),
     Bad = <<"stream-reset-bad">>,
+    _ = register_context(Bad),
     yes = rabbitmq_stream_s3_registry:register_name({Bad, node()}, WriterPid),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Bad, 0, 1, OldManifest),
     ?assertEqual(
@@ -627,6 +695,7 @@ manifest_reset_requires_resync(_Config) ->
     %% broadcast_seq) before the next edit. The replica drops OldManifest,
     %% adopts FreshManifest, then applies the edit onto it.
     Good = <<"stream-reset-good">>,
+    _ = register_context(Good),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Good, 0, 1, OldManifest),
     ok = rabbitmq_stream_s3_manifest_replica:sync(Good, 0, 1, FreshManifest),
     ok = rabbitmq_stream_s3_manifest_replica:apply_edits(Good, [PostResetEdit], 1, 1),


### PR DESCRIPTION
This closes a per-node metadata leak in the manifest replica, and adds the P model that specified the fix.

The per-node manifest replica (`rabbitmq_stream_s3_manifest_replica`) reclaims a stream's cached state (ETS manifest row, gap sequence, osiris context) through a monitor. `maybe_apply_sync`, though, applied a sync regardless of whether a context was registered. So a sync that arrived after the member's `DOWN` or ahead of the context at startup, re-inserted a cache row and gap sequence with no monitor. For a stream that moved off the node, the row leaked until a later re-register, `forget/1`, or node restart. This is a gap in https://github.com/amazon-mq/rabbitmq-stream-s3/pull/299.

The fix was derived from a P model of the lifecycle of the manifest replicas. The README of the model has the details on what it tests and why the guards are as they are.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
