### PR TITLE
api aws pool: Make the pool testable without a real S3 endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include ../../erlang.mk
 # CT suites share a node name (erlang.mk limitation), so they cannot run in parallel.
 .NOTPARALLEL:
 
-CT_QUICK_SUITES = api_fs db replica_reader_core remote_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica manifest_replica_statem
+CT_QUICK_SUITES = api_fs db replica_reader_core remote_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica manifest_replica_statem api_aws_pool_statem
 
 ERLFMT ?= erlfmt
 ERLFMT_FILES = src/*.erl test/*.erl

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -65,7 +65,13 @@ the reader pool avoids reader starvation.
     %% Native monotonic timestamp at which each connection was opened; used
     %% to report age when a connection goes down unexpectedly.
     created = #{} :: #{conn() => integer()},
-    counter :: counters:counters_ref()
+    counter :: counters:counters_ref(),
+    %% Injection points so this pool can be driven in tests without a real S3
+    %% endpoint or `gun` connection. Default to the real behavior; see
+    %% `config()`.
+    open_fun :: open_fun(),
+    usable_fun :: usable_fun(),
+    close_fun :: close_fun()
 }).
 
 %% Gun connection pid.
@@ -76,10 +82,19 @@ the reader pool avoids reader starvation.
 %% An attempt to check out a conn. (Internal.)
 -type checkout() :: reference().
 
+-type open_fun() :: fun(() -> {ok, conn()} | {error, any()}).
+-type usable_fun() :: fun((conn()) -> boolean()).
+-type close_fun() :: fun((conn()) -> any()).
+
 -type config() :: #{
     name := pool(),
     min_size := non_neg_integer(),
-    max_size := pos_integer()
+    max_size := pos_integer(),
+    %% Test-only injection points; default to the real `open/0`, `usable/1`
+    %% and `gun:close/1` when absent. See issue #178.
+    open_fun => open_fun(),
+    usable_fun => usable_fun(),
+    close_fun => close_fun()
 }.
 
 %% API
@@ -100,6 +115,13 @@ the reader pool avoids reader starvation.
     terminate/2,
     code_change/3
 ]).
+
+-ifdef(TEST).
+%% Full-fidelity state dump for api_aws_pool_statem_SUITE. `format_state/1`
+%% (used for logging/`sys:get_status`) only reports sizes/counts, which is not
+%% enough to assert the `checkouts`/`checkouts_rev` mirror-image invariant.
+-export([test_inspect/1]).
+-endif.
 
 %%---------------------------------------------------------------------------
 
@@ -138,7 +160,7 @@ with(Pool, Timeout, Fun) ->
 start_link(Name, Config) ->
     gen_server:start_link({local, Name}, ?MODULE, Config, []).
 
-init(#{min_size := MinSize, max_size := MaxSize, name := Name}) ->
+init(#{min_size := MinSize, max_size := MaxSize, name := Name} = Config) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
     case rabbitmq_stream_s3_api:backend() of
         rabbitmq_stream_s3_api_aws ->
@@ -147,7 +169,14 @@ init(#{min_size := MinSize, max_size := MaxSize, name := Name}) ->
                 pool => Name
             }),
             self() ! grow,
-            {ok, #?MODULE{min_size = MinSize, max_size = MaxSize, counter = Cnt}};
+            {ok, #?MODULE{
+                min_size = MinSize,
+                max_size = MaxSize,
+                counter = Cnt,
+                open_fun = maps:get(open_fun, Config, fun open/0),
+                usable_fun = maps:get(usable_fun, Config, fun usable/1),
+                close_fun = maps:get(close_fun, Config, fun gun:close/1)
+            }};
         _ ->
             ignore
     end.
@@ -242,9 +271,9 @@ handle_gun_up(
         ]
     ),
     {noreply, make_available(Conn, State)};
-handle_gun_up(Conn, State) ->
+handle_gun_up(Conn, #?MODULE{close_fun = CloseFun} = State) ->
     %% Stale gun_up from a connection opened by a previous pool instance.
-    gun:close(Conn),
+    CloseFun(Conn),
     {noreply, State}.
 
 %% With retry=>0, gun stops the connection process immediately after sending
@@ -349,8 +378,8 @@ handle_info(Message, State) ->
 format_status(#{state := State0} = Status0) ->
     Status0#{state := format_state(State0)}.
 
-terminate(_Reason, #?MODULE{monitors = Monitors}) ->
-    _ = [gun:close(Conn) || Conn := _ <- Monitors],
+terminate(_Reason, #?MODULE{monitors = Monitors, close_fun = CloseFun}) ->
+    _ = [CloseFun(Conn) || Conn := _ <- Monitors],
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -377,8 +406,8 @@ grow(
 
 grow(0, State) ->
     State;
-grow(N, #?MODULE{monitors = Monitors0, created = Created0} = State0) ->
-    case open() of
+grow(N, #?MODULE{monitors = Monitors0, created = Created0, open_fun = OpenFun} = State0) ->
+    case OpenFun() of
         {ok, Conn} ->
             State = State0#?MODULE{
                 monitors = Monitors0#{Conn => erlang:monitor(process, Conn)},
@@ -452,12 +481,13 @@ take_available(
     #?MODULE{
         available = Available0,
         checkouts = Checkouts0,
-        checkouts_rev = CheckoutsRev0
+        checkouts_rev = CheckoutsRev0,
+        usable_fun = UsableFun
     } = State0
 ) ->
     case Available0 of
         [Conn | Available] ->
-            case usable(Conn) of
+            case UsableFun(Conn) of
                 true ->
                     MRef = erlang:monitor(process, Pid),
                     State = State0#?MODULE{
@@ -483,12 +513,13 @@ checkout(
         available = Available0,
         checkouts = Checkouts0,
         checkouts_rev = CheckoutsRev0,
-        counter = Cnt
+        counter = Cnt,
+        usable_fun = UsableFun
     } = State0
 ) ->
     case {queue:out(Pending0), Available0} of
         {{{value, #pending{from = From, mref = MRef}}, Pending}, [Conn | Available]} ->
-            case usable(Conn) of
+            case UsableFun(Conn) of
                 true ->
                     counters:add(Cnt, ?C_CHECKOUTS, 1),
                     gen_server:reply(From, Conn),
@@ -563,12 +594,14 @@ make_available(Conn, #?MODULE{available = Available, idle_timers = Timers} = Sta
 %% Close a connection and stop monitoring it. Used when the connection has
 %% been idle too long, or when its caller died holding it (and we cannot
 %% trust its on-wire state). A no-op if the connection is not in `monitors`.
-close_connection(Conn, #?MODULE{monitors = Monitors, created = Created} = State) when
+close_connection(
+    Conn, #?MODULE{monitors = Monitors, created = Created, close_fun = CloseFun} = State
+) when
     is_map_key(Conn, Monitors)
 ->
     ConnMRef = maps:get(Conn, Monitors),
     erlang:demonitor(ConnMRef, [flush]),
-    gun:close(Conn),
+    CloseFun(Conn),
     State#?MODULE{
         monitors = maps:remove(Conn, Monitors),
         created = maps:remove(Conn, Created)
@@ -601,3 +634,26 @@ format_state(#?MODULE{
         checkouts => map_size(Checkouts),
         pending => queue:len(Pending)
     }.
+
+-ifdef(TEST).
+test_inspect(Pool) ->
+    #?MODULE{
+        available = Available,
+        monitors = Monitors,
+        checkouts = Checkouts,
+        checkouts_rev = CheckoutsRev,
+        pending = Pending,
+        idle_timers = IdleTimers
+    } = sys:get_state(Pool),
+    #{
+        available => Available,
+        monitors => Monitors,
+        checkouts => Checkouts,
+        checkouts_rev => CheckoutsRev,
+        pending => [
+            From
+         || #pending{from = From} <- queue:to_list(Pending)
+        ],
+        idle_timers => IdleTimers
+    }.
+-endif.

--- a/test/api_aws_pool_statem_SUITE.erl
+++ b/test/api_aws_pool_statem_SUITE.erl
@@ -1,0 +1,373 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(api_aws_pool_statem_SUITE).
+-moduledoc """
+Property-based (proper_statem) model of rabbitmq_stream_s3_api_aws_pool.
+
+The pool's `open/0` calls `gun:open/3` directly and `usable/1` calls
+`gun:info/1` (which internally makes a `sys:get_state/1` call to the gun
+`gen_statem`), so exercising it against a real state-machine bug needs either
+a real S3 endpoint or, per
+https://github.com/amazon-mq/rabbitmq-stream-s3/issues/178, injectable
+`open_fun`/`usable_fun`/`close_fun`. This suite starts the pool with fakes
+that spawn/track/kill plain Erlang processes instead of `gun` connections, and
+drives the real gen_server through randomized concurrent checkout/checkin/kill
+sequences (checkout callers are spawned processes, since `checkout/2` is a
+single blocking `gen_server:call` -- there is no non-blocking variant to
+model).
+
+The postconditions are the properties this refactor exists to regression-test
+(see #177, #178):
+
+1. `checkouts` and `checkouts_rev` are always exact mirror images of each
+   other, and every connection in `available` or `checkouts` is a key of
+   `monitors` (checked after every command).
+2. A caller dying while holding a checked-out connection (the #177
+   regression) causes that connection to be dropped -- never returned to
+   `available` -- and a replacement grown.
+3. A connection process dying (simulating a `gun` crash) is removed from all
+   tracking and a replacement is grown.
+4. A caller queued in `pending` (pool at `max_size`, all checked out) is
+   served once a connection frees up, and a pending caller that dies is
+   removed from the queue without leaking its entry.
+
+Idle-timeout behavior (#5 in the issue's checklist) is not modeled: it would
+require also making `?IDLE_TIMEOUT_MS` injectable (out of scope for #178,
+which only asks for open/usable/close) and, at a real 10s window, would make
+each `?FORALL` iteration far more expensive for little additional coverage
+over the invariants above.
+""".
+
+-compile([export_all, nowarn_export_all]).
+
+-behaviour(proper_statem).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-define(POOL, statem_aws_pool).
+-define(MIN_SIZE, 1).
+-define(MAX_SIZE, 2).
+%% Comfortably larger than the real `checkout/2` timeout below, so a poll for
+%% the caller's outcome always has time to observe either a served checkout
+%% or the caller's own timeout-triggered cancellation.
+-define(CHECKOUT_TIMEOUT_MS, 300).
+-define(RELEASE_AWAIT_MS, 1500).
+-define(AWAIT_MS, 1500).
+
+all() ->
+    [no_leak_or_inconsistency].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(seshat),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws
+    ),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+%% ------------------------------------------------------------------
+%% Test case
+%% ------------------------------------------------------------------
+
+no_leak_or_inconsistency(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_no_leak_or_inconsistency/0, [], 150).
+
+prop_no_leak_or_inconsistency() ->
+    ?FORALL(
+        Cmds,
+        commands(?MODULE),
+        begin
+            _ = seshat:new_group(rabbitmq_stream_s3),
+            {ok, Pid} = rabbitmq_stream_s3_api_aws_pool:start_link(?POOL, pool_config()),
+            unlink(Pid),
+            {History, State, Result} = run_commands(?MODULE, Cmds),
+            cleanup_callers(State),
+            gen_server:stop(?POOL),
+            ?WHENFAIL(
+                io:format(
+                    "~n~nFailing command sequence~nHistory: ~p~nState: ~p~nResult: ~p~n",
+                    [History, State, Result]
+                ),
+                Result =:= ok
+            )
+        end
+    ).
+
+pool_config() ->
+    #{
+        name => ?POOL,
+        min_size => ?MIN_SIZE,
+        max_size => ?MAX_SIZE,
+        open_fun => fun fake_open/0,
+        usable_fun => fun fake_usable/1,
+        close_fun => fun fake_close/1
+    }.
+
+%% Reap any caller whose checkout was never released or killed during this
+%% ?FORALL iteration; it only blocks on `receive ... end`, so nothing but a
+%% `stop`/`checkin` message or an explicit kill ever ends it.
+cleanup_callers(State) ->
+    maps:foreach(
+        fun
+            (_CallerId, idle) -> ok;
+            (_CallerId, {busy, Pid}) -> catch exit(Pid, kill)
+        end,
+        State
+    ).
+
+%% ------------------------------------------------------------------
+%% proper_statem callbacks
+%% ------------------------------------------------------------------
+
+%% One caller slot more than `?MAX_SIZE` so concurrent checkouts reliably
+%% queue in `pending`.
+caller_ids() -> [c1, c2, c3].
+
+initial_state() ->
+    #{Id => idle || Id <- caller_ids()}.
+
+command(S) ->
+    frequency([
+        {6,
+            ?LET(
+                CallerId,
+                elements(caller_ids()),
+                command_for_caller(CallerId, maps:get(CallerId, S))
+            )},
+        {1, {call, ?MODULE, do_kill_conn, []}}
+    ]).
+
+command_for_caller(CallerId, idle) ->
+    {call, ?MODULE, do_checkout, [CallerId]};
+command_for_caller(CallerId, {busy, Pid}) ->
+    oneof([
+        {call, ?MODULE, do_release, [CallerId, Pid]},
+        {call, ?MODULE, do_kill, [CallerId, Pid]}
+    ]).
+
+precondition(_S, _Call) ->
+    true.
+
+next_state(S, V, {call, _, do_checkout, [CallerId]}) ->
+    S#{CallerId => {busy, V}};
+next_state(S, _V, {call, _, do_release, [CallerId, _Pid]}) ->
+    S#{CallerId => idle};
+next_state(S, _V, {call, _, do_kill, [CallerId, _Pid]}) ->
+    S#{CallerId => idle};
+next_state(S, _V, {call, _, do_kill_conn, []}) ->
+    S.
+
+postcondition(_S, {call, _, do_checkout, [_CallerId]}, Pid) ->
+    is_pid(Pid) andalso invariant_ok();
+postcondition(_S, {call, _, do_release, [_CallerId, _Pid]}, Result) ->
+    invariant_ok() andalso
+        case Result of
+            {released, Conn} ->
+                %% Property 1: a checked-in connection is tracked and either
+                %% back on the shelf or has already been handed to a pending
+                %% caller -- never simply dropped. (A concurrent `do_kill_conn`
+                %% may have already reaped it entirely in the meantime; that is
+                %% also fine, just not "checked out and back in `available`
+                %% while still claiming to be untracked".)
+                ok =:=
+                    await(fun() ->
+                        #{available := A, checkouts := C, monitors := M} = test_inspect(),
+                        not maps:is_key(Conn, M) orelse
+                            (lists:member(Conn, A) orelse maps:is_key(Conn, C))
+                    end);
+            {not_checked_out, _} ->
+                true
+        end;
+postcondition(_S, {call, _, do_kill, [_CallerId, Pid]}, Conn) ->
+    invariant_ok() andalso
+        case Conn of
+            none ->
+                %% Caller died without ever holding a connection: it must
+                %% not linger in the pending queue.
+                ok =:= await(fun() -> not caller_in_pending(Pid) end);
+            _ when is_pid(Conn) ->
+                %% Property 2 (#177 regression): a connection whose caller
+                %% died while it was checked out must never be handed back
+                %% out, and the pool must grow a replacement.
+                ok =:=
+                    await(fun() ->
+                        #{available := A, checkouts := C, monitors := M} = test_inspect(),
+                        not lists:member(Conn, A) andalso
+                            not maps:is_key(Conn, C) andalso
+                            not maps:is_key(Conn, M) andalso
+                            map_size(M) >= ?MIN_SIZE
+                    end)
+        end;
+postcondition(_S, {call, _, do_kill_conn, []}, no_conn) ->
+    true;
+postcondition(_S, {call, _, do_kill_conn, []}, Conn) when is_pid(Conn) ->
+    %% Property 3: a connection process dying is removed from all tracking
+    %% and a replacement is grown.
+    invariant_ok() andalso
+        ok =:=
+            await(fun() ->
+                #{available := A, checkouts := C, monitors := M} = test_inspect(),
+                not lists:member(Conn, A) andalso
+                    not maps:is_key(Conn, C) andalso
+                    not maps:is_key(Conn, M) andalso
+                    map_size(M) >= ?MIN_SIZE
+            end).
+
+%% ------------------------------------------------------------------
+%% Command implementations (real calls against the running gen_server)
+%% ------------------------------------------------------------------
+
+%% Spawns a caller process that performs the real (blocking) checkout call
+%% and reports its outcome back to us, then waits to be released or killed.
+%% Modeling checkout this way (rather than calling it inline) is what lets a
+%% single ?FORALL iteration exercise concurrent/pending checkouts and kill a
+%% caller mid-checkout.
+do_checkout(CallerId) ->
+    TestPid = self(),
+    spawn(fun() ->
+        Result =
+            try rabbitmq_stream_s3_api_aws_pool:checkout(?POOL, ?CHECKOUT_TIMEOUT_MS) of
+                Conn -> {ok, Conn}
+            catch
+                C:E -> {error, {C, E}}
+            end,
+        TestPid ! {checkout_result, CallerId, self(), Result},
+        receive
+            stop -> ok
+        end
+    end).
+
+%% Waits (bounded, comfortably past the caller's own checkout timeout) for
+%% the caller's outcome, checks the connection back in if it got one, and
+%% tells the caller to stop.
+do_release(_CallerId, Pid) ->
+    receive
+        {checkout_result, _, Pid, {ok, Conn}} ->
+            ok = rabbitmq_stream_s3_api_aws_pool:checkin(?POOL, Conn),
+            Pid ! stop,
+            {released, Conn};
+        {checkout_result, _, Pid, {error, _}} ->
+            Pid ! stop,
+            {not_checked_out, error}
+    after ?RELEASE_AWAIT_MS ->
+        Pid ! stop,
+        {not_checked_out, timeout}
+    end.
+
+%% Kills the caller outright, whether it is still waiting on the checkout
+%% call (possibly queued in `pending`) or already holding a connection. A
+%% short bounded peek at our mailbox first: fake connections have no real I/O,
+%% so a checkout that can be served at all is served near-instantly; this
+%% window is to let that race settle (not to wait out a genuinely pending
+%% checkout, which will still time out here and correctly fall to the
+%% pending-queue-death branch). If the caller already reported a successful
+%% checkout, its connection is the one the #177 regression must never hand
+%% back out.
+do_kill(_CallerId, Pid) ->
+    Conn =
+        receive
+            {checkout_result, _, Pid, {ok, C}} -> C;
+            {checkout_result, _, Pid, {error, _}} -> none
+        after 100 -> none
+        end,
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 2000 -> ok
+    end,
+    Conn.
+
+%% Kills a live fake connection outright, simulating a `gun` crash.
+do_kill_conn() ->
+    #{monitors := Monitors} = test_inspect(),
+    case maps:keys(Monitors) of
+        [] ->
+            no_conn;
+        Conns ->
+            Conn = lists:nth(rand:uniform(length(Conns)), Conns),
+            exit(Conn, kill),
+            Conn
+    end.
+
+%% ------------------------------------------------------------------
+%% Fakes (config injection points; see issue #178)
+%% ------------------------------------------------------------------
+
+%% A fake connection is a plain process that only understands `stop`. Real
+%% `gun` only reports a connection usable once it sends `gun_up` (see
+%% `handle_gun_up/2`); `open_fun` runs synchronously inside the pool's own
+%% `grow/2` (called from `init/1`, `handle_call/3`, etc.), so `self()` here is
+%% the pool itself -- sending `gun_up` to it immediately, queued right behind
+%% the message currently being handled, mimics that as closely as a fake
+%% connection can without speaking gun's wire protocol.
+fake_open() ->
+    Pid = spawn(fun() -> fake_conn_loop() end),
+    self() ! {gun_up, Pid, http},
+    {ok, Pid}.
+
+fake_conn_loop() ->
+    receive
+        stop -> ok
+    end.
+
+%% A fake connection is usable exactly as long as it is alive: no real
+%% `gun`/`sys:get_state` protocol to speak to (that call is what motivated
+%% this injection point -- see moduledoc).
+fake_usable(Conn) ->
+    is_process_alive(Conn).
+
+fake_close(Conn) ->
+    catch exit(Conn, kill),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+test_inspect() ->
+    rabbitmq_stream_s3_api_aws_pool:test_inspect(?POOL).
+
+caller_in_pending(Pid) ->
+    #{pending := Pending} = test_inspect(),
+    lists:any(fun({P, _Tag}) -> P =:= Pid end, Pending).
+
+await(Fun) ->
+    await(Fun, ?AWAIT_MS).
+
+await(_Fun, Remaining) when Remaining =< 0 ->
+    {error, timeout};
+await(Fun, Remaining) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(20),
+            await(Fun, Remaining - 20)
+    end.
+
+%% ------------------------------------------------------------------
+%% Global structural invariants (checked after every command)
+%% ------------------------------------------------------------------
+
+invariant_ok() ->
+    #{
+        available := Available,
+        monitors := Monitors,
+        checkouts := Checkouts,
+        checkouts_rev := CheckoutsRev
+    } = test_inspect(),
+    %% `checkouts` and `checkouts_rev` are always exact mirror images.
+    map_size(Checkouts) =:= map_size(CheckoutsRev) andalso
+        lists:all(
+            fun({Conn, MRef}) -> maps:get(MRef, CheckoutsRev, undefined) =:= Conn end,
+            maps:to_list(Checkouts)
+        ) andalso
+        %% Every connection in `available` or `checkouts` is tracked by
+        %% `monitors`.
+        lists:all(fun(Conn) -> maps:is_key(Conn, Monitors) end, Available) andalso
+        lists:all(fun(Conn) -> maps:is_key(Conn, Monitors) end, maps:keys(Checkouts)).


### PR DESCRIPTION
open/0 called gun:open/3 directly with no injection point, so the pool's state machine (checkouts/checkouts_rev kept in lockstep, the #177 caller-death handling, connection replacement) could only be regression-tested against a real S3 endpoint. Adds open_fun/usable_fun/ close_fun config keys, each defaulting to today's real behaviour, so tests can drive the pool with plain Erlang processes standing in for gun connections. usable_fun and close_fun are needed alongside open_fun because usable/1 calls gun:info/1 (a sys:get_state/1 call a fake process can't answer) and gun:close/1 silently no-ops on a pid outside its own supervision tree.

Adds a proper_statem suite driving the real gen_server through randomized concurrent checkout/checkin/kill sequences, checking the checkouts/checkouts_rev mirror invariant, the #177 regression (a checked-out connection whose caller died must never be reused), a crashed connection being replaced, and pending-queue handling under caller death.

See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/178


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
