### PR TITLE
Fix flaky replica_reader tests: preserve await_offset waiters across core rebuild, fix vacuous barrier in local_ahead_discards_manifest

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1373,10 +1373,15 @@ resolve_and_start(#state{cfg = #cfg{stream = StreamId}} = State0) ->
     case resolve_manifest(StreamId) of
         {ok, Manifest} ->
             State1 = on_manifest_resolved(Manifest, State0),
-            {Core, _Effects} = rabbitmq_stream_s3_replica_reader_core:init(
+            {Core0, _Effects} = rabbitmq_stream_s3_replica_reader_core:init(
                 Manifest, State1#state.config
             ),
-            start_reading(State1#state{core = Core});
+            %% Carry any await_offset waiters from the discarded core so a caller
+            %% blocked across the rebuild is not dropped without a reply.
+            {Core, WaiterEffects} = rabbitmq_stream_s3_replica_reader_core:carry_waiters(
+                State1#state.core, Core0
+            ),
+            start_reading(execute_effects(WaiterEffects, State1#state{core = Core}));
         {retry, Reason} ->
             %% Logged at WARNING (not ERROR) like the sibling init_data_reader
             %% retry in start_reading: this retries once a second, so a
@@ -1531,7 +1536,11 @@ restart_at_local_floor(
     #state{cfg = #cfg{stream = StreamId, epoch = Epoch}} = State
 ) ->
     FreshManifest = reset_manifest(LocalFirst, Revision),
-    {Core1, _} = rabbitmq_stream_s3_replica_reader_core:init(FreshManifest, State#state.config),
+    {Core0, _} = rabbitmq_stream_s3_replica_reader_core:init(FreshManifest, State#state.config),
+    %% Carry any await_offset waiters from the discarded core (see resolve_and_start/1).
+    {Core1, WaiterEffects} = rabbitmq_stream_s3_replica_reader_core:carry_waiters(
+        State#state.core, Core0
+    ),
     ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest, Epoch),
     %% Propagate the reset to replicas. The fresh manifest carries the discarded
     %% manifest's revision (the broadcast sequence number), so the sync is not
@@ -1542,7 +1551,7 @@ restart_at_local_floor(
     %% an unsynced register).
     ok = sync_all_replicas(FreshManifest, State),
     gc_stream_async(StreamId, Epoch),
-    start_reading(State#state{core = Core1}).
+    start_reading(execute_effects(WaiterEffects, State#state{core = Core1})).
 
 %% Whether the live local log has been trimmed past the manifest's next_offset.
 %% When true, the segment backing the stalled head fragment is permanently gone

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -29,6 +29,7 @@ testable without mocks or timing.
     persist_failed/2,
     tick/2,
     await_offset/3,
+    carry_waiters/2,
     retention_started/1,
     retention_complete/2,
     retention_failed/2
@@ -456,6 +457,26 @@ await_offset(Offset, From, #state{last_persisted_manifest = Committed} = State) 
         false ->
             {State#state{waiters = [{Offset, From} | State#state.waiters]}, []}
     end.
+
+-doc """
+Carry `await_offset` waiters from a discarded core into a freshly built one.
+
+Every path that rebuilds the core (manifest reinitialize after a commit
+conflict, local-log-ahead / remote-ahead reset) replaces the whole state with
+`init/2`, which starts with no waiters. A caller already blocked in
+`await_offset` would otherwise be dropped without a reply and hang until its
+own timeout, even though the reader is healthy and advancing. Move the
+waiters onto the new core and re-run `notify_waiters` so any the resolved
+manifest already satisfies reply immediately.
+""".
+-spec carry_waiters(Old :: state() | undefined, New :: state()) -> {state(), [core_effect()]}.
+carry_waiters(undefined, NewState) ->
+    %% First init (no prior core), so there is nothing to carry.
+    {NewState, []};
+carry_waiters(#state{waiters = []}, NewState) ->
+    {NewState, []};
+carry_waiters(#state{waiters = Waiters}, NewState) ->
+    notify_waiters(NewState#state{waiters = Waiters ++ NewState#state.waiters}).
 
 -doc """
 A group upload completed. Apply the rebalance edit to the in-memory manifest,

--- a/test/rabbitmq_stream_s3_test_helpers.erl
+++ b/test/rabbitmq_stream_s3_test_helpers.erl
@@ -12,6 +12,15 @@ Shared test helpers for rabbitmq_stream_s3 CT suites.
 
 -compile([export_all, nowarn_export_all]).
 
+%% Default deadline for the await_offset/1,2 barriers. The reader only has to
+%% persist a manifest past the target, which is fast in isolation, but under
+%% full-suite CPU contention it occasionally exceeds a tight deadline and the
+%% gen_server:call exits with {timeout, _}. This is generous enough to absorb
+%% that contention without masking a genuine stall (a real freeze never
+%% clears, however long the wait). Callers that need a different deadline use
+%% await_offset/3.
+-define(AWAIT_OFFSET_TIMEOUT_MS, 5000).
+
 %% ------------------------------------------------------------------
 %% Log seeding DSL
 %% ------------------------------------------------------------------
@@ -305,11 +314,11 @@ argument. The Config form provides better diagnostics on timeout.
 """.
 -spec await_offset(binary() | list(), osiris:offset()) -> ok.
 await_offset(StreamId, Offset) when is_binary(StreamId) ->
-    await_offset(StreamId, Offset, 1000);
+    await_offset(StreamId, Offset, ?AWAIT_OFFSET_TIMEOUT_MS);
 await_offset(Config, Offset) when is_list(Config) ->
     StreamId = ?config(stream_id, Config),
     try
-        await_offset(StreamId, Offset, 1000)
+        await_offset(StreamId, Offset, ?AWAIT_OFFSET_TIMEOUT_MS)
     catch
         exit:{timeout, _} ->
             Name = {via, rabbitmq_stream_s3_registry, {StreamId, node()}},

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -708,9 +708,22 @@ local_ahead_discards_manifest(Config) ->
     %% Phase 3: restart replica reader. It should discard old manifest and upload new data.
     _ = start_replica_reader(Writer, Config, #{fragment_target_size => 500}),
 
-    %% Wait for the new replica reader to upload.
-    [FirstLocal | _] = list_segment_offsets(Config),
-    await_offset(Config, FirstLocal + 10),
+    %% Wait for the reader to durably upload fresh data.
+    %%
+    %% An await_offset barrier cannot be used here: the reset installs an empty
+    %% manifest whose next_offset equals the local log's first *readable* chunk
+    %% id, which the test cannot compute a priori (it can exceed the segment-file
+    %% offset reported by list_segment_offsets). Any offset the test could name is
+    %% therefore satisfied vacuously by the empty reset manifest, before a single
+    %% fresh fragment uploads, racing the assertions below against the in-flight
+    %% uploads. Instead wait directly for the observable outcome: at least one
+    %% fragment that is not one of the pre-restart fragments appears in the remote
+    %% tier.
+    ?awaitMatch(
+        [_ | _],
+        [F || F <- list_fragment_offsets(Config), not lists:member(F, OldFragments)],
+        5000
+    ),
 
     %% Old fragments should be gone (deleted asynchronously by the replica reader).
     ?awaitMatch(
@@ -718,10 +731,15 @@ local_ahead_discards_manifest(Config) ->
         [F || F <- OldFragments, lists:member(F, list_fragment_offsets(Config))],
         1000
     ),
-    %% New fragments exist starting at or after the local first offset.
+    %% New fragments exist and start above the discarded phase-1 range: the reset
+    %% re-tiered from the local floor, not from offset 0. The exact floor is not
+    %% asserted because it is the local log's first readable chunk id at reset
+    %% time, which the test cannot compute and which local retention keeps
+    %% advancing; asserting it is above the highest pre-restart fragment offset
+    %% captures the intent without racing retention.
     NewFragments = list_fragment_offsets(Config),
     ?assert(length(NewFragments) > 0),
-    ?assert(hd(NewFragments) >= FirstLocal).
+    ?assert(hd(NewFragments) > lists:max(OldFragments)).
 
 upload_path_recovers_from_trimmed_segment(Config) ->
     %% Issue #225, mid-stream path: while a fragment upload is in flight, user

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -43,6 +43,9 @@ all() ->
         await_offset_satisfied_immediately,
         await_offset_blocks_until_applied,
         multiple_waiters_notified,
+        carry_waiters_replies_when_new_manifest_satisfies,
+        carry_waiters_preserves_unsatisfied_waiter,
+        carry_waiters_from_empty_old_core_is_noop,
         first_fragment_sets_manifest_metadata,
         interleaved_cut_complete_cut,
         timer_restarts_after_persist_and_new_cut,
@@ -452,6 +455,46 @@ multiple_waiters_notified(_Config) ->
     {_S8, Effects2b} = rabbitmq_stream_s3_replica_reader_core:persist_complete(2, S7),
     Replies2 = lists:flatten([Rs || {reply_waiters, Rs} <- Effects2 ++ Effects2b]),
     ?assertMatch([{from2, ok}], Replies2).
+
+carry_waiters_replies_when_new_manifest_satisfies(_Config) ->
+    %% A waiter blocks on the old core, then the core is rebuilt (reinitialize
+    %% or local-ahead reset) with a manifest already past the waiter's offset.
+    %% carry_waiters must reply immediately rather than drop the waiter.
+    {Old0, _} = init_core(#{persist_threshold => 1}),
+    {Old1, []} = rabbitmq_stream_s3_replica_reader_core:await_offset(100, fake_from, Old0),
+    {New0, _} = init_core_with_manifest(#manifest{next_offset = 500}),
+    {New1, Effects} = rabbitmq_stream_s3_replica_reader_core:carry_waiters(Old1, New0),
+    ?assertMatch([{reply_waiters, [{fake_from, ok}]}], Effects),
+    %% The waiter has been discharged, so it does not linger: a later reply
+    %% names only the new caller, never fake_from again.
+    {_New2, Later} = rabbitmq_stream_s3_replica_reader_core:await_offset(1, another_from, New1),
+    ?assertMatch([{reply_waiters, [{another_from, ok}]}], Later).
+
+carry_waiters_preserves_unsatisfied_waiter(_Config) ->
+    %% If the rebuilt manifest is still behind the waiter's offset, the waiter is
+    %% preserved (not dropped, not replied to early) and fires once the new core
+    %% advances past it.
+    {Old0, _} = init_core(#{persist_threshold => 1}),
+    {Old1, []} = rabbitmq_stream_s3_replica_reader_core:await_offset(150, fake_from, Old0),
+    {New0, _} = init_core(#{persist_threshold => 1}),
+    {New1, []} = rabbitmq_stream_s3_replica_reader_core:carry_waiters(Old1, New0),
+    %% Advance the new core past 150 and confirm the carried waiter is notified.
+    {New2, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 200), New1),
+    {New3, _} = rabbitmq_stream_s3_replica_reader_core:transfer_complete(Ref, 1001, New2),
+    {_New4, Effects} = rabbitmq_stream_s3_replica_reader_core:persist_complete(1, New3),
+    Replies = lists:flatten([Rs || {reply_waiters, Rs} <- Effects]),
+    ?assertMatch([{fake_from, ok}], Replies).
+
+carry_waiters_from_empty_old_core_is_noop(_Config) ->
+    %% The common case: the old core had no waiters, so the rebuild carries
+    %% nothing and emits no replies.
+    {Old0, _} = init_core(),
+    {New0, _} = init_core(),
+    ?assertEqual({New0, []}, rabbitmq_stream_s3_replica_reader_core:carry_waiters(Old0, New0)),
+    %% A first init (no prior core) is likewise a no-op.
+    ?assertEqual(
+        {New0, []}, rabbitmq_stream_s3_replica_reader_core:carry_waiters(undefined, New0)
+    ).
 
 tick_no_op_before_interval(_Config) ->
     {S0, _} = init_core(#{persist_threshold => 100, persist_interval_ms => 5000}),


### PR DESCRIPTION
Fixes two distinct causes of the flaky `replica_reader` tests tracked in #326.

## Mode 2: core rebuild dropped `await_offset` waiters (real reader defect)

`replication_survives_reader_restart` timed out on `await_offset`. The reader was healthy and advancing, but every path that rebuilds the functional core (manifest reinitialize after a commit conflict, local-log-ahead / remote-ahead reset) replaces the whole state via `core:init/2`, which starts with no waiters. A caller already blocked in `await_offset` across such a rebuild was dropped without a reply and hung until its own `gen_server:call` timeout.

Fix: add `carry_waiters/2` to the core and call it at both rebuild sites in the reader (`resolve_and_start/1` and `restart_at_local_floor/3`), moving pending waiters onto the freshly built core and replying to any the resolved manifest already satisfies. Proven via reader pid/state capture across clean reproductions.

Commit 9ff7ed3

## Mode 3: vacuous `await_offset` barrier in `local_ahead_discards_manifest` (test-only)

This case flaked at the "new fragments exist" assertion (roughly 1 in 30 to 100 runs). Reader state captured at the moment of failure showed a single healthy reader, correctly reset to the local floor, with fragment transfers still in flight and no persist completed yet. Nothing regressed and nothing was deleted: the fresh fragments simply had not uploaded when the test asserted.

The barrier was ill-posed. On the local-log-ahead reset the reader resets to the local log's first readable chunk id and installs an empty manifest whose `next_offset` equals that floor. The test derived its `await_offset` target from the segment-file offset reported by `list_segment_offsets` and awaited that plus ten. Because `await_offset` gates on `last_persisted_manifest.next_offset`, the empty reset manifest satisfied it vacuously, before any fresh fragment uploaded, so the assertions raced the in-flight uploads.

`await_offset` cannot be used here: the test cannot compute the reset floor a priori, so any offset it names can be satisfied by the empty reset manifest. The fix waits instead for the observable outcome via the suite's `?awaitMatch` idiom (a fragment that is not one of the pre-restart fragments appears in the remote tier), and relaxes the final assertion from `hd(NewFragments) >= FirstLocal` (which races local retention advancing the segment floor) to `hd(NewFragments) > lists:max(OldFragments)`.

Commit 3250bc8

## Validation

- Mode 3: 300 consecutive isolated runs of `local_ahead_discards_manifest`, 0 failures (the bug previously reproduced by run 30)
- Full `replica_reader` suite: 38 ok, 0 failed
- Mode 2: `replica_reader_core` suite 82 ok; full `replica_reader` suite clean across 40 runs; dialyze and xref pass

## Peer-node death seen during investigation: diagnosed, not a plugin bug

A peer-node death (`erpc,noconnection` cascade across the `with_replica` cases) was seen a couple of times under a 30s hammering diagnostic loop. It is a test-infrastructure artifact, now confirmed end to end.

The `with_replica` group starts one shared peer via `peer:start/1` (`rabbitmq_stream_s3_cth.erl:98`). OTP's `peer` spawns an `origin_link` watchdog on the peer (stdlib `peer.erl:1420`) that monitors the origin (CT) node's control process over distribution and calls `erlang:halt()` on `DOWN`. So whenever the origin/peer distribution connection drops, the peer self-terminates with no `erl_crash.dump`, and every subsequent `erpc` call to the shared peer fails with `{erpc,noconnection}`. Under the 30s hold loop the origin was under enough host CPU/memory pressure that distribution net-ticks were not serviced in time, net_kernel declared the peer down, and the peer halted itself. The reader state captured at that failure (`manifest_next_offset=30`, `persisted_next_offset=30`, `anchor=done`, `waiters=0`) shows the reader had already finished its work, so the plugin was never at fault.

Confirmed both ways:

- Positive: a standalone probe that starts a peer as the hook does, then `erlang:disconnect_node/1` from the origin (what a net-tick timeout does), reproduces the exact signature: the peer OS process is gone (`kill -0` reports no such process), `erpc:call` returns `{erpc,noconnection}`, and no crash dump is written
- Negative: 60 consecutive normal `with_replica` group runs produced 0 peer deaths and 0 `noconnection`; the death only ever appeared under the now-removed 30s hammer loop

This cannot occur in production: the cross-node registry path (`rabbitmq_stream_s3_registry.erl:102`) already catches `_:_` and degrades to `undefined`. No plugin change is warranted.
