### PR TITLE
Jepsen: Add down.sh and run.sh, and a tarball override for up.sh

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -28,16 +28,31 @@ The AWS backend is hardwired to TLS/443 with `verify_peer` and virtual-hosted ad
 
 ## Running
 
-Requires Docker and Compose and a working `make package-generic-unix` at the umbrella root.
+Requires Docker and Compose. Building the broker tarball needs a working `make package-generic-unix` at the umbrella root; if that is inconvenient (for example the umbrella is pre-compiled by another checkout, which trips an erlang.mk escript-zip duplicate), stage a prebuilt tarball with `TARBALL=` instead.
 
 ```sh
 cd docker
-./up.sh                       # builds tarball + certs, brings the cluster up
-docker compose exec control \
-  lein run test --nodes-file /shared/nodes \
-    --username root --ssh-private-key /shared/ssh_key \
-    --time-limit 300 --rate 200 --concurrency 20
+./up.sh                       # build the tarball + certs, bring the cluster up
+./run.sh                      # run one test (default faults), leaving it up
+./down.sh                     # tear the cluster down
 ```
+
+`up.sh` stages the broker tarball at `shared/rabbitmq.tar.xz`, picking, in order:
+
+```sh
+TARBALL=/path/to/rabbitmq-server-generic-unix-*.tar.xz ./up.sh   # use a prebuilt one, skip the build
+SKIP_BUILD=1 ./up.sh                                             # reuse an already-staged tarball
+./up.sh                                                          # build from the umbrella
+```
+
+`run.sh` runs one test against the already-up cluster and, unlike `ci/run-jepsen.sh`, leaves it running so you can iterate and inspect `store/`. It reads `FAULTS`, `TIME_LIMIT`, `RATE` and `CONCURRENCY` from the environment and passes any extra arguments through to `lein run test`:
+
+```sh
+FAULTS=s3-outage,leader-move ./run.sh
+FAULTS=leader-move,trim TIME_LIMIT=300 ./run.sh
+```
+
+`down.sh` kills any in-container test process first (on podman, killing the host-side `docker compose exec` shell does not stop the in-container JVM, so a hung run would otherwise contaminate the next one) and then brings the cluster down; `./down.sh --clean` also removes the generated `shared/`.
 
 ## Status
 
@@ -52,34 +67,22 @@ The `:replica` manifest-replica consistency checker snapshots each node's per-st
 A run under `s3-outage,leader-move` drives manifest churn (uploads stall and resume while leaders relocate and epochs bump) and stays `:valid? true` with the caches converged:
 
 ```sh
-docker compose exec control \
-  lein run test --nodes-file /shared/nodes \
-    --username root --ssh-private-key /shared/ssh_key \
-    --time-limit 150 --rate 50 --concurrency 10 \
-    --faults s3-outage,leader-move
+FAULTS=s3-outage,leader-move TIME_LIMIT=150 RATE=50 CONCURRENCY=10 ./run.sh
 ```
 
 A run under `partition,s3-outage,s3-latency,trim` stays `:valid? true` while serving thousands of reads from the remote tier:
 
 ```sh
-docker compose exec control \
-  lein run test --nodes-file /shared/nodes \
-    --username root --ssh-private-key /shared/ssh_key \
-    --time-limit 150 --rate 50 --concurrency 10 \
-    --faults partition,s3-outage,s3-latency,trim
+FAULTS=partition,s3-outage,s3-latency,trim TIME_LIMIT=150 RATE=50 CONCURRENCY=10 ./run.sh
 ```
 
 A run under `leader-move,trim` stays `:valid? true` with the durability checker confirming zero loss and zero duplication across epochs in the double digits:
 
 ```sh
-docker compose exec control \
-  lein run test --nodes-file /shared/nodes \
-    --username root --ssh-private-key /shared/ssh_key \
-    --time-limit 150 --rate 50 --concurrency 10 \
-    --faults leader-move,trim
+FAULTS=leader-move,trim TIME_LIMIT=150 RATE=50 CONCURRENCY=10 ./run.sh
 ```
 
-GitHub Actions runs these scenarios with the `Jepsen` workflow (`.github/workflows/jepsen.yaml`), on a schedule and on demand. It clones the server, checks the plugin out into the umbrella, and invokes `ci/run-jepsen.sh`, which builds the tarball from the clean tree, brings the cluster up, runs one test, and fails the job if the checker reports anomalies.
+GitHub Actions runs these scenarios with the `Jepsen` workflow (`.github/workflows/jepsen.yaml`), on a schedule and on demand. It clones the server, checks the plugin out into the umbrella, and invokes `ci/run-jepsen.sh`, which composes the same `up.sh`, `run.sh` and `down.sh`, building the tarball from the clean tree and failing the job if the checker reports anomalies.
 
 ## Planned
 

--- a/jepsen/ci/run-jepsen.sh
+++ b/jepsen/ci/run-jepsen.sh
@@ -8,31 +8,32 @@
 # deps/rabbitmq_stream_s3 but built within the umbrella). `up.sh` builds the
 # tarball from the umbrella root that contains this checkout.
 #
-# Tunables (all overridable via the environment):
+# Tunables (all overridable via the environment, consumed by run.sh):
 #   TIME_LIMIT, RATE, CONCURRENCY  - workload size
 #   FAULTS                         - comma-separated nemeses to inject
+#
+# This composes the same up.sh / run.sh / down.sh a developer uses locally; the
+# only CI-specific behaviour is tearing down unconditionally and propagating the
+# test's exit status as the build result.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 docker_dir="$here/../docker"
 
-TIME_LIMIT="${TIME_LIMIT:-120}"
-RATE="${RATE:-100}"
-CONCURRENCY="${CONCURRENCY:-20}"
-# Which faults to inject. Override per CI matrix entry to cover the storage-tier
-# and writer-fencing scenarios separately.
-FAULTS="${FAULTS:-partition,s3-outage,s3-latency,trim}"
+# Defaults for run.sh; export so the child script inherits them. Override per CI
+# matrix entry to cover the storage-tier and writer-fencing scenarios separately.
+export TIME_LIMIT="${TIME_LIMIT:-120}"
+export RATE="${RATE:-100}"
+export CONCURRENCY="${CONCURRENCY:-20}"
+export FAULTS="${FAULTS:-partition,s3-outage,s3-latency,trim}"
 
 "$docker_dir/up.sh"
 
 set +e
-docker compose -f "$docker_dir/docker-compose.yml" exec -T control \
-  lein run test --nodes-file /shared/nodes \
-    --username root --ssh-private-key /shared/ssh_key \
-    --time-limit "$TIME_LIMIT" --rate "$RATE" --concurrency "$CONCURRENCY" \
-    --faults "$FAULTS"
+"$docker_dir/run.sh"
 status=$?
 set -e
 
-docker compose -f "$docker_dir/docker-compose.yml" down -v
+# Always tear down; never let a teardown hiccup mask the test verdict.
+"$docker_dir/down.sh" || true
 exit $status

--- a/jepsen/docker/down.sh
+++ b/jepsen/docker/down.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tears the cluster down: the opposite of up.sh.
+#
+# Kills any in-container test process FIRST. On podman, killing the host-side
+# `docker compose exec` shell does NOT kill the in-container lein/JVM, so a hung
+# `lein run test` keeps running and can contaminate the next run sharing this
+# cluster. Then it brings the compose project down, removing its volumes and
+# network.
+#
+#   ./down.sh            # stop the cluster, keep shared/ so a re-up is fast
+#   ./down.sh --clean    # also remove generated shared/ (certs, keys, tarball)
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+compose="$here/docker-compose.yml"
+
+clean=0
+for arg in "$@"; do
+  case "$arg" in
+    --clean) clean=1 ;;
+    -h|--help) sed -n '2,11p' "$0"; exit 0 ;;
+    *) echo "down.sh: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Kill a possibly-hung in-container test process before tearing down (see above).
+# Ignored if the control container is already gone or nothing is running.
+echo "==> stopping any in-container test process"
+docker compose -f "$compose" exec -T control pkill -f "lein run test" 2>/dev/null || true
+
+echo "==> docker compose down -v"
+docker compose -f "$compose" down -v
+
+if [ "$clean" -eq 1 ]; then
+  echo "==> removing generated shared/"
+  rm -rf "$here/shared"
+fi

--- a/jepsen/docker/run.sh
+++ b/jepsen/docker/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs one Jepsen test against the already-up cluster (see up.sh) and, unlike
+# ci/run-jepsen.sh, does NOT tear it down afterwards, so you can iterate on the
+# harness and inspect store/ between runs.
+#
+# Tunables (environment, all optional):
+#   FAULTS        comma-separated nemeses (default: partition,s3-outage,s3-latency,trim)
+#   TIME_LIMIT    workload seconds     (default 120)
+#   RATE          ops/sec              (default 100)
+#   CONCURRENCY   workers              (default 20)
+# Any extra arguments are passed through to `lein run test`.
+#
+#   ./run.sh
+#   FAULTS=s3-outage,leader-move ./run.sh
+#   FAULTS=leader-move,trim TIME_LIMIT=300 ./run.sh --final-time-limit 240
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+compose="$here/docker-compose.yml"
+
+FAULTS="${FAULTS:-partition,s3-outage,s3-latency,trim}"
+TIME_LIMIT="${TIME_LIMIT:-120}"
+RATE="${RATE:-100}"
+CONCURRENCY="${CONCURRENCY:-20}"
+
+echo "==> lein run test --faults $FAULTS (time-limit ${TIME_LIMIT}s)"
+exec docker compose -f "$compose" exec -T control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit "$TIME_LIMIT" --rate "$RATE" --concurrency "$CONCURRENCY" \
+    --faults "$FAULTS" "$@"

--- a/jepsen/docker/up.sh
+++ b/jepsen/docker/up.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # Builds everything the test needs and brings the cluster up.
 #
-#   1. builds the broker generic-unix tarball (make package-generic-unix) and
-#      stages it at shared/rabbitmq.tar.xz  (no release required)
+#   1. stages the broker generic-unix tarball at shared/rabbitmq.tar.xz, either
+#      by building it (make package-generic-unix) or from a prebuilt path
 #   2. generates the throwaway S3 CA + server cert
 #   3. docker compose build + up
 #
-# After this, run the test:
-#   docker compose exec control lein run test \
-#     --nodes-file /shared/nodes --username root --password root \
-#     --time-limit 300 --rate 200 --concurrency 20
+# Tarball selection (in order):
+#   TARBALL=/path/to/rmq-generic-unix.tar.xz ./up.sh   # stage this, skip build
+#   SKIP_BUILD=1 ./up.sh                                # reuse already-staged one
+#   ./up.sh                                             # build from the umbrella
+#
+# After this, run the test with ./run.sh (or by hand), and tear down with
+# ./down.sh.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
@@ -19,15 +22,36 @@ umbrella="$(cd "$here/../../../.." && pwd)"
 
 mkdir -p "$shared"
 
-echo "==> building broker tarball (make package-generic-unix) in $umbrella"
-# Build serially: the rabbitmq_cli escript-zip step races under a parallel
-# make (parallel recursive appends to the runtime-deps list duplicate a dep,
-# so zip is handed the same ebin/dep_built twice -> "Duplicate filename on
-# disk"). -j1 here overrides any inherited MAKEFLAGS=--jobs=N.
-make -C "$umbrella" -j1 package-generic-unix
-tarball="$(ls -t "$umbrella"/PACKAGES/rabbitmq-server-generic-unix-*.tar.xz | head -n1)"
-cp "$tarball" "$shared/rabbitmq.tar.xz"
-echo "    staged $(basename "$tarball") -> shared/rabbitmq.tar.xz"
+if [ -n "${TARBALL:-}" ]; then
+  echo "==> staging prebuilt tarball: $TARBALL"
+  [ -f "$TARBALL" ] || { echo "up.sh: TARBALL not found: $TARBALL" >&2; exit 1; }
+  cp "$TARBALL" "$shared/rabbitmq.tar.xz"
+elif [ -n "${SKIP_BUILD:-}" ] && [ -f "$shared/rabbitmq.tar.xz" ]; then
+  echo "==> reusing already-staged shared/rabbitmq.tar.xz (SKIP_BUILD)"
+else
+  echo "==> building broker tarball (make package-generic-unix) in $umbrella"
+  # Build serially: the rabbitmq_cli escript-zip step races under a parallel
+  # make (parallel recursive appends to the runtime-deps list duplicate a dep,
+  # so zip is handed the same ebin/dep_built twice -> "Duplicate filename on
+  # disk"). -j1 here overrides any inherited MAKEFLAGS=--jobs=N.
+  if ! make -C "$umbrella" -j1 package-generic-unix; then
+    cat >&2 <<'MSG'
+
+up.sh: package-generic-unix failed. If the error above was
+    ERROR: Duplicate filename on disk: dep_built
+the umbrella is pre-compiled (e.g. by another checkout), so erlang.mk's
+escript-zip dedup is skipped when rabbitmq_cli builds as a dependency and a
+doubled dep entry breaks 7z. It is not a parallelism issue; -j1 does not help.
+Fix by building from a clean tree (a fresh clone, as CI does), or stage a
+prebuilt tarball instead:
+    TARBALL=/path/to/rabbitmq-server-generic-unix-*.tar.xz ./up.sh
+MSG
+    exit 1
+  fi
+  tarball="$(ls -t "$umbrella"/PACKAGES/rabbitmq-server-generic-unix-*.tar.xz | head -n1)"
+  cp "$tarball" "$shared/rabbitmq.tar.xz"
+  echo "    staged $(basename "$tarball") -> shared/rabbitmq.tar.xz"
+fi
 
 echo "==> generating S3 certs"
 "$here/gen-certs.sh"
@@ -50,12 +74,14 @@ docker compose -f "$here/docker-compose.yml" up -d
 
 cat <<'EOF'
 
-Cluster is up. Run the test with:
+Cluster is up. Run a test with:
 
-  docker compose -f docker-compose.yml exec control \
-    lein run test --nodes-file /shared/nodes \
-      --username root --ssh-private-key /shared/ssh_key \
-      --time-limit 300 --rate 200 --concurrency 20
+  ./run.sh                                # default faults
+  FAULTS=leader-move,trim ./run.sh        # pick faults
+
+Tear down with:
+
+  ./down.sh                               # keep shared/ for a fast re-up
 
 Results land under jepsen.streams3/store/ (mounted on the host).
 EOF


### PR DESCRIPTION
The docker harness had only up.sh (build tarball, bring the cluster up) and a CI entry point; teardown and running were ad hoc long command lines.

Add docker/down.sh: the opposite of up.sh. It kills any in-container test process first, since on podman killing the host-side `docker compose exec` shell does not stop the in-container JVM, so a hung run would otherwise contaminate the next one, then brings the cluster down; --clean also removes the generated shared/.

Add docker/run.sh: run one test against the already-up cluster, leaving it up for iteration (unlike ci/run-jepsen.sh, which tears down). It reads FAULTS, TIME_LIMIT, RATE and CONCURRENCY from the environment and passes extra arguments through to `lein run test`.

Teach up.sh to stage a prebuilt tarball instead of always building: TARBALL= points at one and skips the build, SKIP_BUILD=1 reuses an already-staged one. This sidesteps the case where package-generic-unix fails on a pre-compiled umbrella (erlang.mk skips the escript-zip dedup when rabbitmq_cli builds as a dependency, so a doubled dep entry breaks 7z); on that failure up.sh now prints the cause and the TARBALL= workaround.

Refactor ci/run-jepsen.sh to compose up.sh, run.sh and down.sh so the local and CI paths share one invocation, and refresh the README to document the three scripts and the tarball options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
