### PR TITLE
Fix pool checkout timeout misclassified as non-transient (issue #332)

### DIFF
--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -392,26 +392,31 @@ stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) 
                 {ok, Headers} ->
                     Pool = ?UPLOAD_POOL,
                     %% Acquire the connection before touching the request
-                    %% gauges. checkout/2 re-raises on a timeout or pool-down,
-                    %% and C_ACTIVE_REQUESTS is only decremented by finish_async,
-                    %% which runs once we hold a connection and have built State.
-                    %% Incrementing before the checkout leaked the gauge on every
-                    %% failed checkout (a sustained partial outage that drains the
-                    %% pool drove active_requests up with no way back down).
-                    Conn = rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000),
-                    Cnt = counter(),
-                    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-                    counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
-                    StreamRef = gun:headers(Conn, Method, Path, Headers),
-                    State = #{
-                        pool => Pool,
-                        conn => Conn,
-                        stream_ref => StreamRef,
-                        data => [],
-                        pending_bytes => 0,
-                        timeout => maps:get(timeout, Opts0, 60_000)
-                    },
-                    {ok, State};
+                    %% gauges. checkout/2 returns {error, pool_busy} on a
+                    %% saturated pool, and C_ACTIVE_REQUESTS is only decremented
+                    %% by finish_async, which runs once we hold a connection and
+                    %% have built State. Incrementing before the checkout leaked
+                    %% the gauge on every failed checkout (a sustained partial
+                    %% outage that drains the pool drove active_requests up with
+                    %% no way back down).
+                    case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000) of
+                        {ok, Conn} ->
+                            Cnt = counter(),
+                            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
+                            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+                            StreamRef = gun:headers(Conn, Method, Path, Headers),
+                            State = #{
+                                pool => Pool,
+                                conn => Conn,
+                                stream_ref => StreamRef,
+                                data => [],
+                                pending_bytes => 0,
+                                timeout => maps:get(timeout, Opts0, 60_000)
+                            },
+                            {ok, State};
+                        {error, pool_busy} = Err ->
+                            Err
+                    end;
                 {error, _} = Err ->
                     Err
             end;
@@ -1180,8 +1185,8 @@ request_async(Method, Path, Headers0, Body, Opts) ->
     end.
 
 start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
-    try rabbitmq_stream_s3_api_aws_pool:checkout(Pool, ?READ_CHECKOUT_TIMEOUT_MS) of
-        Conn ->
+    case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, ?READ_CHECKOUT_TIMEOUT_MS) of
+        {ok, Conn} ->
             Cnt = counter(),
             counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
             counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
@@ -1198,10 +1203,9 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
                 first_data_at => undefined,
                 bytes_received => 0
             },
-            {ok, StreamRef, maybe_set_timer(Opts, StreamRef, State)}
-    catch
-        exit:{timeout, _} ->
-            {error, pool_busy}
+            {ok, StreamRef, maybe_set_timer(Opts, StreamRef, State)};
+        {error, pool_busy} = Err ->
+            Err
     end.
 
 maybe_set_timer(#{timeout := Timeout}, StreamRef, State) ->

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -125,17 +125,27 @@ the reader pool avoids reader starvation.
 
 %%---------------------------------------------------------------------------
 
--spec checkout(pool(), timeout()) -> conn().
+-spec checkout(pool(), timeout()) -> {ok, conn()} | {error, pool_busy}.
 checkout(Pool, Timeout) ->
     %% NOTE: the server monitors the caller, but we also send a cancellation
     %% message. The cancellation message ensures the checkout attempt is
-    %% dropped if the caller is catching the error re-raised in the catch block
-    %% below. The monitor catches cases where the cancellation message can't
-    %% be sent (disconnects, brutal kills, etc.).
+    %% dropped when the checkout times out (the caller is no longer waiting for
+    %% a connection). The monitor catches cases where the cancellation message
+    %% can't be sent (disconnects, brutal kills, etc.).
     Checkout = erlang:make_ref(),
     try
-        gen_server:call(Pool, {checkout, Checkout}, Timeout)
+        {ok, gen_server:call(Pool, {checkout, Checkout}, Timeout)}
     catch
+        %% A saturated pool times the checkout out with a gen_server:call exit.
+        %% Convert it to a named term here, where the knowledge that the
+        %% checkout is a timed gen_server:call lives, so the raw OTP exit never
+        %% escapes the pool boundary and callers classify pool_busy by name.
+        exit:{timeout, _} ->
+            gen_server:cast(Pool, {cancel_checkout, Checkout}),
+            {error, pool_busy};
+        %% Any other exit (e.g. the pool is down) is not a saturation signal.
+        %% Send the cancellation and re-raise, preserving the caller's view of
+        %% a genuinely broken pool.
         C:E:Stack ->
             gen_server:cast(Pool, {cancel_checkout, Checkout}),
             erlang:raise(C, E, Stack)
@@ -145,13 +155,17 @@ checkout(Pool, Timeout) ->
 checkin(Pool, Conn) ->
     gen_server:cast(Pool, {checkin, Conn}).
 
--spec with(pool(), timeout(), fun((conn()) -> term())) -> term().
+-spec with(pool(), timeout(), fun((conn()) -> term())) -> term() | {error, pool_busy}.
 with(Pool, Timeout, Fun) ->
-    Conn = checkout(Pool, Timeout),
-    try
-        Fun(Conn)
-    after
-        ok = checkin(Pool, Conn)
+    case checkout(Pool, Timeout) of
+        {ok, Conn} ->
+            try
+                Fun(Conn)
+            after
+                ok = checkin(Pool, Conn)
+            end;
+        {error, pool_busy} = Err ->
+            Err
     end.
 
 %%---------------------------------------------------------------------------

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -650,6 +650,8 @@ format_state(#?MODULE{
     }.
 
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 test_inspect(Pool) ->
     #?MODULE{
         available = Available,
@@ -670,4 +672,47 @@ test_inspect(Pool) ->
         ],
         idle_timers => IdleTimers
     }.
+
+%% A saturated pool must surface as {error, pool_busy}, not a raw
+%% gen_server:call exit escaping the pool boundary (issue #332).
+checkout_timeout_returns_pool_busy_test() ->
+    {ok, _} = application:ensure_all_started(seshat),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_aws
+    ),
+    _ = seshat:new_group(rabbitmq_stream_s3),
+    Config = #{
+        name => busy_pool,
+        min_size => 1,
+        max_size => 1,
+        open_fun => fun test_open/0,
+        usable_fun => fun erlang:is_process_alive/1,
+        close_fun => fun test_close/1
+    },
+    {ok, Pid} = start_link(busy_pool, Config),
+    try
+        %% Take the pool's only connection and hold it, so the next checkout
+        %% cannot be served and must time out.
+        {ok, Conn} = checkout(busy_pool, 1000),
+        ?assertEqual({error, pool_busy}, checkout(busy_pool, 100)),
+        %% The connection held above is still valid and checks back in cleanly.
+        ok = checkin(busy_pool, Conn)
+    after
+        gen_server:stop(Pid)
+    end.
+
+%% A fake connection is a plain process that only understands `stop`; the pool
+%% sends itself `gun_up` synchronously, mirroring the real `open/0` path.
+test_open() ->
+    Pid = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    self() ! {gun_up, Pid, http},
+    {ok, Pid}.
+
+test_close(Conn) ->
+    catch exit(Conn, kill),
+    ok.
 -endif.

--- a/src/rabbitmq_stream_s3_replica_reader_core.erl
+++ b/src/rabbitmq_stream_s3_replica_reader_core.erl
@@ -899,5 +899,14 @@ is_retriable(#{status := Status}) ->
     %% 408 request timeout, 429 throttling, and any 5xx are server-side
     %% transients; everything else (e.g. 403, 404) is fatal.
     Status =:= 408 orelse Status =:= 429 orelse (Status >= 500 andalso Status =< 599);
+%% A saturated upload pool. rabbitmq_stream_s3_api_aws_pool:checkout/2 converts
+%% the checkout timeout into this named atom at the pool boundary, so the real
+%% cause (capacity, not a fatal 403/404) is classified transient and takes the
+%% fast retry path.
+is_retriable(pool_busy) ->
+    true;
+%% Any other reason (including a governor-wrapped {Class, Reason} from an
+%% unexpected upload-task crash) is fatal: the delayed-retry path keeps the
+%% fragment and retries it with a backoff, never dropping it.
 is_retriable(_) ->
     false.

--- a/test/api_aws_pool_statem_SUITE.erl
+++ b/test/api_aws_pool_statem_SUITE.erl
@@ -45,6 +45,7 @@ over the invariants above.
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 -define(POOL, statem_aws_pool).
 -define(MIN_SIZE, 1).
@@ -57,7 +58,7 @@ over the invariants above.
 -define(AWAIT_MS, 1500).
 
 all() ->
-    [no_leak_or_inconsistency].
+    [no_leak_or_inconsistency, checkout_timeout_returns_pool_busy].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(seshat),
@@ -75,6 +76,26 @@ end_per_suite(Config) ->
 
 no_leak_or_inconsistency(_Config) ->
     rabbit_ct_proper_helpers:run_proper(fun prop_no_leak_or_inconsistency/0, [], 150).
+
+%% A saturated pool must surface as {error, pool_busy}, not a raw
+%% gen_server:call exit escaping the pool boundary (issue #332).
+checkout_timeout_returns_pool_busy(_Config) ->
+    _ = seshat:new_group(rabbitmq_stream_s3),
+    Config = (pool_config())#{name => busy_pool, min_size => 1, max_size => 1},
+    {ok, Pid} = rabbitmq_stream_s3_api_aws_pool:start_link(busy_pool, Config),
+    try
+        %% Take the pool's only connection and hold it, so the next checkout
+        %% cannot be served and must time out.
+        {ok, Conn} = rabbitmq_stream_s3_api_aws_pool:checkout(busy_pool, 1000),
+        ?assertEqual(
+            {error, pool_busy},
+            rabbitmq_stream_s3_api_aws_pool:checkout(busy_pool, 100)
+        ),
+        %% The connection held above is still valid and checks back in cleanly.
+        ok = rabbitmq_stream_s3_api_aws_pool:checkin(busy_pool, Conn)
+    after
+        gen_server:stop(Pid)
+    end.
 
 prop_no_leak_or_inconsistency() ->
     ?FORALL(
@@ -229,9 +250,12 @@ postcondition(_S, {call, _, do_kill_conn, []}, Conn) when is_pid(Conn) ->
 do_checkout(CallerId) ->
     TestPid = self(),
     spawn(fun() ->
+        %% checkout/2 returns {ok, Conn} on success and {error, pool_busy} on a
+        %% saturated-pool timeout; the catch only guards against an unexpected
+        %% exit (e.g. a dead pool), which this model never induces.
         Result =
-            try rabbitmq_stream_s3_api_aws_pool:checkout(?POOL, ?CHECKOUT_TIMEOUT_MS) of
-                Conn -> {ok, Conn}
+            try
+                rabbitmq_stream_s3_api_aws_pool:checkout(?POOL, ?CHECKOUT_TIMEOUT_MS)
             catch
                 C:E -> {error, {C, E}}
             end,

--- a/test/api_aws_pool_statem_SUITE.erl
+++ b/test/api_aws_pool_statem_SUITE.erl
@@ -45,7 +45,6 @@ over the invariants above.
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("proper/include/proper.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 -define(POOL, statem_aws_pool).
 -define(MIN_SIZE, 1).
@@ -58,7 +57,7 @@ over the invariants above.
 -define(AWAIT_MS, 1500).
 
 all() ->
-    [no_leak_or_inconsistency, checkout_timeout_returns_pool_busy].
+    [no_leak_or_inconsistency].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(seshat),
@@ -76,26 +75,6 @@ end_per_suite(Config) ->
 
 no_leak_or_inconsistency(_Config) ->
     rabbit_ct_proper_helpers:run_proper(fun prop_no_leak_or_inconsistency/0, [], 150).
-
-%% A saturated pool must surface as {error, pool_busy}, not a raw
-%% gen_server:call exit escaping the pool boundary (issue #332).
-checkout_timeout_returns_pool_busy(_Config) ->
-    _ = seshat:new_group(rabbitmq_stream_s3),
-    Config = (pool_config())#{name => busy_pool, min_size => 1, max_size => 1},
-    {ok, Pid} = rabbitmq_stream_s3_api_aws_pool:start_link(busy_pool, Config),
-    try
-        %% Take the pool's only connection and hold it, so the next checkout
-        %% cannot be served and must time out.
-        {ok, Conn} = rabbitmq_stream_s3_api_aws_pool:checkout(busy_pool, 1000),
-        ?assertEqual(
-            {error, pool_busy},
-            rabbitmq_stream_s3_api_aws_pool:checkout(busy_pool, 100)
-        ),
-        %% The connection held above is still valid and checks back in cleanly.
-        ok = rabbitmq_stream_s3_api_aws_pool:checkin(busy_pool, Conn)
-    after
-        gen_server:stop(Pid)
-    end.
 
 prop_no_leak_or_inconsistency() ->
     ?FORALL(

--- a/test/replica_reader_core_SUITE.erl
+++ b/test/replica_reader_core_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
         persist_failed_transient_retries,
         transfer_failed_retriable_resubmits,
         transfer_failed_status_map_retriable_resubmits,
+        transfer_failed_pool_busy_retriable_resubmits,
         transfer_failed_fatal_retries_no_gap,
         transfer_failed_attempt_counter_escalates_and_resets,
         fatal_failure_does_not_drain_subsequent,
@@ -332,6 +333,16 @@ transfer_failed_status_map_retriable_resubmits(_Config) ->
     {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(
         Ref, #{status => 504, headers => []}, S1
     ),
+    ?assertMatch([{resubmit_transfer, Ref, _, _, _, 1}], Effects).
+
+transfer_failed_pool_busy_retriable_resubmits(_Config) ->
+    %% A saturated upload pool surfaces as {error, pool_busy}, which
+    %% classify_transfer delivers to the core as the bare atom pool_busy (issue
+    %% #332). It must be classified transient (resubmit_transfer), not fatal
+    %% (resubmit_transfer_delayed).
+    {S0, _} = init_core(),
+    {S1, Ref, _} = rabbitmq_stream_s3_replica_reader_core:fragment_cut(meta(0, 100), S0),
+    {_S2, Effects} = rabbitmq_stream_s3_replica_reader_core:transfer_failed(Ref, pool_busy, S1),
     ?assertMatch([{resubmit_transfer, Ref, _, _, _, 1}], Effects).
 
 transfer_failed_fatal_retries_no_gap(_Config) ->


### PR DESCRIPTION
Fixes #332

## Problem

A saturated upload pool timed out the `gen_server:call` inside `rabbitmq_stream_s3_api_aws_pool:checkout/2`, and that raw OTP exit term (`{timeout, {gen_server, call, [_Pool, {checkout, _}, _]}}`) escaped the pool boundary. The governor wrapped it in its `{error, {Class, Reason}}` envelope, and the replica reader's `is_retriable/1` never matched the wrapped shape, so it fell through to the fatal branch.

The consequence was a misclassification, not data loss (both branches retry): a transient saturation event took the non-transient retry profile (`upload_retry_delay_ms`, 1s escalating to 30s, instead of the fast transient path), set the stall gauge, and logged a per-fragment WARNING. Under load one node emitted 216k of these lines in ~23 minutes, where the real cause was pool capacity, not the 403/404 class that "non-transient" implies.

## Fix

Own the translation in `checkout/2`, the one function that knows the checkout is a timed `gen_server:call`, rather than teaching a distant classifier to pattern-match OTP exit internals.

- `checkout/2` now returns `{ok, conn()} | {error, pool_busy}`. It catches `exit:{timeout, _}` and returns the named `pool_busy`, and still re-raises any other exit (e.g. a genuinely dead pool) after sending the cancellation cast, preserving the prior behaviour for real breakage
- `with/3` matches the tagged return and propagates `{error, pool_busy}`. This also closes a latent leak in the synchronous `request/5` path, which previously let the raw exit escape (and routes PUTs to the same upload pool)
- Both async call sites in `rabbitmq_stream_s3_api_aws` (`stream_put` upload, `start_async_request` read) drop their local `try`/`catch` and match the tagged return, so the OTP-exit-shape match exists nowhere outside the pool
- `is_retriable/1` classifies the named `pool_busy` atom as transient

`pool_busy` is already a first-class transient elsewhere in the codebase: the read path returned it before this change, `remote_reader_core` gives it a dedicated backoff, and it is in `prop_SUITE`'s transient list. This change makes the upload and synchronous paths consistent with the read path.

## The related `do_commit` note in #332

The issue notes that `do_commit` shares the upload pool and crashed 134x under the same saturation. That is covered by this same fix and needs no separate change. `do_commit` calls `rabbitmq_stream_s3_api:put/2`, which reaches the pool through `with/3`; the crash was the raw checkout exit propagating into the spawned commit process. With `with/3` now returning `{error, pool_busy}`, `classify_persist` delivers `persist_failed(pool_busy)`, and `persist_failed/2` already retries on any reason other than `conflict`/`not_found`. Fixing the leak at the pool boundary resolves both the transfer and persist manifestations at once.

## Tests

- `api_aws_pool_statem_SUITE`: a deterministic `checkout_timeout_returns_pool_busy` (exhaust a size-1 pool, assert the next checkout returns `{error, pool_busy}`)
- `replica_reader_core_SUITE`: `transfer_failed_pool_busy_retriable_resubmits` asserts `pool_busy` is classified transient (`resubmit_transfer`, not `resubmit_transfer_delayed`)

## Validation

- `api_aws_pool_statem_SUITE`: 2 ok, 0 failed
- `replica_reader_core_SUITE`: 83 ok, 0 failed
- `replica_reader_SUITE`: 38 ok, 0 failed
- `replica_reader_tasks_SUITE`: 13 ok, 0 failed
- `gmake dialyze`: passed
- `gmake xref`: passed

## Follow-up

#335 tracks a codebase-wide audit for the same class of leak (a raw exit-raising `*:call` behind an `{ok, _} | {error, _}` contract).
