### PR TITLE
Convert leaked gen_server:call exits to named errors on reader admin paths (issue #335)

### DIFF
--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -198,9 +198,19 @@ apply_edits(StreamId, Edits, Seq, Epoch, Node) ->
 
 -doc "Apply sequenced edits locally (synchronous).".
 -spec apply_edits(stream_id(), [#edit{}], non_neg_integer(), non_neg_integer()) ->
-    ok | {error, gap} | {error, apply_failed} | {error, no_context}.
+    ok | {error, gap} | {error, apply_failed} | {error, no_context} | {error, term()}.
 apply_edits(StreamId, Edits, Seq, Epoch) ->
-    gen_server:call(?MODULE, {apply_edits, StreamId, Edits, Seq, Epoch, node()}).
+    %% Specced with an {error, _} contract; convert a singleton call exit
+    %% (noproc mid-restart, timeout) into a named error so it cannot escape as a
+    %% raw OTP exit to a caller matching the tagged failures above.
+    try
+        gen_server:call(?MODULE, {apply_edits, StreamId, Edits, Seq, Epoch, node()})
+    catch
+        exit:{timeout, _} ->
+            {error, timeout};
+        exit:Reason ->
+            {error, {manifest_replica_down, Reason}}
+    end.
 
 -doc "Send a sync (full manifest reset) to a remote node. Fire-and-forget.".
 -spec sync(stream_id(), non_neg_integer(), non_neg_integer(), #manifest{}, node()) -> ok.
@@ -238,7 +248,19 @@ is_context_registered(StreamId) ->
 -doc "Evaluate local-tier retention for a stream on this node.".
 -spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
 evaluate_local_retention(StreamId) ->
-    gen_server:call(?MODULE, {evaluate_local_retention, StreamId}).
+    %% This is specced ok | {error, term()} and reached over
+    %% rabbit_misc:rpc_call from the CLI. gen_server:call/2 exits the caller if
+    %% the per-node singleton is mid-restart (noproc) or overloaded (timeout);
+    %% convert the exit into a named error so it stays within the contract
+    %% rather than escaping as a raw OTP exit.
+    try
+        gen_server:call(?MODULE, {evaluate_local_retention, StreamId})
+    catch
+        exit:{timeout, _} ->
+            {error, timeout};
+        exit:Reason ->
+            {error, {manifest_replica_down, Reason}}
+    end.
 
 -doc """
 Release all per-node state for a stream: its retention context (and member
@@ -766,6 +788,16 @@ seed_first_offset_counter(
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+%% When the singleton is not running (noproc), the synchronous entry points must
+%% convert the gen_server:call exit into a named error rather than letting the
+%% raw OTP exit escape their {error, _} contracts. The server is not registered
+%% during a plain eunit run, so a call to ?MODULE exits with noproc.
+evaluate_local_retention_converts_call_exit_test() ->
+    ?assertMatch({error, {manifest_replica_down, _}}, evaluate_local_retention(<<"s">>)).
+
+apply_edits_converts_call_exit_test() ->
+    ?assertMatch({error, {manifest_replica_down, _}}, apply_edits(<<"s">>, [], 0, 0)).
 
 is_stale_sync_test() ->
     Node = node(),

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -318,7 +318,7 @@ with_bucket_status(Result) ->
 evaluate_local_retention(StreamId) ->
     case rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}) of
         Pid when is_pid(Pid) ->
-            gen_server:call(Pid, evaluate_local_retention);
+            safe_call(Pid, evaluate_local_retention);
         undefined ->
             rabbitmq_stream_s3_manifest_replica:evaluate_local_retention(StreamId)
     end.
@@ -695,8 +695,28 @@ format_state(#state{
 
 call(StreamId, Msg) ->
     case find_reader(StreamId) of
-        {ok, Pid} -> gen_server:call(Pid, Msg);
+        {ok, Pid} -> safe_call(Pid, Msg);
         undefined -> {error, {not_found, StreamId}}
+    end.
+
+%% gen_server:call exits the caller on timeout and if the reader is already
+%% gone (noproc) or on a remote node that is unreachable (the pid can be on any
+%% node, see find_reader/1). These admin/retention entry points are specced
+%% ok | {error, term()} and reached over rabbit_misc:rpc_call from the CLI, so a
+%% raw exit would escape the contract (surfacing as {badrpc, {'EXIT', _}} that
+%% the command output/1 clauses do not match). Convert the exit into a named
+%% error so it stays within the contract. Mirrors remote_reader:read/5.
+safe_call(Pid, Msg) ->
+    safe_call(Pid, Msg, 5000).
+
+safe_call(Pid, Msg, Timeout) ->
+    try
+        gen_server:call(Pid, Msg, Timeout)
+    catch
+        exit:{timeout, _} ->
+            {error, timeout};
+        exit:Reason ->
+            {error, {reader_down, Reason}}
     end.
 
 call(VHost, QueueName, Msg) ->
@@ -2498,6 +2518,34 @@ evaluate_retention_on_unresolved_manifest_replies_error_test() ->
         {reply, {error, manifest_not_resolved}, State},
         handle_call(evaluate_remote_retention, From, State)
     ).
+
+%% A call to a dead reader (noproc) must be converted to a named error, not let
+%% the raw OTP exit escape the ok | {error, term()} contract of the admin and
+%% retention entry points (which are reached over rabbit_misc:rpc_call from the
+%% CLI).
+safe_call_dead_reader_returns_reader_down_test() ->
+    Dead = spawn(fun() -> ok end),
+    %% Ensure the process has exited so the call sees noproc.
+    Ref = monitor(process, Dead),
+    receive
+        {'DOWN', Ref, process, Dead, _} -> ok
+    after 1000 -> error(process_did_not_exit)
+    end,
+    ?assertMatch({error, {reader_down, _}}, safe_call(Dead, status)).
+
+%% A call that outlives its timeout must be converted to {error, timeout}. The
+%% stub server never replies, so the short call timeout below fires.
+safe_call_timeout_returns_timeout_test() ->
+    Server = spawn(fun() ->
+        receive
+            never -> ok
+        end
+    end),
+    try
+        ?assertEqual({error, timeout}, safe_call(Server, status, 50))
+    after
+        exit(Server, kill)
+    end.
 
 %% A retry_transfer that fires after a reset cleared the in-flight transfer
 %% tracking must be dropped, not re-submitted as a phantom upload (would


### PR DESCRIPTION
Closes #335

## Background

The audit in #335 (prompted by #332) swept every exit-raising call site in `src/` (`gen_server:call`, `gen_statem:call`, `erpc:call`, `gen_server:stop`) and classified each by whether a raw OTP exit (`timeout`, `noproc`, `noconnection`, `{shutdown, _}`) can escape an `{ok, _} | {error, _}` contract to a caller that only handles tagged returns.

Three functions advertise `ok | {error, term()}` but make a bare `gen_server:call` on a pid that can be remote or mid-restart, so a timeout/noproc/noconnection exit escapes the contract. These paths are reached over `rabbit_misc:rpc_call` from the CLI, where a leaked exit surfaces as `{badrpc, {'EXIT', _}}` that the command `output/1` clauses do not match (their catch-all is `{error, Reason}`, not `{badrpc, _}`), crashing the CLI formatter.

## Fix

Convert the exit into a named error at the boundary that owns the call, mirroring the existing `remote_reader:read/5` and `api_aws:safe_call/2` patterns.

`rabbitmq_stream_s3_replica_reader`:
- a new `safe_call/2,3` helper maps `exit:{timeout, _}` to `{error, timeout}` and any other exit to `{error, {reader_down, Reason}}`
- the `call/2` helper (covers `status`, `evaluate_remote_retention`, `force_fragment_cut`) and the local-pid branch of `evaluate_local_retention/1` route through it

`rabbitmq_stream_s3_manifest_replica`:
- `evaluate_local_retention/1` (the singleton fallback, the live leak) and `apply_edits/4` map the exit to `{error, timeout}` / `{error, {manifest_replica_down, Reason}}`
- `apply_edits/4` has no production caller today but carries the same `{error, _}` contract, so it is hardened against a future caller

The remaining singleton calls (`put_manifest`, `apply_edit/2`, `sync/4`, `register_replica_context`, `is_context_registered`, `forget`) are specced `-> ok` or `-> boolean()` with no error channel, so a singleton crash taking the caller down is correct let-it-crash and is left unchanged.

## Audit sites confirmed OK (no change)

- `api_aws:safe_call/2` already converts the credential/region `gen_server:call` exit (a second, already-correct instance of the pattern)
- `registry.erl:102` `erpc:call` is already `try ... catch _:_ -> undefined` (the reference good pattern)
- `remote_reader:read/5` already wraps its call
- `bucket_monitor:status/0` has no error contract and its sole caller wraps it in `try/catch`
- all `gen_server:stop` sites are test-only teardown; the `remote_reader:stop/1` calls are a `gen_server:cast`, which never exits the caller

The full audit is recorded in #335.

## Tests

Deterministic inline eunit exercising the noproc and timeout conversions directly:
- `replica_reader`: `safe_call_dead_reader_returns_reader_down_test`, `safe_call_timeout_returns_timeout_test`
- `manifest_replica`: `evaluate_local_retention_converts_call_exit_test`, `apply_edits_converts_call_exit_test`

## Validation

- `replica_reader` eunit: 24 ok
- `manifest_replica` eunit: 3 ok
- `replica_reader_SUITE` (CT): 38 ok, 0 failed
- `gmake dialyze`: passed
- `gmake xref`: passed
