### PR TITLE
Add automatic periodic tiered storage GC

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -115,6 +115,22 @@ stream_s3.bucket_check.enabled = true
 stream_s3.bucket_check.interval = 300000
 ```
 
+### Automatic garbage collection
+
+Garbage collection reclaims dangling S3 objects (see [Garbage collection](#garbage-collection)). It can run automatically on an interval in addition to the on-demand `stream_s3_gc` CLI command. Automatic GC is off by default: a full sweep is a bucket-wide `LIST` plus one strongly-consistent metadata read per stream, and the objects it reclaims (a straggler left by the deletion race and its tombstone) are not urgent.
+
+Each node runs its own timer, but a non-blocking cluster-wide lock ensures only one node sweeps per round, so a larger cluster does not multiply the sweep cost. There is no fixed leader; the sweep survives the loss of any node.
+
+```ini
+# Whether a delete-mode GC sweep runs automatically on an interval.
+# Type: boolean. Default: false.
+stream_s3.gc.enabled = true
+
+# Interval between automatic GC sweeps, in milliseconds.
+# Type: positive integer. Default: 86400000 (24 hours).
+stream_s3.gc.interval = 86400000
+```
+
 ### Tuning the upload path
 
 ```ini
@@ -696,7 +712,7 @@ curl http://node:15692/metrics/per-object | grep 'queue="my-stream"'
 
 Objects in S3 can become orphaned (not referenced by any manifest) in several scenarios: a deposed writer uploads a fragment but loses the Khepri race, a manifest persist fails or the process crashes before completion, retention deletes entries from the manifest but the corresponding object deletion does not complete, or a stream is deleted (or its Khepri metadata is wiped) and its objects outlive the metadata that referenced them.
 
-The GC mechanism identifies these orphans by listing S3 objects and comparing their keys against current authoritative state. It is invoked on demand via the CLI.
+The GC mechanism identifies these orphans by listing S3 objects and comparing their keys against current authoritative state. It is invoked on demand via the CLI, and can also run automatically on an interval (see [Automatic garbage collection](#automatic-garbage-collection)).
 
 ### Safety guarantee: monotonicity
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -122,13 +122,18 @@ Garbage collection reclaims dangling S3 objects (see [Garbage collection](#garba
 Each node runs its own timer, but a non-blocking cluster-wide lock ensures only one node sweeps per round, so a larger cluster does not multiply the sweep cost. There is no fixed leader; the sweep survives the loss of any node.
 
 ```ini
-# Whether a delete-mode GC sweep runs automatically on an interval.
+# Whether a GC sweep runs automatically on an interval.
 # Type: boolean. Default: false.
 stream_s3.gc.enabled = true
 
 # Interval between automatic GC sweeps, in milliseconds.
 # Type: positive integer. Default: 86400000 (24 hours).
 stream_s3.gc.interval = 86400000
+
+# Mode the automatic sweep runs in. `dry_run` only identifies and logs
+# dangling objects, without reclaiming them.
+# Type: dry_run | delete. Default: delete.
+stream_s3.gc.mode = delete
 ```
 
 ### Tuning the upload path

--- a/priv/schema/rabbitmq_stream_s3.schema
+++ b/priv/schema/rabbitmq_stream_s3.schema
@@ -162,6 +162,23 @@ end}.
 ]}.
 
 %%
+%% Automatic garbage collection
+%%
+
+%% Whether a delete-mode GC sweep runs automatically on an interval. A sweep is
+%% a bucket-wide LIST plus one strongly-consistent metadata read per stream, so
+%% it is off by default; orphan GC via the stream_s3_gc CLI command remains
+%% available on demand.
+
+{mapping, "stream_s3.gc.enabled", "rabbitmq_stream_s3.gc_enabled", [
+    {datatype, {enum, [true, false]}}
+]}.
+
+{mapping, "stream_s3.gc.interval", "rabbitmq_stream_s3.gc_interval", [
+    {datatype, integer}, {validators, ["non_zero_positive_integer"]}
+]}.
+
+%%
 %% Bucket accessibility checks
 %%
 

--- a/priv/schema/rabbitmq_stream_s3.schema
+++ b/priv/schema/rabbitmq_stream_s3.schema
@@ -178,6 +178,13 @@ end}.
     {datatype, integer}, {validators, ["non_zero_positive_integer"]}
 ]}.
 
+%% Mode the automatic sweep runs in. `delete` (the default) reclaims dangling
+%% objects; `dry_run` only identifies and logs them.
+
+{mapping, "stream_s3.gc.mode", "rabbitmq_stream_s3.gc_mode", [
+    {datatype, {enum, [dry_run, delete]}}
+]}.
+
 %%
 %% Bucket accessibility checks
 %%

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -36,6 +36,8 @@ lives here. Callers use these functions instead of calling
     membership_reconciliation_auto_remove/0,
     reconciliation_enabled/0,
     reconciliation_interval/0,
+    gc_enabled/0,
+    gc_interval/0,
     bucket_check_enabled/0,
     bucket_check_interval/0,
     task_retry_delay_max_ms/0,
@@ -189,6 +191,20 @@ bucket_check_enabled() ->
 bucket_check_interval() ->
     application:get_env(?APP, bucket_check_interval, 300_000).
 
+%% Whether a delete-mode GC sweep runs automatically on an interval. A sweep is
+%% a bucket-wide LIST plus one strongly-consistent metadata read per stream, so
+%% it is off by default; orphan GC via the CLI remains available on demand.
+-spec gc_enabled() -> boolean().
+gc_enabled() ->
+    application:get_env(?APP, gc_enabled, false).
+
+%% Interval between automatic GC sweeps, in milliseconds. Defaults to 24 hours:
+%% stragglers and tombstones are not urgent, and each sweep is comparatively
+%% heavy.
+-spec gc_interval() -> non_neg_integer().
+gc_interval() ->
+    application:get_env(?APP, gc_interval, 86_400_000).
+
 -spec task_retry_delay_max_ms() -> non_neg_integer().
 task_retry_delay_max_ms() ->
     application:get_env(?APP, task_retry_delay_max_ms, 5_000).
@@ -299,6 +315,8 @@ defaults_test_() ->
         ?_assertEqual(false, membership_reconciliation_auto_remove()),
         ?_assertEqual(true, reconciliation_enabled()),
         ?_assertEqual(60_000, reconciliation_interval()),
+        ?_assertEqual(false, gc_enabled()),
+        ?_assertEqual(86_400_000, gc_interval()),
         ?_assertEqual(true, bucket_check_enabled()),
         ?_assertEqual(300_000, bucket_check_interval()),
         ?_assertEqual(5_000, task_retry_delay_max_ms()),

--- a/src/rabbitmq_stream_s3_config.erl
+++ b/src/rabbitmq_stream_s3_config.erl
@@ -38,6 +38,7 @@ lives here. Callers use these functions instead of calling
     reconciliation_interval/0,
     gc_enabled/0,
     gc_interval/0,
+    gc_mode/0,
     bucket_check_enabled/0,
     bucket_check_interval/0,
     task_retry_delay_max_ms/0,
@@ -205,6 +206,12 @@ gc_enabled() ->
 gc_interval() ->
     application:get_env(?APP, gc_interval, 86_400_000).
 
+%% Mode an automatic GC sweep runs in. `delete` reclaims dangling objects;
+%% `dry_run` only identifies and logs them. Defaults to `delete`.
+-spec gc_mode() -> rabbitmq_stream_s3_gc:mode().
+gc_mode() ->
+    application:get_env(?APP, gc_mode, delete).
+
 -spec task_retry_delay_max_ms() -> non_neg_integer().
 task_retry_delay_max_ms() ->
     application:get_env(?APP, task_retry_delay_max_ms, 5_000).
@@ -317,6 +324,7 @@ defaults_test_() ->
         ?_assertEqual(60_000, reconciliation_interval()),
         ?_assertEqual(false, gc_enabled()),
         ?_assertEqual(86_400_000, gc_interval()),
+        ?_assertEqual(delete, gc_mode()),
         ?_assertEqual(true, bucket_check_enabled()),
         ?_assertEqual(300_000, bucket_check_interval()),
         ?_assertEqual(5_000, task_retry_delay_max_ms()),

--- a/src/rabbitmq_stream_s3_gc_scheduler.erl
+++ b/src/rabbitmq_stream_s3_gc_scheduler.erl
@@ -12,10 +12,14 @@ a straggler object left by the deletion race (an upload that completes after the
 one-shot deletion sweep) and its tombstone persist until an operator runs GC by
 hand.
 
-This server runs a delete-mode sweep on a timer to make straggler reclamation and
-tombstone cleanup self-healing. A full sweep is a bucket-wide LIST plus one
+This server runs a sweep on a timer to make straggler reclamation and tombstone
+cleanup self-healing. A full sweep is a bucket-wide LIST plus one
 strongly-consistent metadata read per stream, so it is off by default and runs on
 a conservative interval when enabled.
+
+The sweep runs in `delete` mode by default. It can instead be configured to run
+in `dry_run` mode, which only identifies and logs dangling objects without
+reclaiming them.
 
 Reclamation is eventual, not immediate. Objects orphaned by a deleted stream are
 identified from Khepri via a strongly-consistent anchor read, so any sweeping node
@@ -72,8 +76,8 @@ init([]) ->
     case rabbitmq_stream_s3_config:gc_enabled() of
         true ->
             ?LOG_INFO(
-                "Automatic tiered storage GC is enabled; scheduling a sweep every ~b ms.",
-                [rabbitmq_stream_s3_config:gc_interval()]
+                "Automatic tiered storage GC is enabled; scheduling a ~p sweep every ~b ms.",
+                [rabbitmq_stream_s3_config:gc_mode(), rabbitmq_stream_s3_config:gc_interval()]
             ),
             {ok, #?MODULE{timer = schedule()}};
         false ->
@@ -146,12 +150,13 @@ with_sweep_lock(Nodes, Fun) ->
     end.
 
 sweep() ->
-    ?LOG_INFO("Starting automatic tiered storage GC sweep."),
-    case rabbitmq_stream_s3_gc:run(#{mode => delete}) of
+    Mode = rabbitmq_stream_s3_config:gc_mode(),
+    ?LOG_INFO("Starting automatic tiered storage GC sweep (mode: ~p).", [Mode]),
+    case rabbitmq_stream_s3_gc:run(#{mode => Mode}) of
         {ok, Findings} ->
             ?LOG_INFO(
-                "Automatic tiered storage GC sweep complete: ~b dangling object(s).",
-                [length(Findings)]
+                "Automatic tiered storage GC sweep complete: ~b dangling object(s) ~ts.",
+                [length(Findings), verb(Mode)]
             );
         {error, Reason} ->
             ?LOG_WARNING(
@@ -159,6 +164,9 @@ sweep() ->
                 [Reason]
             )
     end.
+
+verb(delete) -> "deleted";
+verb(dry_run) -> "found".
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/rabbitmq_stream_s3_gc_scheduler.erl
+++ b/src/rabbitmq_stream_s3_gc_scheduler.erl
@@ -1,0 +1,189 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_gc_scheduler).
+-moduledoc """
+Periodically triggers a cross-stream garbage collection sweep.
+
+`rabbitmq_stream_s3_gc:run/1` is otherwise only invoked on demand via the
+`rabbitmq-streams stream_s3_gc` CLI command (and the per-stream `run_stream/2`
+path the replica reader uses after a manifest reset). Without a periodic trigger,
+a straggler object left by the deletion race (an upload that completes after the
+one-shot deletion sweep) and its tombstone persist until an operator runs GC by
+hand.
+
+This server runs a delete-mode sweep on a timer to make straggler reclamation and
+tombstone cleanup self-healing. A full sweep is a bucket-wide LIST plus one
+strongly-consistent metadata read per stream, so it is off by default and runs on
+a conservative interval when enabled.
+
+Reclamation is eventual, not immediate. Objects orphaned by a deleted stream are
+identified from Khepri via a strongly-consistent anchor read, so any sweeping node
+reclaims them. An object orphaned below a live stream's first offset, however, is
+recognised only against that node's local manifest replica cache, so a single
+round reclaims those only for the streams the sweeping node caches; an orphan
+under a stream cached only on other nodes waits for a round one of those nodes
+wins. Because the lock is not fair, that can take several rounds, but every node
+runs its own timer, so each stream's caching nodes get their turn.
+
+Every node runs its own timer, but a sweep must run on only one node at a time: a
+concurrent sweep would duplicate the LIST and quorum-read cost with no benefit. A
+non-blocking cluster-wide lock (`global:trans/4` with zero retries) elects the
+sweeper for each round; a node that cannot take the lock skips that round and
+retries on its next tick. There is no fixed leader, so the sweep survives the loss
+of any node.
+""".
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+-include("include/logging.hrl").
+
+-record(?MODULE, {timer :: reference() | undefined}).
+
+-define(SERVER, ?MODULE).
+-define(SWEEP, sweep).
+%% Cluster-wide lock id. The requester id (the second element) must be `self()`,
+%% not a shared constant: `global` grants a lock re-entrantly to an identical
+%% requester id, so a fixed id would let every node hold it at once and defeat
+%% the mutual exclusion. See with_sweep_lock/2.
+-define(GC_LOCK, {{?MODULE, sweep}, self()}).
+
+-export([start_link/0]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% Exported for the multi-node gc_scheduler_SUITE, which exercises the
+%% cluster-wide lock (a distributed property the non-distributed eunit VM cannot
+%% reproduce).
+-export([with_sweep_lock/2]).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
+    case rabbitmq_stream_s3_config:gc_enabled() of
+        true ->
+            ?LOG_INFO(
+                "Automatic tiered storage GC is enabled; scheduling a sweep every ~b ms.",
+                [rabbitmq_stream_s3_config:gc_interval()]
+            ),
+            {ok, #?MODULE{timer = schedule()}};
+        false ->
+            ?LOG_INFO("Automatic tiered storage GC is disabled."),
+            ignore
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(?SWEEP, #?MODULE{} = State) ->
+    %% A sweep error must never kill the timer loop: catch everything and
+    %% reschedule regardless.
+    try
+        run_sweep()
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Automatic tiered storage GC sweep failed: ~ts:~p~n~p",
+                [Class, Reason, Stack]
+            )
+    end,
+    {noreply, State#?MODULE{timer = schedule()}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%----------------------------------------------------------------------------
+
+schedule() ->
+    erlang:send_after(rabbitmq_stream_s3_config:gc_interval(), self(), ?SWEEP).
+
+run_sweep() ->
+    %% `[node() | nodes()]` is the set `global` can arbitrate over (its own
+    %% default node list, and what rabbit_amqqueue's non-blocking rebalance lock
+    %% uses). It is more correct here than rabbit_nodes:list_running/0: `global`
+    %% locks at the Erlang distribution layer, and a rabbit membership view can
+    %% transiently diverge from distribution connectivity, which would let two
+    %% nodes lock over different node sets and sweep at once.
+    _ = with_sweep_lock([node() | nodes()], fun sweep/0),
+    ok.
+
+%% Run `Fun` under a non-blocking cluster-wide lock so only one node sweeps per
+%% round. `global:trans/4` with zero retries runs `Fun` when the lock is free and
+%% returns `aborted` (without running it) when another node holds it. Returns
+%% `skipped` when the lock was held elsewhere, or `{ran, Result}` otherwise.
+%%
+%% `Fun`'s result is wrapped in `{ran, _}` inside the transaction so a run can
+%% never be mistaken for `global:trans/4`'s own `aborted` return, even if `Fun`
+%% itself returns the atom `aborted`.
+-spec with_sweep_lock([node()], fun(() -> Result)) -> skipped | {ran, Result}.
+with_sweep_lock(Nodes, Fun) ->
+    case global:trans(?GC_LOCK, fun() -> {ran, Fun()} end, Nodes, 0) of
+        aborted ->
+            ?LOG_DEBUG(
+                "Skipping automatic tiered storage GC sweep: another node holds "
+                "the sweep lock this round."
+            ),
+            skipped;
+        {ran, _} = Result ->
+            Result
+    end.
+
+sweep() ->
+    ?LOG_INFO("Starting automatic tiered storage GC sweep."),
+    case rabbitmq_stream_s3_gc:run(#{mode => delete}) of
+        {ok, Findings} ->
+            ?LOG_INFO(
+                "Automatic tiered storage GC sweep complete: ~b dangling object(s).",
+                [length(Findings)]
+            );
+        {error, Reason} ->
+            ?LOG_WARNING(
+                "Automatic tiered storage GC sweep could not complete: ~p.",
+                [Reason]
+            )
+    end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+%% When GC is disabled (the default), the server does not start.
+init_disabled_returns_ignore_test() ->
+    application:unset_env(rabbitmq_stream_s3, gc_enabled),
+    ?assertEqual(ignore, init([])).
+
+%% When GC is enabled, the server starts and arms its timer.
+init_enabled_schedules_sweep_test() ->
+    application:set_env(rabbitmq_stream_s3, gc_enabled, true),
+    application:set_env(rabbitmq_stream_s3, gc_interval, 60_000),
+    try
+        {ok, #?MODULE{timer = Timer}} = init([]),
+        ?assert(is_reference(Timer)),
+        _ = erlang:cancel_timer(Timer)
+    after
+        application:unset_env(rabbitmq_stream_s3, gc_enabled),
+        application:unset_env(rabbitmq_stream_s3, gc_interval)
+    end.
+
+%% The cluster-wide lock's mutual exclusion is a distributed property: the eunit
+%% VM runs with `-kernel start_distribution false` (see erlang.mk), so
+%% `global_name_server` is absent and `global:trans/4` does not arbitrate. That
+%% path is exercised in the multi-node gc_scheduler_SUITE instead.
+
+-endif.

--- a/src/rabbitmq_stream_s3_sup.erl
+++ b/src/rabbitmq_stream_s3_sup.erl
@@ -101,6 +101,13 @@ init([]) ->
         type => worker,
         start => {rabbitmq_stream_s3_reconciler, start_link, []}
     },
+    %% Triggers periodic cross-stream GC when enabled; a non-blocking
+    %% cluster-wide lock keeps concurrent sweeps to one node at a time.
+    GcScheduler = #{
+        id => rabbitmq_stream_s3_gc_scheduler,
+        type => worker,
+        start => {rabbitmq_stream_s3_gc_scheduler, start_link, []}
+    },
     Procs = [
         CredentialServer,
         BucketMonitor,
@@ -111,7 +118,8 @@ init([]) ->
         GeneralPool,
         Governor,
         ReplicaReaderSup,
-        Reconciler
+        Reconciler,
+        GcScheduler
     ],
     {ok, {SupFlags, Procs}}.
 

--- a/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
@@ -81,4 +81,12 @@
  {stream_s3_kms_key_id,
   "stream_s3.kms_key_id = arn:aws:kms:us-east-1:123456789012:key/example-key-id",
   [{rabbitmq_stream_s3, [{kms_key_id, <<"arn:aws:kms:us-east-1:123456789012:key/example-key-id">>}]}],
+  []},
+ {stream_s3_gc_enabled,
+  "stream_s3.gc.enabled = true",
+  [{rabbitmq_stream_s3, [{gc_enabled, true}]}],
+  []},
+ {stream_s3_gc_interval,
+  "stream_s3.gc.interval = 86400000",
+  [{rabbitmq_stream_s3, [{gc_interval, 86400000}]}],
   []}].

--- a/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_stream_s3.snippets
@@ -89,4 +89,12 @@
  {stream_s3_gc_interval,
   "stream_s3.gc.interval = 86400000",
   [{rabbitmq_stream_s3, [{gc_interval, 86400000}]}],
+  []},
+ {stream_s3_gc_mode_dry_run,
+  "stream_s3.gc.mode = dry_run",
+  [{rabbitmq_stream_s3, [{gc_mode, dry_run}]}],
+  []},
+ {stream_s3_gc_mode_delete,
+  "stream_s3.gc.mode = delete",
+  [{rabbitmq_stream_s3, [{gc_mode, delete}]}],
   []}].

--- a/test/gc_scheduler_SUITE.erl
+++ b/test/gc_scheduler_SUITE.erl
@@ -1,0 +1,125 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(gc_scheduler_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+-compile([nowarn_export_all, export_all]).
+
+%% The lock resource, mirroring the ?GC_LOCK definition in
+%% rabbitmq_stream_s3_gc_scheduler. The requester id is added per caller.
+-define(LOCK_RESOURCE, {rabbitmq_stream_s3_gc_scheduler, sweep}).
+
+all() ->
+    [sweep_lock_is_cluster_wide].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config, []).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config0) ->
+    rabbit_ct_helpers:testcase_started(Config0, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config0, [
+        {rmq_nodes_count, 2},
+        {rmq_nodes_clustered, true},
+        {rmq_nodename_suffix, Testcase}
+    ]),
+    Config = rabbit_ct_helpers:merge_app_env(
+        Config1,
+        {rabbitmq_stream_s3, [
+            %% All test suites use the FS backend, though this suite does not
+            %% touch the remote tier.
+            {rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fs}
+        ]}
+    ),
+    rabbit_ct_helpers:run_steps(
+        Config,
+        rabbit_ct_broker_helpers:setup_steps()
+    ).
+
+end_per_testcase(Testcase, Config) ->
+    %% Best-effort: release the lock holder in case a failed assertion aborted
+    %% the testcase before it released the lock, so a leaked holder cannot
+    %% outlive the case. release_lock/0 is idempotent and the node may already
+    %% be gone, so ignore any error.
+    catch rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, release_lock, []),
+    Config1 = rabbit_ct_helpers:run_steps(
+        Config,
+        rabbit_ct_broker_helpers:teardown_steps()
+    ),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+
+%% While one node holds the cluster-wide sweep lock, another node's
+%% with_sweep_lock/2 must skip its sweep; once the lock is released, the next
+%% attempt runs. This is the mutual exclusion the eunit tests cannot cover: the
+%% eunit VM runs without distribution, so global does not arbitrate.
+sweep_lock_is_cluster_wide(Config) ->
+    [N0, N1] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Nodes = [N0, N1],
+
+    %% N0 takes and holds the lock.
+    ok = rabbit_ct_broker_helpers:rpc(Config, N0, ?MODULE, hold_lock, [Nodes]),
+
+    %% N1 cannot sweep while N0 holds the lock.
+    ?assertEqual(skipped, try_sweep(Config, N1, Nodes)),
+
+    %% After N0 releases, N1's next attempt runs the sweep function.
+    ok = rabbit_ct_broker_helpers:rpc(Config, N0, ?MODULE, release_lock, []),
+    ?awaitMatch({ran, swept}, try_sweep(Config, N1, Nodes), 5_000),
+
+    ok.
+
+%% -------------------------------------------------------------------
+%% RPC targets (run on the broker nodes).
+%% -------------------------------------------------------------------
+
+%% Acquire the sweep-lock resource from a dedicated, registered holder process so
+%% it outlives this RPC call and keeps the lock held until release_lock/0.
+hold_lock(Nodes) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+        true = global:set_lock({?LOCK_RESOURCE, self()}, Nodes),
+        Parent ! locked,
+        receive
+            release -> ok
+        end
+    end),
+    register(gc_scheduler_suite_lock_holder, Pid),
+    receive
+        locked -> ok
+    after 5_000 ->
+        error(lock_not_acquired)
+    end.
+
+%% Idempotent so end_per_testcase can call it as best-effort cleanup even when
+%% the test already released the holder (or never acquired it).
+release_lock() ->
+    case whereis(gc_scheduler_suite_lock_holder) of
+        undefined ->
+            ok;
+        Pid ->
+            unregister(gc_scheduler_suite_lock_holder),
+            Pid ! release,
+            ok
+    end.
+
+%% Attempt a sweep under the cluster-wide lock, running a trivial function in
+%% place of the real GC so this suite needs no remote-tier fixtures.
+try_sweep_rpc(Nodes) ->
+    rabbitmq_stream_s3_gc_scheduler:with_sweep_lock(Nodes, fun() -> swept end).
+
+%% -------------------------------------------------------------------
+
+try_sweep(Config, Node, Nodes) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ?MODULE, try_sweep_rpc, [Nodes]).


### PR DESCRIPTION
## What

Adds `rabbitmq_stream_s3_gc_scheduler`, a periodic `gen_server` that triggers a delete-mode cross-stream GC sweep on a timer. A sweep must run on only one node at a time, so it is elected each round by a non-blocking cluster-wide lock (`global:trans/4` with zero retries) with no fixed leader, so the sweep survives the loss of any node.

Closes #309.

## Why

`rabbitmq_stream_s3_gc:run/1` was otherwise only invoked on demand via the `stream_s3_gc` CLI command (and the per-stream reset path). Without a periodic trigger, a straggler object left by the deletion race (an upload that completes after the one-shot deletion sweep) and its tombstone persist until an operator runs GC by hand. This backstops that gap and makes straggler reclamation self-healing.

## Configuration

Automatic GC is off by default. When enabled it runs on a conservative 24 hour interval: a full sweep is a bucket-wide `LIST` plus one strongly-consistent metadata read per stream, and the objects it reclaims are not urgent.

```ini
# boolean, default false
stream_s3.gc.enabled = true

# positive integer milliseconds, default 86400000 (24 hours)
stream_s3.gc.interval = 86400000
```

## Notes on reclamation scope

Reclamation is eventual, not immediate. Deleted-stream orphans are identified from Khepri via a strongly-consistent anchor read, so any sweeping node reclaims them. An object orphaned below a live stream's first offset is recognised only against the sweeping node's local manifest replica cache, so those are reclaimed over successive rounds as each stream's caching nodes win the lock. The moduledoc spells this out.

## Testing

- New multi-node `gc_scheduler_SUITE` exercises the cluster-wide lock's mutual exclusion (the eunit VM runs without distribution, so `global` does not arbitrate there)
- eunit gating tests for enabled/disabled init
- `config_schema_SUITE` snippets for the two new keys
- `eunit`, `ct-gc_scheduler`, `ct-config_schema`, `xref`, `dialyze` all green