### PR TITLE
Move stream-deletion listing into a backpressured lister gen_server

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,9 +23,15 @@ rabbitmq_stream_s3_sup (one_for_one, intensity 3 / period 5)
 │     Receives sequenced edits from writer-node replica readers. Detects
 │     gaps and requests re-sync. Triggers retention on replica nodes.
 ├── rabbitmq_stream_s3_reaper (worker, permanent)
-│     Batched S3 object deletion. Collects keys from retention and stream
-│     deletion, issues DeleteObjects in batches of 1000. Stream deletion
-│     spawns a short-lived task that pages through LIST and feeds keys back.
+│     Batched S3 object deletion. Collects keys from retention and the
+│     deletion lister, issues DeleteObjects in batches of 1000. Serves keys
+│     both fire-and-forget (retention) and synchronously (the lister, so
+│     listing is paced against deletion).
+├── rabbitmq_stream_s3_lister (worker, permanent)
+│     Drives whole-stream remote tier deletion under backpressure. Pages
+│     through LIST one page at a time, handing each page to the reaper
+│     synchronously so listing never outruns deletion. Processes streams
+│     first-in-first-out.
 ├── rabbitmq_stream_s3_membership_reconciliation (worker, permanent)
 │     Continuous Membership Reconciliation for streams. Evaluates whether
 │     streams have the correct replica set and triggers corrections.
@@ -177,12 +183,12 @@ When the rate is configured as `unlimited` (the default), the governor imposes n
 When a stream queue is deleted:
 1. RabbitMQ removes the queue from `rabbit_db_queue` in Khepri.
 2. The plugin's keep-while condition on the per-stream container node fires, removing the container and the subtree below it (the manifest pointer and the anchor).
-3. The stored procedure `handle_queue_deletion` runs, calling `rabbitmq_stream_s3_reaper:delete_stream(StreamId)`.
-4. The reaper spawns a short-lived task that pages through `rabbitmq_stream_s3_api:list/2` on the stream's prefix.
-5. Each page of keys is sent back to the reaper as a delete cast.
+3. The stored procedure `handle_queue_deletion` runs, calling `rabbitmq_stream_s3_lister:delete_stream(StreamId)`.
+4. The lister enqueues the stream and pages through `rabbitmq_stream_s3_api:list/2` on the stream's prefix, one page at a time.
+5. Each page of keys is handed to the reaper with a synchronous call that returns only once the page has been deleted, so the lister fetches the next page only after the previous one has drained (backpressure).
 6. The reaper batches keys (up to 1000) and calls `rabbitmq_stream_s3_api:delete/1`.
 
-If the task crashes or S3 is unavailable, the objects are left behind, but the anchor is already gone (step 2 removed the whole subtree), so a later GC run reaps the prefix via the no-anchor path. See [operations.md](./operations.md#garbage-collection).
+If the lister or reaper crashes or S3 is unavailable, the objects are left behind, but the anchor is already gone (step 2 removed the whole subtree), so a later GC run reaps the prefix via the no-anchor path. See [operations.md](./operations.md#garbage-collection).
 
 ## Read path (consumer side)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -294,7 +294,14 @@ Owned by `rabbitmq_stream_s3_reaper`.
 |-------------------------------------|---------|-------------------------------------------------------------------|
 | `rabbitmq_stream_s3_objects_deleted`                   | counter | S3 objects confirmed deleted via the reaper (retention or stream deletion) |
 | `rabbitmq_stream_s3_objects_delete_failed`             | counter | Objects the reaper could not confirm deleted (a DeleteObjects partial or whole-request failure); left for orphan GC |
-| `rabbitmq_stream_s3_streams_deleted`                   | counter | Streams whose deletion task ran to completion                     |
+
+### Lister (per-node)
+
+Owned by `rabbitmq_stream_s3_lister`.
+
+| Metric                              | Type    | Description                                                       |
+|-------------------------------------|---------|-------------------------------------------------------------------|
+| `rabbitmq_stream_s3_streams_deleted`                   | counter | Streams whose deletion ran to completion                          |
 
 ### Manifest replica (per-node)
 

--- a/src/rabbitmq_stream_s3_api.erl
+++ b/src/rabbitmq_stream_s3_api.erl
@@ -157,6 +157,7 @@ init() ->
     ok = rabbitmq_stream_s3_log_reader:init_counters(),
     ok = rabbitmq_stream_s3_governor:init_counters(),
     ok = rabbitmq_stream_s3_reaper:init_counters(),
+    ok = rabbitmq_stream_s3_lister:init_counters(),
     ok = rabbitmq_stream_s3_replica_reader:init_counters(),
     ok = rabbitmq_stream_s3_manifest_replica:init_counters(),
     lists:foreach(

--- a/src/rabbitmq_stream_s3_db.erl
+++ b/src/rabbitmq_stream_s3_db.erl
@@ -142,7 +142,7 @@ handle_queue_deletion(#{path := ?PATH(StreamId)}) ->
     %% Khepri leader node. This may not be the same node as the stream's writer
     %% process. And in larger clusters (5, 7, 9 nodes, etc..) this might not
     %% be a node of a replica either.
-    ok = rabbitmq_stream_s3_reaper:delete_stream(StreamId).
+    ok = rabbitmq_stream_s3_lister:delete_stream(StreamId).
 
 -doc "Gets the latest-known manifest root UID and revision with a low-latency local read.".
 -spec get(stream_id()) -> {ok, entry()} | {error, not_found | any()}.

--- a/src/rabbitmq_stream_s3_lister.erl
+++ b/src/rabbitmq_stream_s3_lister.erl
@@ -123,8 +123,6 @@ maybe_start(#state{} = State) ->
 %% backpressure: the next list happens only after the previous page drained.
 page(StreamId, Prefix, Continuation, State) ->
     case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
-        {ok, [], done} ->
-            finish(StreamId, State);
         {ok, Keys, done} ->
             case delete_page(StreamId, Keys) of
                 ok -> finish(StreamId, State);

--- a/src/rabbitmq_stream_s3_lister.erl
+++ b/src/rabbitmq_stream_s3_lister.erl
@@ -67,8 +67,8 @@ init([]) ->
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
-handle_cast({delete_stream, StreamId}, #state{queue = Q} = State) ->
-    {noreply, maybe_start(State#state{queue = queue:in(StreamId, Q)})};
+handle_cast({delete_stream, StreamId}, State) ->
+    {noreply, enqueue(StreamId, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -89,6 +89,20 @@ code_change(_OldVsn, State, _Extra) ->
 %% ------------------------------------------------------------------
 %% Internal
 %% ------------------------------------------------------------------
+
+%% Enqueue a stream for deletion, skipping it when the same stream is already
+%% in flight or already queued. The Khepri deletion trigger can fire more than
+%% once for a stream (redelivery, leader change), and a duplicate would list an
+%% already-empty prefix and double-count `streams_deleted`.
+enqueue(StreamId, #state{current = {StreamId, _, _}} = State) ->
+    State;
+enqueue(StreamId, #state{queue = Q} = State) ->
+    case queue:member(StreamId, Q) of
+        true ->
+            State;
+        false ->
+            maybe_start(State#state{queue = queue:in(StreamId, Q)})
+    end.
 
 %% Start the next queued stream if idle. When a job is already in flight the new
 %% stream stays queued and is picked up when the current one finishes.
@@ -112,12 +126,18 @@ page(StreamId, Prefix, Continuation, State) ->
         {ok, [], done} ->
             finish(StreamId, State);
         {ok, Keys, done} ->
-            ok = rabbitmq_stream_s3_reaper:delete_objects_sync(StreamId, Keys),
-            finish(StreamId, State);
+            case delete_page(StreamId, Keys) of
+                ok -> finish(StreamId, State);
+                {error, _} -> next(State)
+            end;
         {ok, Keys, NextContinuation} ->
-            ok = rabbitmq_stream_s3_reaper:delete_objects_sync(StreamId, Keys),
-            self() ! ?PAGE,
-            State#state{current = {StreamId, Prefix, NextContinuation}};
+            case delete_page(StreamId, Keys) of
+                ok ->
+                    self() ! ?PAGE,
+                    State#state{current = {StreamId, Prefix, NextContinuation}};
+                {error, _} ->
+                    next(State)
+            end;
         {error, Reason} ->
             ?LOG_WARNING(
                 "Failed to list objects for prefix ~ts: ~p; leaving remaining "
@@ -127,6 +147,24 @@ page(StreamId, Prefix, Continuation, State) ->
             %% Best effort: abandon this stream (orphan GC catches the rest) and
             %% move on so one unlistable stream cannot wedge the queue.
             next(State)
+    end.
+
+%% Hand a page to the reaper for synchronous deletion. The reaper is an
+%% independently supervised worker; if it crashes or is restarting, the
+%% synchronous call exits. Treat that like any other transient failure (log and
+%% leave the objects for orphan GC) rather than letting it cascade into a lister
+%% crash that would discard the entire queue of pending stream deletions.
+delete_page(StreamId, Keys) ->
+    try rabbitmq_stream_s3_reaper:delete_objects_sync(StreamId, Keys) of
+        ok -> ok
+    catch
+        Class:Reason ->
+            ?LOG_WARNING(
+                "Reaper unavailable while deleting a page for stream ~ts: "
+                "~ts:~p; abandoning it for orphan GC",
+                [StreamId, Class, Reason]
+            ),
+            {error, Reason}
     end.
 
 finish(StreamId, State) ->
@@ -153,3 +191,34 @@ inc(Idx, N) ->
         undefined -> ok;
         Cnt -> counters:add(Cnt, Idx, N)
     end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+%% A stream in flight (current set) so enqueue/2 only appends to the queue and
+%% maybe_start/1 leaves it untouched, making the queue contents observable.
+busy_state() ->
+    #state{current = {<<"in_flight">>, <<"prefix/">>, start}}.
+
+enqueue_dedup_test_() ->
+    [
+        {"a fresh stream is queued", fun() ->
+            S = enqueue(<<"s1">>, busy_state()),
+            ?assertEqual([<<"s1">>], queue:to_list(S#state.queue))
+        end},
+        {"distinct streams are all queued in order", fun() ->
+            S = enqueue(<<"s2">>, enqueue(<<"s1">>, busy_state())),
+            ?assertEqual([<<"s1">>, <<"s2">>], queue:to_list(S#state.queue))
+        end},
+        {"a stream already queued is not queued again", fun() ->
+            S0 = enqueue(<<"s1">>, busy_state()),
+            S1 = enqueue(<<"s1">>, S0),
+            ?assertEqual([<<"s1">>], queue:to_list(S1#state.queue))
+        end},
+        {"the in-flight stream is not re-queued", fun() ->
+            S = enqueue(<<"in_flight">>, busy_state()),
+            ?assertEqual([], queue:to_list(S#state.queue))
+        end}
+    ].
+
+-endif.

--- a/src/rabbitmq_stream_s3_lister.erl
+++ b/src/rabbitmq_stream_s3_lister.erl
@@ -1,0 +1,155 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_lister).
+-moduledoc """
+Drives remote tier deletion for whole streams under backpressure.
+
+When a stream is deleted, its remote objects must be listed and removed. Listing
+is cheap (one round-trip per page of up to 1000 keys) while deletion is the
+slower, throttling-prone side, so listing can easily outrun deletion. A naive
+lister that lists as fast as S3 answers and hands every page to the reaper grows
+the reaper's mailbox without bound.
+
+This singleton gen_server serializes stream deletions and paces listing against
+deletion: it lists one page, hands it to `rabbitmq_stream_s3_reaper` via a
+synchronous call that returns only once the page has been deleted, and only then
+lists the next page. Stream-deletion jobs are processed first-in-first-out; a
+large stream delays smaller ones queued behind it, which is acceptable for
+best-effort background cleanup backstopped by orphan GC.
+""".
+
+-behaviour(gen_server).
+
+-include("include/rabbitmq_stream_s3.hrl").
+-include("include/logging.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([start_link/0, delete_stream/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+-export([init_counters/0]).
+
+-define(SERVER, ?MODULE).
+%% Drive paging via a self-message so the gen_server returns to its loop between
+%% pages and stays responsive to newly enqueued deletions.
+-define(PAGE, page).
+
+-define(C_STREAMS_DELETED, 1).
+-define(COUNTERS, [
+    {streams_deleted, ?C_STREAMS_DELETED, counter, "Streams whose deletion ran to completion"}
+]).
+-define(COUNTER_KEY, {?MODULE, counter}).
+
+-record(state, {
+    %% Streams awaiting deletion, processed in order.
+    queue = queue:new() :: queue:queue(stream_id()),
+    %% The stream currently being listed and deleted, if any.
+    current :: undefined | {stream_id(), rabbitmq_stream_s3:key(), term()}
+}).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-doc "Delete all remote tier objects for a stream (async, FIFO).".
+-spec delete_stream(stream_id()) -> ok.
+delete_stream(StreamId) ->
+    gen_server:cast(?SERVER, {delete_stream, StreamId}).
+
+%% ------------------------------------------------------------------
+%% gen_server
+%% ------------------------------------------------------------------
+
+init([]) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({delete_stream, StreamId}, #state{queue = Q} = State) ->
+    {noreply, maybe_start(State#state{queue = queue:in(StreamId, Q)})};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(?PAGE, #state{current = {StreamId, Prefix, Continuation}} = State) ->
+    {noreply, page(StreamId, Prefix, Continuation, State)};
+handle_info(?PAGE, #state{current = undefined} = State) ->
+    %% A stray page tick with no active job; nothing to do.
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------------
+%% Internal
+%% ------------------------------------------------------------------
+
+%% Start the next queued stream if idle. When a job is already in flight the new
+%% stream stays queued and is picked up when the current one finishes.
+maybe_start(#state{current = undefined, queue = Q0} = State) ->
+    case queue:out(Q0) of
+        {{value, StreamId}, Q1} ->
+            Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
+            self() ! ?PAGE,
+            State#state{current = {StreamId, Prefix, start}, queue = Q1};
+        {empty, _} ->
+            State
+    end;
+maybe_start(#state{} = State) ->
+    State.
+
+%% List one page and hand it to the reaper synchronously (the call returns only
+%% once the page has been deleted), then schedule the next page. This is the
+%% backpressure: the next list happens only after the previous page drained.
+page(StreamId, Prefix, Continuation, State) ->
+    case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
+        {ok, [], done} ->
+            finish(StreamId, State);
+        {ok, Keys, done} ->
+            ok = rabbitmq_stream_s3_reaper:delete_objects_sync(StreamId, Keys),
+            finish(StreamId, State);
+        {ok, Keys, NextContinuation} ->
+            ok = rabbitmq_stream_s3_reaper:delete_objects_sync(StreamId, Keys),
+            self() ! ?PAGE,
+            State#state{current = {StreamId, Prefix, NextContinuation}};
+        {error, Reason} ->
+            ?LOG_WARNING(
+                "Failed to list objects for prefix ~ts: ~p; leaving remaining "
+                "objects for orphan GC",
+                [Prefix, Reason]
+            ),
+            %% Best effort: abandon this stream (orphan GC catches the rest) and
+            %% move on so one unlistable stream cannot wedge the queue.
+            next(State)
+    end.
+
+finish(StreamId, State) ->
+    inc(?C_STREAMS_DELETED, 1),
+    ?LOG_DEBUG("Completed remote tier deletion for stream ~ts", [StreamId]),
+    next(State).
+
+%% Clear the current job and start the next queued one, if any.
+next(State) ->
+    maybe_start(State#state{current = undefined}).
+
+%% ------------------------------------------------------------------
+%% Counters
+%% ------------------------------------------------------------------
+
+-spec init_counters() -> ok.
+init_counters() ->
+    Cnt = seshat:new(rabbitmq_stream_s3, ?MODULE, ?COUNTERS, #{module => ?MODULE}),
+    persistent_term:put(?COUNTER_KEY, Cnt),
+    ok.
+
+inc(Idx, N) ->
+    case persistent_term:get(?COUNTER_KEY, undefined) of
+        undefined -> ok;
+        Cnt -> counters:add(Cnt, Idx, N)
+    end.

--- a/src/rabbitmq_stream_s3_reaper.erl
+++ b/src/rabbitmq_stream_s3_reaper.erl
@@ -68,12 +68,19 @@ Returns `ok` once this batch has been processed, regardless of whether every
 individual object was confirmed deleted (unconfirmed ones are left for orphan
 GC). This is the backpressure primitive the lister relies on: the reply does
 not arrive until the reaper has drained the batch.
+
+The call waits `infinity`. Each S3 request the reaper makes is individually
+bounded by `?DELETE_TIMEOUT_MS`, so `handle_batch` always completes in bounded
+time; a finite call timeout here would instead measure the caller's wait
+against the whole batch (which folds in unrelated fire-and-forget casts and
+splits into up to `?MAX_BATCH`-key sub-batches run sequentially) and could
+crash the lister while deletion is still making progress.
 """.
 -spec delete_objects_sync(stream_id(), [rabbitmq_stream_s3:key()]) -> ok.
 delete_objects_sync(_StreamId, []) ->
     ok;
 delete_objects_sync(_StreamId, Keys) ->
-    gen_batch_server:call(?MODULE, {delete, Keys}, ?DELETE_TIMEOUT_MS).
+    gen_batch_server:call(?MODULE, {delete, Keys}, infinity).
 
 init([]) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),

--- a/src/rabbitmq_stream_s3_reaper.erl
+++ b/src/rabbitmq_stream_s3_reaper.erl
@@ -5,13 +5,19 @@
 -moduledoc """
 Batched S3 object deletion.
 
-Collects keys from replica readers, retention evaluation, and stream
-deletion tasks, then issues batched DeleteObjects calls (up to 1000 keys
+Collects keys from replica readers, retention evaluation, and the stream
+deletion lister, then issues batched DeleteObjects calls (up to 1000 keys
 per request).
 
-For stream deletion, a short-lived task pages through LIST on the
-stream's S3 prefix and sends discovered keys back to this process
-for batched deletion. The task exits when the listing is exhausted.
+Keys arrive two ways:
+
+- `delete_objects/2` casts keys fire-and-forget. The set of keys from
+  retention and replica readers is bounded, so a cast cannot grow the
+  mailbox without bound.
+- `delete_objects_sync/2` submits keys and replies only once they have been
+  deleted. `rabbitmq_stream_s3_lister` uses this to page through a stream's
+  prefix under backpressure: it lists one page, hands it over synchronously,
+  and only lists the next page once this reaper has drained the previous one.
 """.
 
 -behaviour(gen_batch_server).
@@ -21,7 +27,7 @@ for batched deletion. The task exits when the listing is exhausted.
 -include_lib("kernel/include/logger.hrl").
 
 -export([start_link/0]).
--export([delete_objects/2, delete_stream/1]).
+-export([delete_objects/2, delete_objects_sync/2]).
 -export([init/1, handle_batch/2, terminate/2]).
 -export([init_counters/0]).
 
@@ -33,12 +39,10 @@ for batched deletion. The task exits when the listing is exhausted.
 -define(DELETE_TIMEOUT_MS, 60_000).
 
 -define(C_OBJECTS_DELETED, 1).
--define(C_STREAMS_DELETED, 2).
--define(C_OBJECTS_DELETE_FAILED, 3).
+-define(C_OBJECTS_DELETE_FAILED, 2).
 -define(COUNTERS, [
     {objects_deleted, ?C_OBJECTS_DELETED, counter,
         "Individual objects confirmed deleted via the reaper (retention or stream deletion)"},
-    {streams_deleted, ?C_STREAMS_DELETED, counter, "Streams whose deletion task ran to completion"},
     {objects_delete_failed, ?C_OBJECTS_DELETE_FAILED, counter,
         "Individual objects the reaper could not confirm deleted, left for orphan GC"}
 ]).
@@ -57,14 +61,19 @@ delete_objects(_StreamId, []) ->
 delete_objects(_StreamId, Keys) ->
     gen_batch_server:cast(?MODULE, {delete, Keys}).
 
--doc "Delete all remote tier objects for a stream (async).".
--spec delete_stream(stream_id()) -> ok.
-delete_stream(StreamId) ->
-    spawn(fun() ->
-        logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
-        list_and_delete(StreamId)
-    end),
-    ok.
+-doc """
+Send object keys for batched deletion and block until they are deleted.
+
+Returns `ok` once this batch has been processed, regardless of whether every
+individual object was confirmed deleted (unconfirmed ones are left for orphan
+GC). This is the backpressure primitive the lister relies on: the reply does
+not arrive until the reaper has drained the batch.
+""".
+-spec delete_objects_sync(stream_id(), [rabbitmq_stream_s3:key()]) -> ok.
+delete_objects_sync(_StreamId, []) ->
+    ok;
+delete_objects_sync(_StreamId, Keys) ->
+    gen_batch_server:call(?MODULE, {delete, Keys}, ?DELETE_TIMEOUT_MS).
 
 init([]) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
@@ -73,7 +82,7 @@ init([]) ->
 handle_batch(Ops, State) ->
     Keys = collect(Ops),
     _ = delete_batched(Keys),
-    {ok, State}.
+    {ok, replies(Ops), State}.
 
 terminate(_Reason, _State) ->
     ok.
@@ -82,8 +91,17 @@ terminate(_Reason, _State) ->
 %% Internal
 %% ------------------------------------------------------------------
 
+%% Keys arrive from both fire-and-forget casts and synchronous calls.
 collect(Ops) ->
-    lists:append([K || {cast, {delete, K}} <- Ops]).
+    lists:append([keys(Op) || Op <- Ops]).
+
+keys({cast, {delete, K}}) -> K;
+keys({call, _From, {delete, K}}) -> K;
+keys(_) -> [].
+
+%% Reply to every synchronous caller once its batch has been deleted above.
+replies(Ops) ->
+    [{reply, From, ok} || {call, From, {delete, _}} <- Ops].
 
 delete_batched([]) ->
     ok;
@@ -121,29 +139,6 @@ delete_batch(Batch) ->
                 "Reaper delete request for ~b objects failed: ~p; leaving them for GC",
                 [N, Reason]
             )
-    end.
-
-list_and_delete(StreamId) ->
-    Prefix = rabbitmq_stream_s3:stream_prefix(StreamId),
-    Result = list_and_delete_loop(Prefix, start),
-    case Result of
-        ok -> inc(?C_STREAMS_DELETED, 1);
-        _ -> ok
-    end.
-
-list_and_delete_loop(_Prefix, done) ->
-    ok;
-list_and_delete_loop(Prefix, Continuation) ->
-    case rabbitmq_stream_s3_api:list(Prefix, Continuation) of
-        {ok, [], done} ->
-            ok;
-        {ok, Keys, NextContinuation} ->
-            gen_batch_server:cast(?MODULE, {delete, Keys}),
-            list_and_delete_loop(Prefix, NextContinuation);
-        {error, Reason} ->
-            ?LOG_WARNING("Failed to list objects for prefix ~ts: ~p", [Prefix, Reason]),
-            %% Best effort - orphan GC will catch anything we miss.
-            error
     end.
 
 %% ------------------------------------------------------------------

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -71,6 +71,11 @@ init([]) ->
         type => worker,
         start => {rabbitmq_stream_s3_reaper, start_link, []}
     },
+    Lister = #{
+        id => rabbitmq_stream_s3_lister,
+        type => worker,
+        start => {rabbitmq_stream_s3_lister, start_link, []}
+    },
     ManifestCache = #{
         id => rabbitmq_stream_s3_manifest_replica,
         type => worker,
@@ -106,6 +111,7 @@ init([]) ->
         BucketMonitor,
         ManifestCache,
         Reaper,
+        Lister,
         MembershipReconciliation,
         UploadPool,
         GeneralPool,

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -900,7 +900,7 @@ stream_deletion_cleans_remote_tier(Config) ->
     osiris_writer:stop(WriterCfg),
 
     %% Delete remote tier objects.
-    ok = rabbitmq_stream_s3_reaper:delete_stream(StreamId),
+    ok = rabbitmq_stream_s3_lister:delete_stream(StreamId),
     ?awaitMatch([], list_fragment_offsets(Config), 1000),
 
     %% Delete local tier.

--- a/test/replica_reader_statem_SUITE.erl
+++ b/test/replica_reader_statem_SUITE.erl
@@ -247,7 +247,7 @@ start_fresh_writer(StreamId) ->
 cleanup(StreamId, Writer) ->
     Cfg = writer_cfg(StreamId),
     catch osiris_writer:stop(Cfg),
-    _ = rabbitmq_stream_s3_reaper:delete_stream(StreamId),
+    _ = rabbitmq_stream_s3_lister:delete_stream(StreamId),
     catch osiris_log:delete_directory(Cfg),
     catch rabbitmq_stream_s3_manifest_replica:forget(StreamId),
     catch rabbitmq_stream_s3_api_fault:reset(),


### PR DESCRIPTION
## What

Moves whole-stream remote tier deletion off the reaper's spawn-based listing task and into a dedicated, supervised `rabbitmq_stream_s3_lister` gen_server that paces LIST against DELETE under backpressure, then hardens that lister against reaper faults and duplicate deletion jobs.

Fixes the listing follow-up in #79.

## Why

Stream deletion used to `spawn` an unsupervised task that listed a stream's S3 prefix as fast as S3 answered and cast every page to the reaper. Listing is cheap while deletion is the slow, throttling-prone side, so listing could outrun deletion and regrow the reaper's mailbox without bound, the exact problem the reaper rework had fixed, just moved to the listing side.

## How

Commit 54f8a2b introduces the lister:

- A supervised singleton gen_server serializes stream deletions FIFO and lists one page at a time
- Each page is handed to the reaper via a new synchronous `delete_objects_sync/2` that returns only once the page has been deleted, so the next LIST happens only after the previous page drains (the backpressure). Keys in flight are bounded to a single page
- The `streams_deleted` counter moves from the reaper to the lister; the exported metric name is unchanged
- Supervisor, `db.erl`, API init, and two test call sites are repointed; `architecture.md` and `operations.md` updated

Commit 93c57b8 hardens the lister against three robustness gaps found in review, all in its synchronous coupling to the reaper:

- The backpressure call waited `?DELETE_TIMEOUT_MS` (60s), but that call waits for the reaper's whole `handle_batch`, which folds in unrelated fire-and-forget retention casts and splits into sequential 60s sub-batches. Under S3 throttling the batch could exceed the caller's deadline and crash the lister while deletion was still progressing. The call now waits `infinity`; each S3 request stays individually bounded, so `handle_batch` always completes in bounded time
- A reaper crash or restart made the synchronous call exit with `noproc`. The lister held its entire FIFO queue in process state, so any such exit restarted it with an empty queue, silently dropping every pending deletion. The reaper call is now wrapped so a reaper fault abandons only the current stream to orphan GC and leaves the lister and its queue intact
- The Khepri deletion trigger can fire more than once for a stream, and the lister did not de-duplicate, so a stream could be listed twice and double-count `streams_deleted`. A stream already in flight or already queued is now skipped

One review finding was left unaddressed by design: if `delete_stream` is cast while the lister is restarting, the cast is silently dropped. This is the intended failure mode, backstopped by orphan GC (see architecture.md), and hardening it would duplicate the GC mechanism as a fragile special case.

## Testing

- `gmake dialyze`, `gmake xref`: clean (only pre-existing unresolved calls in untouched modules)
- `gmake eunit`: 192 passed, including new coverage for the de-duplication logic
- `gmake ct-replica_reader`, `ct-replica_reader_statem`, `ct-broker`: deletion cases (`stream_deletion_cleans_remote_tier`, `stream_deletion_during_active_upload`) green in every run
- `erlfmt -c`: all files conform

The pre-existing flaky `replication_survives_reader_restart` is tracked separately in #326 and is unrelated to this change.
