### PR TITLE
manifest replica: Gate apply_edits on a live reader context

### DIFF
--- a/.github/workflows/p-model-check.yaml
+++ b/.github/workflows/p-model-check.yaml
@@ -396,7 +396,7 @@ jobs:
           cd p/manifest-replica-lifecycle
           for tc in tcCleanupGuarded tcStaleSyncGuarded tcReregisterGuarded \
                     tcConvergenceGuarded tcForgetReleasesWriterRow tcSyncAfterExitFixed \
-                    tcStartupRaceContextFirst tcReconcileRaceResync tcExplore; do
+                    tcEditAfterExitFixed tcStartupRaceContextFirst tcReconcileRaceResync tcExplore; do
             echo "::group::$tc (expect hold)"
             p check -tc "$tc" -i 5000
             echo "::endgroup::"
@@ -434,6 +434,9 @@ jobs:
           # The gap this model surfaces: a sync after a member DOWN re-strands the
           # row (the shipped-in-this-branch A2 guard closes it in tcSyncAfterExitFixed).
           check_gate tcSyncAfterExitStrands 'NOLEAK violated: replica holds per-node state for stream 0 with no live reader'
+          # The same gap on the other write path: apply_edits needed the identical
+          # A2 guard sync already had (tcEditAfterExitFixed closes it).
+          check_gate tcEditAfterExitStrands 'NOLEAK violated: replica holds per-node state for stream 0 with no live reader'
           # Liveness: syncs dropped forever (tcConvergenceStuck), and the two
           # startup triggers that starve the cache without recovery - the
           # WriterFirst acceptor race (A1 fixes it) and the writer-driven reconcile

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include ../../erlang.mk
 # CT suites share a node name (erlang.mk limitation), so they cannot run in parallel.
 .NOTPARALLEL:
 
-CT_QUICK_SUITES = api_fs db replica_reader_core remote_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica
+CT_QUICK_SUITES = api_fs db replica_reader_core remote_reader_core replica_reader log_reader fragment_iterator fragment_assembly prop manifest_replica manifest_replica_statem
 
 ERLFMT ?= erlfmt
 ERLFMT_FILES = src/*.erl test/*.erl

--- a/p/manifest-replica-lifecycle/PSrc/Common.p
+++ b/p/manifest-replica-lifecycle/PSrc/Common.p
@@ -28,7 +28,14 @@
    Syncs from the writer are fire-and-forget casts (eMRSync) that the scheduler
    may drop, delay, or reorder relative to a member exit - the same multi-node
    stale-cache substrate as ../gc-reset-multinode. is_stale_sync gates them:
-   epoch dominates sequence, so a delayed lower-epoch sync is rejected. */
+   epoch dominates sequence, so a delayed lower-epoch sync is rejected.
+
+   Sequenced edits from the writer (apply_edits/5) are a second fire-and-forget
+   write path, eMREdit, modeled distinctly from eMRSync because it requires
+   exact seq contiguity (last_seq + 1) against seqs rather than eMRSync's
+   monotonic-epoch reset check. A recent fix gated eMREdit on a live context
+   exactly like eMRSync already was, reusing the same syncRequiresContextEnabled
+   toggle: see tcEditAfterExitStrands/Fixed in PTst/TestDrivers.p. */
 
 /* A stream id (small ints). */
 type StreamId = int;
@@ -50,6 +57,12 @@ event eDownAck;
 /* sync/5: a full-manifest sync from the writer, fire-and-forget (cast). Carries
    the writer's epoch and sequence; applied only if not is_stale_sync. */
 event eMRSync: (stream: StreamId, floor: int, epoch: int, sn: int, writerNode: int);
+
+/* apply_edits/5: sequenced edits applied to the cached manifest, fire-and-forget
+   (cast). Applied only if sn == last_seq + 1 for the stream's recorded seq (a
+   gap or epoch mismatch is otherwise dropped without touching cache/seqs); same
+   shape as eMRSync so the two write paths can share a driver/writer plumbing. */
+event eMREdit: (stream: StreamId, floor: int, epoch: int, sn: int, writerNode: int);
 
 /* put_manifest/3: the WRITER node writes its own cache row directly (no osiris
    member to monitor); released explicitly by forget/1. Synchronous. */
@@ -82,6 +95,11 @@ event eCommitAck;
 event eEmitSync: (from: machine, target: machine, stream: StreamId,
                   floor: int, epoch: int, sn: int);
 event eEmitAck;
+
+/* Emit an edit (cast) to a replica for a chosen (floor, epoch, sn), the eMREdit
+   counterpart to eEmitSync. Shares eEmitAck. */
+event eEmitEdit: (from: machine, target: machine, stream: StreamId,
+                  floor: int, epoch: int, sn: int);
 
 /* Synchronous barrier through the writer: flushes prior writer->replica casts. */
 event eBarrier: (from: machine, target: machine);

--- a/p/manifest-replica-lifecycle/PSrc/ManifestReplica.p
+++ b/p/manifest-replica-lifecycle/PSrc/ManifestReplica.p
@@ -8,7 +8,7 @@
    plus a reverse index monitors : mref -> stream so a DOWN can find the stream
    to release, exactly as the shipped #state{} carries.
 
-   Four toggles let the validation-gate tests remove one guard at a time:
+   Five toggles let the validation-gate tests remove one guard at a time:
 
      cleanupEnabled            : G1. On a member DOWN, release_stream/2 drops all
                                  per-stream state. OFF models the pre-cc50092 code
@@ -22,16 +22,19 @@
                                  DOWN cannot evict the new context. OFF leaves the
                                  stale mref in the reverse index, so the old DOWN
                                  releases the LIVE new context.
-     syncRequiresContextEnabled: A2. A PROPOSED (not shipped) fix for the gap this
-                                 model surfaces: ignore a sync for a stream with
-                                 no registered context, so a sync that arrives
+     syncRequiresContextEnabled: A2. Ignore a sync OR an edit for a stream with no
+                                 registered context, so either write path arriving
                                  after the member DOWN cannot re-strand a row.
-                                 OFF (the shipped behaviour) re-creates the row.
-     resyncOnRegisterEnabled   : A1'. The PROPOSED writer-independent recovery for
-                                 A2: on registering a context, request a resync
-                                 from the writer (request_resync/2), so the writer
-                                 re-sends the manifest even if an earlier premature
-                                 sync - from the acceptor reply OR the writer-driven
+                                 OFF (the pre-fix behaviour) re-creates the row
+                                 from either path; this now-shipped guard covers
+                                 eMRSync and eMREdit identically (one check, one
+                                 toggle, mirroring the real code's shared
+                                 drop_no_context/6 helper).
+     resyncOnRegisterEnabled   : A1'. The writer-independent recovery for A2: on
+                                 registering a context, request a resync from the
+                                 writer (request_resync/2), so the writer re-sends
+                                 the manifest even if an earlier premature sync or
+                                 edit - from the acceptor reply OR the writer-driven
                                  reconcile path - was dropped by A2. Unlike the A1
                                  attach-ordering fix, this covers the reconcile
                                  trigger, which A1 cannot reach. */
@@ -124,7 +127,7 @@ machine ManifestReplica {
       send p.from, eDownAck;
     }
 
-    /* maybe_apply_sync/7: a fire-and-forget full-manifest sync from the writer.
+    /* maybe_apply_sync/8: a fire-and-forget full-manifest sync from the writer.
        Drop it when is_stale_sync (the recorded (epoch, sn) is at least as new).
        Otherwise write the cache row, update the gap sequence, and announce the
        new cached floor to the monitors. */
@@ -137,9 +140,10 @@ machine ManifestReplica {
         stale = StaleLex(p.epoch, p.sn, rec.epoch, rec.sn);
       }
       if (!stale) {
-        /* PROPOSED gap fix: ignore a sync for a stream with no live context, so
-           a sync racing/after a member DOWN cannot re-strand a cache row. The
-           shipped code does NOT do this (syncRequiresContextEnabled == false). */
+        /* A2 (syncRequiresContextEnabled): ignore a sync for a stream with no
+           live context, so a sync racing/after a member DOWN cannot re-strand a
+           cache row. Models the shipped fix; OFF reproduces the pre-fix code
+           that re-creates the row (tcSyncAfterExitStrands). */
         if (syncRequiresContextEnabled && !(p.stream in contexts)) {
           return;
         }
@@ -147,6 +151,41 @@ machine ManifestReplica {
         seqs[p.stream] = (epoch = p.epoch, sn = p.sn, writerNode = p.writerNode);
         announce eCacheUpdated, (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
       }
+    }
+
+    /* apply_edits/5: a fire-and-forget batch of sequenced edits from the writer.
+       Requires sn == last_seq + 1 against seqs (a gap or epoch mismatch is
+       dropped without touching cache/seqs; the real code requests a resync
+       there, which this model already covers for free via the unconditional
+       resync-on-register in eRegister above). A stream with no recorded seq yet
+       accepts the edit as a fresh baseline - the same "unrecorded is never
+       rejected" convention eMRSync's StaleLex already uses, since gap-recovery
+       of a genuinely out-of-order first arrival is a data-prefix concern left
+       to the TLA+ companion model (see README), not this model's lifecycle
+       scope.
+
+       Same gate as eMRSync (syncRequiresContextEnabled, A2): drop an edit for a
+       stream with no live context, so an edit racing/after a member DOWN
+       cannot re-strand a cache row either. */
+    on eMREdit do (p: (stream: StreamId, floor: int, epoch: int, sn: int, writerNode: int)) {
+      var gap: bool;
+      var rec: (epoch: int, sn: int, writerNode: int);
+      if (syncRequiresContextEnabled && !(p.stream in contexts)) {
+        return;
+      }
+      gap = false;
+      if (p.stream in seqs) {
+        rec = seqs[p.stream];
+        if (!(rec.epoch == p.epoch && rec.sn + 1 == p.sn)) {
+          gap = true;
+        }
+      }
+      if (gap) {
+        return;
+      }
+      cache[p.stream] = (floor = p.floor, epoch = p.epoch, sn = p.sn);
+      seqs[p.stream] = (epoch = p.epoch, sn = p.sn, writerNode = p.writerNode);
+      announce eCacheUpdated, (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn);
     }
 
     /* put_manifest/3: the writer node writes its own cache row (no member). */

--- a/p/manifest-replica-lifecycle/PSrc/Writer.p
+++ b/p/manifest-replica-lifecycle/PSrc/Writer.p
@@ -51,6 +51,15 @@ machine Writer {
       send p.from, eEmitAck;
     }
 
+    /* The eMREdit counterpart to eEmitSync: emit a sequenced edit instead of a
+       full-manifest reset. */
+    on eEmitEdit do (p: (from: machine, target: machine, stream: StreamId,
+                         floor: int, epoch: int, sn: int)) {
+      send p.target, eMREdit,
+        (stream = p.stream, floor = p.floor, epoch = p.epoch, sn = p.sn, writerNode = 0);
+      send p.from, eEmitAck;
+    }
+
     /* Synchronous barrier: flush prior writer->target sync casts by riding the
        FIFO behind them, then confirm to the caller. */
     on eBarrier do (p: (from: machine, target: machine)) {

--- a/p/manifest-replica-lifecycle/PTst/TestDrivers.p
+++ b/p/manifest-replica-lifecycle/PTst/TestDrivers.p
@@ -15,7 +15,9 @@
    GAP (headline finding): with every SHIPPED guard on, a sync that arrives after
    a member DOWN re-creates a cache row for a stream the cleanup already released,
    stranding it forever (no monitor will ever fire again). tcSyncAfterExitStrands
-   demonstrates it; tcSyncAfterExitFixed shows a proposed guard closing it. */
+   demonstrates it; tcSyncAfterExitFixed shows a proposed guard closing it.
+   tcEditAfterExitStrands/Fixed prove the same guard closes the identical gap on
+   the other write path, apply_edits (eMREdit), not just sync. */
 
 fun Register(self: machine, replica: machine, stream: StreamId): int {
   var mref: int;
@@ -40,6 +42,15 @@ fun Commit(self: machine, writer: machine, stream: StreamId, floor: int, epoch: 
 fun EmitSync(self: machine, writer: machine, replica: machine,
              stream: StreamId, floor: int, epoch: int, sn: int) {
   send writer, eEmitSync,
+    (from = self, target = replica, stream = stream, floor = floor, epoch = epoch, sn = sn);
+  receive { case eEmitAck: { } }
+}
+
+/* Emit an edit cast (not yet applied); call Barrier to flush it. The eMREdit
+   counterpart to EmitSync, exercising apply_edits instead of sync. */
+fun EmitEdit(self: machine, writer: machine, replica: machine,
+             stream: StreamId, floor: int, epoch: int, sn: int) {
+  send writer, eEmitEdit,
     (from = self, target = replica, stream = stream, floor = floor, epoch = epoch, sn = sn);
   receive { case eEmitAck: { } }
 }
@@ -239,6 +250,35 @@ fun RunSyncAfterExit(self: machine, gapFix: bool) {
 
 machine DriverSyncAfterExitStrands { start state Init { entry { RunSyncAfterExit(this, false); } } }
 machine DriverSyncAfterExitFixed { start state Init { entry { RunSyncAfterExit(this, true); } } }
+
+/* ---- GAP: edit after exit (the same finding, for apply_edits) ---- */
+
+/* Same shape as RunSyncAfterExit, but the write-path event is eMREdit
+   (apply_edits) instead of eMRSync (sync). Proves the SAME syncRequiresContext
+   guard (A2) that closes the sync strand also closes the edit strand: the
+   apply_edits handlers gained the identical maps:is_key(StreamId, Ctxs) check
+   (drop_no_context/6) that maybe_apply_sync/8 already had. Every shipped guard
+   on; gapFix selects the proposed/now-shipped guard under test. */
+fun RunEditAfterExit(self: machine, gapFix: bool) {
+  var replica: machine;
+  var writer: machine;
+  var mref: int;
+  writer = new Writer();
+  replica = NewReplica(true, true, true, gapFix, false, writer);
+  Commit(self, writer, 0, 1000, 1, 1);
+  mref = Register(self, replica, 0);
+  EmitEdit(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  /* Synchronous: the cleanup has fully released the stream before we proceed. */
+  MemberDown(self, replica, 0, mref);
+  /* The straggler edit, now strictly after the release. */
+  EmitEdit(self, writer, replica, 0, 1000, 1, 1);
+  Barrier(self, writer, replica);
+  Quiesce(self, replica);
+}
+
+machine DriverEditAfterExitStrands { start state Init { entry { RunEditAfterExit(this, false); } } }
+machine DriverEditAfterExitFixed { start state Init { entry { RunEditAfterExit(this, true); } } }
 
 /* ---- STARTUP RACE: attach ordering vs the syncRequiresContext guard ---- */
 
@@ -473,6 +513,14 @@ test tcSyncAfterExitStrands [main = DriverSyncAfterExitStrands]:
 test tcSyncAfterExitFixed [main = DriverSyncAfterExitFixed]:
   assert ReplicaStateMatchesReaders in
   { DriverSyncAfterExitFixed, ManifestReplica, Writer };
+
+test tcEditAfterExitStrands [main = DriverEditAfterExitStrands]:
+  assert ReplicaStateMatchesReaders in
+  { DriverEditAfterExitStrands, ManifestReplica, Writer };
+
+test tcEditAfterExitFixed [main = DriverEditAfterExitFixed]:
+  assert ReplicaStateMatchesReaders in
+  { DriverEditAfterExitFixed, ManifestReplica, Writer };
 
 test tcExplore [main = DriverExplore]:
   assert ReplicaStateMatchesReaders, NoStaleFloorServed in

--- a/p/manifest-replica-lifecycle/README.md
+++ b/p/manifest-replica-lifecycle/README.md
@@ -17,9 +17,13 @@ osiris has no terminate or delete hook, so a member `DOWN` (via `monitor/2`) is 
 
 The model abstracts a member to its monitor reference: the replica's only handle on a member is the monitor it holds. The driver starts and kills members; a kill is `eMemberDown` with that mref (the modeled `'DOWN'`).
 
+There are two write-path events into this state, both fire-and-forget casts from the writer: `eMRSync` (`sync/5`, a full-manifest reset checked against `is_stale_sync`) and `eMREdit` (`apply_edits/5`, a sequenced edit that requires `sn == last_seq + 1` against a recorded `seqs` entry, else a gap dropped without touching cache/seqs; a stream with no recorded entry yet accepts, the same "unrecorded is never rejected" convention `eMRSync` uses, since resolving a first-arrival gap is a data-prefix concern the TLA+ companion model owns, not this one). They are deliberately distinct events rather than one, because their acceptance checks differ, but the resource-lifecycle question this model asks - is the write gated on a live context, so it can never write a row no monitor will ever reclaim - is identical for both, and `syncRequiresContextEnabled` (A2) gates both with one check.
+
 ## The gap: a contextless sync strands the cache
 
 With every shipped guard on, cleanup is not airtight. A sync arriving after a member `DOWN`, when cleanup has already released the stream, falls through `maybe_apply_sync` with `Recorded == undefined`, so `is_stale_sync` returns `false` and `write_manifest` re-inserts the ETS row and `seqs` with no context and no monitor: nothing will ever `'DOWN'` to reclaim it. It lingers rather than being a narrow window because the writer keeps broadcasting to a departed node (decoupling 2 below). It re-introduces exactly the accretion `cc50092` killed. `tcSyncAfterExitStrands` reproduces it (NOLEAK).
+
+The same gap exists on the `apply_edits` path: before the fix below, only `maybe_apply_sync` checked for a live context, so a straggler edit delivered after the `DOWN` re-inserted the row exactly as a straggler sync did. `tcEditAfterExitStrands` reproduces the identical `NOLEAK` counterexample by driving `eMREdit` instead of `eMRSync` after the member exit; `tcEditAfterExitFixed` shows the same `syncRequiresContext` guard closes it.
 
 ## The fix: A2 + A1', and why the guard alone is unsafe
 
@@ -37,8 +41,8 @@ A1' (resync-on-register) covers both: on registering a context the replica reque
 
 ### Machines (`PSrc/`)
 
-- `ManifestReplica`, the system under test: the three maps and reverse index, with a toggle per guard so each gate can remove one (`cleanupEnabled`, `staleSyncGuardEnabled`, `repointEnabled`, `syncRequiresContextEnabled`, `resyncOnRegisterEnabled`)
-- `Writer`, the writer-side broadcaster (`rabbitmq_stream_s3_replica_reader`): the authoritative source of committed floors and the emitter of fire-and-forget syncs, answering two triggers from its persisted floor, `eReconcile` (member-visible-driven, independent of `register_acceptor`) and `eResync` (a replica's `request_resync`)
+- `ManifestReplica`, the system under test: the three maps and reverse index, with a toggle per guard so each gate can remove one (`cleanupEnabled`, `staleSyncGuardEnabled`, `repointEnabled`, `syncRequiresContextEnabled`, `resyncOnRegisterEnabled`), and two write-path events sharing those gates, `eMRSync` (`sync/5`) and `eMREdit` (`apply_edits/5`)
+- `Writer`, the writer-side broadcaster (`rabbitmq_stream_s3_replica_reader`): the authoritative source of committed floors and the emitter of fire-and-forget syncs and edits, answering two triggers from its persisted floor, `eReconcile` (member-visible-driven, independent of `register_acceptor`) and `eResync` (a replica's `request_resync`)
 - `AttachNode` and `ContextRegistrar`, which drive the attach order (the `contextFirst` axis) and the concurrent reconcile race, so a startup sync can be scheduled before or after context registration
 
 ### Monitors (`PSpec/`)
@@ -62,6 +66,8 @@ A1' (resync-on-register) covers both: on registering a context the replica reque
 | `tcForgetReleasesWriterRow` | holds: the writer-node `put_manifest` row is released by `forget/1` |
 | `tcSyncAfterExitStrands` | fails: all shipped guards on, and a sync after the `DOWN` re-strands the row: the same `NOLEAK` counterexample, the gap |
 | `tcSyncAfterExitFixed` | holds: the `syncRequiresContext` guard (A2) ignores the post-exit sync |
+| `tcEditAfterExitStrands` | fails: the same setup, but the write-path event is `eMREdit` (`apply_edits`) instead of `eMRSync`; the identical `NOLEAK` counterexample, proving `apply_edits` needed the same gate |
+| `tcEditAfterExitFixed` | holds: the same `syncRequiresContext` guard (A2) ignores the post-exit edit |
 | `tcStartupRaceWriterFirst` | fails: A2 on plus the shipped writer-first attach; a startup sync beats context registration, is dropped, and is never re-sent: `ReplicaConverges detected liveness bug in hot state 'Lagging' at the end of program execution` (the cache stays empty and NOLEAK stays green, so the guard alone is unsafe) |
 | `tcStartupRaceContextFirst` | holds: A1 attach-ordering (context before writer) plus A2; the startup sync always lands and the post-`DOWN` straggler is dropped (convergence and NOLEAK) |
 | `tcReconcileRaceNoResync` | fails: A1-consistent registration plus A2 with A1' off; the writer-driven reconcile sync races ahead of the context, is dropped, and is never re-sent: `ReplicaConverges detected liveness bug in hot state 'Lagging' at the end of program execution` (A1 cannot cover the writer-side trigger) |
@@ -78,6 +84,7 @@ p check -tc tcReregisterGuarded     -i 2000   # 0 bugs
 p check -tc tcConvergenceGuarded    -i 2000   # 0 bugs
 p check -tc tcForgetReleasesWriterRow -i 2000 # 0 bugs
 p check -tc tcSyncAfterExitFixed    -i 2000   # 0 bugs (A2 closes the strand)
+p check -tc tcEditAfterExitFixed    -i 2000   # 0 bugs (A2 closes the edit strand too)
 p check -tc tcStartupRaceContextFirst -i 2000 # 0 bugs (A1 + A2)
 p check -tc tcReconcileRaceResync   -i 2000   # 0 bugs (A2 + A1' covers reconcile)
 p check -tc tcExplore               -i 5000   # 0 bugs
@@ -86,6 +93,7 @@ p check -tc tcCleanupUnguarded      -i 2000   # 1 bug: NOLEAK
 p check -tc tcStaleSyncUnguarded    -i 2000   # 1 bug: STALEFLOOR
 p check -tc tcReregisterUnguarded   -i 2000   # 1 bug: RETAIN
 p check -tc tcSyncAfterExitStrands  -i 2000   # 1 bug: NOLEAK (the gap)
+p check -tc tcEditAfterExitStrands  -i 2000   # 1 bug: NOLEAK (the same gap, via apply_edits)
 p check -tc tcConvergenceStuck      -i 2000   # 1 bug: liveness (hot Lagging)
 p check -tc tcStartupRaceWriterFirst -i 2000  # 1 bug: liveness (guard alone unsafe)
 p check -tc tcReconcileRaceNoResync -i 2000   # 1 bug: liveness (A1 misses reconcile)
@@ -94,3 +102,5 @@ p check -tc tcReconcileRaceNoResync -i 2000   # 1 bug: liveness (A1 misses recon
 ## Corresponding code fix
 
 A2 and A1' are implemented in `rabbitmq_stream_s3_manifest_replica`. `maybe_apply_sync/8` drops a sync for a stream with no registered context (counted as `syncs_dropped_no_context`) and records the writer node the sync carried in a new `pending_resync` map; `register_replica_context` consumes that entry to `request_resync/2` from the writer once a monitored context can own the row. Sourcing the writer node from the dropped sync, which carries it, covers both the acceptor-reply and reconcile-path syncs without threading a leader lookup into registration. A1 (attach reorder) and A3 are not implemented: A1' is trigger-agnostic (it fires on registration regardless of which premature sync was dropped), so it recovers the acceptor-reply drop that A1 would reorder around as well as the reconcile drop A1 cannot reach, and A3 is unnecessary once the receiver refuses the orphan row. The suite's tests that drove `sync/4` without a context now register one first; `make ct-manifest_replica`, `make xref`, and `make dialyze` are green.
+
+The same A2 gate has since landed on `apply_edits`'s two `handle_call`/`handle_cast` clauses, which previously applied a sequenced edit regardless of whether a context was registered. Both now check `maps:is_key(StreamId, Ctxs)` first and, if absent, drop through a shared `drop_no_context/6` helper (counted as `edits_dropped_no_context`) that records the writer node in the same `pending_resync` map `maybe_apply_sync/8` uses, so `apply_edits` and `sync` recover identically once a context registers.

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -35,11 +35,13 @@ No heartbeat or reconnection mechanism is needed because:
 - An inactive stream (no writes) cannot grow disk regardless of
   whether the replica's manifest is stale.
 
-A sync is applied only for a stream that has a registered reader context, so a
-sync can never create a cached row that no member monitor would ever reclaim. A
-sync that races ahead of registration (or arrives after the context is released)
-is dropped; registering the context then requests a re-sync from that writer, so
-the drop is recovered rather than leaving the cache empty.
+A sync or edit is applied only for a stream that has a registered reader
+context, so neither can create or advance cached state that no member monitor
+would ever reclaim. A sync or edit that races ahead of registration (or arrives
+after the context is released) is dropped; registering the context then
+requests a re-sync from that writer, so the drop is recovered rather than
+leaving the cache empty or `seqs` pinned to a sequence with no corresponding
+manifest row.
 """.
 
 -behaviour(gen_server).
@@ -53,13 +55,16 @@ the drop is recovered rather than leaving the cache empty.
 -define(C_RESYNCS_REQUESTED, 1).
 -define(C_SYNCS_REJECTED, 2).
 -define(C_SYNCS_DROPPED_NO_CONTEXT, 3).
+-define(C_EDITS_DROPPED_NO_CONTEXT, 4).
 -define(COUNTERS, [
     {resyncs_requested, ?C_RESYNCS_REQUESTED, counter,
         "Re-syncs a manifest replica requested after a broadcast gap or epoch mismatch"},
     {syncs_rejected, ?C_SYNCS_REJECTED, counter,
         "Syncs a manifest replica dropped because they were older than the cached epoch or sequence"},
     {syncs_dropped_no_context, ?C_SYNCS_DROPPED_NO_CONTEXT, counter,
-        "Syncs a manifest replica dropped because no live reader context owned the stream on this node"}
+        "Syncs a manifest replica dropped because no live reader context owned the stream on this node"},
+    {edits_dropped_no_context, ?C_EDITS_DROPPED_NO_CONTEXT, counter,
+        "Edits a manifest replica dropped because no live reader context owned the stream on this node"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -193,7 +198,7 @@ apply_edits(StreamId, Edits, Seq, Epoch, Node) ->
 
 -doc "Apply sequenced edits locally (synchronous).".
 -spec apply_edits(stream_id(), [#edit{}], non_neg_integer(), non_neg_integer()) ->
-    ok | {error, gap}.
+    ok | {error, gap} | {error, apply_failed} | {error, no_context}.
 apply_edits(StreamId, Edits, Seq, Epoch) ->
     gen_server:call(?MODULE, {apply_edits, StreamId, Edits, Seq, Epoch, node()}).
 
@@ -269,29 +274,43 @@ handle_call(
     ),
     {reply, ok, State#state{seqs = Seqs1, pending_resync = Pending1}};
 handle_call(
-    {apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, _From, #state{seqs = Seqs} = State
+    {apply_edits, StreamId, Edits, Seq, Epoch, WriterNode},
+    _From,
+    #state{seqs = Seqs, contexts = Ctxs, pending_resync = Pending} = State
 ) ->
-    case maps:get(StreamId, Seqs, undefined) of
-        {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
-            case ets:lookup(?TABLE, StreamId) of
-                [{_, Manifest0, _}] ->
-                    case apply_edits_catching(StreamId, Edits, Manifest0) of
-                        {ok, Manifest} ->
-                            write_manifest(StreamId, Manifest, Epoch),
-                            maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
-                            {reply, ok, State#state{
-                                seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
-                            }};
-                        {error, _} ->
+    case maps:is_key(StreamId, Ctxs) of
+        false ->
+            Pending1 = drop_no_context(edits, StreamId, Epoch, Seq, WriterNode, Pending),
+            {reply, {error, no_context}, State#state{pending_resync = Pending1}};
+        true ->
+            case maps:get(StreamId, Seqs, undefined) of
+                {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
+                    case ets:lookup(?TABLE, StreamId) of
+                        [{_, Manifest0, _}] ->
+                            case apply_edits_catching(StreamId, Edits, Manifest0) of
+                                {ok, Manifest} ->
+                                    write_manifest(StreamId, Manifest, Epoch),
+                                    maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
+                                    {reply, ok, State#state{
+                                        seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
+                                    }};
+                                {error, _} ->
+                                    request_resync(StreamId, WriterNode),
+                                    {reply, {error, apply_failed}, State}
+                            end;
+                        [] ->
+                            %% A live context always has seqs and the cached row
+                            %% advanced together (write_manifest runs alongside
+                            %% every seqs update below), so this should be
+                            %% unreachable. Recover via resync rather than trust
+                            %% an inconsistent cache.
                             request_resync(StreamId, WriterNode),
-                            {reply, {error, apply_failed}, State}
+                            {reply, {error, gap}, State}
                     end;
-                [] ->
-                    {reply, ok, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}}
-            end;
-        _ ->
-            request_resync(StreamId, WriterNode),
-            {reply, {error, gap}, State}
+                _ ->
+                    request_resync(StreamId, WriterNode),
+                    {reply, {error, gap}, State}
+            end
     end;
 handle_call({apply_edit, StreamId, Edit}, _From, State) ->
     Reply =
@@ -391,36 +410,51 @@ handle_cast(
         StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs, Pending
     ),
     {noreply, State#state{seqs = Seqs1, pending_resync = Pending1}};
-handle_cast({apply_edits, StreamId, Edits, Seq, Epoch, WriterNode}, #state{seqs = Seqs} = State) ->
-    case maps:get(StreamId, Seqs, undefined) of
-        {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
-            %% In sequence: apply edits.
-            case ets:lookup(?TABLE, StreamId) of
-                [{_, Manifest0, _}] ->
-                    case apply_edits_catching(StreamId, Edits, Manifest0) of
-                        {ok, Manifest} ->
-                            write_manifest(StreamId, Manifest, Epoch),
-                            maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
-                            {noreply, State#state{
-                                seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
-                            }};
-                        {error, _} ->
-                            %% The edit is structurally inconsistent with this
-                            %% replica's manifest: it has diverged (or the edit
-                            %% is malformed). Don't apply a corrupt edit or crash
-                            %% the per-node cache shared by every stream - keep
-                            %% the last good manifest, leave the sequence
-                            %% unadvanced, and force a full resync.
+handle_cast(
+    {apply_edits, StreamId, Edits, Seq, Epoch, WriterNode},
+    #state{seqs = Seqs, contexts = Ctxs, pending_resync = Pending} = State
+) ->
+    case maps:is_key(StreamId, Ctxs) of
+        false ->
+            Pending1 = drop_no_context(edits, StreamId, Epoch, Seq, WriterNode, Pending),
+            {noreply, State#state{pending_resync = Pending1}};
+        true ->
+            case maps:get(StreamId, Seqs, undefined) of
+                {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
+                    %% In sequence: apply edits.
+                    case ets:lookup(?TABLE, StreamId) of
+                        [{_, Manifest0, _}] ->
+                            case apply_edits_catching(StreamId, Edits, Manifest0) of
+                                {ok, Manifest} ->
+                                    write_manifest(StreamId, Manifest, Epoch),
+                                    maybe_evaluate_retention(StreamId, Manifest0, Manifest, State),
+                                    {noreply, State#state{
+                                        seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}
+                                    }};
+                                {error, _} ->
+                                    %% The edit is structurally inconsistent with
+                                    %% this replica's manifest: it has diverged
+                                    %% (or the edit is malformed). Don't apply a
+                                    %% corrupt edit or crash the per-node cache
+                                    %% shared by every stream - keep the last
+                                    %% good manifest, leave the sequence
+                                    %% unadvanced, and force a full resync.
+                                    request_resync(StreamId, WriterNode),
+                                    {noreply, State}
+                            end;
+                        [] ->
+                            %% A live context always has seqs and the cached row
+                            %% advanced together, so this should be unreachable.
+                            %% Recover via resync rather than trust an
+                            %% inconsistent cache.
                             request_resync(StreamId, WriterNode),
                             {noreply, State}
                     end;
-                [] ->
-                    {noreply, State#state{seqs = Seqs#{StreamId => {Seq, Epoch, WriterNode}}}}
-            end;
-        _ ->
-            %% Gap or epoch mismatch: request re-sync from writer.
-            request_resync(StreamId, WriterNode),
-            {noreply, State}
+                _ ->
+                    %% Gap or epoch mismatch: request re-sync from writer.
+                    request_resync(StreamId, WriterNode),
+                    {noreply, State}
+            end
     end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
@@ -517,14 +551,7 @@ maybe_apply_sync(StreamId, Seq, Epoch, Manifest, WriterNode, Seqs, Ctxs, Pending
             %% remember the writer so registering a context can request a re-sync
             %% (a sync that raced ahead of registration is then recovered rather
             %% than leaving the cache empty).
-            inc(?C_SYNCS_DROPPED_NO_CONTEXT, 1),
-            ?LOG_INFO(
-                "Manifest replica for stream ~ts dropped a sync "
-                "(epoch ~b seq ~b from node ~p) with no live reader context",
-                [StreamId, Epoch, Seq, WriterNode],
-                #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
-            ),
-            {Seqs, Pending#{StreamId => WriterNode}};
+            {Seqs, drop_no_context(sync, StreamId, Epoch, Seq, WriterNode, Pending)};
         true ->
             Recorded = maps:get(StreamId, Seqs, undefined),
             case is_stale_sync(Epoch, Seq, Recorded) of
@@ -586,6 +613,28 @@ is_stale_sync(_Epoch, _Seq, undefined) ->
     false;
 is_stale_sync(Epoch, Seq, {Seq0, Epoch0, _}) ->
     {Epoch, Seq} < {Epoch0, Seq0}.
+
+%% Drop a sync or edit for a stream with no live reader context on this node
+%% (see maybe_apply_sync/8 and the {apply_edits, ...} handlers). Remember the
+%% writer node in pending_resync so registering a context later requests a
+%% re-sync via maybe_request_resync/2, recovering the message that raced ahead
+%% of registration instead of leaving the cache empty or the sequence pinned
+%% with no corresponding manifest row.
+drop_no_context(Kind, StreamId, Epoch, Seq, WriterNode, Pending) ->
+    inc(
+        case Kind of
+            sync -> ?C_SYNCS_DROPPED_NO_CONTEXT;
+            edits -> ?C_EDITS_DROPPED_NO_CONTEXT
+        end,
+        1
+    ),
+    ?LOG_INFO(
+        "Manifest replica for stream ~ts dropped ~ts "
+        "(epoch ~b seq ~b from node ~p) with no live reader context",
+        [StreamId, Kind, Epoch, Seq, WriterNode],
+        #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+    ),
+    Pending#{StreamId => WriterNode}.
 
 request_resync(StreamId, WriterNode) ->
     ?LOG_INFO(

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -31,7 +31,9 @@ all() ->
         forget_releases_writer_row,
         reregister_repoints_monitor,
         sync_without_context_dropped,
-        register_after_dropped_sync_requests_resync
+        register_after_dropped_sync_requests_resync,
+        apply_edits_without_context_dropped,
+        register_after_dropped_edits_requests_resync
     ].
 
 init_per_suite(Config) ->
@@ -156,6 +158,66 @@ register_after_dropped_sync_requests_resync(_Config) ->
     %% The sync arrives before any context: it is dropped and its writer node is
     %% remembered.
     ok = Replica:sync(Stream, 0, 1, Manifest),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)),
+
+    %% Registering the context now requests a resync from that writer.
+    Member = register_context(Stream),
+    receive
+        {resync_received, Node} -> ?assertEqual(node(), Node)
+    after 1000 -> ct:fail("resync request not received after context registration")
+    end,
+
+    rabbitmq_stream_s3_registry:unregister_name({Stream, node()}),
+    unlink(WriterPid),
+    exit(WriterPid, kill),
+    exit(Member, kill).
+
+%% Edits for a stream with no registered reader context are dropped the same
+%% way a sync is: applying them would advance seqs with no cached row for any
+%% member monitor to ever reclaim. get_manifest stays undefined: nothing was
+%% cached, and the sequence was not advanced.
+apply_edits_without_context_dropped(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"no-context-edits-stream">>,
+    Edit = #edit{
+        first_offset = 0,
+        first_timestamp = 1000,
+        first_last_timestamp = 1100,
+        next_offset = 1,
+        size = 1000,
+        entries = ?ENTRY(0, 1000, 1100, ?MANIFEST_KIND_FRAGMENT, 1000, 1),
+        pos = 0,
+        len = 0
+    },
+    ?assertEqual({error, no_context}, Replica:apply_edits(Stream, [Edit], 1, 1)),
+    ?assertEqual(undefined, Replica:get_manifest(Stream)).
+
+%% Registering a context for a stream whose edits were dropped requests a
+%% re-sync from the writer the dropped edits came from, the same recovery path
+%% used for a dropped sync (register_after_dropped_sync_requests_resync).
+register_after_dropped_edits_requests_resync(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"resync-on-register-edits-stream">>,
+    Edit = #edit{
+        first_offset = 0,
+        first_timestamp = 1000,
+        first_last_timestamp = 1100,
+        next_offset = 1,
+        size = 1000,
+        entries = ?ENTRY(0, 1000, 1100, ?MANIFEST_KIND_FRAGMENT, 1000, 1),
+        pos = 0,
+        len = 0
+    },
+
+    %% A fake writer registered under {Stream, node()} receives the resync cast.
+    rabbitmq_stream_s3_registry:init(),
+    Self = self(),
+    WriterPid = spawn_link(fun() -> fake_writer(Self) end),
+    yes = rabbitmq_stream_s3_registry:register_name({Stream, node()}, WriterPid),
+
+    %% The edit arrives before any context: it is dropped and its writer node
+    %% is remembered.
+    ?assertEqual({error, no_context}, Replica:apply_edits(Stream, [Edit], 1, 1)),
     ?assertEqual(undefined, Replica:get_manifest(Stream)),
 
     %% Registering the context now requests a resync from that writer.

--- a/test/manifest_replica_statem_SUITE.erl
+++ b/test/manifest_replica_statem_SUITE.erl
@@ -1,0 +1,399 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(manifest_replica_statem_SUITE).
+-moduledoc """
+Property-based (proper_statem) model of rabbitmq_stream_s3_manifest_replica's
+per-stream state machine.
+
+manifest_replica_SUITE pins the no-context-leak invariant with a handful of
+hand-written examples (sync_without_context_dropped,
+apply_edits_without_context_dropped, ...). This suite instead models the real
+gen_server's abstract per-stream state -- whether a reader context is
+registered, the recorded {seq, epoch, writer_node}, and whether a cache row
+exists -- and drives the real running process with randomized interleavings of
+register_replica_context/5, killing the pid backing a context (to trigger the
+real 'DOWN' handling), sync/4, apply_edits/4, and forget/1.
+
+The postconditions are the properties the no-context fix (see git history for
+rabbitmq_stream_s3_manifest_replica.erl) exists to guarantee:
+
+1. A stream with no registered context is a no-op target for sync and
+   apply_edits: get_manifest/1 and get_manifest_and_epoch/1 never change.
+2. A registered context that receives syncs/edits in a legal seq/epoch order
+   has its cache reflect them exactly.
+3. An edit whose seq does not match last_seq + 1 never corrupts the cached
+   manifest -- the cache is left exactly as it was.
+4. Killing the pid backing a context eventually (the release is asynchronous,
+   via the member monitor) makes is_context_registered/1 false and
+   get_manifest/1 undefined.
+""".
+
+-compile([export_all, nowarn_export_all]).
+
+-behaviour(proper_statem).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("rabbitmq_stream_s3/include/rabbitmq_stream_s3.hrl").
+
+-define(REPLICA, rabbitmq_stream_s3_manifest_replica).
+
+all() ->
+    [no_leak_or_corruption].
+
+init_per_suite(Config) -> Config.
+end_per_suite(Config) -> Config.
+
+%% ------------------------------------------------------------------
+%% Test case
+%% ------------------------------------------------------------------
+
+no_leak_or_corruption(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_no_leak_or_corruption/0, [], 200).
+
+prop_no_leak_or_corruption() ->
+    ?FORALL(
+        Cmds,
+        commands(?MODULE),
+        begin
+            {ok, Pid} = ?REPLICA:start_link(),
+            unlink(Pid),
+            {History, State, Result} = run_commands(?MODULE, Cmds),
+            cleanup_member_pids(State),
+            gen_server:stop(Pid),
+            ?WHENFAIL(
+                io:format(
+                    "~n~nFailing command sequence~nHistory: ~p~nState: ~p~nResult: ~p~n",
+                    [History, State, Result]
+                ),
+                Result =:= ok
+            )
+        end
+    ).
+
+%% Reap the dummy member pids the model registered so they don't leak past
+%% this ?FORALL iteration; they only block on `receive stop -> ok end`, so
+%% nothing but a monitor's DOWN or an explicit kill ever ends them.
+cleanup_member_pids(State) ->
+    maps:foreach(
+        fun(_StreamId, SM) ->
+            case maps:get(pid, SM) of
+                undefined -> ok;
+                P when is_pid(P) -> catch exit(P, kill)
+            end
+        end,
+        State
+    ).
+
+%% ------------------------------------------------------------------
+%% proper_statem callbacks
+%% ------------------------------------------------------------------
+
+stream_ids() ->
+    [<<"statem-stream-a">>, <<"statem-stream-b">>, <<"statem-stream-c">>].
+
+fresh_stream() ->
+    #{registered => false, pid => undefined, seq_epoch => undefined, manifest => undefined}.
+
+initial_state() ->
+    #{Id => fresh_stream() || Id <- stream_ids()}.
+
+command(S) ->
+    ?LET(StreamId, elements(stream_ids()), command_for_stream(StreamId, maps:get(StreamId, S))).
+
+command_for_stream(StreamId, SM) ->
+    oneof([
+        {call, ?MODULE, do_register, [StreamId]},
+        {call, ?MODULE, do_kill, [StreamId, maps:get(pid, SM)]},
+        {call, ?MODULE, do_forget, [StreamId]},
+        ?LET(
+            {Seq, Epoch},
+            gen_seq_epoch(SM),
+            {call, ?MODULE, do_sync, [StreamId, Seq, Epoch]}
+        ),
+        ?LET(
+            {Seq, Epoch},
+            gen_seq_epoch(SM),
+            {call, ?MODULE, do_apply_edits, [
+                StreamId, build_append_edit(maps:get(manifest, SM), Seq), Seq, Epoch
+            ]}
+        )
+    ]).
+
+%% Bias seq/epoch generation toward the cases that matter: the legal
+%% next-in-sequence pair (exercises property 2), a fresh epoch bump as a
+%% reconnecting writer after an election would send (also legal), and
+%% uniform noise (exercises the no-context and gap/corruption properties, 1
+%% and 3).
+gen_seq_epoch(SM) ->
+    Recorded = maps:get(seq_epoch, SM),
+    ?LET(
+        {Choice, RandSeq, RandEpoch},
+        {frequency([{3, legal}, {1, bump}, {2, random}]), integer(0, 10), integer(0, 5)},
+        case Choice of
+            legal -> legal_next(Recorded);
+            bump -> epoch_bump(Recorded);
+            random -> {RandSeq, RandEpoch}
+        end
+    ).
+
+legal_next(undefined) -> {0, 1};
+legal_next({LastSeq, LastEpoch, _}) -> {LastSeq + 1, LastEpoch}.
+
+epoch_bump(undefined) -> {0, 1};
+epoch_bump({_LastSeq, LastEpoch, _}) -> {0, LastEpoch + 1}.
+
+precondition(_S, _Call) ->
+    true.
+
+next_state(S, V, {call, _, do_register, [StreamId]}) ->
+    SM = maps:get(StreamId, S),
+    S#{StreamId => SM#{registered => true, pid => V}};
+next_state(S, _V, {call, _, do_kill, [StreamId, _Pid]}) ->
+    SM = maps:get(StreamId, S),
+    case maps:get(pid, SM) of
+        %% No live pid backs this stream's context: killing is a no-op.
+        undefined -> S;
+        %% release_stream/2 (the real DOWN handler) drops the context, the
+        %% seqs entry, and the cached row together.
+        _ -> S#{StreamId => fresh_stream()}
+    end;
+next_state(S, _V, {call, _, do_forget, [StreamId]}) ->
+    %% forget/1 releases the same trio as a member DOWN, regardless of
+    %% whether a context was registered.
+    S#{StreamId => fresh_stream()};
+next_state(S, _V, {call, _, do_sync, [StreamId, Seq, Epoch]}) ->
+    SM = maps:get(StreamId, S),
+    case maps:get(registered, SM) of
+        false ->
+            %% No context: dropped. Cache state must not change (property 1).
+            S;
+        true ->
+            Recorded = maps:get(seq_epoch, SM),
+            case ?REPLICA:is_stale_sync(Epoch, Seq, Recorded) of
+                true ->
+                    S;
+                false ->
+                    NewManifest = build_sync_manifest(Seq),
+                    S#{
+                        StreamId => SM#{
+                            seq_epoch => {Seq, Epoch, node()}, manifest => NewManifest
+                        }
+                    }
+            end
+    end;
+next_state(S, _V, {call, _, do_apply_edits, [StreamId, Edit, Seq, Epoch]}) ->
+    SM = maps:get(StreamId, S),
+    case maps:get(registered, SM) of
+        false ->
+            %% No context: dropped. Cache state must not change (property 1).
+            S;
+        true ->
+            case maps:get(seq_epoch, SM) of
+                {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
+                    Base = manifest_or_default(SM),
+                    NewManifest = rabbitmq_stream_s3_manifest:apply_edit(Edit, Base),
+                    S#{
+                        StreamId => SM#{
+                            seq_epoch => {Seq, Epoch, node()}, manifest => NewManifest
+                        }
+                    };
+                _ ->
+                    %% Gap or epoch mismatch: must never corrupt the cache
+                    %% (property 3). The manifest is left exactly as-is.
+                    S
+            end
+    end.
+
+postcondition(_S, {call, _, do_register, [StreamId]}, Pid) ->
+    is_pid(Pid) andalso ?REPLICA:is_context_registered(StreamId);
+postcondition(S, {call, _, do_kill, [StreamId, _Pid]}, _Res) ->
+    SM = maps:get(StreamId, S),
+    case maps:get(pid, SM) of
+        undefined ->
+            true;
+        _ ->
+            %% Property 4: the release is asynchronous (via the member
+            %% monitor's DOWN), so poll rather than assert immediately.
+            ok =:= await(fun() -> not ?REPLICA:is_context_registered(StreamId) end) andalso
+                ok =:= await(fun() -> ?REPLICA:get_manifest(StreamId) =:= undefined end)
+    end;
+postcondition(_S, {call, _, do_forget, [StreamId]}, Res) ->
+    Res =:= ok andalso
+        not ?REPLICA:is_context_registered(StreamId) andalso
+        ?REPLICA:get_manifest(StreamId) =:= undefined;
+postcondition(S, {call, _, do_sync, [StreamId, Seq, Epoch]}, Res) ->
+    SM = maps:get(StreamId, S),
+    Res =:= ok andalso
+        case maps:get(registered, SM) of
+            false ->
+                %% Property 1: no leaked row for a stream with no context.
+                ?REPLICA:get_manifest(StreamId) =:= undefined andalso
+                    ?REPLICA:get_manifest_and_epoch(StreamId) =:= undefined;
+            true ->
+                Recorded = maps:get(seq_epoch, SM),
+                case ?REPLICA:is_stale_sync(Epoch, Seq, Recorded) of
+                    true ->
+                        %% Stale: dropped, cache unchanged.
+                        ?REPLICA:get_manifest(StreamId) =:= maps:get(manifest, SM) andalso
+                            ?REPLICA:get_manifest_and_epoch(StreamId) =:=
+                                expected_manifest_and_epoch(SM);
+                    false ->
+                        %% Property 2: applied, cache reflects it exactly.
+                        Expected = build_sync_manifest(Seq),
+                        ?REPLICA:get_manifest(StreamId) =:= Expected andalso
+                            ?REPLICA:get_manifest_and_epoch(StreamId) =:= {Expected, Epoch}
+                end
+        end;
+postcondition(S, {call, _, do_apply_edits, [StreamId, Edit, Seq, Epoch]}, Res) ->
+    SM = maps:get(StreamId, S),
+    case maps:get(registered, SM) of
+        false ->
+            %% Property 1: no leaked row/seq for a stream with no context.
+            %% write_manifest/3 stores the manifest and epoch together, so
+            %% both accessors must be untouched, not just get_manifest/1.
+            Res =:= {error, no_context} andalso
+                ?REPLICA:get_manifest(StreamId) =:= undefined andalso
+                ?REPLICA:get_manifest_and_epoch(StreamId) =:= expected_manifest_and_epoch(SM);
+        true ->
+            case maps:get(seq_epoch, SM) of
+                {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
+                    %% Property 2: in-sequence edit applied, cache reflects it.
+                    Expected = rabbitmq_stream_s3_manifest:apply_edit(
+                        Edit, manifest_or_default(SM)
+                    ),
+                    Res =:= ok andalso
+                        ?REPLICA:get_manifest(StreamId) =:= Expected andalso
+                        ?REPLICA:get_manifest_and_epoch(StreamId) =:= {Expected, Epoch};
+                _ ->
+                    %% Property 3: gap/epoch mismatch never corrupts the cache.
+                    Res =:= {error, gap} andalso
+                        ?REPLICA:get_manifest(StreamId) =:= maps:get(manifest, SM) andalso
+                        ?REPLICA:get_manifest_and_epoch(StreamId) =:=
+                            expected_manifest_and_epoch(SM)
+            end
+    end.
+
+manifest_or_default(SM) ->
+    case maps:get(manifest, SM) of
+        undefined -> #manifest{};
+        M -> M
+    end.
+
+%% The {Manifest, Epoch} pair get_manifest_and_epoch/1 must report for a
+%% stream the model has not (yet) recorded a fresh accepted sync/edit for:
+%% undefined if nothing was ever cached, otherwise the last cached manifest
+%% paired with the epoch it was written at (write_manifest/3 always stores
+%% both together).
+expected_manifest_and_epoch(#{manifest := undefined}) ->
+    undefined;
+expected_manifest_and_epoch(#{manifest := M, seq_epoch := {_Seq, Epoch, _}}) ->
+    {M, Epoch}.
+
+%% ------------------------------------------------------------------
+%% Command implementations (real calls against the running gen_server)
+%% ------------------------------------------------------------------
+
+do_register(StreamId) ->
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    %% A fresh dummy pid backs the context; it is monitored by the real
+    %% gen_server and reaped either by do_kill or by cleanup_member_pids/1
+    %% at the end of this ?FORALL iteration.
+    Pid = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    ok = ?REPLICA:register_replica_context(StreamId, Pid, <<"/tmp/statem">>, Shared, Counter),
+    Pid.
+
+do_kill(_StreamId, undefined) ->
+    no_pid;
+do_kill(_StreamId, Pid) ->
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 2000 -> timeout
+    end.
+
+do_sync(StreamId, Seq, Epoch) ->
+    ?REPLICA:sync(StreamId, Seq, Epoch, build_sync_manifest(Seq)).
+
+do_apply_edits(StreamId, Edit, Seq, Epoch) ->
+    ?REPLICA:apply_edits(StreamId, [Edit], Seq, Epoch).
+
+do_forget(StreamId) ->
+    ?REPLICA:forget(StreamId).
+
+%% ------------------------------------------------------------------
+%% Deterministic manifest/edit builders (pure functions of Seq, so the model
+%% and postconditions can recompute the expected value independently)
+%% ------------------------------------------------------------------
+
+%% A full-reset manifest whose content is a deterministic function of Seq, so
+%% two syncs at different Seq are always structurally distinguishable.
+build_sync_manifest(Seq) ->
+    {Manifest, _GetGroupFun} = rabbitmq_stream_s3_test_helpers:build_manifest([
+        {fragment, #{offset => 0, size => 1000 + Seq, first_ts => Seq * 1000, uid => Seq}}
+    ]),
+    Manifest.
+
+%% An append edit for a new fragment onto the end of Base (defaulting to an
+%% empty manifest), deterministic in Seq. Built from the model's own tracked
+%% manifest, so when a legal seq/epoch is generated the edit is structurally
+%% valid (its append position matches what the real cached row will hold).
+build_append_edit(MaybeManifest, Seq) ->
+    Base =
+        case MaybeManifest of
+            undefined -> #manifest{};
+            M -> M
+        end,
+    #manifest{next_offset = NextOffset, entries = Entries} = Base,
+    Ts = Seq * 1000,
+    LastTs = Ts + 100,
+    Size = 1000 + Seq,
+    Entry = ?ENTRY(NextOffset, Ts, LastTs, ?MANIFEST_KIND_FRAGMENT, Size, Seq),
+    %% The first append into an empty manifest (next_offset =:= 0) also
+    %% establishes the floor fields; a later append preserves them.
+    {FirstOffset, FirstTs, FirstLastTs} =
+        case NextOffset of
+            0 ->
+                {NextOffset, Ts, LastTs};
+            _ ->
+                {
+                    Base#manifest.first_offset,
+                    Base#manifest.first_timestamp,
+                    Base#manifest.first_last_timestamp
+                }
+        end,
+    #edit{
+        first_offset = FirstOffset,
+        first_timestamp = FirstTs,
+        first_last_timestamp = FirstLastTs,
+        next_offset = NextOffset + 1,
+        size = Size,
+        entries = Entry,
+        pos = byte_size(Entries),
+        len = 0
+    }.
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+await(Fun) ->
+    await(Fun, 2000).
+
+await(_Fun, Remaining) when Remaining =< 0 ->
+    {error, timeout};
+await(Fun, Remaining) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(20),
+            await(Fun, Remaining - 20)
+    end.


### PR DESCRIPTION
This is basically the same as https://github.com/amazon-mq/rabbitmq-stream-s3/pull/318 but covers applying edits rather than syncing. The related P module is updated to add edits, showing that the same gate is effective for both.

This also adds a `proper_statem` for the manifest replica gen_server, holding the same properties as the P models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
