### PR TITLE
Jepsen: Add manifest-replica consistency scenario

### DIFF
--- a/.github/workflows/jepsen.yaml
+++ b/.github/workflows/jepsen.yaml
@@ -50,10 +50,12 @@ jobs:
       fail-fast: false
       matrix:
         rmq-version: ['streams-tiered-storage']
-        # One job per scenario: storage-tier faults, and writer fencing.
+        # One job per scenario: storage-tier faults, writer fencing, and
+        # manifest-replica cache consistency under an S3 outage plus leader churn.
         faults:
           - 'partition,s3-outage,s3-latency,trim'
           - 'leader-move,trim'
+          - 's3-outage,leader-move'
         include:
           - rmq-version: 'streams-tiered-storage'
             otp-version: 27

--- a/jepsen/BACKLOG.md
+++ b/jepsen/BACKLOG.md
@@ -17,9 +17,11 @@ Reliably exercising it needs a nemesis that makes members genuinely leave a node
 
 Until then the convergence and stale-floor assertions carry the meaningful verdict for this scenario.
 
-## Run this scenario as a regression check once the manifest-replica fix lands
+## Regression check for the manifest-replica fix (validated)
 
-The manifest-replica sync-context fix (branch `manifest-replica-lifecycle`: drop a sync for a stream with no reader context, and request a resync when a context registers) changes the replica cache's write path. Once it lands on `main`, run this scenario against a cluster carrying it and confirm the convergence, stale-floor, and durability assertions still hold, with the run's `:divergence-exercised?` telemetry and the `syncs_dropped_no_context` and `resyncs_requested` counters confirming the gated and recovery paths were actually taken. This is regression coverage only: it does not positively prove the fix closes the leak, because `:leaked-replica-row` does not fire without the hard-kill or stream-churn nemesis above. The fix itself is validated by the `p/manifest-replica-lifecycle` model's gates and the module's unit tests.
+The manifest-replica sync-context fix (drop a sync for a stream with no reader context, and request a resync when a context registers) landed on `main` and changed the replica cache's write path. This scenario was run against a cluster carrying it under `s3-outage,leader-move` and confirmed the convergence, stale-floor, and durability assertions all still hold (`:diverged`, `:stale-floors`, `:leaked-rows` and durability violations all empty, 49/49 keys). The gated and recovery paths were genuinely exercised, not merely present: `syncs_dropped_no_context` and `resyncs_requested` both ticked 240 times over the run, so `:divergence-exercised?` was true and `:convergence-hollow?` false. The matched counts are the fix end to end, every contextless sync the A2 guard dropped was recovered by an A1' resync once a context registered.
+
+This is regression coverage only: it does not positively prove the fix closes the leak, because `:leaked-replica-row` still does not fire without the hard-kill or stream-churn nemesis above (it stayed empty here, as expected under graceful leader-move). The fix itself is validated by the `p/manifest-replica-lifecycle` model's gates and the module's unit tests.
 
 ## Super-streams (multi-partition)
 

--- a/jepsen/BACKLOG.md
+++ b/jepsen/BACKLOG.md
@@ -17,6 +17,10 @@ Reliably exercising it needs a nemesis that makes members genuinely leave a node
 
 Until then the convergence and stale-floor assertions carry the meaningful verdict for this scenario.
 
+## Run this scenario as a regression check once the manifest-replica fix lands
+
+The manifest-replica sync-context fix (branch `manifest-replica-lifecycle`: drop a sync for a stream with no reader context, and request a resync when a context registers) changes the replica cache's write path. Once it lands on `main`, run this scenario against a cluster carrying it and confirm the convergence, stale-floor, and durability assertions still hold, with the run's `:divergence-exercised?` telemetry and the `syncs_dropped_no_context` and `resyncs_requested` counters confirming the gated and recovery paths were actually taken. This is regression coverage only: it does not positively prove the fix closes the leak, because `:leaked-replica-row` does not fire without the hard-kill or stream-churn nemesis above. The fix itself is validated by the `p/manifest-replica-lifecycle` model's gates and the module's unit tests.
+
 ## Super-streams (multi-partition)
 
 Extend the workload to super-streams so partitioned producers and consumers are exercised, not just single streams.

--- a/jepsen/BACKLOG.md
+++ b/jepsen/BACKLOG.md
@@ -1,0 +1,22 @@
+# Jepsen harness backlog
+
+Follow-up work for the `rabbitmq_stream_s3` Jepsen harness, in rough priority order.
+
+## Bounded-durability checker for aggressive retention
+
+A `force-trim` nemesis that drops a stream's local retention past the upload seam `n`, paired with a checker scoped to the `[f, n)` range, so loss is only flagged inside the durable range the plugin actually promises (see `../docs/invariants.md`, "Non-guarantee"). The current durability checker assumes retention is wide enough that nothing legitimately drops, which is why retention is configured generously today.
+
+## Hard-kill / stream-churn nemesis to reproduce the manifest-replica leak
+
+The `:replica` manifest-replica consistency checker's `:leaked-replica-row` assertion (a cache row on a non-leader node with no registered replica context) only *fires* when an osiris member departs a node permanently mid-sync: a sync arriving after the member's `DOWN` re-creates a cache row with no monitor to reclaim it. Graceful `leader-move` (which transfers leadership, leaving the member set intact) does not cause this, so the assertion ships as a cheap always-on guard rather than something the current faults reproduce.
+
+Reliably exercising it needs a nemesis that makes members genuinely leave a node mid-sync, for example:
+
+- a hard kill (SIGKILL) of a broker while uploads/syncs are in flight, then a restart that relocates the member, or
+- stream churn (delete and re-create streams, or add/remove replicas) under the S3-outage fault so syncs race the member teardown
+
+Until then the convergence and stale-floor assertions carry the meaningful verdict for this scenario.
+
+## Super-streams (multi-partition)
+
+Extend the workload to super-streams so partitioned producers and consumers are exercised, not just single streams.

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -45,7 +45,19 @@ The partition nemesis runs against a 5-node cluster with the kafka anomaly check
 
 The storage-tier nemeses make data really tier to S3 and exercise the read-from-S3 path under fault. Small segments and fragments plus padded payloads force segments to roll, upload and trim within a short run; MinIO needs a KMS key for the plugin's SSE uploads (see `docker/docker-compose.yml`). The `--faults` option selects `s3-outage` and `s3-latency` (via Toxiproxy), `trim` (periodic `evaluate_local_retention`, which trims uploaded segments locally so reads of older offsets fall to the S3 tier), and `leader-move` (each tick, transfer a random stream's leader to a replica, relocating that writer and bumping the stream epoch so a deposed writer's in-flight upload must be fenced).
 
-Two extra checkers run alongside the kafka anomaly checkers. The `:tiering` coverage checker scrapes the plugin's S3 counters before teardown and fails the run unless fragments were uploaded, and with `trim` that reads were served from S3, and with `leader-move` that the epoch advanced; this keeps a run from passing green while silently not using the remote tier or not moving leaders. The `s3-outage` fault is instead proven injected by the Toxiproxy status check in the nemesis (it fails on a non-2xx response), since the plugin tolerates an outage gracefully and need not surface an error counter. The `:durability` checker reads every stream end-to-end after the run and fails if any acknowledged write is lost or duplicated; it is authoritative under `leader-move`, where the kafka offset analyzers are downgraded to advisory (see "Why the Kafka workload").
+Three extra checkers run alongside the kafka anomaly checkers. The `:tiering` coverage checker scrapes the plugin's S3 counters before teardown and fails the run unless fragments were uploaded, and with `trim` that reads were served from S3, and with `leader-move` that the epoch advanced; this keeps a run from passing green while silently not using the remote tier or not moving leaders. The `s3-outage` fault is instead proven injected by the Toxiproxy status check in the nemesis (it fails on a non-2xx response), since the plugin tolerates an outage gracefully and need not surface an error counter. The `:durability` checker reads every stream end-to-end after the run and fails if any acknowledged write is lost or duplicated; it is authoritative under `leader-move`, where the kafka offset analyzers are downgraded to advisory (see "Why the Kafka workload").
+
+The `:replica` manifest-replica consistency checker snapshots each node's per-stream manifest cache (the table `rabbitmq_stream_s3_manifest_cache`) after the run quiesces and asserts three things: every stream's cached floor is identical across the nodes that cache it (convergence); the cross-node-agreed floor never sits beyond the stream's committed offset (a stale or corrupt floor would claim data the remote tier does not hold); and no cache row on a non-leader node lacks a registered replica context (a contextless replica row is one a sync re-created after the owning osiris member's `DOWN`, with no monitor to reclaim it). The cached epoch is reported alongside each floor for diagnosis but is deliberately left out of the convergence equality: a deposed leader's cache legitimately keeps the older epoch on an idle stream until the next edit, and the plugin's GC explicitly tolerates a cache that lags the committed epoch (`get_manifest_and_epoch/1`), so an epoch lag is not a convergence violation. The leader's own row is written by the writer path with no replica context, so the leader node is excluded from the last test to avoid a false positive. The convergence and stale-floor assertions are genuinely exercised by the `s3-outage`, `leader-move` and `partition` faults; the leaked-row assertion is a cheap always-on guard that only *fires* when a member departs a node permanently mid-sync, which graceful `leader-move` does not cause — reliably reproducing the leak needs a hard-kill / stream-churn nemesis (see `BACKLOG.md`).
+
+A run under `s3-outage,leader-move` drives manifest churn (uploads stall and resume while leaders relocate and epochs bump) and stays `:valid? true` with the caches converged:
+
+```sh
+docker compose exec control \
+  lein run test --nodes-file /shared/nodes \
+    --username root --ssh-private-key /shared/ssh_key \
+    --time-limit 150 --rate 50 --concurrency 10 \
+    --faults s3-outage,leader-move
+```
 
 A run under `partition,s3-outage,s3-latency,trim` stays `:valid? true` while serving thousands of reads from the remote tier:
 
@@ -67,7 +79,7 @@ docker compose exec control \
     --faults leader-move,trim
 ```
 
-GitHub Actions runs both of these scenarios with the `Jepsen` workflow (`.github/workflows/jepsen.yaml`), on a schedule and on demand. It clones the server, checks the plugin out into the umbrella, and invokes `ci/run-jepsen.sh`, which builds the tarball from the clean tree, brings the cluster up, runs one test, and fails the job if the checker reports anomalies.
+GitHub Actions runs these scenarios with the `Jepsen` workflow (`.github/workflows/jepsen.yaml`), on a schedule and on demand. It clones the server, checks the plugin out into the umbrella, and invokes `ci/run-jepsen.sh`, which builds the tarball from the clean tree, brings the cluster up, runs one test, and fails the job if the checker reports anomalies.
 
 ## Planned
 

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
@@ -143,9 +143,11 @@
 
   A converged-floor verdict only means something if the run actually drove the
   caches apart and the sync machinery pulled them back. The result therefore
-  reports syncs_rejected (a stale sync dropped) and resyncs_requested (a gap
-  triggered a resync) from the run's counters as :divergence-exercised?, and
-  flags :convergence-hollow? when the check passed but neither ever ticked — a
+  reports syncs_rejected (a stale sync dropped), syncs_dropped_no_context (the
+  manifest-replica fix's A2 guard dropped a sync that raced ahead of a reader
+  context) and resyncs_requested (a gap, or a context registering with a sync
+  pending, triggered a resync) from the run's counters as :divergence-exercised?,
+  and flags :convergence-hollow? when the check passed but none ever ticked — a
   green that proves nothing rather than a failure."
   []
   (reify checker/Checker
@@ -154,12 +156,17 @@
             committed @db/committed-offsets-snapshot
             stats     @db/tiering-stats
             ;; Evidence the run actually stressed the sync machinery: a stale
-            ;; sync was dropped, or a detected gap requested a resync. With both
-            ;; at zero nothing ever diverged, so a converged-floor verdict is
-            ;; hollow. Reported, not failed: a quiet schedule is not a bug.
+            ;; sync was dropped, the A2 guard dropped a contextless sync, or a
+            ;; detected gap (or a context registering with a sync pending)
+            ;; requested a resync. With all three at zero nothing ever diverged,
+            ;; so a converged-floor verdict is hollow. Reported, not failed: a
+            ;; quiet schedule is not a bug.
             syncs-rejected        (long (get stats "rabbitmq_stream_s3_syncs_rejected" 0))
+            syncs-dropped-noctx   (long (get stats "rabbitmq_stream_s3_syncs_dropped_no_context" 0))
             resyncs-requested     (long (get stats "rabbitmq_stream_s3_resyncs_requested" 0))
-            divergence-exercised? (or (pos? syncs-rejected) (pos? resyncs-requested))
+            divergence-exercised? (or (pos? syncs-rejected)
+                                      (pos? syncs-dropped-noctx)
+                                      (pos? resyncs-requested))
             ;; stream key -> {node -> rec} over only the nodes that cache it.
             by-stream (reduce-kv
                         (fn [acc node kmap]
@@ -192,16 +199,17 @@
                         (seq diverged)    (conj :replicas-diverged)
                         (seq stale)       (conj :stale-floor-served)
                         (seq leaked)      (conj :leaked-replica-row))]
-        {:valid?                (empty? problems)
-         :problems              problems
-         :streams-cached        (count by-stream)
-         :diverged              (vec diverged)
-         :stale-floors          (vec stale)
-         :leaked-rows           (vec leaked)
-         :syncs-rejected        syncs-rejected
-         :resyncs-requested     resyncs-requested
-         :divergence-exercised? divergence-exercised?
-         :convergence-hollow?   (and (empty? problems) (not divergence-exercised?))}))))
+        {:valid?                   (empty? problems)
+         :problems                 problems
+         :streams-cached           (count by-stream)
+         :diverged                 (vec diverged)
+         :stale-floors             (vec stale)
+         :leaked-rows              (vec leaked)
+         :syncs-rejected           syncs-rejected
+         :syncs-dropped-no-context syncs-dropped-noctx
+         :resyncs-requested        resyncs-requested
+         :divergence-exercised?    divergence-exercised?
+         :convergence-hollow?      (and (empty? problems) (not divergence-exercised?))}))))
 
 (defn downgrade-when
   "Wraps a checker so that when (pred test) holds its result cannot invalidate

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
@@ -101,6 +101,89 @@
          :keys-read   (count reads)
          :violations  (vec errs)}))))
 
+(defn replica-consistency-checker
+  "Asserts the per-node manifest-replica caches stay consistent under churn,
+  reading the snapshots db captured after the run quiesced (db/replica-floors,
+  the per-node cache; db/committed-offsets-snapshot, the committed-offset oracle).
+  Black-box analogue of the manifest-replica model's convergence, stale-floor and
+  NOLEAK properties. Three problems:
+
+    :replicas-diverged   - some stream's cached floor is not identical across the
+                           nodes that cache it. After the final settle and reads
+                           the caches must have converged on the floor; a lingering
+                           disagreement means a sync or edit was lost or applied
+                           out of order. The cached epoch is reported alongside for
+                           diagnosis but is NOT part of the equality: a deposed
+                           leader's cache legitimately keeps the older epoch on an
+                           idle stream until the next edit, and the plugin's GC
+                           explicitly tolerates a cache that lags the committed
+                           epoch (get_manifest_and_epoch/1), so an epoch lag is not
+                           a convergence violation.
+    :stale-floor-served  - the cross-node-agreed floor sits beyond the stream's
+                           committed offset (floor > committed + 1). The remote
+                           tier cannot start past committed data and retention is
+                           wide, so a floor ahead of the committed tail is a stale
+                           or corrupt cached floor. An empty stream reports a
+                           committed offset of -1, so its bound is 0.
+    :leaked-replica-row  - a cache row on a node that is NOT the stream's leader
+                           has no replica context registered. A replica row is
+                           created alongside a monitored osiris member, so a
+                           contextless one is a row a sync re-created after the
+                           member's DOWN released it, with no monitor to reclaim
+                           it. The leader's own row is written by the writer path
+                           (no replica context) and is legitimate, so the leader
+                           node is excluded to avoid a false positive.
+
+  Honesty note: convergence and the stale-floor bound are genuinely exercised by
+  the s3-outage / leader-move / partition faults. The leaked-row guard only fires
+  when an osiris member departs a node permanently mid-sync, which graceful
+  leader-move does not cause, so it ships as a cheap always-on guard, not
+  something the current faults reproduce. Reliably exercising it needs a hard-kill
+  / stream-churn nemesis (see jepsen/BACKLOG.md)."
+  []
+  (reify checker/Checker
+    (check [_ _test _history _opts]
+      (let [per-node  @db/replica-floors
+            committed @db/committed-offsets-snapshot
+            ;; stream key -> {node -> rec} over only the nodes that cache it.
+            by-stream (reduce-kv
+                        (fn [acc node kmap]
+                          (reduce-kv (fn [a k rec]
+                                       (if (:cached? rec)
+                                         (assoc-in a [k node] rec)
+                                         a))
+                                     acc kmap))
+                        {} per-node)
+            diverged  (for [[k node->rec] by-stream
+                            :let [floors (set (map (fn [[_ r]] (:floor r)) node->rec))]
+                            :when (> (count floors) 1)]
+                        {:key k
+                         :node->floor-epoch
+                         (into {} (map (fn [[n r]] [n [(:floor r) (:epoch r)]]) node->rec))})
+            ;; Only meaningful when the floor itself converged (a divergent floor
+            ;; is already reported above); compare that agreed floor to committed.
+            stale     (for [[k node->rec] by-stream
+                            :let [floors (set (map (fn [[_ r]] (:floor r)) node->rec))
+                                  agreed (when (= 1 (count floors)) (first floors))
+                                  c      (get committed k -1)]
+                            :when (and agreed (> agreed (inc c)))]
+                        {:key k :agreed-floor agreed :committed-offset c})
+            leaked    (for [[k node->rec] by-stream
+                            [node rec] node->rec
+                            :when (and (not (:leader? rec)) (not (:ctx? rec)))]
+                        {:key k :node node})
+            problems  (cond-> []
+                        (empty? per-node) (conj :no-replica-cache-collected)
+                        (seq diverged)    (conj :replicas-diverged)
+                        (seq stale)       (conj :stale-floor-served)
+                        (seq leaked)      (conj :leaked-replica-row))]
+        {:valid?            (empty? problems)
+         :problems          problems
+         :streams-cached    (count by-stream)
+         :diverged          (vec diverged)
+         :stale-floors      (vec stale)
+         :leaked-rows       (vec leaked)}))))
+
 (defn downgrade-when
   "Wraps a checker so that when (pred test) holds its result cannot invalidate
   the run: anomalies are kept for inspection but :valid? is forced true. Used for

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/checker.clj
@@ -139,12 +139,27 @@
   when an osiris member departs a node permanently mid-sync, which graceful
   leader-move does not cause, so it ships as a cheap always-on guard, not
   something the current faults reproduce. Reliably exercising it needs a hard-kill
-  / stream-churn nemesis (see jepsen/BACKLOG.md)."
+  / stream-churn nemesis (see jepsen/BACKLOG.md).
+
+  A converged-floor verdict only means something if the run actually drove the
+  caches apart and the sync machinery pulled them back. The result therefore
+  reports syncs_rejected (a stale sync dropped) and resyncs_requested (a gap
+  triggered a resync) from the run's counters as :divergence-exercised?, and
+  flags :convergence-hollow? when the check passed but neither ever ticked — a
+  green that proves nothing rather than a failure."
   []
   (reify checker/Checker
     (check [_ _test _history _opts]
       (let [per-node  @db/replica-floors
             committed @db/committed-offsets-snapshot
+            stats     @db/tiering-stats
+            ;; Evidence the run actually stressed the sync machinery: a stale
+            ;; sync was dropped, or a detected gap requested a resync. With both
+            ;; at zero nothing ever diverged, so a converged-floor verdict is
+            ;; hollow. Reported, not failed: a quiet schedule is not a bug.
+            syncs-rejected        (long (get stats "rabbitmq_stream_s3_syncs_rejected" 0))
+            resyncs-requested     (long (get stats "rabbitmq_stream_s3_resyncs_requested" 0))
+            divergence-exercised? (or (pos? syncs-rejected) (pos? resyncs-requested))
             ;; stream key -> {node -> rec} over only the nodes that cache it.
             by-stream (reduce-kv
                         (fn [acc node kmap]
@@ -177,12 +192,16 @@
                         (seq diverged)    (conj :replicas-diverged)
                         (seq stale)       (conj :stale-floor-served)
                         (seq leaked)      (conj :leaked-replica-row))]
-        {:valid?            (empty? problems)
-         :problems          problems
-         :streams-cached    (count by-stream)
-         :diverged          (vec diverged)
-         :stale-floors      (vec stale)
-         :leaked-rows       (vec leaked)}))))
+        {:valid?                (empty? problems)
+         :problems              problems
+         :streams-cached        (count by-stream)
+         :diverged              (vec diverged)
+         :stale-floors          (vec stale)
+         :leaked-rows           (vec leaked)
+         :syncs-rejected        syncs-rejected
+         :resyncs-requested     resyncs-requested
+         :divergence-exercised? divergence-exercised?
+         :convergence-hollow?   (and (empty? problems) (not divergence-exercised?))}))))
 
 (defn downgrade-when
   "Wraps a checker so that when (pred test) holds its result cannot invalidate

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/core.clj
@@ -70,7 +70,10 @@
                      :durability (s3-checker/durability-checker)
                      ;; Fails the run unless S3 was actually exercised, so a
                      ;; green result can't silently stop using the remote tier.
-                     :tiering  (s3-checker/tiering-checker)})
+                     :tiering  (s3-checker/tiering-checker)
+                     ;; Asserts the per-node manifest-replica caches converge and
+                     ;; serve no stale floor or leaked (contextless) row.
+                     :replica  (s3-checker/replica-consistency-checker)})
        :generator (gen/phases
                     ;; Main phase: workload ops + faults for the time limit.
                     (->> (:generator wl)

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
@@ -286,6 +286,64 @@
         ints (map parse-long (re-seq #"-?\d+" (str out)))]
     (into {} (map vec (partition 2 ints)))))
 
+;; For each jepsen-<k> stream, this node's view of the manifest-replica cache
+;; (ETS table rabbitmq_stream_s3_manifest_cache, rows {StreamId, Manifest, Epoch})
+;; plus the stream's cluster-global leader. Per stream we emit six integers:
+;;   {K, Cached, Floor, Epoch, Ctx, IsLeader}
+;; where
+;;   * Cached   1 if this node holds a cache row for the stream, else 0
+;;   * Floor    the cached manifest's first_offset (the remote-tier floor), read
+;;              via get_range/1 whose first element IS the manifest first_offset;
+;;              0 for an empty (entries = <<>>) cached manifest, -1 if not cached
+;;   * Epoch    the writer epoch the row was stored at (-1 if cached without one)
+;;   * Ctx      1 if a replica context (a monitored osiris member) is registered
+;;              on this node for the stream, else 0
+;;   * IsLeader 1 if this node is the stream's current leader, else 0
+;; The leader's own cache row is written by the writer path (put_manifest), not by
+;; a monitored replica context, so it legitimately has Ctx = 0; IsLeader lets the
+;; checker exclude it from the leaked-row test. All-integer output so it parses the
+;; same way as committed-offsets-eval.
+(def ^:private replica-cache-eval
+  (str "Qs = [Q || Q <- rabbit_amqqueue:list(<<\"/\">>), "
+       "begin N = element(4, amqqueue:get_name(Q)), "
+       "byte_size(N) >= 8 andalso binary:part(N, 0, 7) =:= <<\"jepsen-\">> end], "
+       "Mod = rabbitmq_stream_s3_manifest_replica, Self = node(), "
+       "[begin "
+       "Name = element(4, amqqueue:get_name(Q)), "
+       "K = binary_to_integer(binary:part(Name, 7, byte_size(Name) - 7)), "
+       "TS = amqqueue:get_type_state(Q), "
+       ;; The stream_id is the manifest cache's ETS key, a binary; type_state
+       ;; carries it as a char list, so coerce it or every lookup misses.
+       "SId = iolist_to_binary(maps:get(name, TS)), "
+       "IsLeader = case maps:get(leader_node, TS, undefined) of Self -> 1; _ -> 0 end, "
+       "{Cached, Floor, Epoch, Ctx} = "
+       "case catch Mod:get_manifest_and_epoch(SId) of "
+       "{_M, E} -> "
+       "Fl = case catch Mod:get_range(SId) of {Fst, _} -> Fst; _ -> 0 end, "
+       "Ep = case E of Ei when is_integer(Ei) -> Ei; _ -> -1 end, "
+       "Cx = case catch Mod:is_context_registered(SId) of true -> 1; _ -> 0 end, "
+       "{1, Fl, Ep, Cx}; "
+       "_ -> {0, -1, -1, 0} "
+       "end, "
+       "{K, Cached, Floor, Epoch, Ctx, IsLeader} "
+       "end || Q <- Qs]."))
+
+(defn replica-cache
+  "Returns {key -> {:cached? :floor :epoch :ctx? :leader?}} describing the
+  manifest-replica cache state on `node` for each jepsen stream, where :leader?
+  is whether `node` is the stream's current leader (a cluster-global fact). Runs
+  in an SSH context."
+  [node]
+  (let [out  (try (rabbitmqctl-eval node replica-cache-eval) (catch Exception _ ""))
+        ints (map parse-long (re-seq #"-?\d+" (str out)))]
+    (into {}
+          (for [[k cached floor epoch ctx leader] (partition 6 ints)]
+            [k {:cached? (= 1 cached)
+                :floor   floor
+                :epoch   epoch
+                :ctx?    (= 1 ctx)
+                :leader? (= 1 leader)}]))))
+
 ;; Cluster-wide S3 counter sums for the run, accumulated across nodes in
 ;; log-files (which runs after the workload but before the checker, while the
 ;; brokers are still up). The coverage checker reads this. Collecting it here
@@ -301,6 +359,23 @@
          (fn [acc]
            (-> (merge-with + acc (scrape-tiering-metrics node))
                (update "max_epoch" (fnil max 0) (scrape-max-epoch node))))))
+
+;; Per-node manifest-replica cache snapshots for the run, captured in log-files
+;; (brokers still up) alongside record-tiering-stats!. node -> {key -> {:cached?
+;; :floor :epoch :ctx? :leader?}}. The replica-consistency checker reads this to
+;; assert the caches converged and served no stale floor or leaked row.
+(defonce replica-floors (atom {}))
+
+;; The committed offset of each jepsen stream at the end of the run (the same
+;; scrape capture-authoritative-reads! uses), captured once on the primary in
+;; log-files. The replica-consistency checker reads this as the oracle for the
+;; stale-floor test. key -> committed offset (-1 for an empty stream).
+(defonce committed-offsets-snapshot (atom {}))
+
+(defn record-replica-cache!
+  "Stores `node`'s manifest-replica cache snapshot into the shared per-run map."
+  [node]
+  (swap! replica-floors assoc node (replica-cache node)))
 
 (defn start! [test node]
   (info node "starting broker")
@@ -354,6 +429,8 @@
       ;; one JVM does not carry stale stream declarations or publishingId
       ;; counters against a freshly-wiped cluster). Idempotent across nodes.
       (reset! tiering-stats {})
+      (reset! replica-floors {})
+      (reset! committed-offsets-snapshot {})
       (reset! sc/authoritative-reads {})
       (sc/reset-run-state!)
       (install! test node)
@@ -374,13 +451,21 @@
       ;; Scrape this node's S3 counters into the run totals (brokers are still
       ;; up here, before teardown) so the coverage checker can read them.
       (util/meh (record-tiering-stats! node))
+      ;; Snapshot this node's manifest-replica cache (floor, epoch, context and
+      ;; leadership per jepsen stream) for the replica-consistency checker, while
+      ;; the brokers are still up.
+      (util/meh (record-replica-cache! node))
       ;; Authoritatively read every jepsen stream end-to-end for the durability
       ;; checker, once (on the primary), while the brokers are still up. The read
       ;; waits for each consumer to reach the stream's committed offset, so query
       ;; those (over SSH) and hand them to the read (which uses the Stream client
-      ;; over a fresh Environment, no SSH context).
+      ;; over a fresh Environment, no SSH context). The same committed offsets are
+      ;; the replica-consistency checker's stale-floor oracle, so snapshot them.
       (when (= node (first (:nodes test)))
-        (util/meh (sc/capture-authoritative-reads! test (committed-offsets node))))
+        (util/meh
+          (let [co (committed-offsets node)]
+            (reset! committed-offsets-snapshot co)
+            (sc/capture-authoritative-reads! test co))))
       ;; Broker logs + the S3 plugin's status output for post-mortem.
       (util/meh
         (rabbitmqctl node :stream_s3_status

--- a/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
+++ b/jepsen/jepsen.streams3/src/jepsen/streams3/db.clj
@@ -216,6 +216,12 @@
    "rabbitmq_stream_s3_persist_conflicts"
    "rabbitmq_stream_s3_syncs_rejected"
    "rabbitmq_stream_s3_resyncs_requested"
+   ;; The manifest-replica sync-context fix's gated path: a sync arriving for a
+   ;; stream with no registered replica context is dropped (rather than
+   ;; re-creating an unmonitored cache row) and a resync is requested once a
+   ;; context registers. The replica-consistency checker reports this as evidence
+   ;; the A2 guard actually engaged.
+   "rabbitmq_stream_s3_syncs_dropped_no_context"
    ;; S3-disruption evidence, reported for visibility (not asserted): the plugin
    ;; tolerates an s3-outage gracefully (writes stay local, uploads pause and
    ;; retry), so these often stay 0 even when the link is cut. The Toxiproxy


### PR DESCRIPTION
This is somewhat of a regression black-box test for https://github.com/amazon-mq/rabbitmq-stream-s3/pull/318. This adds a manifest-replica consistency checker and a s3-outage+leader-move scenario to exercise it. This is the whole-stack counterpart to `p/manifest-replica-lifecycle` and `tla/manifest-replication` models. Commit messages have the details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
