### PR TITLE
Optimize remote reader binary handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,14 @@ fmt-check:
 ct-quick: test-build
 	$(verbose) mkdir -p $(CT_LOGS_DIR)
 	$(gen_verbose) $(CT_RUN) -sname ct_$(PROJECT) -suite $(addsuffix _SUITE,$(CT_QUICK_SUITES)) $(CT_EXTRA) $(CT_OPTS)
+
+# Benchmarks (test/*_bench.erl). Not CI-gated; for before/after comparisons
+# on a quiet machine. `make bench` runs all, `make bench-<module>` runs one.
+# The harness itself matches the *_bench.erl glob; it is not a benchmark.
+BENCH_MODULES = $(filter-out rabbitmq_stream_s3_bench,$(patsubst test/%.erl,%,$(wildcard test/*_bench.erl)))
+
+.PHONY: bench
+bench: $(addprefix bench-,$(BENCH_MODULES))
+
+bench-%: test-build
+	$(gen_verbose) erl -noshell -pa ebin -pa test -eval '$*:run(), halt(0).'

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,6 +89,26 @@ open cover/index.html
 
 Coverage data files land in `cover/` (ct.coverdata, eunit.coverdata). The report shows per-module line coverage with annotated source.
 
+## Benchmarks
+
+Benchmarks live in `test/*_bench.erl` and run on the `rabbitmq_stream_s3_bench` harness (warmup, timed iterations in an isolated process, iterations-per-second and percentile report with a comparison against the fastest scenario).
+
+```bash
+# Run all benchmarks
+gmake bench
+
+# Run one benchmark module
+gmake bench-read_buffer_bench
+```
+
+Benchmarks are for humans comparing before/after numbers on a quiet machine. They are deliberately not CI-gated and assert nothing: relative performance assertions are flaky on shared runners, and a benchmark that must pass gets tuned until it does. When a change touches a hot path (the read or upload path), run the relevant benchmark before and after and put both numbers in the commit message or PR.
+
+To add one, create `test/<name>_bench.erl` exporting `run/0` that calls `rabbitmq_stream_s3_bench:run/1,2` with named scenario funs; `make bench` picks it up by filename. Keep a scenario's iteration meaningful (one window of work, not one tiny operation) and keep the default runtime in seconds, not minutes.
+
+Wall time is the primary signal. In particular, do not trust `tprof`'s `call_memory` view for binary-heavy paths: it counts heap words and cannot see refc binary payloads, which is precisely what the plugin's hot paths move.
+
+For memory questions the harness provides `sample_binary_memory/1` (peak VM binary memory over a run, baselined after garbage-collecting every process). Peak readings are GC-timing dependent and jitter run to run; for a deterministic number, measure what live references pin after a forced GC — see the memory phase of `read_buffer_bench` for the pattern (a sink retains the last N replies, GCs itself, and reports its deduplicated `process_info(_, binary)` total).
+
 ## Formatting
 
 All Erlang source is formatted with `erlfmt`:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -40,6 +40,12 @@ The manifest stores entries as a flat binary (34 bytes per entry) rather than a 
 
 Use binary arrays for any fixed-size record collection that needs binary search or sequential access. Do not convert to lists of records for processing.
 
+## Never grow a binary that reads are served from
+
+Do not accumulate a long-lived buffer with `<<Buffer/binary, Data/binary>>` if sub-binaries of it are handed to other processes (replies, messages). Copying a sub-binary into a message seals the writable binary, so the next append copies the whole buffer; the sub-binary also pins the entire buffer in the receiver's heap until it collects garbage.
+
+Keep the delivered binaries whole in a queue instead and assemble reads from the pieces. `rabbitmq_stream_s3_read_buffer` implements this for the remote read path (see its moduledoc and [read-path.md](./read-path.md#buffer)); reuse it rather than growing a flat binary.
+
 ## List accumulation
 
 Do not use `List ++ [Element]` to build lists incrementally. Tail-append copies the entire list on every call, making N appends O(N²).

--- a/docs/investigations/remote-reader-memory.md
+++ b/docs/investigations/remote-reader-memory.md
@@ -1,0 +1,326 @@
+# Remote reader memory behavior
+
+This doc is an investigation into the memory impact of remote tier reads.
+
+Measurements were taken on a single development machine (Linux, Erlang/OTP 27, ERTS 15.2.7.6).
+
+## Why uploads are cheaper than reads
+
+The upload path never accumulates: `stream_put/stream_data` (`rabbitmq_stream_s3_api_aws.erl`) batches outgoing data to 1 MiB chunks and hands each to gun immediately, so a replica reader in steady state holds roughly one chunk of in-flight data per stream.
+
+The read path must accumulate by design. The remote reader prefetches an AIMD-sized window ahead of the consumer (up to `read_size_max`, 64 MiB) and additionally prefetches the next fragment at the full window size, so tens of MiB of *intentional* buffer per remote consumer is the baseline. The waste investigated here was on top of that: the same bytes being copied repeatedly, and dead buffer memory surviving long after it was consumed.
+
+## Mechanism: appending and slicing the same binary
+
+The original buffer was a single binary grown per S3 delivery with `<<Buffer/binary, Data/binary>>`, and reads were served as `binary:part/3` sub-binaries replied to the log reader. Each half of that pattern is fine alone; together they degrade. In the OTP source:
+
+- An append reuses the binary in place only while the underlying refc binary is still flagged writable. Otherwise `erts_bs_append_checked` takes the `not_writable` path and copies the entire buffer into a fresh writable binary (`erts/emulator/beam/erl_bits.c`, the `not_writable` label).
+- `binary:part/3` over a writable binary yields a sub-binary marked *volatile* (`erts_build_sub_bitstring`). Results of 64 bytes or less are copied to the heap instead (`ERL_ONHEAP_BITS_LIMIT`) — but the smallest read on this path is the chunk-header over-read of `?CHUNK_HEADER_B + ?MAX_FILTER_SIZE` = 303 bytes, so every read produced a volatile sub-binary.
+- The moment a volatile sub-binary is copied into a message (which `gen_server:reply` does) `erts_pin_writable_binary` clears the writable flag (`erts/emulator/beam/copy.c`).
+
+The consumption pattern is read header, read chunk data, repeat, interleaved with ~1 MiB `{data, ...}` deliveries. So in steady state the buffer was sealed by the time each delivery arrived, and **every append copied the whole window**: up to 64 copies of an up-to-64 MiB buffer per window, with each superseded generation becoming binary-allocator garbage. Meanwhile each reply sub-binary (even a 303-byte header read) kept its entire window generation alive in the consumer connection's heap until that process happened to collect garbage.
+
+## Measurement: the append/slice pattern in isolation
+
+Simulating exactly the buffer pattern (64 deliveries of 1 MiB; 4 reads of 311 bytes served and replied to a sink process between deliveries):
+
+| Scenario | Time |
+|---|---|
+| Pure appends, no reads | 30.1 ms |
+| Appends + `binary:part` replies (the original pattern) | 1,192.7 ms |
+| Same, but each reply `binary:copy`'d first | 43.2 ms |
+| Segment/block queue (list of deliveries) | 0.3 ms |
+
+The 40x gap between the first two rows is the seal-then-copy cycle. The pinning half was demonstrated directly: after serving one 311-byte read from a 64 MiB buffer, the receiving process's `process_info(_, binary)` showed it keeping the full **64 MiB** alive.
+
+<details><summary>Measurement script (<code>buffer_bench.erl</code>, standalone escript)...</summary>
+
+```erlang
+-module(buffer_bench).
+-export([main/1, run/3]).
+
+-define(DELIVERY, 1 bsl 20).
+-define(DELIVERIES, 64).
+-define(READS_PER_DELIVERY, 4).
+-define(READ_BYTES, 311).
+
+main(_) ->
+    Data = rand:bytes(?DELIVERY),
+    Sink = spawn(fun sink/0),
+    _ = run(pure, Data, Sink),
+    lists:foreach(
+        fun(Mode) ->
+            {Time, GCs, Words} = measure(fun() -> run(Mode, Data, Sink) end),
+            io:format("~-22s: ~8.1f ms   ~4b GCs   ~10b words GC-reclaimed~n",
+                      [Mode, Time / 1000, GCs, Words])
+        end,
+        [pure, part_send, part_copy_send, segments]),
+    Big = rand:bytes(64 bsl 20),
+    Sink ! {ok, binary:part(Big, 1000, ?READ_BYTES)},
+    Sink ! {report, self()},
+    receive
+        {binary_refs, Refs} ->
+            Total = lists:sum([Sz || {_, Sz, _} <- Refs]),
+            io:format("pinning: sink holds ~b bytes of reads, keeping ~b MiB of "
+                      "buffer alive~n", [?READ_BYTES, Total div (1 bsl 20)])
+    end,
+    Sink ! stop,
+    ok.
+
+sink() ->
+    receive
+        stop -> ok;
+        {report, From} ->
+            {binary, Refs} = process_info(self(), binary),
+            From ! {binary_refs, Refs},
+            sink();
+        _ -> sink()
+    end.
+
+measure(Fun) ->
+    erlang:garbage_collect(),
+    {garbage_collection, G0} = process_info(self(), garbage_collection),
+    GCs0 = proplists:get_value(minor_gcs, G0),
+    {_, Reclaimed0, _} = erlang:statistics(garbage_collection),
+    T0 = erlang:monotonic_time(microsecond),
+    Fun(),
+    T1 = erlang:monotonic_time(microsecond),
+    {garbage_collection, G1} = process_info(self(), garbage_collection),
+    GCs1 = proplists:get_value(minor_gcs, G1),
+    {_, Reclaimed1, _} = erlang:statistics(garbage_collection),
+    {T1 - T0, GCs1 - GCs0, Reclaimed1 - Reclaimed0}.
+
+run(pure, Data, _Sink) ->
+    lists:foldl(fun(_, Buf0) -> <<Buf0/binary, Data/binary>> end, <<>>,
+                lists:seq(1, ?DELIVERIES));
+run(part_send, Data, Sink) ->
+    lists:foldl(
+        fun(_, Buf0) ->
+            Buf = <<Buf0/binary, Data/binary>>,
+            lists:foreach(
+                fun(I) ->
+                    Off = (I * 4096) rem (byte_size(Buf) - ?READ_BYTES),
+                    Sink ! {ok, binary:part(Buf, Off, ?READ_BYTES)}
+                end,
+                lists:seq(1, ?READS_PER_DELIVERY)),
+            Buf
+        end, <<>>, lists:seq(1, ?DELIVERIES));
+run(part_copy_send, Data, Sink) ->
+    lists:foldl(
+        fun(_, Buf0) ->
+            Buf = <<Buf0/binary, Data/binary>>,
+            lists:foreach(
+                fun(I) ->
+                    Off = (I * 4096) rem (byte_size(Buf) - ?READ_BYTES),
+                    Sink ! {ok, binary:copy(binary:part(Buf, Off, ?READ_BYTES))}
+                end,
+                lists:seq(1, ?READS_PER_DELIVERY)),
+            Buf
+        end, <<>>, lists:seq(1, ?DELIVERIES));
+run(segments, Data, Sink) ->
+    lists:foldl(
+        fun(_, Segs0) ->
+            Segs = [Data | Segs0],
+            lists:foreach(
+                fun(_) ->
+                    Sink ! {ok, binary:copy(binary:part(Data, 4096, ?READ_BYTES))}
+                end,
+                lists:seq(1, ?READS_PER_DELIVERY)),
+            Segs
+        end, [], lists:seq(1, ?DELIVERIES)).
+```
+
+</details>
+
+## The fix: a block queue
+
+`rabbitmq_stream_s3_read_buffer` stores the delivered binaries as-is, in offset order, addressed by absolute fragment byte positions (see [read-path.md](../read-path.md#buffer) for the design and invariants, and the module doc for the runtime rationale). The key properties:
+
+- Appending retains the delivery as an immutable block: no binary is ever grown, so there is nothing for the runtime to seal and nothing to re-copy
+- Consumed blocks are dropped whole as reads advance, freeing block-by-block
+- A reply pins at most the blocks it overlaps: reads of at most 512 bytes are copied and pin nothing, larger single-block reads share a sub-binary of one ~1 MiB block, and block-spanning reads assemble a fresh binary of exactly the requested bytes
+
+The API layer's existing 1 MiB batching (`?BUFFER_PENDING_DATA_BYTES`) becomes the block size, bounding both what a shared read can pin and the block count per window (64 at the AIMD ceiling).
+
+### Benchmark
+
+`gmake bench-read_buffer_bench` compares the shipped block queue against the flat-binary implementation it replaced, under the production access pattern: 1 MiB deliveries with the consumer trailing the newest delivered byte by a steady 8 MiB prefetch lag, interleaved 303-byte header and 32 KiB chunk reads replied to a sink process, consumed data discarded as the read floor advances. One iteration is a 16 MiB window.
+
+The lag is load-bearing methodology, not decoration. The prefetch running ahead of the consumer is what the AIMD window exists for, and it is what keeps unconsumed bytes in the buffer. An early version of this benchmark had the consumer reading at the delivery edge; the old implementation's compaction then kept even the flat binary at ~1.25 MiB, and both the window-sized copying and the pinning largely vanished from the measurement (the designs looked about 160x apart, and consumer-side pinning looked near-identical). With the steady lag the buffer retains a realistic ~9 MiB unconsumed span:
+
+The scenarios come in matched pairs so each design faces the same workload: header + chunk reads (`flat_binary` vs `block_queue`) and 2 MiB reads (`flat_binary_spanning` vs `block_queue_spanning`, where every block-queue read spans blocks and pays the assembly copy (the block queue's worst case)).
+
+| Scenario | ips | average | p99 | GC/iter |
+|---|---|---|---|---|
+| `flat_binary` (regression baseline) | 25.2 | 39.6 ms | 41.4 ms | 12.0 |
+| `flat_binary_spanning` | 51.1 | 19.6 ms | 22.0 ms | 3.8 |
+| `block_queue` | 21.7 K | 46.2 µs | 270 µs | 1.9 |
+| `block_queue_spanning` | 4.9 K | 204 µs | 295 µs | 4.0 |
+
+~860x on the real pattern, and ~95x for the block queue's worst case against the flat binary's *best* case (2 MiB reads amortize flat's per-delivery window copy across more consumed bytes). The flat-binary scenarios are kept in the benchmark deliberately: if `block_queue` ever drifts toward them, window-sized copying has crept back into the read path.
+
+### Memory: showing the pinning directly
+
+Speed and GC counts are proxies; the benchmark's memory phase measures pinning itself, in the two places it hides. Deliveries are fresh 1 MiB copies here (the timing phase reuses one template binary since append cost is content-independent, but a memory measurement must allocate like production does).
+
+**Consumer-side pinning, deterministic.** The sink retains its newest 8 replies — a consumer holding a delivery's worth of header and chunk reads in its socket send queue — then force-GCs itself and reports `process_info(self(), binary)` deduplicated per binary instance. The forced GC removes all timing dependence: what remains is exactly what those 8 live replies keep alive. Against the actual byte size of the replies this yields a pinning amplification factor:
+
+| Scenario | Reply bytes held | Pinned | Amplification |
+|---|---|---|---|
+| `flat_binary` | 129.2 KiB | 9.0 MiB | 71.3x |
+| `flat_binary_spanning` | 16.0 MiB | 72.0 MiB | 4.5x |
+| `block_queue` | 129.2 KiB | 1.0 MiB | 7.9x |
+| `block_queue_spanning` | 16.0 MiB | 16.0 MiB | 1.0x |
+
+These numbers are exact and reproduce run over run. Reading them requires the amplification column, not the raw pinned column: `block_queue_spanning`'s 16 MiB is a consumer *choosing* to hold 16 MiB of chunk data and paying for exactly that (assembly produces fresh binaries, so nothing extra rides along), while `flat_binary`'s 9 MiB is 129 KiB of useful data dragging a full window behind it.
+
+The two flat rows also expose an effect with real teeth: **generation multiplication**. Under the flat design every delivery produces a new buffer generation (the seal forces the copy), and replies from different read events are sub-binaries of *different* generations — overlapping content, distinct binaries, each pinned in full. `flat_binary`'s 8 retained replies all come from one read batch, so they dedup to a single 9 MiB generation; that is the flat design's *best possible* retention pattern. `flat_binary_spanning`'s 8 replies come from 8 read events, so they pin 8 distinct ~9 MiB generations: 72 MiB, more than 4x the live window, for the same 16 MiB of payload the block queue serves at 1.0x. Any consumer whose held replies span read events — which is the normal case — sits between those two rows under the flat design. Under the block queue there is nothing to multiply: blocks are shared, not superseded, so pinning is bounded by the blocks the replies overlap regardless of how many read events they span. Scaled to the AIMD ceiling, one flat generation is up to 64 MiB — per retained read event, per consumer.
+
+### Supply x demand matrix
+
+The scenarios above fix supply at 1 MiB blocks and demand at two read sizes. Chunks can be small or large, and the batching constant could have been chosen differently, so the benchmark also sweeps both axes: block size (what the S3 API layer's batching supplies) against read size (what the consumer demands), with a uniform-read consumer under the same 8 MiB lag and the flat binary as a baseline row. Reads ≤512 bytes are copied by `read/3`; reads larger than a block are assembled; everything between is served as a sub-binary of one or more blocks.
+
+Average time per 16 MiB window:
+
+| | read 303 B | read 32 KiB | read 256 KiB | read 2 MiB |
+|---|---|---|---|---|
+| flat, 1 MiB deliveries | 46.7 ms | 42.1 ms | 39.9 ms | 20.0 ms |
+| queue, 256 KiB blocks | 17.4 ms | 131 µs | 21 µs | 207 µs |
+| queue, 1 MiB blocks | 18.8 ms | 110 µs | 15 µs | 213 µs |
+| queue, 4 MiB blocks | 16.0 ms | 93 µs | 12 µs | 2 µs |
+
+Pinning amplification (sink retains its last 8 replies, then GCs):
+
+| | read 303 B | read 32 KiB | read 256 KiB | read 2 MiB |
+|---|---|---|---|---|
+| flat, 1 MiB deliveries | 3893.2x | 36.0x | 9.0x | 4.5x |
+| queue, 256 KiB blocks | 1.0x | 1.0x | 1.0x | 1.0x |
+| queue, 1 MiB blocks | 1.0x | 4.0x | 1.0x | 1.0x |
+| queue, 4 MiB blocks | 1.0x | 16.0x | 2.0x | 1.0x |
+
+What the matrix shows:
+
+- **Amplification has a closed form, and block size is its ceiling.** For shared reads it is the size of the blocks overlapped divided by the bytes held, so it peaks when a small retained set sits inside a big block (32 KiB reads: 4x in 1 MiB blocks, 16x in 4 MiB blocks) and falls to 1.0x when the retained set covers whole blocks. The copy threshold zeroes it for tiny reads (the 303 B column) and assembly zeroes it for block-spanning reads (the 2 MiB column). The flat row has no ceiling: its amplification is the retained window over the bytes held, which explodes as demand shrinks — **3893x** for header-sized reads
+- **The 1 MiB batching constant is a reasonable middle.** 256 KiB blocks pin least but quadruple the per-window block count for slightly worse small-read timing; 4 MiB blocks buy microseconds while quadrupling the mid-size-read pinning ceiling to 16x. This is the measurement that makes `?BUFFER_PENDING_DATA_BYTES` an evidence-backed choice rather than an inherited one
+- **The 303 B column is read-overhead-bound for every design** (thousands of copy+send operations per window); the block queue wins ~2.5x there, not hundreds of times. The real read path pairs each header read with a chunk-data read, which is why the headline scenarios interleave both. Everywhere else the buffer mechanics dominate and the gap is 100–4000x
+- **Large reads from larger blocks are pure sharing**: 2 MiB reads out of 4 MiB blocks cost 2 µs per window and still pin at 1.0x — sharing beats assembly when the read fits a block, which is the argument for keeping blocks at least as large as common chunk sizes
+
+**Whole-VM footprint, indicative.** A sampler process records peak `erlang:memory(binary)` over the run, against a baseline taken after garbage-collecting every process (without that quiescing step, leftovers from the previous scenario inflate the baseline and then deflate the apparent peak by dying mid-run). Peak-over-baseline captures the churn no per-process view shows — dead window generations awaiting collection plus the live working set. Representative readings: `flat_binary` ~90–130 MiB for a workload whose live window is 9 MiB, `flat_binary_spanning` ~240 MiB (generation churn plus multi-generation pinning), `block_queue` ~10–45 MiB, `block_queue_spanning` ~85–105 MiB (its 2 MiB assemblies are real allocations, freed by any GC and pinned by nothing). Unlike the pinning column this jitters run to run — it depends on where the collector happened to land — so treat it as context, not a regression gate.
+
+## Process flags
+
+The block queue removes the copying, but a second promptness question remained: block *references* live in the reader's gen_server state across many collections, get tenured to the old heap, and once `drop_before/2` discards them, minor GCs cannot reclaim them. An idle reader (consumer stalled, or parked at the tail) could pin its last prefetch window until a major GC that may never come. This is the same profile the connection pool already tunes for with `{receiver_spawn_opts, [{fullsweep_after, 0}]}` (`rabbitmq_stream_s3_api_aws_pool.erl`): a data pipe for large refc binaries whose own heap is small.
+
+Measured on a reader-shaped process (200 deliveries of 1 MiB into a read buffer, a shared sub-binary read served from each, ~4-block window kept, then churn stops; "pinned" is what `process_info(Pid, binary)` shows the quiescent process still referencing, before anything forces a GC):
+
+| Spawn flags | Pinned after churn | Loop time | GCs during loop |
+|---|---|---|---|
+| default | 6.0 MiB | 10.7 ms | 39 minor |
+| `fullsweep_after 0` | 0.0 MiB | 5.4 ms | 0 minor (all full sweeps) |
+| `fullsweep_after 10` | 6.0 MiB | 6.0 ms | 2 minor |
+| `message_queue_data off_heap` alone | 6.0 MiB | 6.2 ms | 35 minor |
+| `fullsweep_after 0` + `off_heap` | 0.0 MiB | 5.2 ms | 0 |
+
+Findings:
+
+- `fullsweep_after 0` releases everything promptly *and* runs the loop 2x faster: full sweeps of a near-empty heap are cheaper than minor collections that copy and tenure live block refs
+- `fullsweep_after 10` is not a middle ground for promptness: the last major happens before the churn ends, and the process quiesces still pinning the dead window. Promptness needs every collection to be a full sweep
+- `message_queue_data off_heap` is neutral in this simulation (its mailbox is empty) but is included on reasoning: the real reader's mailbox receives S3 response bodies as gun data frames with no flow control, and with every GC now a full sweep, an on-heap backlog would be scanned and copied on each one
+- `min_bin_vheap_size` was considered and skipped: raising it delays collections (the opposite of what this process wants), and lowering it adds GC count with nothing to save once full sweeps are this cheap
+
+Both flags are set at spawn in `rabbitmq_stream_s3_log_reader:init_remote_reader/2` (they are `spawn_opt`-only; `process_flag/2` cannot set `fullsweep_after`).
+
+Consumer connection processes were left alone: the plugin does not own them, and the block queue already minimized their exposure (they pin at most one ~1 MiB block, and small reads pin nothing).
+
+<details><summary>Measurement script (<code>flags_bench.erl</code>, run with <code>-pa ebin</code>)...</summary>
+
+```erlang
+-module(flags_bench).
+-export([main/1]).
+
+-define(BLOCK, 1 bsl 20).
+-define(ITERATIONS, 200).
+-define(WINDOW_BLOCKS, 4).
+
+main(_) ->
+    Template = binary:copy(<<0>>, ?BLOCK),
+    Sink = spawn(fun sink/0),
+    lists:foreach(
+        fun({Name, SpawnOpts}) ->
+            {Pinned, ElapsedUs, GCInfo} = run(Template, Sink, SpawnOpts),
+            io:format(
+                "~-24s pinned-after-churn: ~7.1f MiB   loop: ~6.1f ms   minor_gcs: ~p~n",
+                [Name, Pinned / (1 bsl 20), ElapsedUs / 1000,
+                 proplists:get_value(minor_gcs, GCInfo)]
+            )
+        end,
+        [
+            {"default flags", []},
+            {"fullsweep_after=0", [{fullsweep_after, 0}]},
+            {"fullsweep_after=10", [{fullsweep_after, 10}]},
+            {"offheap mailbox", [{message_queue_data, off_heap}]},
+            {"fullsweep0 + offheap", [{fullsweep_after, 0}, {message_queue_data, off_heap}]}
+        ]
+    ),
+    Sink ! stop,
+    ok.
+
+sink() ->
+    receive
+        stop -> ok;
+        _ -> sink()
+    end.
+
+run(Template, Sink, SpawnOpts) ->
+    Parent = self(),
+    Pid = spawn_opt(
+        fun() ->
+            T0 = erlang:monotonic_time(microsecond),
+            Buf = churn(?ITERATIONS, rabbitmq_stream_s3_read_buffer:new(0), Template, Sink),
+            _Empty = rabbitmq_stream_s3_read_buffer:drop_before(
+                rabbitmq_stream_s3_read_buffer:end_pos(Buf), Buf
+            ),
+            T1 = erlang:monotonic_time(microsecond),
+            {garbage_collection, GCInfo} = process_info(self(), garbage_collection),
+            Parent ! {done, self(), T1 - T0, GCInfo},
+            %% Stay alive, idle, WITHOUT a further GC, so the parent can see
+            %% what a quiescent reader keeps pinned.
+            receive release -> ok end
+        end,
+        [link | SpawnOpts]
+    ),
+    receive
+        {done, Pid, Elapsed, GCInfo} ->
+            {binary, Refs} = process_info(Pid, binary),
+            Pinned = lists:sum([Sz || {_, Sz, _} <- Refs]),
+            Pid ! release,
+            {Pinned, Elapsed, GCInfo}
+    end.
+
+churn(0, Buf, _Template, _Sink) ->
+    Buf;
+churn(N, Buf0, Template, Sink) ->
+    Block = binary:copy(Template),
+    Buf1 = rabbitmq_stream_s3_read_buffer:append(Block, Buf0),
+    EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buf1),
+    Sink ! {ok, rabbitmq_stream_s3_read_buffer:read(EndPos - 65_536, 32_768, Buf1)},
+    Buf =
+        case rabbitmq_stream_s3_read_buffer:size(Buf1) > ?WINDOW_BLOCKS * ?BLOCK of
+            true ->
+                rabbitmq_stream_s3_read_buffer:drop_before(
+                    EndPos - ?WINDOW_BLOCKS * ?BLOCK, Buf1
+                );
+            false ->
+                Buf1
+        end,
+    churn(N - 1, Buf, Template, Sink).
+```
+
+</details>
+
+## Follow-ups considered but not pursued here
+
+- **iodata reads for the send path.** `read_iodata/3` exists, is exported, and is property-tested. Adopting it in `send_file` would make block-spanning chunks fully zero-copy (`gen_tcp:send`, `ssl:send`, and `erlang:crc32` all take iodata); `chunk_iterator` must keep flat reads for record parsing. Deferred: after the block queue, the remaining spanning-read copy is chunk-sized and rare (the benchmark's worst case is the `block_queue_spanning` row), so measure before changing the read contract
+- **gun flow control.** The pool sets no `flow` option, so a 64 MiB range GET streams into the reader's mailbox without backpressure; a busy reader can accumulate the response in its message queue. `off_heap` makes this cheap for GC but does not bound the memory. Bounding it means per-stream `flow` plus `gun:update_flow/3` calls on consumption
+- **AIMD ceiling and prefetch sizing.** `read_size_max` (64 MiB) plus a full-window next-fragment prefetch means up to ~128 MiB of intentional buffer per remote consumer. With the accidental overhead gone, this is now the dominant per-consumer memory term; a smaller initial prefetch for the *next* fragment, or a ceiling informed by consumer count, would flatten the worst case
+- **Replica reader flags.** The upload path's replica reader is also binary-heavy, but it holds real heap state (fragment assembly); the fullsweep-0 trade-off needs its own measurement rather than assumption

--- a/docs/read-path.md
+++ b/docs/read-path.md
@@ -54,6 +54,18 @@ The remote reader is split into a functional core and a gen_server shell, follow
 
 Effects that require local data (manifest range lookups, iterator refreshes) are resolved synchronously in the shell's effect-execution loop and fed back to the core immediately. This avoids extra async round-trips for what are fast ETS lookups.
 
+### Buffer
+
+The core buffers fragment data in a `rabbitmq_stream_s3_read_buffer`: a queue of the delivered binaries ("blocks", batched to ~1 MiB by the S3 API layer) held as-is in offset order, addressed by absolute byte positions within the fragment object. One buffer holds the current fragment's window; a second accumulates the prefetched next fragment and is moved into place whole at the transition.
+
+This design complements the Erlang VM binary implementation. A naive approach, growing a binary by appending each delivery, interacts badly with an owned binary structure that lends out references. Serving a read as a sub-binary seals it, preventing the runtime from optimizing appends.
+
+- Blocks are contiguous and immutable: `end_pos - start_pos` equals the sum of block sizes, and a delivery is never copied into place (append is O(1)).
+- Consumed data is freed block-by-block: reads are non-decreasing, so when a read is served every block entirely below its start offset is dropped. `start_pos` advances block-granularly, never past the last read's start.
+- A read pins at most the blocks it overlaps: reads ≤ 512 bytes (chunk-header over-reads are 303 bytes) are copied and pin nothing; larger single-block reads share a sub-binary of one block; reads spanning blocks are assembled into a fresh binary.
+
+Reads spanning blocks concatenate only the requested bytes (chunk-sized, not window-sized), which is rare and cheap once the AIMD window is large relative to chunks.
+
 ### Prefetch
 
 The starting byte position within a fragment is determined once, at offset-spec resolution time, by the log reader (see [Index lookup within a fragment](#index-lookup-within-a-fragment)), not by the remote reader. Once reading begins, the remote reader issues forward range requests only for the chunk-data region `[8 + start, 8 + Size)` (it never re-fetches the index), reading ahead of the consumer's position and walking chunk headers sequentially within the buffered data.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -57,6 +57,11 @@ A wrapper around the AWS S3 HTTP API.
 -define(READ_CHECKOUT_TIMEOUT_MS, 100).
 %% Amount of data to buffer in async state before giving it to the remote
 %% reader process. See the async_state() type.
+%%
+%% This also sets the remote reader's buffer granularity: each batch becomes
+%% one immutable block in its rabbitmq_stream_s3_read_buffer, so this constant
+%% caps how much memory a shared sub-binary read can pin (one block) and keeps
+%% the block count per prefetch window low.
 %% 1024^2 (1 MiB).
 -define(BUFFER_PENDING_DATA_BYTES, 1_048_576).
 

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -878,7 +878,16 @@ init_remote_reader(
         stream => StreamId,
         location => Location
     },
-    case gen_server:start(rabbitmq_stream_s3_remote_reader, Conf, []) of
+    %% The remote reader is a data pipe for large refc binaries with a small
+    %% heap of its own, the same profile as the pool's gun processes. Full
+    %% sweeps are nearly free, and making every GC a full sweep releases
+    %% dropped buffer blocks immediately instead of leaving tenured dead
+    %% references pinned until a rare major GC (an idle reader could otherwise
+    %% hold a full prefetch window indefinitely). The off-heap message queue
+    %% keeps those full sweeps from scanning a backed-up mailbox of gun data
+    %% frames. See docs/investigations/remote-reader-memory.md.
+    SpawnOpts = [{spawn_opt, [{fullsweep_after, 0}, {message_queue_data, off_heap}]}],
+    case gen_server:start(rabbitmq_stream_s3_remote_reader, Conf, SpawnOpts) of
         {ok, Pid} ->
             counters:add(counter(), ?C_REMOTE_INIT, 1),
             Reader = #?MODULE{

--- a/src/rabbitmq_stream_s3_read_buffer.erl
+++ b/src/rabbitmq_stream_s3_read_buffer.erl
@@ -161,6 +161,12 @@ read_iodata(Pos, Len, #buffer{start_pos = StartPos, end_pos = EndPos}) ->
 %% into it, so a read near start_pos never pays for the whole block list.
 take(_Skip, 0, _Front, _Rear) ->
     [];
+take(_Skip, _Len, [], []) ->
+    %% No blocks remain but Len > 0 (the clause above consumed Len == 0). This
+    %% is unreachable while read_iodata/3's range check guards every call, but
+    %% crashing here turns a broken invariant into a loud error rather than an
+    %% infinite loop: the clause below would otherwise spin on lists:reverse([]).
+    error(buffer_underrun);
 take(Skip, Len, [], Rear) ->
     take(Skip, Len, lists:reverse(Rear), []);
 take(Skip, Len, [Block | Blocks], Rear) when Skip >= byte_size(Block) ->

--- a/src/rabbitmq_stream_s3_read_buffer.erl
+++ b/src/rabbitmq_stream_s3_read_buffer.erl
@@ -1,0 +1,196 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_read_buffer).
+-moduledoc """
+A contiguous window of stream bytes stored as a queue of immutable binary
+blocks.
+
+The remote read path buffers data delivered by S3 range requests and serves
+the log reader's reads out of that buffer. Storing the window as a single
+binary and growing it with `<<Buffer/binary, Data/binary>>` interacts badly
+with the runtime once reads are served from it:
+
+- Serving a read with `binary:part/3` and replying with the result seals the
+  underlying writable binary (the runtime pins it when the sub-binary is
+  copied into a message), so the next append copies the entire window rather
+  than appending in place. In steady state nearly every delivery re-copies
+  the whole prefetch window (up to `read_size_max`, 64 MiB).
+- A reply sub-binary keeps the entire window generation alive in the
+  consumer's heap: a ~300-byte chunk-header read can pin 64 MiB until the
+  consumer process happens to collect garbage.
+
+This module avoids both by never appending into a binary. Deliveries are
+retained as-is, in order, as sealed blocks; consumed blocks are dropped
+whole; reads assemble exactly the requested bytes from the blocks they
+overlap. Appending is O(1), dropping frees block-by-block, and a reply pins
+at most the blocks it overlaps.
+
+Addressing is absolute: positions are byte offsets within the fragment
+object, the same coordinates the remote reader core uses. The buffer covers
+`[start_pos, end_pos)` and maintains the invariant that blocks are
+contiguous: `end_pos - start_pos` always equals the sum of the block sizes.
+
+Reads of at most 512 bytes are returned as fresh copies rather than
+sub-binaries, so the frequent small chunk-header over-reads
+(`?CHUNK_HEADER_B + ?MAX_FILTER_SIZE` = 303 bytes) pin nothing at all.
+""".
+
+-include("include/rabbitmq_stream_s3.hrl").
+
+%% Reads at or below this size are copied out rather than returned as
+%% sub-binaries into a block. Copying a few hundred bytes is cheaper than
+%% letting a short read pin a block (typically ~1 MiB, see
+%% ?BUFFER_PENDING_DATA_BYTES in the S3 API module) in the consumer's heap.
+%% Sized to cover the chunk-header over-read (?CHUNK_HEADER_B +
+%% ?MAX_FILTER_SIZE = 303 bytes), the only small read on this path, with
+%% headroom; if that over-read ever grows past this, header reads pin a
+%% block again.
+-define(COPY_MAX_B, 512).
+%% Enforced at compile time so a grown filter size cannot silently
+%% reintroduce block pinning for header reads.
+-if(?CHUNK_HEADER_B + ?MAX_FILTER_SIZE > ?COPY_MAX_B).
+-error("chunk-header over-read exceeds COPY_MAX_B; header reads would pin a block").
+-endif.
+
+-record(buffer, {
+    %% Offset of the first retained byte (the base of the head block), or
+    %% the position the next append lands at when the buffer is empty.
+    start_pos :: byte_offset(),
+    %% Offset one past the last retained byte.
+    end_pos :: byte_offset(),
+    %% Blocks in offset order, split amortized-deque style: `front` is
+    %% oldest-first, `rear` is newest-first. The logical sequence is
+    %% `front ++ lists:reverse(rear)`.
+    front = [] :: [binary()],
+    rear = [] :: [binary()]
+}).
+
+-doc "A contiguous byte window over a queue of immutable blocks.".
+-opaque buffer() :: #buffer{}.
+
+-export_type([buffer/0]).
+
+-export([
+    new/1,
+    append/2,
+    drop_before/2,
+    read/3,
+    read_iodata/3,
+    start_pos/1,
+    end_pos/1,
+    size/1,
+    block_count/1
+]).
+
+-doc "Returns an empty buffer positioned at `Pos`.".
+-spec new(byte_offset()) -> buffer().
+new(Pos) when is_integer(Pos) andalso Pos >= 0 ->
+    #buffer{start_pos = Pos, end_pos = Pos}.
+
+-doc """
+Appends a block of bytes at `end_pos`.
+
+The block is retained as-is (no copying); it must never be mutated by the
+caller. Empty blocks are not retained.
+""".
+-spec append(binary(), buffer()) -> buffer().
+append(<<>>, Buffer) ->
+    Buffer;
+append(Block, #buffer{end_pos = EndPos, rear = Rear} = Buffer) when is_binary(Block) ->
+    Buffer#buffer{end_pos = EndPos + byte_size(Block), rear = [Block | Rear]}.
+
+-doc """
+Drops whole blocks that lie entirely before `Pos`.
+
+Every byte at an offset at or past `Pos` is retained. Bytes before `Pos` in
+a block that straddles it are retained too: blocks are dropped whole, so
+`start_pos` advances block-granularly, up to but never past `Pos`.
+""".
+-spec drop_before(byte_offset(), buffer()) -> buffer().
+drop_before(Pos, #buffer{start_pos = StartPos} = Buffer) when Pos =< StartPos ->
+    Buffer;
+drop_before(Pos, #buffer{start_pos = StartPos, front = [Block | Front]} = Buffer) when
+    StartPos + byte_size(Block) =< Pos
+->
+    drop_before(Pos, Buffer#buffer{start_pos = StartPos + byte_size(Block), front = Front});
+drop_before(Pos, #buffer{front = [], rear = [_ | _] = Rear} = Buffer) ->
+    drop_before(Pos, Buffer#buffer{front = lists:reverse(Rear), rear = []});
+drop_before(_Pos, Buffer) ->
+    Buffer.
+
+-doc """
+Reads `Len` bytes at `Pos` as a single binary.
+
+The range must lie within `[start_pos, end_pos)`. Reads of at most 512
+bytes are copied so they pin no block; larger reads that fall within one
+block are shared as a sub-binary of that block; reads spanning blocks are
+assembled into a fresh binary.
+""".
+-spec read(byte_offset(), non_neg_integer(), buffer()) -> binary().
+read(Pos, Len, Buffer) ->
+    case read_iodata(Pos, Len, Buffer) of
+        [Bin] when Len =< ?COPY_MAX_B ->
+            binary:copy(Bin);
+        [Bin] ->
+            Bin;
+        IoData ->
+            iolist_to_binary(IoData)
+    end.
+
+-doc """
+Reads `Len` bytes at `Pos` as a list of binaries, copying nothing.
+
+The range must lie within `[start_pos, end_pos)`. Each element is either a
+whole block or a sub-binary of the block at the range's edge, so the result
+shares (and pins) only the blocks the range overlaps.
+""".
+-spec read_iodata(byte_offset(), non_neg_integer(), buffer()) -> [binary()].
+read_iodata(_Pos, 0, _Buffer) ->
+    [];
+read_iodata(Pos, Len, #buffer{start_pos = StartPos, end_pos = EndPos} = Buffer) when
+    is_integer(Pos) andalso is_integer(Len) andalso Len > 0 andalso
+        Pos >= StartPos andalso Pos + Len =< EndPos
+->
+    #buffer{front = Front, rear = Rear} = Buffer,
+    take(Pos - StartPos, Len, Front, Rear);
+read_iodata(Pos, Len, #buffer{start_pos = StartPos, end_pos = EndPos}) ->
+    error({out_of_range, {Pos, Len}, {StartPos, EndPos}}).
+
+%% Walks `front` and reverses `rear` only if the requested range extends
+%% into it, so a read near start_pos never pays for the whole block list.
+take(_Skip, 0, _Front, _Rear) ->
+    [];
+take(Skip, Len, [], Rear) ->
+    take(Skip, Len, lists:reverse(Rear), []);
+take(Skip, Len, [Block | Blocks], Rear) when Skip >= byte_size(Block) ->
+    take(Skip - byte_size(Block), Len, Blocks, Rear);
+take(0, Len, [Block | Blocks], Rear) when Len >= byte_size(Block) ->
+    %% The whole block is in range: share the block term itself rather than
+    %% wrapping it in a full-range sub-binary.
+    [Block | take(0, Len - byte_size(Block), Blocks, Rear)];
+take(Skip, Len, [Block | Blocks], Rear) when Skip + Len > byte_size(Block) ->
+    Taken = byte_size(Block) - Skip,
+    [binary:part(Block, Skip, Taken) | take(0, Len - Taken, Blocks, Rear)];
+take(Skip, Len, [Block | _Blocks], _Rear) ->
+    [binary:part(Block, Skip, Len)].
+
+-doc "Returns the offset of the first retained byte.".
+-spec start_pos(buffer()) -> byte_offset().
+start_pos(#buffer{start_pos = StartPos}) ->
+    StartPos.
+
+-doc "Returns the offset one past the last retained byte.".
+-spec end_pos(buffer()) -> byte_offset().
+end_pos(#buffer{end_pos = EndPos}) ->
+    EndPos.
+
+-doc "Returns the number of retained bytes.".
+-spec size(buffer()) -> non_neg_integer().
+size(#buffer{start_pos = StartPos, end_pos = EndPos}) ->
+    EndPos - StartPos.
+
+-doc "Returns the number of retained blocks.".
+-spec block_count(buffer()) -> non_neg_integer().
+block_count(#buffer{front = Front, rear = Rear}) ->
+    length(Front) + length(Rear).

--- a/src/rabbitmq_stream_s3_remote_reader_core.erl
+++ b/src/rabbitmq_stream_s3_remote_reader_core.erl
@@ -39,6 +39,11 @@ fragment state to determine if a pending read can be served. When it cannot,
 the core returns effects to fetch more data. When data arrives, the shell
 feeds it back and the core re-evaluates.
 
+Buffered data is held in a `rabbitmq_stream_s3_read_buffer`: a queue of the
+delivered binaries as-is rather than one flat binary, so a delivery is never
+copied into place and consumed data is freed block-by-block (see that
+module's docs for why flat-binary appends degrade here).
+
 The AIMD algorithm adjusts `read_size` (prefetch window):
 - Buffer hit: after N consecutive hits, additive increase by 1 MiB
 - Buffer miss: multiplicative decrease (halve)
@@ -84,13 +89,10 @@ and transitions immediately if available, or signals that more data is needed.
     %% Current fragment
     fragment_ref :: #fragment_ref{},
     key :: rabbitmq_stream_s3:key(),
-    buffer = <<>> :: binary(),
-    start_pos :: byte_offset(),
-    current_pos :: byte_offset(),
-    end_pos :: byte_offset(),
+    buffer :: rabbitmq_stream_s3_read_buffer:buffer(),
 
     %% Next fragment (pre-fetched)
-    next :: {#fragment_ref{}, binary()} | undefined | not_found,
+    next :: {#fragment_ref{}, rabbitmq_stream_s3_read_buffer:buffer()} | undefined | not_found,
 
     %% Fragment iterator
     iterator :: rabbitmq_stream_s3_fragment_iterator:iterator(),
@@ -176,10 +178,7 @@ init(StreamId, FragRef, Position, Iterator, Opts) ->
         retry_delay = Cfg#cfg.min_retry_delay_ms,
         fragment_ref = FragRef,
         key = Key,
-        buffer = <<>>,
-        start_pos = Position,
-        current_pos = Position,
-        end_pos = Position,
+        buffer = rabbitmq_stream_s3_read_buffer:new(Position),
         iterator = Iterator,
         next = undefined
     },
@@ -278,14 +277,12 @@ step(State0, retry) ->
     {State2, Effects ++ Effects2};
 step(#state{cfg = #cfg{min_retry_delay_ms = MinDelay}} = State0, deadline_expired) ->
     %% The shell's pending-read deadline fired. Reply with an error and reset
-    %% buffer state so the next read at any position passes Offset >= StartPos.
+    %% buffer state so the next read at any position is within the buffer's
+    %% bounds once data arrives.
     %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/157
     %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/161
     State = State0#state{
-        buffer = <<>>,
-        start_pos = 0,
-        current_pos = 0,
-        end_pos = 0,
+        buffer = rabbitmq_stream_s3_read_buffer:new(0),
         pending = undefined,
         requests_in_flight = #{},
         retry_delay = MinDelay
@@ -311,10 +308,7 @@ step(State0, {iterator_refreshed, Iterator}) ->
                 retry_delay = Cfg#cfg.min_retry_delay_ms,
                 fragment_ref = FragRef,
                 key = Key,
-                buffer = <<>>,
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B,
+                buffer = rabbitmq_stream_s3_read_buffer:new(?SEGMENT_HEADER_B),
                 iterator = Iterator1,
                 next = undefined
             },
@@ -388,18 +382,21 @@ try_read(#state{fragment_ref = #fragment_ref{size = FragSize}} = State, Offset, 
 ->
     %% Past end of current fragment. Transition.
     try_fragment_transition(State);
-try_read(#state{end_pos = EndPos} = State, Offset, Bytes) when
-    Offset + Bytes > EndPos
-->
-    %% Not enough data buffered.
-    IdxStartPos = ?SEGMENT_HEADER_B + (State#state.fragment_ref)#fragment_ref.size,
-    case EndPos >= IdxStartPos of
-        true ->
-            %% All chunk data is buffered (the index region, which follows the
-            %% chunk data, has started), so nothing more is coming for a read
-            %% within the chunk-data range: this is the consumer over-reading a
-            %% chunk header at the fragment tail. Cap the read at the index
-            %% boundary and serve the remaining chunk data.
+try_read(
+    #state{fragment_ref = #fragment_ref{size = FragSize}, buffer = Buffer} = State,
+    Offset,
+    Bytes
+) ->
+    EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buffer),
+    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
+    case Offset + Bytes > EndPos of
+        true when EndPos >= IdxStartPos ->
+            %% Not enough data buffered, but all chunk data is buffered (the
+            %% index region, which follows the chunk data, has started), so
+            %% nothing more is coming for a read within the chunk-data range:
+            %% this is the consumer over-reading a chunk header at the fragment
+            %% tail. Cap the read at the index boundary and serve the remaining
+            %% chunk data.
             %%
             %% The only read that overshoots EndPos is the header over-read,
             %% which read_header1/1 always issues at a chunk boundary, so
@@ -411,7 +408,7 @@ try_read(#state{end_pos = EndPos} = State, Offset, Bytes) when
             %% the consumer hung. (The 64 was also arbitrary: the over-read is
             %% CHUNK_HEADER_B + MAX_FILTER_SIZE bytes, not 64.)
             try_read(State, Offset, EndPos - Offset);
-        false ->
+        true ->
             %% Chunk data is still streaming in (EndPos has not reached the
             %% index boundary). Wait for more, unless the fragment 404'd.
             case State of
@@ -419,23 +416,15 @@ try_read(#state{end_pos = EndPos} = State, Offset, Bytes) when
                     {not_found_check_range, State};
                 _ ->
                     {await, State}
-            end
-    end;
-try_read(
-    #state{
-        fragment_ref = #fragment_ref{size = FragSize},
-        start_pos = StartPos,
-        current_pos = _CurrentPos,
-        buffer = Buffer
-    } = State,
-    Offset,
-    Bytes0
-) ->
-    IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
-    Bytes = min(Bytes0, IdxStartPos - Offset),
-    ?assert(Offset >= StartPos),
-    Data = binary:part(Buffer, Offset - StartPos, Bytes),
-    {ok, Data, State#state{current_pos = Offset}}.
+            end;
+        false ->
+            ReadBytes = min(Bytes, IdxStartPos - Offset),
+            Data = rabbitmq_stream_s3_read_buffer:read(Offset, ReadBytes, Buffer),
+            %% Reads are non-decreasing, so blocks entirely below this read's
+            %% start are consumed; drop them so they are freed incrementally.
+            Buffer1 = rabbitmq_stream_s3_read_buffer:drop_before(Offset, Buffer),
+            {ok, Data, State#state{buffer = Buffer1}}
+    end.
 
 try_fragment_transition(
     #state{next = {#fragment_ref{offset = NextOffset}, _}} = State0
@@ -547,9 +536,6 @@ goto_next_fragment(
             ?assert(NextOffset > CurrentOffset),
             Key = rabbitmq_stream_s3:fragment_key(StreamId, NextOffset, NextUid),
             State#state{
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B + byte_size(Buffer),
                 buffer = Buffer,
                 fragment_ref = NextFragRef,
                 key = Key,
@@ -559,10 +545,7 @@ goto_next_fragment(
             };
         _ ->
             State#state{
-                start_pos = ?SEGMENT_HEADER_B,
-                current_pos = ?SEGMENT_HEADER_B,
-                end_pos = ?SEGMENT_HEADER_B,
-                buffer = <<>>,
+                buffer = rabbitmq_stream_s3_read_buffer:new(?SEGMENT_HEADER_B),
                 iterator = Iterator,
                 next = undefined,
                 current_not_found = false
@@ -584,43 +567,24 @@ add_data(Fragment, Data, #state{fragment_ref = #fragment_ref{offset = Fragment}}
 add_data(Fragment, Data, State) ->
     add_data_next(Fragment, Data, State).
 
-add_data_current(
-    Data,
-    #state{
-        start_pos = StartPos0,
-        current_pos = CurrentPos,
-        end_pos = EndPos0,
-        buffer = Buffer0
-    } = State
-) ->
-    Buffer =
-        case CurrentPos =:= StartPos0 of
-            true ->
-                <<Buffer0/binary, Data/binary>>;
-            false ->
-                <<
-                    (binary:part(Buffer0, CurrentPos - StartPos0, EndPos0 - CurrentPos))/binary,
-                    Data/binary
-                >>
-        end,
-    State#state{
-        start_pos = CurrentPos,
-        end_pos = EndPos0 + byte_size(Data),
-        buffer = Buffer
-    }.
+add_data_current(Data, #state{buffer = Buffer} = State) ->
+    State#state{buffer = rabbitmq_stream_s3_read_buffer:append(Data, Buffer)}.
 
 add_data_next(NextOffset, Data, #state{next = Next0, iterator = Iterator} = State) ->
     Next =
         case Next0 of
             undefined ->
+                Buffer = rabbitmq_stream_s3_read_buffer:append(
+                    Data, rabbitmq_stream_s3_read_buffer:new(?SEGMENT_HEADER_B)
+                ),
                 case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
                     {ok, #fragment_ref{offset = NextOffset} = FragRef, _} ->
-                        {FragRef, Data};
+                        {FragRef, Buffer};
                     _ ->
-                        {#fragment_ref{offset = NextOffset, uid = 0, size = 0}, Data}
+                        {#fragment_ref{offset = NextOffset, uid = 0, size = 0}, Buffer}
                 end;
             {#fragment_ref{offset = NextOffset} = FragRef, Buffer0} ->
-                {FragRef, <<Buffer0/binary, Data/binary>>}
+                {FragRef, rabbitmq_stream_s3_read_buffer:append(Data, Buffer0)}
         end,
     State#state{next = Next}.
 
@@ -645,11 +609,12 @@ maybe_start_current_request(
     #state{
         read_size = ReadSize,
         fragment_ref = #fragment_ref{offset = Fragment, size = FragSize},
-        end_pos = EndPos,
+        buffer = Buffer,
         key = Key,
         requests_in_flight = Reqs
     } = State
 ) ->
+    EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buffer),
     IdxStartPos = ?SEGMENT_HEADER_B + FragSize,
     case EndPos < IdxStartPos andalso not maps:is_key(Fragment, Reqs) of
         true ->
@@ -666,13 +631,15 @@ maybe_start_next_request(
         stream = StreamId,
         read_size = ReadSize,
         fragment_ref = #fragment_ref{size = FragSize},
-        end_pos = EndPos,
+        buffer = Buffer,
         next = undefined,
         iterator = Iterator,
         requests_in_flight = Reqs
     } = State
-) when EndPos >= ?SEGMENT_HEADER_B + FragSize ->
-    case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+) ->
+    CurrentFullyFetched =
+        rabbitmq_stream_s3_read_buffer:end_pos(Buffer) >= ?SEGMENT_HEADER_B + FragSize,
+    case CurrentFullyFetched andalso rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
         {ok, #fragment_ref{offset = NextOffset, uid = NextUid}, _} ->
             case maps:is_key(NextOffset, Reqs) of
                 true ->

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -18,6 +18,9 @@ Covers:
 - A manifest-replica sync is dropped iff it is older than what is recorded,
   comparing epoch before sequence (the manifest-replica-lifecycle model's
   epoch-monotonicity invariant)
+- The read buffer (block queue) serves byte-exact reads against a flat-binary
+  model under arbitrary append/read/drop interleavings, and the remote reader
+  core built on it replies with byte-exact data at every read offset
 """.
 
 -compile([export_all, nowarn_export_all]).
@@ -66,6 +69,9 @@ all() ->
         %% Remote reader core
         remote_reader_core_no_crash,
         remote_reader_core_reply_size_bounded,
+        remote_reader_core_reply_bytes_exact,
+        %% Read buffer (block queue)
+        read_buffer_matches_model,
         %% Garbage collection reap decision
         gc_classify_never_reaps_live,
         gc_classify_reclaims_orphans,
@@ -1780,6 +1786,150 @@ run_rrc_events([{retry} | Rest], State0) ->
 run_rrc_events([Event | Rest], State0) ->
     {State1, _} = rabbitmq_stream_s3_remote_reader_core:step(State0, Event),
     run_rrc_events(Rest, State1).
+
+%% Every reply carries exactly the bytes of the stream at the read offset.
+%% Data content is a function of absolute position, so any bookkeeping error in
+%% the buffer (a block dropped too eagerly, an off-by-one in block slicing, a
+%% stale block surviving a drop) surfaces as a content mismatch, not just a
+%% size mismatch. Steps interleave a delivery with a forward (non-decreasing)
+%% read, the log reader's access pattern.
+remote_reader_core_reply_bytes_exact(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_remote_reader_core_reply_bytes_exact/0, [], 500).
+
+prop_remote_reader_core_reply_bytes_exact() ->
+    ?FORALL(
+        Steps,
+        list({range(1, 5000), range(0, 99), range(1, 4000)}),
+        begin
+            FragSize = 100_000_000,
+            FragRef = #fragment_ref{offset = 0, uid = 1, size = FragSize},
+            Manifest = #manifest{
+                first_offset = 0,
+                next_offset = 200,
+                entries = ?ENTRY(0, 0, 0, ?MANIFEST_KIND_FRAGMENT, FragSize, 1)
+            },
+            GetGroupFun = fun(_) -> {error, not_found} end,
+            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(Manifest, 0, GetGroupFun),
+            Iterator =
+                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+                    {ok, _, It} -> It;
+                    _ -> Iterator0
+                end,
+            {S0, _} = rabbitmq_stream_s3_remote_reader_core:init(
+                <<"prop-stream">>, FragRef, 8, Iterator, #{}
+            ),
+            run_rrc_exact_steps(Steps, S0, 8, 8)
+        end
+    ).
+
+run_rrc_exact_steps([], _State, _DataEnd, _ReadFloor) ->
+    true;
+run_rrc_exact_steps([{DataLen, PosFrac, LenWant} | Steps], S0, DataEnd0, ReadFloor) ->
+    %% Deliver DataLen bytes of position-patterned data.
+    Data = rb_pattern(DataEnd0, DataLen),
+    {S1, _} = rabbitmq_stream_s3_remote_reader_core:step(
+        S0, {data, make_ref(), 0, Data, done}
+    ),
+    DataEnd = DataEnd0 + DataLen,
+    %% Read at a position at or past the previous read (reads are
+    %% non-decreasing) and within delivered data, so a reply is guaranteed.
+    ReadPos = ReadFloor + ((DataEnd - 1 - ReadFloor) * PosFrac) div 100,
+    ReadLen = min(LenWant, DataEnd - ReadPos),
+    {S2, Effects} = rabbitmq_stream_s3_remote_reader_core:step(
+        S1, {read, ReadPos, ReadLen, chunk_boundary}
+    ),
+    case [D || {reply, {ok, D}} <- Effects] of
+        [Reply] ->
+            Reply =:= rb_pattern(ReadPos, ReadLen) andalso
+                run_rrc_exact_steps(Steps, S2, DataEnd, ReadPos);
+        _ ->
+            false
+    end.
+
+%% =========================================================================
+%% Read buffer (block queue) properties
+%%
+%% The model is the flat binary of everything ever appended, based at the
+%% buffer's initial position. Whatever interleaving of appends, reads, and
+%% block-granular drops occurs, the retained window and every in-range read
+%% must be byte-identical to the corresponding slice of that history.
+%% =========================================================================
+
+read_buffer_matches_model(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(fun prop_read_buffer_matches_model/0, [], 500).
+
+prop_read_buffer_matches_model() ->
+    ?FORALL(
+        {StartPos, Ops},
+        {range(0, 100), list(gen_rb_op())},
+        begin
+            Buf = rabbitmq_stream_s3_read_buffer:new(StartPos),
+            check_rb_ops(Ops, Buf, StartPos, <<>>)
+        end
+    ).
+
+gen_rb_op() ->
+    frequency([
+        %% Zero-length appends exercise the empty-block no-op.
+        {4, {append, range(0, 2000)}},
+        {3, {read, range(0, 99), range(0, 2000)}},
+        %% Fractions above 100 drop past end_pos.
+        {2, {drop, range(0, 120)}}
+    ]).
+
+check_rb_ops([], _Buf, _Base, _History) ->
+    true;
+check_rb_ops([{append, Len} | Ops], Buf0, Base, History0) ->
+    Data = rb_pattern(rabbitmq_stream_s3_read_buffer:end_pos(Buf0), Len),
+    Buf = rabbitmq_stream_s3_read_buffer:append(Data, Buf0),
+    History = <<History0/binary, Data/binary>>,
+    check_rb_window(Buf, Base, History) andalso check_rb_ops(Ops, Buf, Base, History);
+check_rb_ops([{read, PosFrac, LenWant} | Ops], Buf, Base, History) ->
+    Start = rabbitmq_stream_s3_read_buffer:start_pos(Buf),
+    End = rabbitmq_stream_s3_read_buffer:end_pos(Buf),
+    case End - Start of
+        0 ->
+            check_rb_ops(Ops, Buf, Base, History);
+        Size ->
+            Pos = Start + (Size * PosFrac) div 100,
+            Len = min(LenWant, End - Pos),
+            Expected = binary:part(History, Pos - Base, Len),
+            Flat = rabbitmq_stream_s3_read_buffer:read(Pos, Len, Buf),
+            IoData = rabbitmq_stream_s3_read_buffer:read_iodata(Pos, Len, Buf),
+            Flat =:= Expected andalso
+                iolist_to_binary(IoData) =:= Expected andalso
+                check_rb_ops(Ops, Buf, Base, History)
+    end;
+check_rb_ops([{drop, PosFrac} | Ops], Buf0, Base, History) ->
+    Start0 = rabbitmq_stream_s3_read_buffer:start_pos(Buf0),
+    End = rabbitmq_stream_s3_read_buffer:end_pos(Buf0),
+    Pos = Start0 + ((End - Start0) * PosFrac) div 100,
+    Buf = rabbitmq_stream_s3_read_buffer:drop_before(Pos, Buf0),
+    Start = rabbitmq_stream_s3_read_buffer:start_pos(Buf),
+    %% Blocks are dropped whole: the new start never passes Pos (nor end_pos),
+    %% never regresses, and the end is untouched.
+    Start >= Start0 andalso
+        Start =< max(Start0, min(Pos, End)) andalso
+        rabbitmq_stream_s3_read_buffer:end_pos(Buf) =:= End andalso
+        check_rb_window(Buf, Base, History) andalso
+        check_rb_ops(Ops, Buf, Base, History).
+
+%% The retained window [start_pos, end_pos) is byte-identical to the history
+%% slice at those offsets, and the size accounting agrees.
+check_rb_window(Buf, Base, History) ->
+    Start = rabbitmq_stream_s3_read_buffer:start_pos(Buf),
+    End = rabbitmq_stream_s3_read_buffer:end_pos(Buf),
+    Size = rabbitmq_stream_s3_read_buffer:size(Buf),
+    Size =:= End - Start andalso
+        rabbitmq_stream_s3_read_buffer:read(Start, Size, Buf) =:=
+            binary:part(History, Start - Base, Size).
+
+%% Bytes whose value is a function of their absolute offset, so a read's
+%% content proves which offsets it came from.
+rb_pattern(_Pos, 0) ->
+    <<>>;
+rb_pattern(Pos, Len) ->
+    <<<<(P rem 251)>> || P <- lists:seq(Pos, Pos + Len - 1)>>.
 
 %% =========================================================================
 %% Garbage collection reap-decision properties

--- a/test/rabbitmq_stream_s3_bench.erl
+++ b/test/rabbitmq_stream_s3_bench.erl
@@ -1,0 +1,200 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(rabbitmq_stream_s3_bench).
+-moduledoc """
+A minimal benchmark harness for `*_bench` modules (run with `gmake bench`).
+
+Scenarios are `{Name, fun(() -> _)}` pairs. Each scenario runs in a fresh
+process: a warmup period first (JIT, allocator, and code-path warm), then
+timed iterations until the measurement period elapses. The report shows
+iterations per second, average/median/p99 iteration time, and a
+Benchee-style comparison against the fastest scenario.
+
+Benchmarks are for humans comparing before/after numbers on a quiet
+machine; they are deliberately not CI-gated and assert nothing. Wall time
+is the primary signal. GC counts are VM-wide deltas around the measurement
+loop (the VM is otherwise idle during a bench run, and receiver-side GC
+caused by a scenario is part of its cost, so this is the honest number).
+
+Note that `tprof`-style call_memory profiling does not see refc binary
+payloads, which several plugin hot paths are dominated by; when a scenario
+exists to compare binary-handling strategies, trust the wall clock.
+""".
+
+-export([run/1, run/2, sample_binary_memory/1]).
+
+-define(DEFAULT_WARMUP_MS, 500).
+-define(DEFAULT_TIME_MS, 2_000).
+
+-type scenario() :: {Name :: atom() | string(), fun(() -> term())}.
+-type opts() :: #{warmup_ms => non_neg_integer(), time_ms => pos_integer()}.
+
+-spec run([scenario()]) -> ok.
+run(Scenarios) ->
+    run(Scenarios, #{}).
+
+-spec run([scenario()], opts()) -> ok.
+run(Scenarios, Opts) when is_list(Scenarios) andalso Scenarios =/= [] ->
+    Results = [{name_to_list(Name), measure(Name, Fun, Opts)} || {Name, Fun} <- Scenarios],
+    report(Results).
+
+%% ------------------------------------------------------------------
+%% Measurement
+%% ------------------------------------------------------------------
+
+measure(Name, Fun, Opts) ->
+    WarmupMs = maps:get(warmup_ms, Opts, ?DEFAULT_WARMUP_MS),
+    TimeMs = maps:get(time_ms, Opts, ?DEFAULT_TIME_MS),
+    Parent = self(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        warmup(Fun, now_us() + WarmupMs * 1000),
+        {GCs0, Reclaimed0, _} = erlang:statistics(garbage_collection),
+        Durations = iterate(Fun, now_us() + TimeMs * 1000, []),
+        {GCs1, Reclaimed1, _} = erlang:statistics(garbage_collection),
+        Parent ! {bench_result, self(), {Durations, GCs1 - GCs0, Reclaimed1 - Reclaimed0}}
+    end),
+    receive
+        {bench_result, Pid, Result} ->
+            erlang:demonitor(MRef, [flush]),
+            Result;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            error({benchmark_failed, Name, Reason})
+    end.
+
+warmup(Fun, Deadline) ->
+    case now_us() >= Deadline of
+        true ->
+            ok;
+        false ->
+            _ = Fun(),
+            warmup(Fun, Deadline)
+    end.
+
+%% Runs at least one iteration, then keeps iterating until the deadline.
+iterate(Fun, Deadline, Durations0) ->
+    T0 = now_us(),
+    _ = Fun(),
+    T1 = now_us(),
+    Durations = [T1 - T0 | Durations0],
+    case T1 >= Deadline of
+        true -> Durations;
+        false -> iterate(Fun, Deadline, Durations)
+    end.
+
+now_us() ->
+    erlang:monotonic_time(microsecond).
+
+-doc """
+Runs `Fun` while a helper process samples `erlang:memory(binary)` roughly
+every millisecond, and returns the VM-wide binary memory baseline (after a
+GC of the calling process) and the peak observed during the run.
+
+Peak-over-baseline captures what per-process views cannot: transient dead
+buffer generations, in-flight copies, and the live working set together.
+Like the GC numbers in `run/2`, it is a VM-wide measurement and assumes an
+otherwise idle bench VM.
+""".
+-spec sample_binary_memory(fun(() -> term())) ->
+    #{baseline := non_neg_integer(), peak := non_neg_integer()}.
+sample_binary_memory(Fun) ->
+    %% Quiesce the whole VM before taking the baseline. Refc binaries are
+    %% freed when the last *reference* is collected, so garbage from an
+    %% earlier scenario can linger in any process's heap: it would inflate
+    %% this baseline, then deflate the apparent peak by being freed while
+    %% Fun runs.
+    lists:foreach(fun erlang:garbage_collect/1, processes()),
+    Baseline = erlang:memory(binary),
+    Parent = self(),
+    Sampler = spawn_link(fun() -> memory_sampler(Parent, Baseline) end),
+    _ = Fun(),
+    Sampler ! stop,
+    receive
+        {binary_memory_peak, Peak} ->
+            #{baseline => Baseline, peak => Peak}
+    end.
+
+memory_sampler(Parent, Peak0) ->
+    Peak = max(Peak0, erlang:memory(binary)),
+    receive
+        stop ->
+            Parent ! {binary_memory_peak, Peak}
+    after 1 ->
+        memory_sampler(Parent, Peak)
+    end.
+
+%% ------------------------------------------------------------------
+%% Reporting
+%% ------------------------------------------------------------------
+
+report(Results) ->
+    Stats = [
+        {Name, stats(Durations, GCs, Reclaimed)}
+     || {Name, {Durations, GCs, Reclaimed}} <- Results
+    ],
+    NameW = lists:max([length(Name) || {Name, _} <- Stats] ++ [8]),
+    io:format(
+        "~n~-*s ~12s ~12s ~12s ~12s ~10s~n",
+        [NameW, "Name", "ips", "average", "median", "p99", "GC/iter"]
+    ),
+    lists:foreach(
+        fun({Name, #{ips := Ips, avg := Avg, median := Median, p99 := P99, gcs_per_iter := GCs}}) ->
+            io:format(
+                "~-*s ~12s ~12s ~12s ~12s ~10.1f~n",
+                [
+                    NameW,
+                    Name,
+                    format_ips(Ips),
+                    format_us(Avg),
+                    format_us(Median),
+                    format_us(P99),
+                    GCs
+                ]
+            )
+        end,
+        Stats
+    ),
+    case Stats of
+        [_] ->
+            ok;
+        _ ->
+            [{FastIps, FastName} | Rest] = lists:reverse(
+                lists:sort([{maps:get(ips, S), Name} || {Name, S} <- Stats])
+            ),
+            io:format("~nComparison:~n  ~-*s ~12s~n", [NameW, FastName, format_ips(FastIps)]),
+            lists:foreach(
+                fun({Ips, Name}) ->
+                    io:format(
+                        "  ~-*s ~12s -- ~.2fx slower~n",
+                        [NameW, Name, format_ips(Ips), FastIps / Ips]
+                    )
+                end,
+                Rest
+            )
+    end,
+    ok.
+
+stats(Durations, GCs, Reclaimed) ->
+    Sorted = lists:sort(Durations),
+    N = length(Sorted),
+    TotalUs = lists:sum(Sorted),
+    #{
+        n => N,
+        ips => N / (TotalUs / 1_000_000),
+        avg => TotalUs / N,
+        median => lists:nth(max(1, N div 2), Sorted),
+        p99 => lists:nth(max(1, round(N * 0.99)), Sorted),
+        gcs_per_iter => GCs / N,
+        reclaimed_words => Reclaimed
+    }.
+
+format_ips(Ips) when Ips >= 1_000_000 -> io_lib:format("~.2fM", [Ips / 1_000_000]);
+format_ips(Ips) when Ips >= 1_000 -> io_lib:format("~.2fK", [Ips / 1_000]);
+format_ips(Ips) -> io_lib:format("~.2f", [Ips * 1.0]).
+
+format_us(Us) when Us >= 1_000_000 -> io_lib:format("~.2f s", [Us / 1_000_000]);
+format_us(Us) when Us >= 1_000 -> io_lib:format("~.2f ms", [Us / 1_000]);
+format_us(Us) -> io_lib:format("~.2f us", [Us * 1.0]).
+
+name_to_list(Name) when is_atom(Name) -> atom_to_list(Name);
+name_to_list(Name) when is_list(Name) -> Name.

--- a/test/read_buffer_SUITE.erl
+++ b/test/read_buffer_SUITE.erl
@@ -1,0 +1,223 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(read_buffer_SUITE).
+-moduledoc """
+Tests for the remote read path's block-queue buffer.
+
+The buffer's model is a flat binary at a base offset; every operation here is
+checked against that model. The sharing/copying tests pin down the memory
+properties the module exists for: small reads pin no block, large
+single-block reads share their block, and whole blocks are shared as-is.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(BUF, rabbitmq_stream_s3_read_buffer).
+
+all() ->
+    [
+        new_is_empty,
+        append_advances_end_pos,
+        empty_append_is_noop,
+        read_within_single_block,
+        read_across_blocks,
+        read_whole_window,
+        read_zero_bytes,
+        read_out_of_range_raises,
+        drop_before_is_block_granular,
+        drop_before_start_is_noop,
+        drop_before_end_drops_everything,
+        drop_never_moves_empty_buffer,
+        small_read_is_copied,
+        large_read_shares_block,
+        whole_block_read_shares_block_term,
+        read_iodata_copies_nothing_at_edges,
+        interleaved_append_read_drop
+    ].
+
+init_per_suite(Config) -> Config.
+end_per_suite(_Config) -> ok.
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+%% Bytes whose value is a function of their absolute offset, so a read's
+%% content proves which offsets it came from.
+pattern(Pos, Len) ->
+    <<<<(P rem 251)>> || P <- lists:seq(Pos, Pos + Len - 1)>>.
+
+%% Builds a buffer at Pos from a list of block lengths, filled with pattern
+%% data so contents are position-verifiable.
+build(Pos, BlockLens) ->
+    {Buf, _} = lists:foldl(
+        fun(Len, {B, P}) ->
+            {?BUF:append(pattern(P, Len), B), P + Len}
+        end,
+        {?BUF:new(Pos), Pos},
+        BlockLens
+    ),
+    Buf.
+
+%% ------------------------------------------------------------------
+%% Basic accounting
+%% ------------------------------------------------------------------
+
+new_is_empty(_Config) ->
+    Buf = ?BUF:new(100),
+    ?assertEqual(100, ?BUF:start_pos(Buf)),
+    ?assertEqual(100, ?BUF:end_pos(Buf)),
+    ?assertEqual(0, ?BUF:size(Buf)),
+    ?assertEqual(0, ?BUF:block_count(Buf)).
+
+append_advances_end_pos(_Config) ->
+    Buf = build(8, [10, 20, 30]),
+    ?assertEqual(8, ?BUF:start_pos(Buf)),
+    ?assertEqual(68, ?BUF:end_pos(Buf)),
+    ?assertEqual(60, ?BUF:size(Buf)),
+    ?assertEqual(3, ?BUF:block_count(Buf)).
+
+empty_append_is_noop(_Config) ->
+    Buf0 = build(8, [10]),
+    Buf = ?BUF:append(<<>>, Buf0),
+    ?assertEqual(18, ?BUF:end_pos(Buf)),
+    ?assertEqual(1, ?BUF:block_count(Buf)).
+
+%% ------------------------------------------------------------------
+%% Reads
+%% ------------------------------------------------------------------
+
+read_within_single_block(_Config) ->
+    Buf = build(8, [100]),
+    ?assertEqual(pattern(20, 50), ?BUF:read(20, 50, Buf)),
+    %% Block edges.
+    ?assertEqual(pattern(8, 1), ?BUF:read(8, 1, Buf)),
+    ?assertEqual(pattern(107, 1), ?BUF:read(107, 1, Buf)).
+
+read_across_blocks(_Config) ->
+    Buf = build(8, [10, 10, 10, 10]),
+    %% Spans all four blocks.
+    ?assertEqual(pattern(9, 38), ?BUF:read(9, 38, Buf)),
+    %% Spans exactly one block boundary.
+    ?assertEqual(pattern(17, 2), ?BUF:read(17, 2, Buf)).
+
+read_whole_window(_Config) ->
+    Buf = build(0, [7, 13, 3]),
+    ?assertEqual(pattern(0, 23), ?BUF:read(0, 23, Buf)).
+
+read_zero_bytes(_Config) ->
+    Buf = build(8, [10]),
+    ?assertEqual(<<>>, ?BUF:read(12, 0, Buf)),
+    ?assertEqual([], ?BUF:read_iodata(12, 0, Buf)),
+    %% Zero-length reads are in range even on an empty buffer.
+    ?assertEqual(<<>>, ?BUF:read(5, 0, ?BUF:new(5))).
+
+read_out_of_range_raises(_Config) ->
+    Buf = build(8, [10]),
+    ?assertError({out_of_range, _, _}, ?BUF:read(7, 1, Buf)),
+    ?assertError({out_of_range, _, _}, ?BUF:read(8, 11, Buf)),
+    ?assertError({out_of_range, _, _}, ?BUF:read(18, 1, Buf)),
+    ?assertError({out_of_range, _, _}, ?BUF:read(0, 1, ?BUF:new(0))).
+
+%% ------------------------------------------------------------------
+%% Dropping
+%% ------------------------------------------------------------------
+
+drop_before_is_block_granular(_Config) ->
+    Buf0 = build(8, [10, 10, 10]),
+    %% 25 lies inside the second block [18, 28): only the first block can go.
+    Buf = ?BUF:drop_before(25, Buf0),
+    ?assertEqual(18, ?BUF:start_pos(Buf)),
+    ?assertEqual(2, ?BUF:block_count(Buf)),
+    %% Every byte at or past 25 is retained; so are the straddling block's
+    %% earlier bytes.
+    ?assertEqual(pattern(18, 20), ?BUF:read(18, 20, Buf)).
+
+drop_before_start_is_noop(_Config) ->
+    Buf0 = build(8, [10, 10]),
+    ?assertEqual(Buf0, ?BUF:drop_before(8, Buf0)),
+    ?assertEqual(Buf0, ?BUF:drop_before(0, Buf0)).
+
+drop_before_end_drops_everything(_Config) ->
+    Buf0 = build(8, [10, 10]),
+    Buf = ?BUF:drop_before(28, Buf0),
+    ?assertEqual(28, ?BUF:start_pos(Buf)),
+    ?assertEqual(28, ?BUF:end_pos(Buf)),
+    ?assertEqual(0, ?BUF:block_count(Buf)),
+    %% Appends continue at end_pos.
+    Buf1 = ?BUF:append(pattern(28, 5), Buf),
+    ?assertEqual(pattern(28, 5), ?BUF:read(28, 5, Buf1)).
+
+drop_never_moves_empty_buffer(_Config) ->
+    Buf = ?BUF:new(8),
+    %% Dropping past the end of an empty buffer does not reposition it;
+    %% repositioning is new/1's job.
+    ?assertEqual(Buf, ?BUF:drop_before(1000, Buf)).
+
+%% ------------------------------------------------------------------
+%% Sharing and copying
+%% ------------------------------------------------------------------
+
+small_read_is_copied(_Config) ->
+    %% A small read must not pin its block: the result references only its
+    %% own bytes. 303 bytes is the log reader's chunk-header over-read.
+    Buf = build(8, [100_000]),
+    Data = ?BUF:read(50, 303, Buf),
+    ?assertEqual(303, binary:referenced_byte_size(Data)).
+
+large_read_shares_block(_Config) ->
+    %% A large single-block read shares the block (no copy): the result
+    %% references the whole block's bytes.
+    Buf = build(8, [100_000]),
+    Data = ?BUF:read(50, 4096, Buf),
+    ?assertEqual(4096, byte_size(Data)),
+    ?assertEqual(100_000, binary:referenced_byte_size(Data)).
+
+whole_block_read_shares_block_term(_Config) ->
+    %% A read covering exactly one whole block returns the block itself.
+    Block = pattern(8, 100_000),
+    Buf = ?BUF:append(Block, ?BUF:new(8)),
+    [Same] = ?BUF:read_iodata(8, 100_000, Buf),
+    ?assertEqual(Block, Same),
+    ?assertEqual(100_000, binary:referenced_byte_size(Same)).
+
+read_iodata_copies_nothing_at_edges(_Config) ->
+    %% A spanning read shares sub-binaries at the edges and whole blocks in
+    %% the middle; flattening is the caller's choice.
+    Buf = build(0, [1000, 1000, 1000]),
+    IoData = ?BUF:read_iodata(500, 2000, Buf),
+    ?assertEqual(3, length(IoData)),
+    [First, Middle, Last] = IoData,
+    ?assertEqual(500, byte_size(First)),
+    ?assertEqual(1000, byte_size(Middle)),
+    ?assertEqual(500, byte_size(Last)),
+    ?assertEqual(pattern(500, 2000), iolist_to_binary(IoData)).
+
+%% ------------------------------------------------------------------
+%% Interleaving
+%% ------------------------------------------------------------------
+
+interleaved_append_read_drop(_Config) ->
+    %% Simulates the remote reader's usage: deliveries append, forward reads
+    %% drop consumed blocks, and every read's content stays position-exact.
+    Deliveries = [1024, 700, 2048, 100, 4096],
+    {Buf, _} = lists:foldl(
+        fun(Len, {B0, P}) ->
+            B1 = ?BUF:append(pattern(P, Len), B0),
+            %% Read forward to roughly the middle of the retained window.
+            ReadPos = ?BUF:start_pos(B1) + ?BUF:size(B1) div 2,
+            ReadLen = min(64, ?BUF:end_pos(B1) - ReadPos),
+            ?assertEqual(pattern(ReadPos, ReadLen), ?BUF:read(ReadPos, ReadLen, B1)),
+            B2 = ?BUF:drop_before(ReadPos, B1),
+            ?assert(?BUF:start_pos(B2) =< ReadPos),
+            ?assertEqual(?BUF:end_pos(B1), ?BUF:end_pos(B2)),
+            {B2, P + Len}
+        end,
+        {?BUF:new(8), 8},
+        Deliveries
+    ),
+    ?assert(?BUF:size(Buf) > 0).

--- a/test/read_buffer_SUITE.erl
+++ b/test/read_buffer_SUITE.erl
@@ -36,6 +36,9 @@ all() ->
         large_read_shares_block,
         whole_block_read_shares_block_term,
         read_iodata_copies_nothing_at_edges,
+        copy_share_boundary,
+        small_spanning_read_is_copied,
+        read_spans_front_and_rear,
         interleaved_append_read_drop
     ].
 
@@ -196,6 +199,46 @@ read_iodata_copies_nothing_at_edges(_Config) ->
     ?assertEqual(1000, byte_size(Middle)),
     ?assertEqual(500, byte_size(Last)),
     ?assertEqual(pattern(500, 2000), iolist_to_binary(IoData)).
+
+copy_share_boundary(_Config) ->
+    %% Pins down the copy-vs-share cutoff (?COPY_MAX_B = 512). A read at the
+    %% threshold is copied and pins nothing; one byte over it is shared as a
+    %% sub-binary of the whole block. A flip of `=<` to `<` in read/3 would
+    %% regress the threshold read into pinning the block.
+    Buf = build(8, [100_000]),
+    AtLimit = ?BUF:read(50, 512, Buf),
+    ?assertEqual(512, byte_size(AtLimit)),
+    ?assertEqual(512, binary:referenced_byte_size(AtLimit)),
+    OverLimit = ?BUF:read(50, 513, Buf),
+    ?assertEqual(513, byte_size(OverLimit)),
+    ?assertEqual(100_000, binary:referenced_byte_size(OverLimit)).
+
+small_spanning_read_is_copied(_Config) ->
+    %% A small read that straddles two blocks cannot be a sub-binary of any one
+    %% block, so read/3 assembles it into a fresh binary that pins nothing.
+    Buf = build(0, [1000, 1000]),
+    Data = ?BUF:read(950, 100, Buf),
+    ?assertEqual(pattern(950, 100), Data),
+    ?assertEqual(100, binary:referenced_byte_size(Data)).
+
+read_spans_front_and_rear(_Config) ->
+    %% Exercises take/4's front/rear split: a drop migrates blocks into `front`,
+    %% later appends land in `rear`, and a read then crosses the boundary,
+    %% forcing take to drain `front` and reverse `rear`. The deterministic
+    %% build/2 helper only appends (everything lands in `rear`), so without this
+    %% the split state is left to the stochastic property test.
+    Buf0 = build(8, [10, 10, 10]),
+    %% Dropping migrates rear into front and advances start_pos into the second
+    %% block, leaving front = [b2, b3], rear = [].
+    Buf1 = ?BUF:drop_before(20, Buf0),
+    ?assertEqual(18, ?BUF:start_pos(Buf1)),
+    %% Fresh appends land in rear, so the buffer now straddles both lists.
+    %% end_pos is 38 after the drop, so append at 38 first, then at 48.
+    Buf2 = ?BUF:append(pattern(48, 10), ?BUF:append(pattern(38, 10), Buf1)),
+    ?assertEqual(4, ?BUF:block_count(Buf2)),
+    %% A read from a front block into a rear block must be byte-exact.
+    ?assertEqual(pattern(30, 25), ?BUF:read(30, 25, Buf2)),
+    ?assertEqual(pattern(18, 40), ?BUF:read(18, 40, Buf2)).
 
 %% ------------------------------------------------------------------
 %% Interleaving

--- a/test/read_buffer_bench.erl
+++ b/test/read_buffer_bench.erl
@@ -1,0 +1,519 @@
+%% Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(read_buffer_bench).
+-moduledoc """
+Benchmarks the remote reader's buffer under its real access pattern: S3
+deliveries append ~1 MiB batches while the consumer's reads interleave
+(small chunk-header over-reads plus chunk-data reads), each read replied to
+another process, with the consumed prefix discarded as reads advance.
+
+Three scenarios:
+
+- `flat_binary`: the pre-block-queue implementation, kept for comparison.
+  Grows one binary per delivery and serves reads as sub-binaries. Replying
+  seals the writable binary (the runtime pins it when the sub-binary is
+  copied into the message), so each subsequent append copies the whole
+  window. This is the regression baseline: if `block_queue` ever
+  approaches it, something reintroduced window-sized copying.
+- `flat_binary_spanning`: as `flat_binary` but with 2 MiB reads, one per
+  delivery. Each read event replies a sub-binary of a *different* buffer
+  generation (the seal forces a fresh generation per delivery), so a
+  consumer retaining replies across read events pins one full window per
+  event — overlapping content, distinct binaries.
+- `block_queue`: `rabbitmq_stream_s3_read_buffer` doing the same work.
+- `block_queue_spanning`: as `block_queue` but with 2 MiB reads so every
+  read spans blocks and pays the assembly copy, bounding the worst case.
+
+One iteration processes a full window (`?DELIVERIES` x `?DELIVERY_B`).
+
+Two phases. The timing phase measures buffer mechanics only, so every
+delivery appends the same shared template binary (allocation cost excluded
+equally from all scenarios). The memory phase copies the template per
+delivery, as real S3 deliveries arrive as fresh binaries, and reports two
+direct pinning measurements:
+
+- Peak VM binary memory over the run (captures dead buffer generations and
+  in-flight copies that no per-process view shows)
+- Bytes kept alive by a consumer holding the last `?RETAINED_REPLIES`
+  replies, measured from the sink's `process_info(_, binary)` after a
+  forced GC, deduplicated per binary instance. The forced GC makes the
+  number deterministic: only live references pin anything. Comparing it
+  against the byte size of the replies themselves gives the pinning
+  amplification (collateral memory per byte actually held).
+
+Finally, a supply x demand matrix sweeps block size (what the S3 API
+layer's batching supplies) against read size (what the consumer demands),
+with a uniform-read consumer under the same prefetch lag. Block size is
+the block queue's pinning bound, so the matrix is what justifies the
+choice of `?BUFFER_PENDING_DATA_BYTES`; the flat binary appears as a
+baseline row.
+""".
+
+-export([run/0]).
+%% Exported for ad-hoc experiments in a shell.
+-export([
+    flat_binary_window/2,
+    flat_binary_spanning_window/2,
+    block_queue_window/2,
+    block_queue_spanning_window/2
+]).
+
+%% 16 MiB window per iteration: large enough that flat_binary's quadratic
+%% copying dominates, small enough that a bench run takes seconds.
+-define(DELIVERY_B, 1_048_576).
+-define(DELIVERIES, 16).
+%% The prefetch runs ahead of the consumer; that is what the AIMD window is
+%% for. The consumer starts reading only once this many unconsumed bytes are
+%% buffered and then consumes one delivery's worth per delivery, holding the
+%% lag steady (half the window). Without the lag the consumer tracks the
+%% delivery edge, the old compaction keeps even the flat binary tiny, and
+%% both the copying and the pinning vanish from the measurement.
+-define(PREFETCH_LAG_B, 8_388_608).
+%% Per delivery: chunk-header over-reads (?CHUNK_HEADER_B + ?MAX_FILTER_SIZE)
+%% and chunk-data reads, spread across one delivery's worth of bytes at the
+%% lagged read position.
+-define(READS_PER_DELIVERY, 4).
+-define(HEADER_READ_B, 303).
+-define(CHUNK_READ_B, 32_768).
+-define(SPANNING_READ_B, 2_097_152).
+%% Replies a consumer plausibly holds at once (a delivery's worth of header
+%% and chunk reads in the socket send queue).
+-define(RETAINED_REPLIES, 8).
+%% How long each memory-phase scenario runs (many windows, so the peak
+%% reflects steady state rather than the first window).
+-define(MEMORY_PHASE_MS, 300).
+
+%% Supply x demand matrix axes: block sizes the S3 API layer could batch
+%% to, against read sizes from the header over-read up to a large chunk.
+-define(MATRIX_BLOCK_SIZES, [262_144, 1_048_576, 4_194_304]).
+-define(MATRIX_READ_SIZES, [303, 32_768, 262_144, 2_097_152]).
+%% Bytes supplied per matrix window; deliveries per window is this divided
+%% by the row's block size.
+-define(MATRIX_WINDOW_B, 16_777_216).
+-define(MATRIX_CELL_MS, 250).
+
+-spec run() -> ok.
+run() ->
+    Template = rand:bytes(?DELIVERY_B),
+    Sink = spawn_link(fun sink/0),
+    %% Timing phase: shared template, buffer mechanics only.
+    SameBlock = fun() -> Template end,
+    ok = rabbitmq_stream_s3_bench:run([
+        {flat_binary, fun() -> flat_binary_window(SameBlock, Sink) end},
+        {flat_binary_spanning, fun() -> flat_binary_spanning_window(SameBlock, Sink) end},
+        {block_queue, fun() -> block_queue_window(SameBlock, Sink) end},
+        {block_queue_spanning, fun() -> block_queue_spanning_window(SameBlock, Sink) end}
+    ]),
+    unlink(Sink),
+    exit(Sink, kill),
+    memory_report(Template),
+    matrix_report().
+
+sink() ->
+    receive
+        _ -> sink()
+    end.
+
+%% ------------------------------------------------------------------
+%% Memory phase
+%% ------------------------------------------------------------------
+
+memory_report(Template) ->
+    io:format(
+        "~nMemory (fresh 1 MiB blocks; sink retains last ~b replies, then GCs):~n"
+        "~-22s ~14s ~14s ~14s ~14s~n",
+        [?RETAINED_REPLIES, "Name", "peak binary", "reply bytes", "pinned", "amplification"]
+    ),
+    lists:foreach(
+        fun({Name, WindowFun}) ->
+            NewBlock = fun() -> binary:copy(Template) end,
+            Sink = spawn_link(fun() -> retaining_sink([]) end),
+            #{baseline := Baseline, peak := Peak} = rabbitmq_stream_s3_bench:sample_binary_memory(
+                fun() ->
+                    repeat_for(?MEMORY_PHASE_MS, fun() -> WindowFun(NewBlock, Sink) end)
+                end
+            ),
+            Sink ! {report, self()},
+            receive
+                {pinned, ReplyBytes, Pinned} ->
+                    io:format(
+                        "~-22s ~14s ~14s ~14s ~13.1fx~n",
+                        [
+                            Name,
+                            format_bytes(Peak - Baseline),
+                            format_bytes(ReplyBytes),
+                            format_bytes(Pinned),
+                            Pinned / max(1, ReplyBytes)
+                        ]
+                    )
+            end,
+            %% Wait for the sink to be gone so its pinned references cannot
+            %% leak into the next scenario's baseline.
+            MRef = erlang:monitor(process, Sink),
+            unlink(Sink),
+            exit(Sink, kill),
+            receive
+                {'DOWN', MRef, process, Sink, _} -> ok
+            end
+        end,
+        [
+            {flat_binary, fun flat_binary_window/2},
+            {flat_binary_spanning, fun flat_binary_spanning_window/2},
+            {block_queue, fun block_queue_window/2},
+            {block_queue_spanning, fun block_queue_spanning_window/2}
+        ]
+    ),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Supply x demand matrix
+%% ------------------------------------------------------------------
+
+matrix_report() ->
+    Rows = [{flat, ?DELIVERY_B} | [{queue, B} || B <- ?MATRIX_BLOCK_SIZES]],
+    print_grid(
+        io_lib:format(
+            "Matrix: average time per ~s window (block size x read size, ~s lag)",
+            [format_bytes(?MATRIX_WINDOW_B), format_bytes(?PREFETCH_LAG_B)]
+        ),
+        Rows,
+        fun(Impl, BlockSize, ReadSize) ->
+            Template = rand:bytes(BlockSize),
+            Sink = spawn_link(fun sink/0),
+            Window = fun() ->
+                matrix_window(Impl, BlockSize, ReadSize, fun() -> Template end, Sink)
+            end,
+            %% Warm briefly, then time.
+            repeat_for(?MATRIX_CELL_MS div 5, Window),
+            T0 = erlang:monotonic_time(microsecond),
+            N = count_for(?MATRIX_CELL_MS, Window),
+            Elapsed = erlang:monotonic_time(microsecond) - T0,
+            unlink(Sink),
+            exit(Sink, kill),
+            format_cell_us(Elapsed / N)
+        end
+    ),
+    print_grid(
+        io_lib:format(
+            "Matrix: pinning amplification (sink retains last ~b replies, then GCs)",
+            [?RETAINED_REPLIES]
+        ),
+        Rows,
+        fun(Impl, BlockSize, ReadSize) ->
+            Template = rand:bytes(BlockSize),
+            NewBlock = fun() -> binary:copy(Template) end,
+            Sink = spawn_link(fun() -> retaining_sink([]) end),
+            repeat_for(?MATRIX_CELL_MS, fun() ->
+                matrix_window(Impl, BlockSize, ReadSize, NewBlock, Sink)
+            end),
+            Sink ! {report, self()},
+            Cell =
+                receive
+                    {pinned, ReplyBytes, Pinned} ->
+                        io_lib:format("~.1fx", [Pinned / max(1, ReplyBytes)])
+                end,
+            MRef = erlang:monitor(process, Sink),
+            unlink(Sink),
+            exit(Sink, kill),
+            receive
+                {'DOWN', MRef, process, Sink, _} -> ok
+            end,
+            Cell
+        end
+    ).
+
+print_grid(Title, Rows, CellFun) ->
+    io:format("~n~ts~n~-22s", [Title, ""]),
+    lists:foreach(
+        fun(ReadSize) -> io:format(" ~12s", [["read ", format_bytes(ReadSize)]]) end,
+        ?MATRIX_READ_SIZES
+    ),
+    io:format("~n"),
+    lists:foreach(
+        fun({Impl, BlockSize}) ->
+            Label =
+                case Impl of
+                    flat -> ["flat ", format_bytes(BlockSize), " deliv"];
+                    queue -> ["queue ", format_bytes(BlockSize), " blocks"]
+                end,
+            io:format("~-22ts", [Label]),
+            lists:foreach(
+                fun(ReadSize) ->
+                    io:format(" ~12ts", [CellFun(Impl, BlockSize, ReadSize)])
+                end,
+                ?MATRIX_READ_SIZES
+            ),
+            io:format("~n")
+        end,
+        Rows
+    ).
+
+%% One window: supply ?MATRIX_WINDOW_B bytes in BlockSize deliveries; after
+%% each delivery the consumer issues uniform ReadSize reads from its floor
+%% while more than the prefetch lag is buffered ahead of it.
+matrix_window(queue, BlockSize, ReadSize, NewBlock, Sink) ->
+    Deliveries = ?MATRIX_WINDOW_B div BlockSize,
+    lists:foldl(
+        fun(_, {Buffer0, Floor0}) ->
+            Buffer1 = rabbitmq_stream_s3_read_buffer:append(NewBlock(), Buffer0),
+            EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buffer1),
+            Floor = matrix_consume_queue(Floor0, EndPos, ReadSize, Buffer1, Sink),
+            {rabbitmq_stream_s3_read_buffer:drop_before(Floor, Buffer1), Floor}
+        end,
+        {rabbitmq_stream_s3_read_buffer:new(0), 0},
+        lists:seq(1, Deliveries)
+    ),
+    ok;
+matrix_window(flat, BlockSize, ReadSize, NewBlock, Sink) ->
+    Deliveries = ?MATRIX_WINDOW_B div BlockSize,
+    lists:foldl(
+        fun(_, {Buffer0, StartPos, CurrentPos, EndPos0}) ->
+            Delivery = NewBlock(),
+            Buffer1 =
+                case CurrentPos =:= StartPos of
+                    true ->
+                        <<Buffer0/binary, Delivery/binary>>;
+                    false ->
+                        <<
+                            (binary:part(
+                                Buffer0, CurrentPos - StartPos, EndPos0 - CurrentPos
+                            ))/binary,
+                            Delivery/binary
+                        >>
+                end,
+            EndPos = EndPos0 + byte_size(Delivery),
+            Floor = matrix_consume_flat(CurrentPos, CurrentPos, EndPos, ReadSize, Buffer1, Sink),
+            {Buffer1, CurrentPos, Floor, EndPos}
+        end,
+        {<<>>, 0, 0, 0},
+        lists:seq(1, Deliveries)
+    ),
+    ok.
+
+matrix_consume_queue(Floor, EndPos, ReadSize, Buffer, Sink) ->
+    case consumer_ready(Floor, EndPos) of
+        true ->
+            Sink ! {ok, rabbitmq_stream_s3_read_buffer:read(Floor, ReadSize, Buffer)},
+            matrix_consume_queue(Floor + ReadSize, EndPos, ReadSize, Buffer, Sink);
+        false ->
+            Floor
+    end.
+
+matrix_consume_flat(Base, Floor, EndPos, ReadSize, Buffer, Sink) ->
+    case consumer_ready(Floor, EndPos) of
+        true ->
+            Sink ! {ok, binary:part(Buffer, Floor - Base, ReadSize)},
+            matrix_consume_flat(Base, Floor + ReadSize, EndPos, ReadSize, Buffer, Sink);
+        false ->
+            Floor
+    end.
+
+format_cell_us(Us) when Us >= 1000 -> io_lib:format("~.2f ms", [Us / 1000]);
+format_cell_us(Us) -> io_lib:format("~b us", [round(Us)]).
+
+count_for(Ms, Fun) ->
+    Deadline = erlang:monotonic_time(millisecond) + Ms,
+    count_until(Deadline, Fun, 0).
+
+count_until(Deadline, Fun, N) ->
+    _ = Fun(),
+    case erlang:monotonic_time(millisecond) >= Deadline of
+        true -> N + 1;
+        false -> count_until(Deadline, Fun, N + 1)
+    end.
+
+%% Keeps the newest ?RETAINED_REPLIES replies alive, then reports how much
+%% binary memory those live references pin once everything dead is gone.
+retaining_sink(Ring) ->
+    receive
+        {ok, Data} ->
+            retaining_sink(lists:sublist([Data | Ring], ?RETAINED_REPLIES));
+        {report, From} ->
+            erlang:garbage_collect(),
+            ReplyBytes = lists:sum([byte_size(D) || D <- Ring]),
+            {binary, Bins} = process_info(self(), binary),
+            %% One entry per reference; several references into the same
+            %% binary must count its bytes once.
+            Deduped = maps:from_list([{Id, Size} || {Id, Size, _RefCount} <- Bins]),
+            From ! {pinned, ReplyBytes, lists:sum(maps:values(Deduped))},
+            retaining_sink(Ring)
+    end.
+
+repeat_for(Ms, Fun) ->
+    Deadline = erlang:monotonic_time(millisecond) + Ms,
+    repeat_until(Deadline, Fun).
+
+repeat_until(Deadline, Fun) ->
+    _ = Fun(),
+    case erlang:monotonic_time(millisecond) >= Deadline of
+        true -> ok;
+        false -> repeat_until(Deadline, Fun)
+    end.
+
+format_bytes(B) when B >= 1 bsl 20 -> io_lib:format("~.1f MiB", [B / (1 bsl 20)]);
+format_bytes(B) when B >= 1 bsl 10 -> io_lib:format("~.1f KiB", [B / (1 bsl 10)]);
+format_bytes(B) -> io_lib:format("~b B", [B]).
+
+%% ------------------------------------------------------------------
+%% Scenario: flat binary (the previous remote reader buffer)
+%% ------------------------------------------------------------------
+
+flat_binary_window(NewBlock, Sink) ->
+    lists:foldl(
+        fun(_, {Buffer0, StartPos, CurrentPos, EndPos0}) ->
+            Delivery = NewBlock(),
+            %% add_data_current from before the block queue: append, or
+            %% compact-and-append once reads have consumed a prefix.
+            Buffer1 =
+                case CurrentPos =:= StartPos of
+                    true ->
+                        <<Buffer0/binary, Delivery/binary>>;
+                    false ->
+                        <<
+                            (binary:part(
+                                Buffer0, CurrentPos - StartPos, EndPos0 - CurrentPos
+                            ))/binary,
+                            Delivery/binary
+                        >>
+                end,
+            EndPos = EndPos0 + byte_size(Delivery),
+            ReadFloor =
+                case consumer_ready(CurrentPos, EndPos) of
+                    true ->
+                        lists:foreach(
+                            fun(I) ->
+                                Pos = read_pos(CurrentPos, I),
+                                Sink !
+                                    {ok,
+                                        binary:part(
+                                            Buffer1, Pos - CurrentPos, ?HEADER_READ_B
+                                        )},
+                                Sink !
+                                    {ok,
+                                        binary:part(
+                                            Buffer1,
+                                            Pos + ?HEADER_READ_B - CurrentPos,
+                                            ?CHUNK_READ_B
+                                        )}
+                            end,
+                            lists:seq(0, ?READS_PER_DELIVERY - 1)
+                        ),
+                        CurrentPos + ?DELIVERY_B;
+                    false ->
+                        CurrentPos
+                end,
+            {Buffer1, CurrentPos, ReadFloor, EndPos}
+        end,
+        {<<>>, 0, 0, 0},
+        lists:seq(1, ?DELIVERIES)
+    ),
+    ok.
+
+%% As flat_binary_window but serving one ?SPANNING_READ_B sub-binary read
+%% per delivery, the flat counterpart of block_queue_spanning. Each reply
+%% comes from that delivery's freshly copied buffer generation.
+flat_binary_spanning_window(NewBlock, Sink) ->
+    lists:foldl(
+        fun(_, {Buffer0, StartPos, CurrentPos, EndPos0}) ->
+            Delivery = NewBlock(),
+            Buffer1 =
+                case CurrentPos =:= StartPos of
+                    true ->
+                        <<Buffer0/binary, Delivery/binary>>;
+                    false ->
+                        <<
+                            (binary:part(
+                                Buffer0, CurrentPos - StartPos, EndPos0 - CurrentPos
+                            ))/binary,
+                            Delivery/binary
+                        >>
+                end,
+            EndPos = EndPos0 + byte_size(Delivery),
+            ReadFloor =
+                case consumer_ready(CurrentPos, EndPos) of
+                    true ->
+                        Sink ! {ok, binary:part(Buffer1, 0, ?SPANNING_READ_B)},
+                        CurrentPos + ?SPANNING_READ_B;
+                    false ->
+                        CurrentPos
+                end,
+            {Buffer1, CurrentPos, ReadFloor, EndPos}
+        end,
+        {<<>>, 0, 0, 0},
+        lists:seq(1, ?DELIVERIES)
+    ),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Scenario: block queue (rabbitmq_stream_s3_read_buffer)
+%% ------------------------------------------------------------------
+
+block_queue_window(NewBlock, Sink) ->
+    lists:foldl(
+        fun(_, {Buffer0, Floor0}) ->
+            Buffer1 = rabbitmq_stream_s3_read_buffer:append(NewBlock(), Buffer0),
+            EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buffer1),
+            Floor =
+                case consumer_ready(Floor0, EndPos) of
+                    true ->
+                        lists:foreach(
+                            fun(I) ->
+                                Pos = read_pos(Floor0, I),
+                                Sink !
+                                    {ok,
+                                        rabbitmq_stream_s3_read_buffer:read(
+                                            Pos, ?HEADER_READ_B, Buffer1
+                                        )},
+                                Sink !
+                                    {ok,
+                                        rabbitmq_stream_s3_read_buffer:read(
+                                            Pos + ?HEADER_READ_B, ?CHUNK_READ_B, Buffer1
+                                        )}
+                            end,
+                            lists:seq(0, ?READS_PER_DELIVERY - 1)
+                        ),
+                        Floor0 + ?DELIVERY_B;
+                    false ->
+                        Floor0
+                end,
+            {rabbitmq_stream_s3_read_buffer:drop_before(Floor, Buffer1), Floor}
+        end,
+        {rabbitmq_stream_s3_read_buffer:new(0), 0},
+        lists:seq(1, ?DELIVERIES)
+    ),
+    ok.
+
+block_queue_spanning_window(NewBlock, Sink) ->
+    lists:foldl(
+        fun(_, {Buffer0, Floor0}) ->
+            Buffer1 = rabbitmq_stream_s3_read_buffer:append(NewBlock(), Buffer0),
+            EndPos = rabbitmq_stream_s3_read_buffer:end_pos(Buffer1),
+            Floor =
+                case consumer_ready(Floor0, EndPos) of
+                    true ->
+                        Sink !
+                            {ok,
+                                rabbitmq_stream_s3_read_buffer:read(
+                                    Floor0, ?SPANNING_READ_B, Buffer1
+                                )},
+                        Floor0 + ?SPANNING_READ_B;
+                    false ->
+                        Floor0
+                end,
+            {rabbitmq_stream_s3_read_buffer:drop_before(Floor, Buffer1), Floor}
+        end,
+        {rabbitmq_stream_s3_read_buffer:new(0), 0},
+        lists:seq(1, ?DELIVERIES)
+    ),
+    ok.
+
+%% The consumer reads only while more than the prefetch lag is buffered
+%% ahead of it, consuming from its floor. Forward-moving, so every read is
+%% at or past the previous one (the log reader's pattern).
+consumer_ready(Floor, EndPos) ->
+    EndPos - Floor > ?PREFETCH_LAG_B.
+
+read_pos(ReadBase, I) ->
+    Step = ?DELIVERY_B div ?READS_PER_DELIVERY,
+    ReadBase + I * Step.


### PR DESCRIPTION
*Issue #, if available:* related to https://github.com/amazon-mq/rabbitmq-stream-s3/issues/176, https://github.com/amazon-mq/rabbitmq-stream-s3/issues/298

*Description of changes:* This change swaps out the remote reader's buffer type. It was a flat binary and newly prefetched data was appended to it (`<<Buffer/binary, NewData/binary>>`. This change adds a queue which holds the prefeteched binaries in order, without modifying/appending any binaries.

Appending a binary is fairly cheap and `binary:part/3` is fairly cheap too, but together with sending the binaries as messages, they pin binaries so that they cannot be reclaimed quickly, and produce extra copies of the binaries. This is very noticeable in the log reader at high throughput. Instead we want to avoid modifying the binaries that we get from the HTTP client at all, so we avoid making extra copies of the data. The investigation doc has all of the details on why the old mechanism was expensive, and data on how quick and memory efficient the new block queue type is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
