### PR TITLE
Mark manifests as pending during resolution

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,16 @@
 
 This document describes how the plugin's processes fit together: what starts them, what they own, and how data flows between them.
 
+## Design stance: durability versus availability
+
+The plugin resolves the durability-versus-availability trade differently on its two paths, and every mechanism below follows from this asymmetry.
+
+On the write path, availability wins and durability is a bounded, explicitly scoped promise. Producers never wait on S3: publishing, replication, and local consumption are unaffected by an object-store outage of any length. Durability in S3 is promised only for the uploaded range `[f, n)`, and the user's retention bound is authoritative over upload progress, so an outage longer than the local retention window can buffer costs the un-uploaded tail. The window is an operator-sized knob, not a guarantee (see [Durability versus the local retention bound](#durability-versus-the-local-retention-bound)).
+
+On the read path, correctness wins and availability degrades only in two sanctioned, visible ways. A read whose answer is momentarily unknowable (a transient fetch failure, an unresolved manifest cache) fails closed and the consumer retries. A read whose data is permanently gone (retention, a gap from an outage) is repositioned at the oldest available offset, the same observable semantics as vanilla stream retention. What is never sanctioned is silently serving an incomplete answer: a stalled read is recoverable, a wrong one is not (see the Cached state and Read path sections of [invariants.md](./invariants.md)).
+
+In one sentence: the write path never lets an S3 outage become a local availability problem, at the cost of a bounded, un-uploaded tail; the read path never lets an unknown answer look like a correct one, at the cost of availability.
+
 ## Plugin lifecycle
 
 The plugin is enabled via `rabbitmq-plugins enable rabbitmq_stream_s3`. RabbitMQ starts it after the broker is fully up (after `core_started`). On start, the plugin's supervisor initializes all infrastructure and sets the osiris hooks. Streams that already exist at this point are discovered and attached to (see [Stream discovery](#stream-discovery)). Streams created after plugin start are handled by the hooks.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,6 +24,18 @@ The `log_hooks` key follows this pattern. Passing `log_hooks => undefined` in th
 
 The chunk header is not a fixed 48 bytes. It includes a bloom filter whose size depends on `filter_size` configuration. Do not hardcode chunk header sizes. Use `data_size` and `position`/`next_position` from the header map to reason about byte offsets.
 
+## Derived state has no catch-alls
+
+Any state derived from the manifest (the per-node manifest cache, the osiris first-offset counters, iterator snapshots) can be missing or not yet established, and "missing" is never the same value as "empty". When branching on such state, write one clause per state and no catch-all: a `_ ->` arm over cache states is how a cache miss gets silently collapsed into "no remote tier", which is the boot-window read bug (see the Cached state section of [invariants.md](./invariants.md)). If a new state is added, every consumer should fail to compile or crash loudly, not inherit an arbitrary neighbor's behavior.
+
+The direction of each explicit miss clause matters: consumers must fail in the direction that cannot lose data. Readers fail closed (error, the consumer retries), retention deletes nothing, GC skips, resolution goes to the authoritative store. A fallback that degrades silently reads as robustness in review and is exactly where correctness leaks out.
+
+## Cold-state test dimension
+
+Every stateful fixture a test warms up implicitly is a state the suite must also construct cold. An end-to-end test that publishes and then reads has, as a side effect, seeded the manifest cache, attached the hooks, and resolved the manifest: the act of arranging the fixture destroys the cold-start state, so the warm path is the only path such suites can ever exercise.
+
+When a subsystem keeps per-node volatile state, its suite needs at least one case that restarts the owning process or node and exercises the consumer before anything re-warms the state (for streams: subscribe before any publish). Note the topology: with replicas present, the writer's sync re-seeds an acceptor's cache within milliseconds, so cold-cache cases need the single-node shape where no peer can heal the state (see `broker_SUITE:restarted_node_serves_first_from_remote_tier/1`).
+
 ## Pure functional cores
 
 Complex state machines use a functional-core / imperative-shell split inspired by Ra's `ra_server` / `ra_server_proc` separation.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,6 +28,8 @@ The chunk header is not a fixed 48 bytes. It includes a bloom filter whose size 
 
 Any state derived from the manifest (the per-node manifest cache, the osiris first-offset counters, iterator snapshots) can be missing or not yet established, and "missing" is never the same value as "empty". When branching on such state, write one clause per state and no catch-all: a `_ ->` arm over cache states is how a cache miss gets silently collapsed into "no remote tier", which is the boot-window read bug (see the Cached state section of [invariants.md](./invariants.md)). If a new state is added, every consumer should fail to compile or crash loudly, not inherit an arbitrary neighbor's behavior.
 
+For the manifest cache this is enforced structurally, not by convention: branching goes through `rabbitmq_stream_s3_manifest_replica:with_manifest/2`, whose handler map has mandatory keys for all three states (`resolved`, `pending`, `absent`). A call site that fails to consider a state does not compile a quiet fallback into place; it fails to match. `get_manifest/1` remains only for non-branching uses (diagnostics, tests). New derived-state APIs should follow the same shape: expose a total fold, not a bare accessor that invites per-caller `case` expressions.
+
 The direction of each explicit miss clause matters: consumers must fail in the direction that cannot lose data. Readers fail closed (error, the consumer retries), retention deletes nothing, GC skips, resolution goes to the authoritative store. A fallback that degrades silently reads as robustness in review and is exactly where correctness leaks out.
 
 ## Cold-state test dimension

--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -85,6 +85,24 @@ Discarding remote manifest and restarting from the local log.
 
 ---
 
+## Node restart with an idle stream (cold manifest cache)
+
+**Trigger.** A node restarts, emptying its in-memory manifest cache, and no publish follows. This is the most ordinary event in the catalog: an upgrade, a reboot, a crash-and-recover, followed by consumers reconnecting before producers do.
+
+**Impact assessment.** None. The member-init hooks mark the stream's cache row `pending` before the member finishes starting, and the replica reader's manifest resolution (writer node) or the writer's sync (replica nodes) replaces the marker moments later. A consumer that attaches inside that window has its subscription fail closed with `{error, {manifest_not_resolved, _}}` and retries; it cannot be silently attached at the local floor.
+
+**Detection.**
+
+- `rabbitmq_stream_s3_log_reader` counter `resolve_failed_closed` counts attaches that failed closed during the window; a burst right after a restart is expected, a sustained rate is not.
+- `rabbitmq_stream_s3_replica_reader` counter `manifest_resolution_failures` increments when resolution itself cannot complete (S3 or metadata store unavailable), which is what keeps rows pending.
+- Logs: `Failing reader setup closed for stream <stream_id>` (INFO, expected during the window); `Reconciliation: re-seeding the local manifest cache` (the reconciler healing a row that resolution could not seed, for example after a manifest_replica crash).
+
+**Mitigation.** None needed in the normal case; the window is milliseconds. If consumers fail closed for longer, manifest resolution is stuck: check S3 reachability and the metadata store, exactly as for an S3 outage.
+
+**Resolution.** Automatic. Resolution or sync replaces the pending marker; the reconciler heals leaked markers within one period.
+
+---
+
 ## Segment deleted before upload
 
 **Trigger.** Local retention deletes a segment the replica reader has not yet uploaded. Most likely during an S3 outage or when local retention is aggressive relative to throughput.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -79,9 +79,19 @@ GC reaps an S3 object only when it can prove the object is not live. For an obje
 | Anchor removal | The anchor is kept alive by a `keep_while` on the stream queue, so it is removed in the same transaction that deletes the queue. The "stream deleted" signal is permanent and cannot be lost to a crash. | [operations.md](./operations.md#safety-guarantee-the-anchor) |
 | Anchor read | An object whose stream is absent from the lookup is reaped only when a strongly-consistent read reports its anchor absent; a present anchor or a non-quorum read fails closed. A stale local read could report a live stream's anchor absent, so the consistent read is load-bearing. Modeled in [PR #311](https://github.com/amazon-mq/rabbitmq-stream-s3/pull/311). | [operations.md](./operations.md#safety-guarantee-the-anchor) |
 
+## Cached state
+
+The invariants above are stated over the manifest `M`, but no reader consults `M` directly: every consumer reads a node-local cache of it (`rabbitmq_stream_s3_manifest_replica`'s ETS table). The cache is volatile state with its own lifecycle, and the read-path invariants only follow from the durable-state invariants if the cache's relationship to `M` is itself pinned down. `Cache(node, S)` denotes the cache row for stream `S` on a node, with three states: a resolved manifest (possibly empty), `pending` (attached but not yet resolved or synced), and absent (no row).
+
+| Invariant | Statement | Where |
+|---|---|---|
+| Cache availability | On any node hosting a member of `S`, `Cache(node, S)` exists (pending or resolved) from before the member finishes init, and therefore from before any reader can attach. The member-init hooks write the pending marker synchronously; resolution or the writer's sync replaces it. An absent row is therefore a positive statement: the plugin never attached to `S` on this node (an un-tiered stream), whose local log is the whole stream. | [read-path.md](./read-path.md) (Offset spec resolution) |
+| Cache coherence | A resolved row is the writer's manifest at some point in time, and only moves forward: a replica's row is a prefix of the writer's edit history (Replica prefix), the writer's own row is written only by its resolution, persist, and reset paths, and `mark_pending` is insert-if-absent so a resolved row is never downgraded to pending. | [manifest.md](./manifest.md) (Manifest edit replication) |
+| Miss semantics | `pending` means the remote tier's extent is unknown, and every consumer must fail in the direction that cannot lose data: the read path fails closed (a retryable error, never a local fallback that would skip `[f, f_local)`), local retention deletes nothing, GC treats the stream as unsweepable, counters are left uncorrected, and the writer's own resolution ignores the row and reads the store. Absent means un-tiered: the read path serves locally, which is exact, not a fallback. No consumer may branch on a catch-all over cache states. | [read-path.md](./read-path.md) (Offset spec resolution) |
+
 ## Read path
 
 | Invariant | Statement | Where |
 |---|---|---|
-| Exactly-once | A read started at spec `s` delivers each offset of `[max(s, f), T)` exactly once, in strictly increasing order, across both tiers. A seek into a group resolves to the unique fragment containing the target (Ordering), not the group's first child. | [read-path.md](./read-path.md) |
+| Exactly-once | A read started at spec `s` delivers each offset of `[max(s, f), T)` exactly once, in strictly increasing order, across both tiers. A seek into a group resolves to the unique fragment containing the target (Ordering), not the group's first child. A fail-closed attach (Miss semantics) is not a violation: it delivers nothing and the consumer retries; only a delivery that skips an offset of `[max(s, f), T)` violates this invariant. | [read-path.md](./read-path.md) |
 | Tier overlap | The local segments cover `[n, T)` while the remote tier covers `[f, n)`; the ranges overlap and the reader hands off at a shared offset, so no offset is skipped or repeated at the seam. | [read-path.md](./read-path.md) |

--- a/docs/read-path.md
+++ b/docs/read-path.md
@@ -23,13 +23,18 @@ A consumer subscribes to a stream with an offset spec (`first`, `last`, `next`, 
 
 Resolution determines which tier holds the requested offset and where within that tier to start reading.
 
-The log reader checks the manifest cache (`rabbitmq_stream_s3_manifest_replica:get_range/1`) to get the remote tier's `{first_offset, next_offset}`. It also checks the local log's first chunk ID via shared atomics.
+The log reader checks the manifest cache (`rabbitmq_stream_s3_manifest_replica:get_manifest/1`) for the remote tier's extent. It also checks the local log's first chunk ID via shared atomics. The cache row is in one of three states, and the decision depends on the state, not just the extent (see the Cached state section of [invariants.md](./invariants.md)):
 
-Decision logic:
+Decision logic with a resolved manifest:
 
+- If the offset is at or above the local first chunk ID: resolve to local (delegate to `osiris_log`). The cache is not consulted; `last` and `next` also short-circuit to local.
 - If the offset is below the local first chunk ID and within the manifest's range: resolve to remote.
-- If the offset is at or above the local first chunk ID: resolve to local (delegate to `osiris_log`).
-- If the offset is below both the local range and the manifest range: the data has been retained away. Return `{error, {offset_out_of_range, ...}}`.
+- If the offset is below both the local range and the manifest range: the data has been retained away. Attach at the oldest available data, matching vanilla stream retention behavior.
+
+Decision logic without one:
+
+- If the row is `pending` (the plugin is attached on this node but the manifest has not been resolved or synced yet, for example in the first moments after a member starts): fail closed with `{error, {manifest_not_resolved, StreamId}}` for any spec the remote tier may hold (`first`, a below-floor offset, a timestamp, `{abs, _}`). The subscription fails and the client retries; falling back to the local tier here would silently skip the remote range below the local floor. The `resolve_failed_closed` counter records these.
+- If there is no row at all: the plugin never attached to this stream on this node (an un-tiered stream), so the local log is the whole stream and local resolution is exact.
 
 For timestamp-based specs, the log reader binary-searches the manifest's entries (each entry has `first_timestamp` and `last_timestamp`) to find the fragment containing the target timestamp.
 

--- a/p/README.md
+++ b/p/README.md
@@ -53,7 +53,7 @@ The read and tier-resolution seam: resolving the `first` offset spec when the le
 
 ### `tier-routing`
 
-The offset-to-tier routing branch of `resolve_remote_location`: when the local log is empty (`first_chunk_id == -1`), every offset must fall through to the remote tier. Verifies that dropping the `=/= -1` guard routes a remote-only offset to the local tail (a silent remote skip). A second INV#4 guard, distinct from the group-fetch catch-all. See [`tier-routing/README.md`](tier-routing/README.md).
+The offset-to-tier routing branch of `resolve_remote_location`, including the manifest cache's lifecycle (`Cold -> Pending -> Serving`). Verifies two INV#4 guards: the `=/= -1` empty-local floor guard, and the fail-closed handling of an unresolved cache (the boot-window bug: a node restart used to make the remote tier invisible to readers until a persist or the reconciler re-seeded the cache, so `first` attached at the local floor and silently skipped the remote range). The spec's oracle is the ground-truth extent announced by the driver, independent of the cache the reader consults, and the gates include a weakened-environment run (no pending marker) alongside the weakened-code runs. See [`tier-routing/README.md`](tier-routing/README.md).
 
 ### `trimmed-segment`
 

--- a/p/read-resolution/README.md
+++ b/p/read-resolution/README.md
@@ -36,3 +36,7 @@ p check -tc tcReadResolveGuarded -i 5000   # 0 bugs
 p check -tc tcReadResolveBuggy   -i 2000   # 1 bug: INV#4 silent remote skip
 p check -tc tcReadResolveExplore -i 5000   # 0 bugs
 ```
+
+## Scope note
+
+This model covers the group-fetch classification inside `resolve_first` (a transient fetch failure must retry, never fall back local). The manifest cache's availability axis - `pending` versus resolved versus absent rows, and the boot window they create - lives in the sibling [`tier-routing`](../tier-routing/README.md) model; the `pending` clause in `resolve_first` itself is exercised directly by `read_resolution_SUITE`, which drives the real module.

--- a/p/tier-routing/PSpec/Monitors.p
+++ b/p/tier-routing/PSpec/Monitors.p
@@ -1,13 +1,37 @@
 /* INV#4 (tier resolution total / correct): an offset held only by the remote
-   tier (covered by the remote extent, not by the local log) must route to the
-   remote tier. Routing it locally silently skips the remote data. An offset the
-   local tier also holds may route locally (osiris prefers the local reader), so
-   the obligation is only on offsets the local tier does NOT cover. */
-spec TierRoutingCorrect observes eResolution {
+   tier (covered by the remote extent, not by the local log) must not route to
+   the local tier. Routing it locally silently skips the remote data. RETRY is
+   acceptable there (fail closed, the consumer retries); LOCAL is not. An
+   offset the local tier also holds may route locally (osiris prefers the local
+   reader), so the obligation is only on offsets the local tier does NOT cover.
+
+   Independent oracle: coverage is re-derived here from the ground-truth extent
+   the DRIVER announced, never from anything the Reader or the cache reported.
+   The previous version of this spec computed remoteCovers from the
+   ManifestStore's reply, which made the cache simultaneously the component's
+   input and the monitor's oracle: a reader that believed an empty or missing
+   cache could not be flagged, and the boot-window bug was unrepresentable. */
+spec TierRoutingCorrect observes eGroundTruth, eResolution {
+  var truthKnown: bool;
+  var nonEmpty: bool;
+  var remoteFirst: int;
+  var remoteNext: int;
+
   start state Watching {
-    on eResolution do (r: (tier: Tier, remoteCovers: bool, localCovers: bool)) {
-      if (r.remoteCovers && !r.localCovers) {
-        assert r.tier == REMOTE,
+    on eGroundTruth do (g: (nonEmpty: bool, remoteFirst: int, remoteNext: int)) {
+      truthKnown = true;
+      nonEmpty = g.nonEmpty;
+      remoteFirst = g.remoteFirst;
+      remoteNext = g.remoteNext;
+    }
+    on eResolution do (r: (outcome: Outcome, offset: int, firstChunkId: int)) {
+      var remoteCovers: bool;
+      var localCovers: bool;
+      assert truthKnown, "eResolution observed before eGroundTruth: driver must announce the true extent first";
+      remoteCovers = nonEmpty && r.offset >= remoteFirst && r.offset < remoteNext;
+      localCovers = (r.firstChunkId != -1) && (r.offset >= r.firstChunkId);
+      if (remoteCovers && !localCovers) {
+        assert r.outcome != LOCAL,
           "INV#4 violated: an offset held only by the remote tier routed to the local tier (silent remote skip)";
       }
     }

--- a/p/tier-routing/PSrc/Common.p
+++ b/p/tier-routing/PSrc/Common.p
@@ -1,25 +1,53 @@
 /* Shared types and events for the offset -> tier routing seam.
 
    log_reader:resolve_remote_location/2 routes an integer offset to the local or
-   remote tier. The local-tier check is
+   remote tier by consulting the node's manifest CACHE, which is not the same
+   thing as the remote tier itself. The cache row for a stream is in one of
+   three states, and the reader's obligation differs per state:
+
+   - RESOLVED: the manifest is known; route by extent comparison.
+   - PENDING: the plugin is attached but the manifest has not resolved or
+     synced yet. The remote extent is unknown, so an offset below the local
+     floor must FAIL CLOSED (retry), never fall back to the local tier.
+   - ABSENT: no plugin state for the stream on this node (un-tiered stream).
+     The local log is the whole stream, so local fallback is correct.
+
+   The historical bug modeled here (alongside the older =/= -1 floor-guard bug)
+   is collapsing PENDING/ABSENT into "no remote tier -> local", which silently
+   skips the remote range below the local floor for up to one reconciliation
+   period after a node restart.
+
+   The local-tier check itself is
 
      first_chunk_id =/= -1 andalso Offset >= first_chunk_id
 
    first_chunk_id = -1 means the local log is empty (fully trimmed or not yet
-   populated). Without the =/= -1 guard, Offset >= -1 is always true, so an empty
-   local log routes every offset to the local tail and silently skips the remote
-   tier. The =/= -1 guard makes an empty local log fall through to remote
-   resolution. */
+   populated). Without the =/= -1 guard, Offset >= -1 is always true, so an
+   empty local log routes every offset to the local tail and silently skips the
+   remote tier. */
 
-enum Tier { LOCAL, REMOTE }
+enum Outcome { LOCAL, REMOTE, RETRY }
+enum CacheReply { RESOLVED, PENDING, ABSENT }
 
-/* Manifest store (remote tier extent). */
+/* Manifest cache. eGetManifest reports the CACHE's view; the extent fields are
+   meaningful only when reply == RESOLVED. */
 event eGetManifest: (from: machine);
-event eManifestResult: (nonEmpty: bool, remoteFirst: int, remoteNext: int);
+event eManifestResult: (reply: CacheReply, nonEmpty: bool, remoteFirst: int, remoteNext: int);
+
+/* Lifecycle: the member-init hook marks the row pending (insert-if-absent);
+   manifest resolution installs the extent. eMSAck acknowledges either, so
+   drivers can sequence deterministically when they need to. */
+event eMarkPending: (from: machine);
+event eResolveManifest: (from: machine);
+event eMSAck;
 
 /* Reader. */
 event eResolve: (from: machine, firstChunkId: int, offset: int);
-event eResolveDone: Tier;
+event eResolveDone: Outcome;
 
-/* Spec event (announce): the routing decision plus the ground-truth coverage. */
-event eResolution: (tier: Tier, remoteCovers: bool, localCovers: bool);
+/* Spec events (announce). eGroundTruth carries the ACTUAL remote extent,
+   announced by the driver, never read by the Reader: the monitor's oracle is
+   independent of the component under test. eResolution carries the decision
+   plus its inputs, and the monitor re-derives coverage itself. */
+event eGroundTruth: (nonEmpty: bool, remoteFirst: int, remoteNext: int);
+event eResolution: (outcome: Outcome, offset: int, firstChunkId: int);

--- a/p/tier-routing/PSrc/ManifestStore.p
+++ b/p/tier-routing/PSrc/ManifestStore.p
@@ -1,11 +1,17 @@
-/* The remote-tier extent as seen by a reader: whether the remote tier has any
-   entries, and the offset range [remoteFirst, remoteNext) it covers. */
+/* The node's manifest CACHE for one stream: a lifecycle state machine, not a
+   static oracle. Cold (no row) -> Pending (member-init marker) -> Serving
+   (resolved extent). The true remote extent is fixed at construction but is
+   only REPORTED once Serving, mirroring the real cache: the remote tier can
+   hold data the cache does not yet describe.
+
+   mark_pending is insert-if-absent in the real code, so it never downgrades
+   Serving; resolution is idempotent. */
 machine ManifestStore {
   var nonEmpty: bool;
   var remoteFirst: int;
   var remoteNext: int;
 
-  start state Serving {
+  start state Cold {
     entry (init: (nonEmpty: bool, remoteFirst: int, remoteNext: int)) {
       nonEmpty = init.nonEmpty;
       remoteFirst = init.remoteFirst;
@@ -13,7 +19,45 @@ machine ManifestStore {
     }
     on eGetManifest do (p: (from: machine)) {
       send p.from, eManifestResult,
-        (nonEmpty = nonEmpty, remoteFirst = remoteFirst, remoteNext = remoteNext);
+        (reply = ABSENT, nonEmpty = false, remoteFirst = 0, remoteNext = 0);
+    }
+    on eMarkPending do (p: (from: machine)) {
+      send p.from, eMSAck;
+      goto Pending;
+    }
+    /* A persist can seed the row without a marker (put_manifest). */
+    on eResolveManifest do (p: (from: machine)) {
+      send p.from, eMSAck;
+      goto Serving;
+    }
+  }
+
+  state Pending {
+    on eGetManifest do (p: (from: machine)) {
+      send p.from, eManifestResult,
+        (reply = PENDING, nonEmpty = false, remoteFirst = 0, remoteNext = 0);
+    }
+    on eMarkPending do (p: (from: machine)) {
+      /* Idempotent: a re-registration re-marks an already pending row. */
+      send p.from, eMSAck;
+    }
+    on eResolveManifest do (p: (from: machine)) {
+      send p.from, eMSAck;
+      goto Serving;
+    }
+  }
+
+  state Serving {
+    on eGetManifest do (p: (from: machine)) {
+      send p.from, eManifestResult,
+        (reply = RESOLVED, nonEmpty = nonEmpty, remoteFirst = remoteFirst, remoteNext = remoteNext);
+    }
+    on eMarkPending do (p: (from: machine)) {
+      /* Insert-if-absent: never downgrade a resolved row. */
+      send p.from, eMSAck;
+    }
+    on eResolveManifest do (p: (from: machine)) {
+      send p.from, eMSAck;
     }
   }
 }

--- a/p/tier-routing/PSrc/Reader.p
+++ b/p/tier-routing/PSrc/Reader.p
@@ -1,26 +1,36 @@
 /* The reader routing an integer offset to a tier (resolve_remote_location/2).
-   bugNoMinusOneGuard drops the `first_chunk_id =/= -1` guard from the local-tier
-   check, reproducing the empty-local-log silent remote skip. */
+
+   Two injectable bugs, each a shipped defect this model gates on:
+   - bugNoMinusOneGuard drops the `first_chunk_id =/= -1` guard from the
+     local-tier check, reproducing the empty-local-log silent remote skip.
+   - bugMissFallsLocal collapses a PENDING cache reply into the local fallback
+     ({local, first}), reproducing the boot-window silent remote skip that
+     shipped when the cache had no pending state and a miss meant "no remote
+     tier".
+
+   The Reader never sees the ground-truth extent: it decides from the cache
+   reply alone, exactly like the real code. The monitor judges the decision
+   against the truth the driver announced. */
 machine Reader {
   var bugNoMinusOneGuard: bool;
+  var bugMissFallsLocal: bool;
   var manifest: machine;
   var driver: machine;
 
   start state Idle {
-    entry (init: (bug: bool, manifest: machine, driver: machine)) {
-      bugNoMinusOneGuard = init.bug;
+    entry (init: (bugNoMinusOneGuard: bool, bugMissFallsLocal: bool, manifest: machine, driver: machine)) {
+      bugNoMinusOneGuard = init.bugNoMinusOneGuard;
+      bugMissFallsLocal = init.bugMissFallsLocal;
       manifest = init.manifest;
       driver = init.driver;
     }
     on eResolve do (p: (from: machine, firstChunkId: int, offset: int)) {
-      var m: (nonEmpty: bool, remoteFirst: int, remoteNext: int);
-      var tier: Tier;
+      var m: (reply: CacheReply, nonEmpty: bool, remoteFirst: int, remoteNext: int);
+      var outcome: Outcome;
       var localCheck: bool;
-      var localCovers: bool;
-      var remoteCovers: bool;
       send manifest, eGetManifest, (from = this,);
       receive {
-        case eManifestResult: (r: (nonEmpty: bool, remoteFirst: int, remoteNext: int)) { m = r; }
+        case eManifestResult: (r: (reply: CacheReply, nonEmpty: bool, remoteFirst: int, remoteNext: int)) { m = r; }
       }
       if (bugNoMinusOneGuard) {
         localCheck = p.offset >= p.firstChunkId;
@@ -28,20 +38,30 @@ machine Reader {
         localCheck = (p.firstChunkId != -1) && (p.offset >= p.firstChunkId);
       }
       if (localCheck) {
-        tier = LOCAL;
-      } else if (!m.nonEmpty) {
-        /* No remote tier: emulate osiris_log and attach locally. */
-        tier = LOCAL;
-      } else if (p.firstChunkId == -1 && p.offset >= m.remoteNext) {
-        /* Local empty and the offset is beyond the remote tail: local tail wait. */
-        tier = LOCAL;
+        outcome = LOCAL;
+      } else if (m.reply == RESOLVED) {
+        if (!m.nonEmpty) {
+          /* Resolved and empty: no remote tier, attach locally. */
+          outcome = LOCAL;
+        } else if (p.firstChunkId == -1 && p.offset >= m.remoteNext) {
+          /* Local empty and the offset is beyond the remote tail: local tail
+             wait. */
+          outcome = LOCAL;
+        } else {
+          outcome = REMOTE;
+        }
+      } else if (bugMissFallsLocal) {
+        /* Pre-fix behavior: any miss is treated as "no remote tier". */
+        outcome = LOCAL;
+      } else if (m.reply == PENDING) {
+        /* Attached but unresolved: fail closed, the consumer retries. */
+        outcome = RETRY;
       } else {
-        tier = REMOTE;
+        /* ABSENT: un-tiered stream, the local log is the whole stream. */
+        outcome = LOCAL;
       }
-      localCovers = (p.firstChunkId != -1) && (p.offset >= p.firstChunkId);
-      remoteCovers = m.nonEmpty && (p.offset >= m.remoteFirst) && (p.offset < m.remoteNext);
-      announce eResolution, (tier = tier, remoteCovers = remoteCovers, localCovers = localCovers);
-      send p.from, eResolveDone, tier;
+      announce eResolution, (outcome = outcome, offset = p.offset, firstChunkId = p.firstChunkId);
+      send p.from, eResolveDone, outcome;
     }
   }
 }

--- a/p/tier-routing/PTst/TestDrivers.p
+++ b/p/tier-routing/PTst/TestDrivers.p
@@ -1,24 +1,44 @@
 /* Test drivers and declarations for the offset -> tier routing seam.
 
-   The remote tier covers [0, 100). The gate contrasts tcTierRoutingGuarded
-   (the first_chunk_id =/= -1 guard present: routing is correct for every probed
-   offset and local floor, must hold) with tcTierRoutingBuggy (the guard removed:
-   an empty local log routes a remote-only offset to the local tier, must fail
-   with the INV#4 silent remote skip). */
+   The remote tier covers [0, 100) in every tiered scenario. Guarded tests must
+   hold; each buggy test removes one load-bearing piece and MUST fail with the
+   INV#4 silent remote skip, proving the spec has discriminating power against
+   that exact defect (the validation gate):
 
-/* Deterministically probe every combination of a local floor (including -1 =
-   empty local) and an offset spanning below / within / beyond the remote extent.
-   One run covers the whole grid, so totality does not rely on random sampling. */
-fun RunRouteAll(self: machine, bug: bool) {
-  var manifest: machine;
-  var reader: machine;
+   - tcTierRoutingGuardedWarm: full lifecycle (mark pending, resolve), then the
+     probe grid. Holds.
+   - tcTierRoutingGuardedColdStart: readers attach at every point of the
+     lifecycle (before resolution completes); the checker interleaves probes
+     with the resolution. Pending attaches RETRY; nothing routes LOCAL. Holds,
+     and a probe after the acknowledged resolution must not RETRY.
+   - tcTierRoutingBuggyNoMinusOneGuard: the =/= -1 floor guard removed on a
+     warm cache. Must fail.
+   - tcTierRoutingBuggyMissFallsLocal: the pre-fix miss collapse (PENDING ->
+     local first) with an unresolved cache. Must fail: this is the boot-window
+     bug, a consumer attaching below the local floor after a node restart and
+     before resolution.
+   - tcTierRoutingBuggyNoMarker: the environment weakened instead of the code:
+     no eMarkPending, reader attaches while the cache row is absent on a tiered
+     stream (models the code before the member-init marker existed). Must
+     fail, proving the marker's placement (before readers can attach) is
+     load-bearing, not just the reader's PENDING branch. */
+
+fun Probe(self: machine, reader: machine, fcid: int, off: int) : Outcome {
+  var o: Outcome;
+  send reader, eResolve, (from = self, firstChunkId = fcid, offset = off);
+  receive { case eResolveDone: (oo: Outcome) { o = oo; } }
+  return o;
+}
+
+/* Probe every combination of a local floor (including -1 = empty local) and an
+   offset spanning below / within / beyond the remote extent. Deterministic:
+   one run covers the whole grid, so totality does not rely on random
+   sampling. */
+fun ProbeGrid(self: machine, reader: machine) {
   var fcids: seq[int];
   var fi: int;
   var oi: int;
-  var t: Tier;
-
-  manifest = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
-  reader = new Reader((bug = bug, manifest = manifest, driver = self));
+  var o: Outcome;
 
   fcids += (0, -1);
   fcids += (1, 0);
@@ -28,45 +48,143 @@ fun RunRouteAll(self: machine, bug: bool) {
   while (fi < sizeof(fcids)) {
     oi = 0;
     while (oi < 8) {
-      send reader, eResolve, (from = self, firstChunkId = fcids[fi], offset = oi * 25);
-      receive { case eResolveDone: (tt: Tier) { t = tt; } }
+      o = Probe(self, reader, fcids[fi], oi * 25);
       oi = oi + 1;
     }
     fi = fi + 1;
   }
 }
 
-/* Deterministic empty-local case with the offset inside the remote extent. */
-fun RunRouteFixed(self: machine, bug: bool, fcid: int, off: int) {
-  var manifest: machine;
-  var reader: machine;
-  var t: Tier;
-
-  manifest = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
-  reader = new Reader((bug = bug, manifest = manifest, driver = self));
-
-  send reader, eResolve, (from = self, firstChunkId = fcid, offset = off);
-  receive { case eResolveDone: (tt: Tier) { t = tt; } }
+fun MarkPending(self: machine, store: machine) {
+  send store, eMarkPending, (from = self,);
+  receive { case eMSAck: { } }
 }
 
-machine DriverGuarded {
+fun ResolveManifest(self: machine, store: machine) {
+  send store, eResolveManifest, (from = self,);
+  receive { case eMSAck: { } }
+}
+
+/* Full lifecycle before any reader exists, then the grid. */
+machine DriverGuardedWarm {
   start state Init {
-    entry { RunRouteAll(this, false); }
+    entry {
+      var store: machine;
+      var reader: machine;
+      announce eGroundTruth, (nonEmpty = true, remoteFirst = 0, remoteNext = 100);
+      store = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+      MarkPending(this, store);
+      ResolveManifest(this, store);
+      reader = new Reader((bugNoMinusOneGuard = false, bugMissFallsLocal = false, manifest = store, driver = this));
+      ProbeGrid(this, reader);
+    }
   }
 }
 
-machine DriverBuggy {
+/* Cold start: the marker is placed (as member init does, before readers can
+   attach), then probes and the resolution race. Probes that land before the
+   resolution see PENDING and must RETRY, never LOCAL; a probe after the
+   acknowledged resolution must be served. */
+machine DriverGuardedColdStart {
   start state Init {
-    entry { RunRouteFixed(this, true, -1, 50); }
+    entry {
+      var store: machine;
+      var reader: machine;
+      var o: Outcome;
+      var i: int;
+      announce eGroundTruth, (nonEmpty = true, remoteFirst = 0, remoteNext = 100);
+      store = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+      MarkPending(this, store);
+      reader = new Reader((bugNoMinusOneGuard = false, bugMissFallsLocal = false, manifest = store, driver = this));
+      i = 0;
+      while (i < 4) {
+        /* Below the local floor (30), inside the remote extent: the offset the
+           boot-window bug used to skip. */
+        o = Probe(this, reader, 30, 5);
+        assert o != LOCAL, "cold-start probe below the floor routed LOCAL";
+        if ($) {
+          ResolveManifest(this, store);
+        }
+        i = i + 1;
+      }
+      ResolveManifest(this, store);
+      /* Resolution acknowledged: the read must now be served remotely. */
+      o = Probe(this, reader, 30, 5);
+      assert o == REMOTE, "probe after acknowledged resolution was not served remotely";
+      ProbeGrid(this, reader);
+    }
   }
 }
 
-/* Current code: routing is correct for every local floor and offset. Must hold. */
-test tcTierRoutingGuarded [main = DriverGuarded]:
-  assert TierRoutingCorrect in { DriverGuarded, ManifestStore, Reader };
+/* The =/= -1 guard removed on a warm cache: an empty local log routes a
+   remote-only offset to the local tier. */
+machine DriverBuggyNoMinusOneGuard {
+  start state Init {
+    entry {
+      var store: machine;
+      var reader: machine;
+      var o: Outcome;
+      announce eGroundTruth, (nonEmpty = true, remoteFirst = 0, remoteNext = 100);
+      store = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+      MarkPending(this, store);
+      ResolveManifest(this, store);
+      reader = new Reader((bugNoMinusOneGuard = true, bugMissFallsLocal = false, manifest = store, driver = this));
+      o = Probe(this, reader, -1, 50);
+    }
+  }
+}
 
-/* Guard removed: an empty local log (first_chunk_id = -1) routes a remote-only
-   offset to the local tier. MUST fail with the INV#4 silent remote skip. This
-   failing run is the gate. */
-test tcTierRoutingBuggy [main = DriverBuggy]:
-  assert TierRoutingCorrect in { DriverBuggy, ManifestStore, Reader };
+/* The pre-fix miss collapse: the cache row is pending (marked, unresolved) and
+   the reader treats the miss as "no remote tier -> local first". */
+machine DriverBuggyMissFallsLocal {
+  start state Init {
+    entry {
+      var store: machine;
+      var reader: machine;
+      var o: Outcome;
+      announce eGroundTruth, (nonEmpty = true, remoteFirst = 0, remoteNext = 100);
+      store = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+      MarkPending(this, store);
+      reader = new Reader((bugNoMinusOneGuard = false, bugMissFallsLocal = true, manifest = store, driver = this));
+      o = Probe(this, reader, 30, 5);
+    }
+  }
+}
+
+/* The environment weakened: no pending marker at all (the code before the
+   member-init marker existed). The reader is fully guarded, yet a reader
+   attaching while the row is absent on a tiered stream still routes LOCAL,
+   because ABSENT is indistinguishable from an un-tiered stream. */
+machine DriverBuggyNoMarker {
+  start state Init {
+    entry {
+      var store: machine;
+      var reader: machine;
+      var o: Outcome;
+      announce eGroundTruth, (nonEmpty = true, remoteFirst = 0, remoteNext = 100);
+      store = new ManifestStore((nonEmpty = true, remoteFirst = 0, remoteNext = 100));
+      reader = new Reader((bugNoMinusOneGuard = false, bugMissFallsLocal = false, manifest = store, driver = this));
+      o = Probe(this, reader, 30, 5);
+    }
+  }
+}
+
+/* Current code, warm cache: must hold. */
+test tcTierRoutingGuardedWarm [main = DriverGuardedWarm]:
+  assert TierRoutingCorrect in { DriverGuardedWarm, ManifestStore, Reader };
+
+/* Current code, readers racing the resolution: must hold. */
+test tcTierRoutingGuardedColdStart [main = DriverGuardedColdStart]:
+  assert TierRoutingCorrect in { DriverGuardedColdStart, ManifestStore, Reader };
+
+/* Guard removed: MUST fail with the INV#4 silent remote skip. */
+test tcTierRoutingBuggyNoMinusOneGuard [main = DriverBuggyNoMinusOneGuard]:
+  assert TierRoutingCorrect in { DriverBuggyNoMinusOneGuard, ManifestStore, Reader };
+
+/* Pre-fix miss collapse: MUST fail with the INV#4 silent remote skip. */
+test tcTierRoutingBuggyMissFallsLocal [main = DriverBuggyMissFallsLocal]:
+  assert TierRoutingCorrect in { DriverBuggyMissFallsLocal, ManifestStore, Reader };
+
+/* No marker in the lifecycle: MUST fail with the INV#4 silent remote skip. */
+test tcTierRoutingBuggyNoMarker [main = DriverBuggyNoMarker]:
+  assert TierRoutingCorrect in { DriverBuggyNoMarker, ManifestStore, Reader };

--- a/p/tier-routing/README.md
+++ b/p/tier-routing/README.md
@@ -1,37 +1,49 @@
 # Offset-to-tier routing
 
-Models the integer-offset branch of `log_reader:resolve_remote_location/2`: the decision to serve an offset from the local log or the remote tier.
+Models the integer-offset branch of `log_reader:resolve_remote_location/2`: the decision to serve an offset from the local log or the remote tier, including the lifecycle of the manifest cache the decision reads.
 
-## The bug
+## The bugs
 
-The local-tier check is:
+Two shipped defects, both INV#4 silent remote skips, both gated on below.
+
+The floor-guard bug. The local-tier check is:
 
 ```erlang
 first_chunk_id =/= -1 andalso Offset >= first_chunk_id
 ```
 
-`first_chunk_id = -1` means the local log is empty (fully trimmed or not yet populated). Without the `=/= -1` guard, `Offset >= -1` is always true, so an empty local log routes every offset to the local tail and silently skips the remote tier: the consumer sees no data (or waits at the tail) for offsets the remote tier actually holds. The guard makes an empty local log fall through to remote resolution.
+`first_chunk_id = -1` means the local log is empty (fully trimmed or not yet populated). Without the `=/= -1` guard, `Offset >= -1` is always true, so an empty local log routes every offset to the local tail and silently skips the remote tier.
 
-This is a second INV#4 guard, distinct from the `read-resolution` group-fetch catch-all: that one is about a transient failure while descending into a group, this one is about routing the offset to the correct tier in the first place.
+The boot-window bug. The reader consults the node's manifest CACHE, not the manifest. Before the cache had a `pending` state, a missing row meant "no remote tier", so on a freshly restarted node (empty cache, no publish to re-seed it) an offset below the local floor fell back to `{local, first}` and silently skipped the whole remote range for up to one reconciliation period. The fix distinguishes three cache states: `RESOLVED` (route by extent), `PENDING` (attached but unresolved: fail closed, the consumer retries), `ABSENT` (un-tiered stream: local is the whole stream), and places the pending marker in member init, before any reader can attach.
 
 ## What the model captures
 
-- A `Reader` routing an offset given `first_chunk_id` (the local floor, `-1` when empty) and the remote extent `[remoteFirst, remoteNext)`
-- The full branch lattice: local-covered, no-remote, empty-local-beyond-tail, and remote
-- `bugNoMinusOneGuard` drops the `=/= -1` guard
-- `TierRoutingCorrect` (INV#4): an offset held only by the remote tier (covered by the remote extent, not by the local log) must route to the remote tier. An offset the local tier also holds may route locally (osiris prefers the local reader), so the obligation is only on offsets the local tier does not cover
+- A `ManifestStore` as a lifecycle state machine (`Cold -> Pending -> Serving`), not a static oracle: the true remote extent is fixed at construction but only reported once resolved, exactly like the real cache
+- A `Reader` deciding from the cache reply alone, never from the ground truth
+- `bugNoMinusOneGuard` drops the `=/= -1` guard; `bugMissFallsLocal` restores the pre-fix miss collapse (`PENDING -> local`)
+- `TierRoutingCorrect` (INV#4): an offset held only by the remote tier must not route `LOCAL` (`RETRY` is acceptable, it fails closed). Coverage is re-derived by the monitor from the ground truth the driver announces (`eGroundTruth`), never from the cache's reply. The previous version of this spec used the cache's own answer as the oracle, which made the boot-window bug unrepresentable: a reader that believed a cold cache could not be flagged. The oracle must stay independent of the component under test.
 
 ## Tests
 
 | Test case | Expectation |
 | --- | --- |
-| `tcTierRoutingGuarded` | holds: the guarded driver deterministically probes every combination of local floor (`-1`, `0`, `30`) and offset (`0`..`175`), so totality does not rely on random sampling |
-| `tcTierRoutingBuggy` | fails: the `=/= -1` guard removed; an empty-local read of a remote-only offset routes local; `INV#4 violated: an offset held only by the remote tier routed to the local tier` |
+| `tcTierRoutingGuardedWarm` | holds: full lifecycle, then a deterministic probe grid over every local floor (`-1`, `0`, `30`) and offset (`0`..`175`) |
+| `tcTierRoutingGuardedColdStart` | holds: readers attach while the resolution races them; pending probes `RETRY`, never `LOCAL`, and a probe after the acknowledged resolution is served remotely |
+| `tcTierRoutingBuggyNoMinusOneGuard` | fails: the `=/= -1` guard removed; an empty-local read of a remote-only offset routes local |
+| `tcTierRoutingBuggyMissFallsLocal` | fails: the pre-fix miss collapse; a below-floor read on an unresolved cache routes local (the boot-window bug) |
+| `tcTierRoutingBuggyNoMarker` | fails: the environment weakened instead of the code; no pending marker, so a reader attaching on a tiered stream with an absent row routes local. Proves the marker's member-init placement is load-bearing, not just the reader's `PENDING` branch |
 
-`tcTierRoutingBuggy` is expected to fail: that counterexample is the proof the model reproduces the empty-local silent remote skip.
+The three failing runs are the validation gate: each proves the spec reproduces one specific shipped (or nearly shipped) defect.
 
 ```bash
 p compile
-p check -tc tcTierRoutingGuarded -i 5000   # 0 bugs (full floor x offset grid)
-p check -tc tcTierRoutingBuggy   -i 2000   # 1 bug: INV#4 misrouting
+p check -tc tcTierRoutingGuardedWarm      -s 2000   # 0 bugs
+p check -tc tcTierRoutingGuardedColdStart -s 2000   # 0 bugs
+p check -tc tcTierRoutingBuggyNoMinusOneGuard -s 500   # 1 bug: INV#4 misrouting
+p check -tc tcTierRoutingBuggyMissFallsLocal  -s 500   # 1 bug: INV#4 misrouting
+p check -tc tcTierRoutingBuggyNoMarker        -s 500   # 1 bug: INV#4 misrouting
 ```
+
+## Scope note
+
+The cache-availability axis lives in this model. The sibling `read-resolution` model covers the group-fetch classification inside `resolve_first`; the `pending` clause added to `resolve_first` itself is exercised directly by `read_resolution_SUITE` (Erlang property and eunit cases), which drives the real module rather than a model of it.

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -286,8 +286,8 @@ still_dangling(#{reason := no_anchor}) ->
     %% the absence is permanent, so there is nothing to re-validate.
     true;
 still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key}) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = FirstOffset} = Manifest ->
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun(#manifest{first_offset = FirstOffset} = Manifest) ->
             case parse_key(Key) of
                 {data, _StreamId, Offset} ->
                     Offset < FirstOffset;
@@ -296,14 +296,14 @@ still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key
                         not live_leading_group(StreamId, Key, Manifest);
                 _ ->
                     false
-            end;
-        Unresolved when Unresolved =:= undefined; Unresolved =:= pending ->
-            %% No live manifest to compare against (missing row, or a pending
-            %% marker whose manifest has not resolved yet): do not delete (a
-            %% later sweep reclaims a genuine orphan once a floor is known
-            %% again).
-            false
-    end.
+            end
+        end,
+        %% No live manifest to compare against (a pending marker whose manifest
+        %% has not resolved yet, or a missing row): do not delete (a later
+        %% sweep reclaims a genuine orphan once a floor is known again).
+        pending => fun() -> false end,
+        absent => fun() -> false end
+    }).
 
 %% Whether the group object Key is protected by the LIVE manifest's leading-group
 %% carve-out: it is the live referenced leading group, or the live manifest is in

--- a/src/rabbitmq_stream_s3_gc.erl
+++ b/src/rabbitmq_stream_s3_gc.erl
@@ -297,9 +297,11 @@ still_dangling(#{reason := below_first_offset, stream_id := StreamId, key := Key
                 _ ->
                     false
             end;
-        undefined ->
-            %% No live manifest to compare against: do not delete (a later sweep
-            %% reclaims a genuine orphan once a floor is known again).
+        Unresolved when Unresolved =:= undefined; Unresolved =:= pending ->
+            %% No live manifest to compare against (missing row, or a pending
+            %% marker whose manifest has not resolved yet): do not delete (a
+            %% later sweep reclaims a genuine orphan once a floor is known
+            %% again).
             false
     end.
 

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -150,20 +150,22 @@ on_retention_evaluated(Cnt, #{name := Name}) ->
     %% of -1, which must never reach the counter. get_range/1 returns `empty`
     %% in that case, so the override only runs when the remote tier actually
     %% holds data and its first_timestamp is a real timestamp.
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{entries = <<>>} ->
-            ok;
-        #manifest{first_offset = RemoteFirst, first_timestamp = RemoteFirstTs} ->
-            LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
-            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst)),
-            LocalFirstTs = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP),
-            counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, min(LocalFirstTs, RemoteFirstTs));
-        pending ->
-            %% Not yet resolved: nothing known to override the counters with.
-            ok;
-        undefined ->
-            ok
-    end.
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun
+            (#manifest{entries = <<>>}) ->
+                ok;
+            (#manifest{first_offset = RemoteFirst, first_timestamp = RemoteFirstTs}) ->
+                LocalFirst = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET),
+                counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst)),
+                LocalFirstTs = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP),
+                counters:put(
+                    Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, min(LocalFirstTs, RemoteFirstTs)
+                )
+        end,
+        %% Not yet resolved: nothing known to override the counters with.
+        pending => fun() -> ok end,
+        absent => fun() -> ok end
+    }).
 
 -doc """
 Discover existing osiris writers and replicas on this node and attach

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -89,6 +89,10 @@ on_init(acceptor, Pid, #{name := Name, leader_pid := LeaderPid, counter := Count
     ),
     Shared = maps:get(shared, Config),
     Dir = maps:get(dir, Config),
+    %% register_replica_context marks the cache row pending before the member
+    %% finishes init, so a consumer attaching on this node fails closed (and
+    %% retries) until the writer's sync lands, rather than resolving the
+    %% remote tier as absent.
     rabbitmq_stream_s3_manifest_replica:register_replica_context(
         StreamId, Pid, Dir, Shared, Counter
     ),
@@ -97,6 +101,10 @@ on_init(acceptor, Pid, #{name := Name, counter := Counter} = Config) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     Shared = maps:get(shared, Config),
     Dir = maps:get(dir, Config),
+    %% No leader is known yet, so no sync can be requested here; the writer's
+    %% periodic replica reconciliation will register this node and sync it.
+    %% Until then readers fail closed on the pending row that
+    %% register_replica_context marks.
     rabbitmq_stream_s3_manifest_replica:register_replica_context(
         StreamId, Pid, Dir, Shared, Counter
     ),
@@ -150,6 +158,9 @@ on_retention_evaluated(Cnt, #{name := Name}) ->
             counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_OFFSET, min(LocalFirst, RemoteFirst)),
             LocalFirstTs = counters:get(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP),
             counters:put(Cnt, ?C_OSIRIS_LOG_FIRST_TIMESTAMP, min(LocalFirstTs, RemoteFirstTs));
+        pending ->
+            %% Not yet resolved: nothing known to override the counters with.
+            ok;
         undefined ->
             ok
     end.
@@ -353,6 +364,9 @@ attach_replica(Pid) ->
     StreamId = rabbitmq_stream_s3:ensure_stream_id(Name),
     %% Seshat registers replica counters under {osiris_replica, Reference}.
     Counter = osiris_counters:fetch({osiris_replica, Reference}),
+    %% Same pending marker as on_init(acceptor, ...), applied by
+    %% register_replica_context: readers fail closed until the writer's sync
+    %% lands. Re-discovery of an already synced replica changes nothing.
     rabbitmq_stream_s3_manifest_replica:register_replica_context(
         StreamId, Pid, Dir, Shared, Counter
     ),

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -44,6 +44,7 @@ tier.
 -define(C_RESOLVE_DURATION_MS, 11).
 -define(C_RESOLVE, 12).
 -define(C_REMOTE_READER_RESTART, 13).
+-define(C_RESOLVE_FAILED_CLOSED, 14).
 -define(COUNTERS, [
     {remote_init, ?C_REMOTE_INIT, counter, "Readers initialized in remote mode"},
     {local_init, ?C_LOCAL_INIT, counter, "Readers initialized in local mode"},
@@ -68,7 +69,9 @@ tier.
         "Total milliseconds spent resolving offset specs"},
     {resolve, ?C_RESOLVE, counter, "Number of offset spec resolutions"},
     {remote_reader_restart, ?C_REMOTE_READER_RESTART, counter,
-        "Remote tier readers restarted after an unexpected exit"}
+        "Remote tier readers restarted after an unexpected exit"},
+    {resolve_failed_closed, ?C_RESOLVE_FAILED_CLOSED, counter,
+        "Offset spec resolutions failed closed on a pending (unresolved) manifest"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -141,6 +144,12 @@ init_counters() ->
 counter() ->
     persistent_term:get(?COUNTER_KEY).
 
+record_resolve_failed_closed(T0) ->
+    Cnt = counter(),
+    counters:add(Cnt, ?C_RESOLVE_DURATION_MS, rabbitmq_stream_s3_util:elapsed_ms(T0)),
+    counters:add(Cnt, ?C_RESOLVE, 1),
+    counters:add(Cnt, ?C_RESOLVE_FAILED_CLOSED, 1).
+
 record_resolve(T0, Tier, OffsetSpec) ->
     Cnt = counter(),
     Duration = rabbitmq_stream_s3_util:elapsed_ms(T0),
@@ -167,11 +176,19 @@ record_resolve(T0, Tier, OffsetSpec) ->
 %%%===================================================================
 
 resolve_offset_spec(OffsetSpec, Config) ->
+    T0 = erlang:monotonic_time(),
     case resolve_remote_location(OffsetSpec, Config) of
         {ok, #remote_location{chunk_id = ChunkId}} ->
             {ok, ChunkId};
         {local, LocalSpec} ->
             osiris_log:resolve_offset_spec(LocalSpec, Config);
+        {error, {manifest_not_resolved, _}} = Err ->
+            %% Same fail-closed accounting as init_offset_reader/2: without
+            %% this, a caller that resolves through this callback instead of
+            %% init_offset_reader/2 has its fail-closed attaches invisible to
+            %% the alertable counter.
+            record_resolve_failed_closed(T0),
+            Err;
         {error, _} = Err ->
             Err
     end.
@@ -185,6 +202,24 @@ init_offset_reader(OffsetSpec, Config) ->
         {local, LocalSpec} ->
             record_resolve(T0, local, OffsetSpec),
             init_local_reader(LocalSpec, Config);
+        {error, {manifest_not_resolved, StreamId}} = Err ->
+            %% Fail closed: the manifest cache row is still pending, so the
+            %% remote tier's extent is unknown for a spec that may live in it.
+            %% The consumer's retry lands after resolution (normally
+            %% milliseconds after member start). INFO, not WARNING: expected
+            %% during the attach window; sustained repeats mean manifest
+            %% resolution is stuck and the resolve_failed_closed counter (and
+            %% the replica reader's manifest_resolution_failures) is the
+            %% alertable signal.
+            ?LOG_INFO(
+                "Failing reader setup closed for stream '~ts': offset spec ~w "
+                "may be in the remote tier but the manifest is not yet "
+                "resolved on this node",
+                [StreamId, OffsetSpec],
+                ?DOMAIN
+            ),
+            record_resolve_failed_closed(T0),
+            Err;
         {error, _} = Err ->
             Err
     end.
@@ -207,7 +242,19 @@ resolve_remote_location(first, #{name := StreamId, shared := Shared}) ->
                 ?DOMAIN
             ),
             resolve_first(StreamId, RemoteFirstOffset);
-        _ ->
+        #manifest{} ->
+            %% Resolved, and the remote tier does not start before the local
+            %% log: the local first offset is the stream's beginning.
+            {local, first};
+        pending ->
+            %% The plugin is attached but the manifest is not yet resolved or
+            %% synced, so where the stream begins is unknown. Fail closed: a
+            %% local fallback here would silently skip the remote range below
+            %% the local floor. The consumer retries.
+            {error, {manifest_not_resolved, StreamId}};
+        undefined ->
+            %% No plugin state for this stream on this node (un-tiered): the
+            %% local log is the whole stream.
             {local, first}
     end;
 resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
@@ -240,13 +287,19 @@ resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
             ),
             case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
                 undefined ->
-                    %% No remote manifest is cached: a cold or not-yet-synced
-                    %% cache, or genuinely no remote tier. The requested offset
+                    %% No plugin state for this stream on this node (un-tiered):
+                    %% the local log is the whole stream. The requested offset
                     %% is below the local floor, so emulate osiris_log and attach
                     %% at the local first offset. Returning {local, next} here
-                    %% would attach at the tail and silently skip all local (and
-                    %% any remote) data the consumer asked for.
+                    %% would attach at the tail and silently skip all local
+                    %% data the consumer asked for.
                     {local, first};
+                pending ->
+                    %% Attached but not yet resolved or synced: the remote
+                    %% tier's extent is unknown and the offset is below the
+                    %% local floor, so it cannot be served without it. Fail
+                    %% closed rather than silently skip; the consumer retries.
+                    {error, {manifest_not_resolved, StreamId}};
                 #manifest{next_offset = RemoteNext} when
                     FirstChunkId =:= -1, Offset >= RemoteNext
                 ->
@@ -289,15 +342,28 @@ resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
                 _ ->
                     {local, Spec}
             end;
+        pending ->
+            %% Attached but not yet resolved or synced: the timestamp may live
+            %% in the remote tier. Fail closed rather than silently skip.
+            {error, {manifest_not_resolved, StreamId}};
         undefined ->
             {local, Spec}
     end;
-resolve_remote_location({abs, Offset}, Config) ->
-    case total_range(Config) of
-        {First, Last} when First =< Offset andalso Offset =< Last ->
-            resolve_remote_location(Offset, Config);
-        Range ->
-            {error, {offset_out_of_range, Range}}
+resolve_remote_location({abs, Offset}, #{name := StreamId} = Config) ->
+    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
+        pending ->
+            %% {abs, Offset} validates the offset against the stream's total
+            %% range, which is unknown until the manifest resolves. Fail closed
+            %% with a retryable error; an out_of_range here would be a lie the
+            %% client treats as permanent.
+            {error, {manifest_not_resolved, StreamId}};
+        _ ->
+            case total_range(Config) of
+                {First, Last} when First =< Offset andalso Offset =< Last ->
+                    resolve_remote_location(Offset, Config);
+                Range ->
+                    {error, {offset_out_of_range, Range}}
+            end
     end.
 
 -doc "Finds the range of offsets in both local and remote tiers".
@@ -1152,7 +1218,20 @@ resolve_first(StreamId, FirstOffset) ->
                     %% local floor.
                     {error, Reason}
             end;
-        _ ->
+        #manifest{} ->
+            %% Resolved but no fragment entries: the remote tier is empty here
+            %% (behind the local floor, or retention emptied it), so the local
+            %% first offset is the oldest data that exists.
+            {local, first};
+        pending ->
+            %% Unreachable from the resolution clauses (they only call in after
+            %% observing a resolved manifest, and a row is never downgraded),
+            %% but stated rather than caught-all: a pending row must never be
+            %% collapsed into the local fallback.
+            {error, {manifest_not_resolved, StreamId}};
+        undefined ->
+            %% The row was released concurrently (the member is going down);
+            %% the local fallback is moot, the reader is about to die with it.
             {local, first}
     end.
 
@@ -1239,11 +1318,11 @@ read(RemoteReader, Offset, Bytes, Hint, Attempt) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-%% A subscription by offset below the local floor, when no remote manifest is
-%% cached (a cold/not-yet-synced cache), must fall back to the local first
-%% offset, not the tail. Attaching at the tail ({local, next}) silently skips
-%% every record the consumer asked for.
-resolve_below_floor_cold_cache_falls_back_to_first_test_() ->
+%% A stream with no cache row at all is un-tiered on this node (the plugin
+%% never attached to it), so the local log is the whole stream: emulate
+%% osiris_log and attach at the local first offset, not the tail. Attaching at
+%% the tail ({local, next}) silently skips every record the consumer asked for.
+resolve_below_floor_unattached_falls_back_to_first_test_() ->
     {setup,
         fun() ->
             {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
@@ -1253,13 +1332,47 @@ resolve_below_floor_cold_cache_falls_back_to_first_test_() ->
         fun(Pid) -> gen_server:stop(Pid) end, fun(_) ->
             Shared = osiris_log_shared:new(),
             ok = osiris_log_shared:set_first_chunk_id(Shared, 100),
-            Config = #{name => <<"cold-stream">>, shared => Shared},
+            Config = #{name => <<"untiered-stream">>, shared => Shared},
             [
-                %% Below the local floor, cold cache: fall back to local first.
+                %% Below the local floor, no plugin state: fall back to local
+                %% first.
                 ?_assertEqual({local, first}, resolve_remote_location(5, Config)),
+                ?_assertEqual({local, first}, resolve_remote_location(first, Config)),
                 %% At/above the local floor: local reader at the offset (no
-                %% cache needed), unaffected by this change.
+                %% cache needed).
                 ?_assertEqual({local, 150}, resolve_remote_location(150, Config))
+            ]
+        end}.
+
+%% A pending cache row means the plugin is attached but the manifest is not yet
+%% resolved: the remote tier's extent is unknown, so any spec that may live in
+%% it must fail closed (a retryable error) rather than fall back to the local
+%% tier and silently skip the remote range below the local floor. Specs the
+%% local tier answers by itself are unaffected.
+resolve_pending_fails_closed_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
+            unlink(Pid),
+            Pid
+        end,
+        fun(Pid) -> gen_server:stop(Pid) end, fun(_) ->
+            StreamId = <<"pending-stream">>,
+            ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
+            Shared = osiris_log_shared:new(),
+            ok = osiris_log_shared:set_first_chunk_id(Shared, 100),
+            Config = #{name => StreamId, shared => Shared},
+            Err = {error, {manifest_not_resolved, StreamId}},
+            [
+                ?_assertEqual(Err, resolve_remote_location(first, Config)),
+                ?_assertEqual(Err, resolve_remote_location(5, Config)),
+                ?_assertEqual(Err, resolve_remote_location({timestamp, 123}, Config)),
+                ?_assertEqual(Err, resolve_remote_location({abs, 5}, Config)),
+                %% At/above the local floor the local tier alone answers, so
+                %% pending does not block the read.
+                ?_assertEqual({local, 150}, resolve_remote_location(150, Config)),
+                ?_assertEqual({local, last}, resolve_remote_location(last, Config)),
+                ?_assertEqual({local, next}, resolve_remote_location(next, Config))
             ]
         end}.
 

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -228,35 +228,36 @@ resolve_remote_location(Spec, _Config) when Spec =:= last orelse Spec =:= next -
     {local, Spec};
 resolve_remote_location(first, #{name := StreamId, shared := Shared}) ->
     LocalFirstOffset = osiris_log_shared:first_chunk_id(Shared),
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = RemoteFirstOffset} when
-            LocalFirstOffset =:= -1; RemoteFirstOffset < LocalFirstOffset
-        ->
-            %% The remote tier starts before the local log (or the local log is
-            %% empty, first_chunk_id = -1, fully trimmed), so 'first' is in the
-            %% remote tier. Without the -1 case an empty local log would resolve
-            %% to the local tail and skip the entire remote tier.
-            ?LOG_DEBUG(
-                "Attaching remote reader at first offset ~b for spec 'first'",
-                [RemoteFirstOffset],
-                ?DOMAIN
-            ),
-            resolve_first(StreamId, RemoteFirstOffset);
-        #manifest{} ->
-            %% Resolved, and the remote tier does not start before the local
-            %% log: the local first offset is the stream's beginning.
-            {local, first};
-        pending ->
-            %% The plugin is attached but the manifest is not yet resolved or
-            %% synced, so where the stream begins is unknown. Fail closed: a
-            %% local fallback here would silently skip the remote range below
-            %% the local floor. The consumer retries.
-            {error, {manifest_not_resolved, StreamId}};
-        undefined ->
-            %% No plugin state for this stream on this node (un-tiered): the
-            %% local log is the whole stream.
-            {local, first}
-    end;
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun
+            (#manifest{first_offset = RemoteFirstOffset}) when
+                LocalFirstOffset =:= -1; RemoteFirstOffset < LocalFirstOffset
+            ->
+                %% The remote tier starts before the local log (or the local
+                %% log is empty, first_chunk_id = -1, fully trimmed), so
+                %% 'first' is in the remote tier. Without the -1 case an empty
+                %% local log would resolve to the local tail and skip the
+                %% entire remote tier.
+                ?LOG_DEBUG(
+                    "Attaching remote reader at first offset ~b for spec 'first'",
+                    [RemoteFirstOffset],
+                    ?DOMAIN
+                ),
+                resolve_first(StreamId, RemoteFirstOffset);
+            (#manifest{}) ->
+                %% The remote tier does not start before the local log: the
+                %% local first offset is the stream's beginning.
+                {local, first}
+        end,
+        %% Attached but the manifest is not yet resolved or synced, so where
+        %% the stream begins is unknown. Fail closed: a local fallback here
+        %% would silently skip the remote range below the local floor. The
+        %% consumer retries.
+        pending => fun() -> {error, {manifest_not_resolved, StreamId}} end,
+        %% No plugin state for this stream on this node (un-tiered): the local
+        %% log is the whole stream.
+        absent => fun() -> {local, first} end
+    });
 resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
     is_integer(Offset)
 ->
@@ -285,44 +286,48 @@ resolve_remote_location(Offset, #{name := StreamId, shared := Shared}) when
                 ],
                 ?DOMAIN
             ),
-            case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                undefined ->
-                    %% No plugin state for this stream on this node (un-tiered):
-                    %% the local log is the whole stream. The requested offset
-                    %% is below the local floor, so emulate osiris_log and attach
-                    %% at the local first offset. Returning {local, next} here
-                    %% would attach at the tail and silently skip all local
-                    %% data the consumer asked for.
-                    {local, first};
-                pending ->
-                    %% Attached but not yet resolved or synced: the remote
-                    %% tier's extent is unknown and the offset is below the
-                    %% local floor, so it cannot be served without it. Fail
-                    %% closed rather than silently skip; the consumer retries.
-                    {error, {manifest_not_resolved, StreamId}};
-                #manifest{next_offset = RemoteNext} when
-                    FirstChunkId =:= -1, Offset >= RemoteNext
-                ->
-                    %% The local log is empty and the offset is at or beyond the
-                    %% remote tier's tail, i.e. beyond the committed stream.
-                    %% Attach at the live tail and wait for new writes, as a
-                    %% local reader at or past the tail would.
-                    {local, next};
-                #manifest{first_offset = FirstOffset} when Offset < FirstOffset ->
-                    %% Emulate osiris_log's behavior: attach at the beginning
-                    %% of the stream.
-                    resolve_first(StreamId, FirstOffset);
-                #manifest{entries = Entries} = Manifest when byte_size(Entries) >= ?ENTRY_B ->
-                    find_position({offset, Offset}, Manifest, StreamId);
-                #manifest{} ->
-                    %% The remote manifest has no fragment entries (the remote
-                    %% tier is behind the local floor, or retention emptied it).
-                    %% The offset is below the local floor and no remote fragment
-                    %% can serve it, so emulate osiris_log and attach at the local
-                    %% first offset rather than crashing in find_fragment on an
-                    %% empty entry array.
-                    {local, first}
-            end
+            rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+                resolved => fun
+                    (#manifest{next_offset = RemoteNext}) when
+                        FirstChunkId =:= -1, Offset >= RemoteNext
+                    ->
+                        %% The local log is empty and the offset is at or
+                        %% beyond the remote tier's tail, i.e. beyond the
+                        %% committed stream. Attach at the live tail and wait
+                        %% for new writes, as a local reader at or past the
+                        %% tail would.
+                        {local, next};
+                    (#manifest{first_offset = FirstOffset}) when Offset < FirstOffset ->
+                        %% Emulate osiris_log's behavior: attach at the
+                        %% beginning of the stream.
+                        resolve_first(StreamId, FirstOffset);
+                    (#manifest{entries = Entries} = Manifest) when
+                        byte_size(Entries) >= ?ENTRY_B
+                    ->
+                        find_position({offset, Offset}, Manifest, StreamId);
+                    (#manifest{}) ->
+                        %% The remote manifest has no fragment entries (the
+                        %% remote tier is behind the local floor, or retention
+                        %% emptied it). The offset is below the local floor and
+                        %% no remote fragment can serve it, so emulate
+                        %% osiris_log and attach at the local first offset
+                        %% rather than crashing in find_fragment on an empty
+                        %% entry array.
+                        {local, first}
+                end,
+                %% Attached but not yet resolved or synced: the remote tier's
+                %% extent is unknown and the offset is below the local floor,
+                %% so it cannot be served without it. Fail closed rather than
+                %% silently skip; the consumer retries.
+                pending => fun() -> {error, {manifest_not_resolved, StreamId}} end,
+                %% No plugin state for this stream on this node (un-tiered):
+                %% the local log is the whole stream. The requested offset is
+                %% below the local floor, so emulate osiris_log and attach at
+                %% the local first offset. Returning {local, next} here would
+                %% attach at the tail and silently skip all local data the
+                %% consumer asked for.
+                absent => fun() -> {local, first} end
+            })
     end;
 resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
     ?LOG_DEBUG(
@@ -332,39 +337,43 @@ resolve_remote_location({timestamp, Ts} = Spec, #{name := StreamId}) ->
     ),
     %% We can't cheaply query the first timestamp from `osiris_log_shared`.
     %% Instead try the remote tier first.
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = FirstOffset, first_timestamp = FirstTs} when Ts < FirstTs ->
-            resolve_first(StreamId, FirstOffset);
-        #manifest{entries = Entries} = Manifest ->
-            case rabbitmq_stream_s3_array:last(?ENTRY_B, Entries) of
-                ?ENTRY(_O, _FTs, LTs, _, _, _) when LTs >= Ts ->
-                    find_position({timestamp, Ts}, Manifest, StreamId);
-                _ ->
-                    {local, Spec}
-            end;
-        pending ->
-            %% Attached but not yet resolved or synced: the timestamp may live
-            %% in the remote tier. Fail closed rather than silently skip.
-            {error, {manifest_not_resolved, StreamId}};
-        undefined ->
-            {local, Spec}
-    end;
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun
+            (#manifest{first_offset = FirstOffset, first_timestamp = FirstTs}) when
+                Ts < FirstTs
+            ->
+                resolve_first(StreamId, FirstOffset);
+            (#manifest{entries = Entries} = Manifest) ->
+                case rabbitmq_stream_s3_array:last(?ENTRY_B, Entries) of
+                    ?ENTRY(_O, _FTs, LTs, _, _, _) when LTs >= Ts ->
+                        find_position({timestamp, Ts}, Manifest, StreamId);
+                    _ ->
+                        {local, Spec}
+                end
+        end,
+        %% Attached but not yet resolved or synced: the timestamp may live in
+        %% the remote tier. Fail closed rather than silently skip.
+        pending => fun() -> {error, {manifest_not_resolved, StreamId}} end,
+        absent => fun() -> {local, Spec} end
+    });
 resolve_remote_location({abs, Offset}, #{name := StreamId} = Config) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        pending ->
-            %% {abs, Offset} validates the offset against the stream's total
-            %% range, which is unknown until the manifest resolves. Fail closed
-            %% with a retryable error; an out_of_range here would be a lie the
-            %% client treats as permanent.
-            {error, {manifest_not_resolved, StreamId}};
-        _ ->
-            case total_range(Config) of
-                {First, Last} when First =< Offset andalso Offset =< Last ->
-                    resolve_remote_location(Offset, Config);
-                Range ->
-                    {error, {offset_out_of_range, Range}}
-            end
-    end.
+    CheckRange = fun() ->
+        case total_range(Config) of
+            {First, Last} when First =< Offset andalso Offset =< Last ->
+                resolve_remote_location(Offset, Config);
+            Range ->
+                {error, {offset_out_of_range, Range}}
+        end
+    end,
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun(_) -> CheckRange() end,
+        %% {abs, Offset} validates the offset against the stream's total range,
+        %% which is unknown until the manifest resolves. Fail closed with a
+        %% retryable error; an out_of_range here would be a lie the client
+        %% treats as permanent.
+        pending => fun() -> {error, {manifest_not_resolved, StreamId}} end,
+        absent => fun() -> CheckRange() end
+    }).
 
 -doc "Finds the range of offsets in both local and remote tiers".
 -spec total_range(osiris_log:config()) -> rabbitmq_stream_s3:range().
@@ -1198,42 +1207,42 @@ advance_past_current(Iterator) ->
     end.
 
 resolve_first(StreamId, FirstOffset) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{entries = Entries} = Manifest when byte_size(Entries) >= ?ENTRY_B ->
-            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-            Iterator = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, FirstOffset, GetGroupFun
-            ),
-            Lookup = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
-            case resolve_first_lookup(Lookup) of
-                {remote, Location} ->
-                    {ok, Location};
-                {local, first} ->
-                    {local, first};
-                {retry, Reason} ->
-                    %% A transient group fetch failed while descending to the
-                    %% first fragment. Failing the read setup (rather than
-                    %% falling back to the local tier) makes the consumer retry
-                    %% instead of silently skipping the remote range below the
-                    %% local floor.
-                    {error, Reason}
-            end;
-        #manifest{} ->
-            %% Resolved but no fragment entries: the remote tier is empty here
-            %% (behind the local floor, or retention emptied it), so the local
-            %% first offset is the oldest data that exists.
-            {local, first};
-        pending ->
-            %% Unreachable from the resolution clauses (they only call in after
-            %% observing a resolved manifest, and a row is never downgraded),
-            %% but stated rather than caught-all: a pending row must never be
-            %% collapsed into the local fallback.
-            {error, {manifest_not_resolved, StreamId}};
-        undefined ->
-            %% The row was released concurrently (the member is going down);
-            %% the local fallback is moot, the reader is about to die with it.
-            {local, first}
-    end.
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun
+            (#manifest{entries = Entries} = Manifest) when byte_size(Entries) >= ?ENTRY_B ->
+                GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
+                Iterator = rabbitmq_stream_s3_fragment_iterator:init(
+                    Manifest, FirstOffset, GetGroupFun
+                ),
+                Lookup = rabbitmq_stream_s3_fragment_iterator:next(Iterator),
+                case resolve_first_lookup(Lookup) of
+                    {remote, Location} ->
+                        {ok, Location};
+                    {local, first} ->
+                        {local, first};
+                    {retry, Reason} ->
+                        %% A transient group fetch failed while descending to
+                        %% the first fragment. Failing the read setup (rather
+                        %% than falling back to the local tier) makes the
+                        %% consumer retry instead of silently skipping the
+                        %% remote range below the local floor.
+                        {error, Reason}
+                end;
+            (#manifest{}) ->
+                %% No fragment entries: the remote tier is empty here (behind
+                %% the local floor, or retention emptied it), so the local
+                %% first offset is the oldest data that exists.
+                {local, first}
+        end,
+        %% Unreachable from the resolution clauses (they only call in after
+        %% observing a resolved manifest, and a row is never downgraded), but
+        %% stated: a pending row must never be collapsed into the local
+        %% fallback.
+        pending => fun() -> {error, {manifest_not_resolved, StreamId}} end,
+        %% The row was released concurrently (the member is going down); the
+        %% local fallback is moot, the reader is about to die with it.
+        absent => fun() -> {local, first} end
+    }).
 
 %% Interpret the first-fragment lookup returned by the fragment iterator. Total
 %% over the three outcomes of `fragment_iterator:next/1`, with no catch-all so a

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -74,6 +74,7 @@ manifest row.
     get_manifest/1,
     get_manifest_and_epoch/1,
     get_range/1,
+    mark_pending/1,
     put_manifest/2,
     put_manifest/3,
     apply_edit/2,
@@ -133,8 +134,18 @@ manifest row.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--doc "Get the cached manifest for a stream. Direct ETS read.".
--spec get_manifest(stream_id()) -> #manifest{} | undefined.
+-doc """
+Get the cached manifest for a stream. Direct ETS read.
+
+Returns three distinct states, and callers must not conflate them:
+`#manifest{}` is the resolved manifest (possibly empty); `pending` means the
+plugin is attached to this stream on this node but the manifest has not been
+resolved or synced yet, so the remote tier's extent is unknown (readers must
+fail closed, not fall back to the local tier); `undefined` means no plugin
+state exists for the stream on this node (an un-tiered stream), so the local
+log is the whole stream.
+""".
+-spec get_manifest(stream_id()) -> #manifest{} | pending | undefined.
 get_manifest(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
         [{_, Manifest, _Epoch}] -> Manifest;
@@ -144,24 +155,48 @@ get_manifest(StreamId) ->
 -doc """
 Get the cached manifest together with the writer epoch it was stored at. Direct
 ETS read. The epoch is `undefined` when the manifest was stored without one. GC
-uses this to skip a stream whose cache lags the committed epoch.
+uses this to skip a stream whose cache lags the committed epoch. A `pending`
+row (attached but not yet resolved) is reported as `undefined` so GC fails
+closed on it exactly as it does on a missing row.
 """.
 -spec get_manifest_and_epoch(stream_id()) ->
     {#manifest{}, non_neg_integer() | undefined} | undefined.
 get_manifest_and_epoch(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
-        [{_, Manifest, Epoch}] -> {Manifest, Epoch};
+        [{_, #manifest{} = Manifest, Epoch}] -> {Manifest, Epoch};
+        [{_, pending, _}] -> undefined;
         [] -> undefined
     end.
 
--doc "Get the remote tier range for a stream. Direct ETS read.".
+-doc """
+Get the remote tier range for a stream. Direct ETS read. A `pending` row is
+reported as `empty`: the callers of this function (local retention, UI range)
+must act as if nothing is known to be in the remote tier, which for both means
+doing nothing destructive.
+""".
 -spec get_range(stream_id()) -> rabbitmq_stream_s3:range().
 get_range(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
         [{_, #manifest{entries = <<>>}, _}] -> empty;
         [{_, #manifest{first_offset = First, next_offset = Next}, _}] -> {First, Next};
+        [{_, pending, _}] -> empty;
         [] -> empty
     end.
+
+-doc """
+Mark a stream's cache row as `pending` (synchronous): the plugin is attached on
+this node but the manifest is not yet resolved or synced, so readers must fail
+closed rather than treat the remote tier as absent. `register_replica_context/5`
+marks pending automatically for every replica context registration; call this
+directly only for the writer node, which has no replica context to register
+before its remote replica reader resolves the manifest. Insert-if-absent: a row
+surviving from a previous incarnation (a transient reader restart deliberately
+leaves the cache intact, see the replica reader's terminate/2) is never
+downgraded.
+""".
+-spec mark_pending(stream_id()) -> ok.
+mark_pending(StreamId) ->
+    gen_server:call(?MODULE, {mark_pending, StreamId}).
 
 -doc """
 Store a manifest locally (synchronous), recording the writer epoch that produced
@@ -286,6 +321,11 @@ init([]) ->
 handle_call({put_manifest, StreamId, Manifest, Epoch}, _From, State) ->
     write_manifest(StreamId, Manifest, Epoch),
     {reply, ok, State};
+handle_call({mark_pending, StreamId}, _From, State) ->
+    %% Insert-if-absent: never downgrade a resolved manifest (or an existing
+    %% pending marker) that survived a reader restart.
+    _ = ets:insert_new(?TABLE, {StreamId, pending, undefined}),
+    {reply, ok, State};
 handle_call(
     {sync, StreamId, Seq, Epoch, Manifest, WriterNode},
     _From,
@@ -308,7 +348,7 @@ handle_call(
             case maps:get(StreamId, Seqs, undefined) of
                 {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
                     case ets:lookup(?TABLE, StreamId) of
-                        [{_, Manifest0, _}] ->
+                        [{_, #manifest{} = Manifest0, _}] ->
                             case apply_edits_catching(StreamId, Edits, Manifest0) of
                                 {ok, Manifest} ->
                                     write_manifest(StreamId, Manifest, Epoch),
@@ -320,10 +360,11 @@ handle_call(
                                     request_resync(StreamId, WriterNode),
                                     {reply, {error, apply_failed}, State}
                             end;
-                        [] ->
-                            %% A live context always has seqs and the cached row
-                            %% advanced together (write_manifest runs alongside
-                            %% every seqs update below), so this should be
+                        _ ->
+                            %% Missing row or a pending marker. A live context
+                            %% always has seqs and a resolved row advanced
+                            %% together (write_manifest runs alongside every
+                            %% seqs update below), so this should be
                             %% unreachable. Recover via resync rather than trust
                             %% an inconsistent cache.
                             request_resync(StreamId, WriterNode),
@@ -337,7 +378,7 @@ handle_call(
 handle_call({apply_edit, StreamId, Edit}, _From, State) ->
     Reply =
         case ets:lookup(?TABLE, StreamId) of
-            [{_, Manifest0, Epoch0}] ->
+            [{_, #manifest{} = Manifest0, Epoch0}] ->
                 case apply_edits_catching(StreamId, [Edit], Manifest0) of
                     {ok, Manifest} ->
                         write_manifest(StreamId, Manifest, Epoch0),
@@ -346,6 +387,10 @@ handle_call({apply_edit, StreamId, Edit}, _From, State) ->
                     {error, _} = Err ->
                         Err
                 end;
+            %% A pending row has no manifest to edit; the sync that resolves it
+            %% carries the current state, so the edit is not lost, just moot.
+            [{_, pending, _}] ->
+                {error, not_found};
             [] ->
                 {error, not_found}
         end,
@@ -368,6 +413,12 @@ handle_call(
         end,
     MRef = monitor(process, MemberPid),
     Ctx = #replica_ctx{dir = Dir, shared = Shared, counter = Counter, mref = MRef},
+    %% Mark the row pending here rather than at each caller: every context
+    %% registration (member init, or reconciliation re-registering after this
+    %% process itself restarts and drops its contexts) is a point past which a
+    %% reader could attach before the row is resolved. Insert-if-absent: a
+    %% resolved row or an existing pending marker is never downgraded.
+    _ = ets:insert_new(?TABLE, {StreamId, pending, undefined}),
     %% If a sync for this stream was dropped before this context existed, ask its
     %% writer to re-send it now that a monitored context can own the cached row.
     Pending1 = maybe_request_resync(StreamId, Pending0),
@@ -392,6 +443,8 @@ handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs}
                     #manifest{} = Manifest ->
                         run_local_retention(StreamId, Manifest, Ctx),
                         ok;
+                    pending ->
+                        {error, manifest_not_resolved};
                     undefined ->
                         {error, manifest_not_resolved}
                 end;
@@ -409,7 +462,7 @@ handle_cast({put_manifest, StreamId, Manifest, Epoch}, State) ->
     {noreply, State};
 handle_cast({apply_edit, StreamId, Edit}, State) ->
     case ets:lookup(?TABLE, StreamId) of
-        [{_, Manifest0, Epoch0}] ->
+        [{_, #manifest{} = Manifest0, Epoch0}] ->
             case apply_edits_catching(StreamId, [Edit], Manifest0) of
                 {ok, Manifest} ->
                     write_manifest(StreamId, Manifest, Epoch0),
@@ -420,7 +473,8 @@ handle_cast({apply_edit, StreamId, Edit}, State) ->
                     %% gap or sync.
                     ok
             end;
-        [] ->
+        _ ->
+            %% Missing row or a pending marker: nothing to edit.
             ok
     end,
     {noreply, State};
@@ -445,7 +499,7 @@ handle_cast(
                 {LastSeq, Epoch, _} when Seq =:= LastSeq + 1 ->
                     %% In sequence: apply edits.
                     case ets:lookup(?TABLE, StreamId) of
-                        [{_, Manifest0, _}] ->
+                        [{_, #manifest{} = Manifest0, _}] ->
                             case apply_edits_catching(StreamId, Edits, Manifest0) of
                                 {ok, Manifest} ->
                                     write_manifest(StreamId, Manifest, Epoch),
@@ -464,11 +518,12 @@ handle_cast(
                                     request_resync(StreamId, WriterNode),
                                     {noreply, State}
                             end;
-                        [] ->
-                            %% A live context always has seqs and the cached row
-                            %% advanced together, so this should be unreachable.
-                            %% Recover via resync rather than trust an
-                            %% inconsistent cache.
+                        _ ->
+                            %% Missing row or a pending marker. A live context
+                            %% always has seqs and a resolved row advanced
+                            %% together, so this should be unreachable. Recover
+                            %% via resync rather than trust an inconsistent
+                            %% cache.
                             request_resync(StreamId, WriterNode),
                             {noreply, State}
                     end;

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -74,6 +74,7 @@ manifest row.
     get_manifest/1,
     get_manifest_and_epoch/1,
     get_range/1,
+    with_manifest/2,
     mark_pending/1,
     put_manifest/2,
     put_manifest/3,
@@ -144,12 +145,42 @@ resolved or synced yet, so the remote tier's extent is unknown (readers must
 fail closed, not fall back to the local tier); `undefined` means no plugin
 state exists for the stream on this node (an un-tiered stream), so the local
 log is the whole stream.
+
+Code that branches on the state must use `with_manifest/2` instead, which
+makes handling all three states a structural property of the call site. This
+accessor exists for non-branching uses (diagnostics, tests) and for callers
+that immediately re-dispatch through their own total interface.
 """.
 -spec get_manifest(stream_id()) -> #manifest{} | pending | undefined.
 get_manifest(StreamId) ->
     case ets:lookup(?TABLE, StreamId) of
         [{_, Manifest, _Epoch}] -> Manifest;
         [] -> undefined
+    end.
+
+-doc """
+Fold over the cache row's state. The three handlers are mandatory map keys, so
+a caller that fails to consider a state does not compile a quiet fallback into
+place; it fails to match at the call site. This is the enforcement mechanism
+for the Miss semantics invariant (see the Cached state section of
+docs/invariants.md). When a new state is ever added, every `with_manifest/2`
+caller crashes loudly rather than inheriting a neighbor's behavior.
+
+`resolved` receives the manifest (possibly empty); `pending` means attached but
+not yet resolved or synced (readers fail closed, mutators do nothing
+destructive); `absent` means the plugin never attached on this node (an
+un-tiered stream, the local log is the whole stream).
+""".
+-spec with_manifest(stream_id(), #{
+    resolved := fun((#manifest{}) -> Result),
+    pending := fun(() -> Result),
+    absent := fun(() -> Result)
+}) -> Result.
+with_manifest(StreamId, #{resolved := Resolved, pending := Pending, absent := Absent}) ->
+    case get_manifest(StreamId) of
+        #manifest{} = Manifest -> Resolved(Manifest);
+        pending -> Pending();
+        undefined -> Absent()
     end.
 
 -doc """
@@ -433,21 +464,22 @@ handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs}
     Reply =
         case maps:get(StreamId, Ctxs, undefined) of
             #replica_ctx{} = Ctx ->
-                case get_manifest(StreamId) of
-                    #manifest{entries = <<>>} ->
-                        %% No remote tier yet: nothing has been uploaded, so no
-                        %% local segment is safe to delete. Returning early also
-                        %% avoids feeding the empty manifest's -1 first_timestamp
-                        %% sentinel into the counter (see run_local_retention).
-                        ok;
-                    #manifest{} = Manifest ->
-                        run_local_retention(StreamId, Manifest, Ctx),
-                        ok;
-                    pending ->
-                        {error, manifest_not_resolved};
-                    undefined ->
-                        {error, manifest_not_resolved}
-                end;
+                with_manifest(StreamId, #{
+                    resolved => fun
+                        (#manifest{entries = <<>>}) ->
+                            %% No remote tier yet: nothing has been uploaded,
+                            %% so no local segment is safe to delete. Returning
+                            %% early also avoids feeding the empty manifest's
+                            %% -1 first_timestamp sentinel into the counter
+                            %% (see run_local_retention).
+                            ok;
+                        (#manifest{} = Manifest) ->
+                            run_local_retention(StreamId, Manifest, Ctx),
+                            ok
+                    end,
+                    pending => fun() -> {error, manifest_not_resolved} end,
+                    absent => fun() -> {error, manifest_not_resolved} end
+                });
             undefined ->
                 {error, {not_found, StreamId}}
         end,

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -481,44 +481,51 @@ execute_effect(stop, State) ->
 %% Rebuild the fragment iterator from the manifest cache, advancing past
 %% the given offset (the fragment known to be 404).
 refresh_iterator(StreamId, NotFoundOffset) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{first_offset = First, next_offset = Next} = Manifest ->
-            GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
-            Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
-                Manifest, NotFoundOffset, GetGroupFun
-            ),
-            %% Advance past the 404'd fragment.
-            Iterator =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
-                    {ok, #fragment_ref{offset = O}, It} when O =< NotFoundOffset -> It;
-                    _ -> Iterator0
-                end,
-            %% Check if there's anything after.
-            Result =
-                case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
-                    {ok, #fragment_ref{offset = NextOff}, _} -> {iterator, NextOff};
-                    _ -> end_of_manifest
-                end,
-            ?LOG_DEBUG(
-                "refresh_iterator for stream '~ts': not_found_offset=~b"
-                " manifest_first=~b manifest_next=~b result=~p",
-                [StreamId, NotFoundOffset, First, Next, Result]
-            ),
-            case Result of
-                {iterator, _} -> Iterator;
-                end_of_manifest -> end_of_manifest
-            end;
-        Missing when Missing =:= undefined; Missing =:= pending ->
-            %% A resolved row is never downgraded, so mid-read this means the
-            %% row was released: the member is going down and this reader is
-            %% about to die with it. end_of_manifest hands off to the local
-            %% tier, whose own teardown handles the rest.
-            ?LOG_DEBUG(
-                "refresh_iterator for stream '~ts': not_found_offset=~b"
-                " manifest=~p result=end_of_manifest",
-                [StreamId, NotFoundOffset, Missing]
-            ),
-            end_of_manifest
+    %% A resolved row is never downgraded, so a pending or absent row mid-read
+    %% means the row was released: the member is going down and this reader is
+    %% about to die with it. end_of_manifest hands off to the local tier, whose
+    %% own teardown handles the rest.
+    Released = fun() ->
+        ?LOG_DEBUG(
+            "refresh_iterator for stream '~ts': not_found_offset=~b"
+            " manifest unavailable, result=end_of_manifest",
+            [StreamId, NotFoundOffset]
+        ),
+        end_of_manifest
+    end,
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun(Manifest) -> refresh_iterator1(StreamId, NotFoundOffset, Manifest) end,
+        pending => Released,
+        absent => Released
+    }).
+
+refresh_iterator1(
+    StreamId, NotFoundOffset, #manifest{first_offset = First, next_offset = Next} = Manifest
+) ->
+    GetGroupFun = rabbitmq_stream_s3_manifest:get_group_fun(StreamId),
+    Iterator0 = rabbitmq_stream_s3_fragment_iterator:init(
+        Manifest, NotFoundOffset, GetGroupFun
+    ),
+    %% Advance past the 404'd fragment.
+    Iterator =
+        case rabbitmq_stream_s3_fragment_iterator:next(Iterator0) of
+            {ok, #fragment_ref{offset = O}, It} when O =< NotFoundOffset -> It;
+            _ -> Iterator0
+        end,
+    %% Check if there's anything after.
+    Result =
+        case rabbitmq_stream_s3_fragment_iterator:next(Iterator) of
+            {ok, #fragment_ref{offset = NextOff}, _} -> {iterator, NextOff};
+            _ -> end_of_manifest
+        end,
+    ?LOG_DEBUG(
+        "refresh_iterator for stream '~ts': not_found_offset=~b"
+        " manifest_first=~b manifest_next=~b result=~p",
+        [StreamId, NotFoundOffset, First, Next, Result]
+    ),
+    case Result of
+        {iterator, _} -> Iterator;
+        end_of_manifest -> end_of_manifest
     end.
 
 maybe_stop(#state{stopping = true} = State) ->

--- a/src/rabbitmq_stream_s3_remote_reader.erl
+++ b/src/rabbitmq_stream_s3_remote_reader.erl
@@ -508,11 +508,15 @@ refresh_iterator(StreamId, NotFoundOffset) ->
                 {iterator, _} -> Iterator;
                 end_of_manifest -> end_of_manifest
             end;
-        _ ->
+        Missing when Missing =:= undefined; Missing =:= pending ->
+            %% A resolved row is never downgraded, so mid-read this means the
+            %% row was released: the member is going down and this reader is
+            %% about to die with it. end_of_manifest hands off to the local
+            %% tier, whose own teardown handles the rest.
             ?LOG_DEBUG(
                 "refresh_iterator for stream '~ts': not_found_offset=~b"
-                " manifest=undefined result=end_of_manifest",
-                [StreamId, NotFoundOffset]
+                " manifest=~p result=end_of_manifest",
+                [StreamId, NotFoundOffset, Missing]
             ),
             end_of_manifest
     end.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -775,23 +775,25 @@ maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId, epoch
             %% No remote tier yet; nothing to cache.
             ok;
         #manifest{} = Manifest ->
-            case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                Missing when Missing =:= undefined; Missing =:= pending ->
-                    %% undefined: the manifest_replica restarted and lost the
-                    %% row. pending: a marker leaked from an incarnation that
-                    %% died between init and resolution. Both leave readers
-                    %% unable to resolve the remote tier, so re-seed.
-                    ?LOG_INFO(
-                        "Reconciliation: re-seeding the local manifest cache for "
-                        "stream ~ts after a manifest_replica restart",
-                        [StreamId]
-                    ),
-                    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
-                        StreamId, Manifest, Epoch
-                    );
-                #manifest{} ->
-                    ok
-            end
+            %% An absent row means the manifest_replica restarted and lost it;
+            %% a pending row is a marker leaked from an incarnation that died
+            %% between init and resolution. Both leave readers unable to
+            %% resolve the remote tier, so re-seed.
+            Reseed = fun() ->
+                ?LOG_INFO(
+                    "Reconciliation: re-seeding the local manifest cache for "
+                    "stream ~ts after a manifest_replica restart",
+                    [StreamId]
+                ),
+                ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
+                    StreamId, Manifest, Epoch
+                )
+            end,
+            rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+                resolved => fun(_) -> ok end,
+                pending => Reseed,
+                absent => Reseed
+            })
     end.
 
 %% Proactively register replica nodes for manifest broadcast.
@@ -1297,19 +1299,20 @@ maybe_spawn_group_retention(_Manifest, _Retention, _Now, _StreamId, State) ->
 
 -spec resolve_manifest(stream_id()) -> {ok, #manifest{}} | {retry, term()}.
 resolve_manifest(StreamId) ->
-    case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-        #manifest{} = M ->
+    %% A pending row is this incarnation's own init marker (or a
+    %% predecessor's): there is no cached manifest to trust, so resolve
+    %% authoritatively, exactly as for an absent row.
+    FromStore = fun() -> resolve_manifest_from_store(StreamId) end,
+    rabbitmq_stream_s3_manifest_replica:with_manifest(StreamId, #{
+        resolved => fun(M) ->
             case classify_cache_result(M, catch rabbitmq_stream_s3_db:get(StreamId)) of
                 {ok, _} = Ok -> Ok;
                 resolve_from_store -> resolve_manifest_from_store(StreamId)
-            end;
-        %% pending is this incarnation's own init marker (or a predecessor's):
-        %% there is no cached manifest to trust, so resolve authoritatively.
-        pending ->
-            resolve_manifest_from_store(StreamId);
-        undefined ->
-            resolve_manifest_from_store(StreamId)
-    end.
+            end
+        end,
+        pending => FromStore,
+        absent => FromStore
+    }).
 
 %% Decide whether the locally cached manifest may be trusted on resolution
 %% (startup, promotion, reinitialize, recovery). Split out like

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -382,6 +382,13 @@ init(
         epoch = Epoch
     },
     Retention = maps:get(retention, Args, []),
+    %% Mark this node's manifest cache row pending before returning: init runs
+    %% inside the on_init(writer) hook, synchronously within osiris_log:init,
+    %% so the row exists before the member finishes starting and therefore
+    %% before any consumer can attach a reader. Readers fail closed on pending
+    %% until resolve_manifest seeds the resolved manifest. Insert-if-absent: a
+    %% row surviving a transient reader restart is never downgraded.
+    ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
     {ok,
         #state{
             cfg = Cfg,
@@ -769,7 +776,11 @@ maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId, epoch
             ok;
         #manifest{} = Manifest ->
             case rabbitmq_stream_s3_manifest_replica:get_manifest(StreamId) of
-                undefined ->
+                Missing when Missing =:= undefined; Missing =:= pending ->
+                    %% undefined: the manifest_replica restarted and lost the
+                    %% row. pending: a marker leaked from an incarnation that
+                    %% died between init and resolution. Both leave readers
+                    %% unable to resolve the remote tier, so re-seed.
                     ?LOG_INFO(
                         "Reconciliation: re-seeding the local manifest cache for "
                         "stream ~ts after a manifest_replica restart",
@@ -778,7 +789,7 @@ maybe_reseed_local_cache(#state{core = Core, cfg = #cfg{stream = StreamId, epoch
                     ok = rabbitmq_stream_s3_manifest_replica:put_manifest(
                         StreamId, Manifest, Epoch
                     );
-                _ ->
+                #manifest{} ->
                     ok
             end
     end.
@@ -1292,6 +1303,10 @@ resolve_manifest(StreamId) ->
                 {ok, _} = Ok -> Ok;
                 resolve_from_store -> resolve_manifest_from_store(StreamId)
             end;
+        %% pending is this incarnation's own init marker (or a predecessor's):
+        %% there is no cached manifest to trust, so resolve authoritatively.
+        pending ->
+            resolve_manifest_from_store(StreamId);
         undefined ->
             resolve_manifest_from_store(StreamId)
     end.
@@ -2413,16 +2428,31 @@ apply_task_crash(retention, Reason, #state{tasks = Tasks0, cfg = #cfg{stream = S
     ),
     apply_retention_decisions(Decisions, State0#state{tasks = Tasks}).
 
-on_manifest_resolved(#manifest{next_offset = 0}, State) ->
+on_manifest_resolved(
+    #manifest{next_offset = 0} = Manifest,
+    #state{cfg = #cfg{stream = StreamId, epoch = Epoch}} = State
+) ->
     inc(State, ?C_MANIFESTS_RESOLVED_EMPTY, 1),
     update_manifest_gauges(#manifest{}, State),
+    %% Seed the cache row even when the resolved manifest is empty: the row
+    %% replaces the pending marker written at init, telling readers the remote
+    %% tier is resolved (and empty) so they stop failing closed and serve
+    %% locally. Without this a brand-new stream would fail closed until its
+    %% first persist.
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, Manifest, Epoch),
     State;
 on_manifest_resolved(
     #manifest{first_offset = ManifestFirst, first_timestamp = ManifestFirstTs} = Manifest,
-    #state{cfg = #cfg{counter = Cnt}} = State
+    #state{cfg = #cfg{stream = StreamId, epoch = Epoch, counter = Cnt}} = State
 ) ->
     inc(State, ?C_MANIFESTS_RESOLVED, 1),
     update_manifest_gauges(Manifest, State),
+    %% Seed this node's manifest cache row from the just-resolved manifest,
+    %% replacing the pending marker written at init, so consumers attaching at
+    %% 'first' (or any offset below the local floor) can see the remote tier
+    %% without waiting for a publish-driven persist or the reconciler's
+    %% periodic reseed.
+    ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, Manifest, Epoch),
     %% Seed the osiris first-offset and first-timestamp counters immediately so
     %% the management UI reflects the remote tier's range without waiting for the
     %% first retention evaluation or manifest edit. Without this, an idle stream

--- a/test/broker_SUITE.erl
+++ b/test/broker_SUITE.erl
@@ -12,7 +12,7 @@
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
 all() ->
-    [{group, cluster_size_3}].
+    [{group, cluster_size_3}, {group, cluster_size_1}].
 
 groups() ->
     [
@@ -24,6 +24,14 @@ groups() ->
             plugin_disable_reenable,
             prometheus_metrics,
             bucket_monitor_reports_accessible
+        ]},
+        %% Single node on purpose: with replicas, an acceptor's cache is seeded
+        %% by the writer's sync within milliseconds of the member starting, so
+        %% the cold-cache boot window is only reachable on the writer's own
+        %% node with no peer to sync from. A 3-node version of the restart case
+        %% passes with and without the seeding fix (a hollow green).
+        {cluster_size_1, [], [
+            restarted_node_serves_first_from_remote_tier
         ]}
     ].
 
@@ -39,11 +47,16 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-init_per_group(cluster_size_3, Config) ->
+init_per_group(Group, Config) ->
+    Count =
+        case Group of
+            cluster_size_3 -> 3;
+            cluster_size_1 -> 1
+        end,
     DataDir = filename:join([?config(priv_dir, Config), "remote_tier"]),
     Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodes_count, 3},
-        {rmq_nodename_suffix, ?MODULE}
+        {rmq_nodes_count, Count},
+        {rmq_nodename_suffix, Group}
     ]),
     Config2 = rabbit_ct_helpers:merge_app_env(Config1, [
         {rabbitmq_stream_s3, [
@@ -143,6 +156,46 @@ consumer_reads_across_tiers(Config) ->
     [?assertEqual(Payload, M) || M <- Messages],
 
     amqp_channel:call(Ch, #'queue.delete'{queue = QName}),
+    ok.
+
+%% A node restart empties the node's manifest cache (ETS), and with no publish
+%% afterwards nothing re-seeds it through a persist. A consumer subscribing at
+%% 'first' on the restarted node, after local retention has trimmed the
+%% earliest segments, must still read from the beginning of the stream in the
+%% remote tier - never silently attach at the local floor. Attach may
+%% transiently fail closed while the manifest resolves; the subscribe helper
+%% retries like a real reconnecting client.
+restarted_node_serves_first_from_remote_tier(Config) ->
+    QName = <<"restart_first_remote">>,
+    Ch = rabbit_ct_client_helpers:open_channel(Config),
+    stream_declare(Ch, QName, [{<<"x-stream-max-segment-size-bytes">>, long, 5000}]),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+
+    Payload = binary:copy(<<0>>, 600),
+    N = 20,
+    [publish(Ch, QName, Payload) || _ <- lists:seq(1, N)],
+    true = amqp_channel:wait_for_confirms(Ch, 30),
+    %% The channel lives on node 0, which may be the node restarted below.
+    rabbit_ct_client_helpers:close_channel(Ch),
+
+    #{stream_id := StreamId, writer_node := WriterNode} = get_stream_info(Config, QName),
+    ok = await_offset(Config, WriterNode, StreamId, N),
+    %% Wait for local retention to trim the earliest segment on the writer
+    %% node, so 'first' exists only in the remote tier there.
+    ?awaitMatch([S | _] when S > 0, list_segments(Config, WriterNode, StreamId), 5000),
+
+    WriterIdx = node_index(Config, WriterNode),
+    ok = rabbit_ct_broker_helpers:restart_node(Config, WriterIdx),
+
+    %% Subscribe at 'first' on the restarted node without publishing anything.
+    {S, C1, SubId} = connect_subscribe_first_retry(Config, WriterIdx, QName, 60),
+    Messages = receive_messages(S, C1, SubId, N),
+    gen_tcp:close(S),
+    ?assertEqual(N, length(Messages)),
+    [?assertEqual(Payload, M) || M <- Messages],
+
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config),
+    amqp_channel:call(Ch2, #'queue.delete'{queue = QName}),
     ok.
 
 leadership_transfer_continues_upload(Config) ->
@@ -509,6 +562,34 @@ list_segments(Config, Node, StreamId) ->
         list_segment_offsets_local,
         [StreamId]
     ).
+
+node_index(Config, Node) ->
+    Names = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    length(lists:takewhile(fun(N) -> N =/= Node end, Names)).
+
+%% Connect to the given node and subscribe at 'first', retrying on any
+%% failure: right after a node restart the member may not be running yet, and
+%% a fail-closed attach (manifest not yet resolved) closes the connection.
+%% Real clients reconnect and retry; so does this helper.
+connect_subscribe_first_retry(_Config, _Idx, QName, 0) ->
+    ct:fail({subscribe_first_never_succeeded, QName});
+connect_subscribe_first_retry(Config, Idx, QName, Attempts) ->
+    SubId = 1,
+    try
+        {ok, S, C0} = stream_test_utils:connect(Config, Idx),
+        try stream_test_utils:subscribe(S, C0, QName, SubId, 10000, #{}, first) of
+            {ok, C1} ->
+                {S, C1, SubId}
+        catch
+            _:_ ->
+                catch gen_tcp:close(S),
+                error(subscribe_failed)
+        end
+    catch
+        _:_ ->
+            timer:sleep(250),
+            connect_subscribe_first_retry(Config, Idx, QName, Attempts - 1)
+    end.
 
 receive_messages(S, C0, SubId, N) ->
     receive_messages(S, C0, SubId, N, []).

--- a/test/manifest_replica_SUITE.erl
+++ b/test/manifest_replica_SUITE.erl
@@ -33,7 +33,9 @@ all() ->
         sync_without_context_dropped,
         register_after_dropped_sync_requests_resync,
         apply_edits_without_context_dropped,
-        register_after_dropped_edits_requests_resync
+        register_after_dropped_edits_requests_resync,
+        register_replica_context_marks_pending,
+        mark_pending_does_not_downgrade_resolved
     ].
 
 init_per_suite(Config) ->
@@ -130,6 +132,51 @@ reregister_repoints_monitor(_Config) ->
     %% The new member dies: now the context is released.
     exit(New, kill),
     ok = await(fun() -> not Replica:is_context_registered(Stream) end).
+
+%% register_replica_context marks the row pending before the member finishes
+%% starting: a reader attaching in the window before a sync or resolution lands
+%% must fail closed rather than see the row as absent.
+register_replica_context_marks_pending(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"pending-on-register-stream">>,
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    Member = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+
+    ?assertEqual(undefined, Replica:get_manifest(Stream)),
+    ok = Replica:register_replica_context(Stream, Member, <<"/tmp/s">>, Shared, Counter),
+    ?assertEqual(pending, Replica:get_manifest(Stream)).
+
+%% The pending marker is insert-if-absent: it must never downgrade a row that
+%% has already resolved, whether the caller racing behind the resolution is a
+%% repeated register_replica_context (reconciliation re-registering a replica
+%% after manifest_replica itself restarts) or a direct mark_pending call (the
+%% writer path).
+mark_pending_does_not_downgrade_resolved(_Config) ->
+    Replica = rabbitmq_stream_s3_manifest_replica,
+    Stream = <<"resolved-then-pending-stream">>,
+    Shared = atomics:new(1, []),
+    Counter = counters:new(5, []),
+    Member = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    {Manifest, _} = build_manifest([{fragment, #{offset => 0, size => 1000}}]),
+
+    ok = Replica:register_replica_context(Stream, Member, <<"/tmp/s">>, Shared, Counter),
+    ok = Replica:sync(Stream, 0, 1, Manifest),
+    ?assertEqual(Manifest, Replica:get_manifest(Stream)),
+
+    ok = Replica:register_replica_context(Stream, Member, <<"/tmp/s">>, Shared, Counter),
+    ?assertEqual(Manifest, Replica:get_manifest(Stream)),
+
+    ok = Replica:mark_pending(Stream),
+    ?assertEqual(Manifest, Replica:get_manifest(Stream)).
 
 %% A sync for a stream with no registered reader context is dropped rather than
 %% caching a row that no member monitor would ever reclaim (the pre-registration

--- a/test/manifest_replica_statem_SUITE.erl
+++ b/test/manifest_replica_statem_SUITE.erl
@@ -236,7 +236,7 @@ postcondition(S, {call, _, do_sync, [StreamId, Seq, Epoch]}, Res) ->
                 case ?REPLICA:is_stale_sync(Epoch, Seq, Recorded) of
                     true ->
                         %% Stale: dropped, cache unchanged.
-                        ?REPLICA:get_manifest(StreamId) =:= maps:get(manifest, SM) andalso
+                        ?REPLICA:get_manifest(StreamId) =:= expected_manifest(SM) andalso
                             ?REPLICA:get_manifest_and_epoch(StreamId) =:=
                                 expected_manifest_and_epoch(SM);
                     false ->
@@ -269,11 +269,23 @@ postcondition(S, {call, _, do_apply_edits, [StreamId, Edit, Seq, Epoch]}, Res) -
                 _ ->
                     %% Property 3: gap/epoch mismatch never corrupts the cache.
                     Res =:= {error, gap} andalso
-                        ?REPLICA:get_manifest(StreamId) =:= maps:get(manifest, SM) andalso
+                        ?REPLICA:get_manifest(StreamId) =:= expected_manifest(SM) andalso
                         ?REPLICA:get_manifest_and_epoch(StreamId) =:=
                             expected_manifest_and_epoch(SM)
             end
     end.
+
+%% get_manifest/1's return for a stream in this model state. A registered
+%% stream's row always exists: register_replica_context/5 marks it pending, so
+%% a stream that has never synced or applied an edit reports pending, not
+%% undefined. get_manifest_and_epoch/1 and get_range/1 do not make this
+%% distinction (see expected_manifest_and_epoch/1); only get_manifest/1 does.
+expected_manifest(#{registered := false}) ->
+    undefined;
+expected_manifest(#{manifest := undefined}) ->
+    pending;
+expected_manifest(#{manifest := M}) ->
+    M.
 
 manifest_or_default(SM) ->
     case maps:get(manifest, SM) of

--- a/test/prop_SUITE.erl
+++ b/test/prop_SUITE.erl
@@ -76,6 +76,7 @@ all() ->
         gc_classify_never_reaps_live,
         gc_classify_reclaims_orphans,
         gc_still_dangling_respects_live_manifest,
+        gc_still_dangling_pending_row_never_deletes,
         gc_stream_lookup_epoch_gate,
         gc_fresh_enough_fails_closed,
         gc_anchor_decision_fails_closed,
@@ -2181,6 +2182,34 @@ prop_gc_still_dangling_respects_live_manifest() ->
                 fun(B) -> B end,
                 LeadingChecks ++ DataChecks ++ GroupChecks ++ EpochChecks
             )
+        end
+    ).
+
+%% A pending row (attached but not yet resolved) is not a live manifest to
+%% compare against: still_dangling must never treat any offset or group as
+%% deletable while a stream's row is in that state.
+gc_still_dangling_pending_row_never_deletes(_Config) ->
+    {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
+    unlink(Pid),
+    try
+        rabbit_ct_proper_helpers:run_proper(
+            fun prop_gc_still_dangling_pending_row_never_deletes/0, [], 300
+        )
+    after
+        gen_server:stop(Pid)
+    end.
+
+prop_gc_still_dangling_pending_row_never_deletes() ->
+    ?FORALL(
+        {Offset, Uid},
+        {non_neg_integer(), gc_uid()},
+        begin
+            StreamId = <<"gc-still-dangling-pending-prop-stream">>,
+            ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
+            DataKey = rabbitmq_stream_s3:fragment_key(StreamId, Offset, Uid),
+            GroupKey = gc_group_key(StreamId, Offset, Uid),
+            not gc_still_dangling(StreamId, DataKey) andalso
+                not gc_still_dangling(StreamId, GroupKey)
         end
     ).
 

--- a/test/read_resolution_SUITE.erl
+++ b/test/read_resolution_SUITE.erl
@@ -42,7 +42,9 @@ all() ->
         property_catches_collapsed_transient_error,
         collapsed_transient_error_is_deterministically_caught,
         routing_offset_in_local_tier_resolves_local,
-        routing_cold_cache_below_floor_resolves_first,
+        routing_unattached_below_floor_resolves_first,
+        routing_pending_below_floor_fails_closed,
+        routing_pending_spec_first_fails_closed,
         routing_empty_local_log_routes_remote
     ].
 
@@ -139,14 +141,16 @@ prop_offset_in_local_tier_local() ->
         end
     ).
 
-%% An offset below the local floor with no cached manifest (a cold or
-%% not-yet-synced cache) attaches at the local first offset, never the tail.
-routing_cold_cache_below_floor_resolves_first(_Config) ->
+%% An offset below the local floor on a stream with no cache row at all (the
+%% plugin never attached: an un-tiered stream) attaches at the local first
+%% offset, never the tail. The local log is the whole stream here, so local
+%% emulation is correct, not a silent skip.
+routing_unattached_below_floor_resolves_first(_Config) ->
     rabbit_ct_proper_helpers:run_proper(
-        fun() -> prop_cold_cache_below_floor_first() end, [], 1000
+        fun() -> prop_unattached_below_floor_first() end, [], 1000
     ).
 
-prop_cold_cache_below_floor_first() ->
+prop_unattached_below_floor_first() ->
     ?FORALL(
         {Floor, BelowDelta},
         {range(1, 1_000_000), range(1, 1_000_000)},
@@ -154,9 +158,58 @@ prop_cold_cache_below_floor_first() ->
             Offset = max(0, Floor - BelowDelta),
             Shared = osiris_log_shared:new(),
             ok = osiris_log_shared:set_first_chunk_id(Shared, Floor),
-            %% A stream id with no manifest ever put: get_manifest -> undefined.
-            Config = #{name => <<"routing-cold-cache-never-put">>, shared => Shared},
+            %% A stream id with no row ever written: get_manifest -> undefined.
+            Config = #{name => <<"routing-unattached-never-put">>, shared => Shared},
             ?LR:resolve_remote_location(Offset, Config) =:= {local, first}
+        end
+    ).
+
+%% An offset below the local floor while the cache row is pending (the plugin is
+%% attached but the manifest is not yet resolved or synced) must fail closed
+%% with a retryable error. The remote tier's extent is unknown at that moment;
+%% falling back to the local tier would silently skip the remote range below
+%% the local floor.
+routing_pending_below_floor_fails_closed(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_pending_below_floor_fails_closed() end, [], 1000
+    ).
+
+prop_pending_below_floor_fails_closed() ->
+    ?FORALL(
+        {Floor, BelowDelta},
+        {range(1, 1_000_000), range(1, 1_000_000)},
+        begin
+            Offset = max(0, Floor - BelowDelta),
+            StreamId = <<"routing-pending-below-floor">>,
+            ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
+            Shared = osiris_log_shared:new(),
+            ok = osiris_log_shared:set_first_chunk_id(Shared, Floor),
+            Config = #{name => StreamId, shared => Shared},
+            ?LR:resolve_remote_location(Offset, Config) =:=
+                {error, {manifest_not_resolved, StreamId}}
+        end
+    ).
+
+%% The 'first' spec while the cache row is pending must fail closed for any
+%% local floor, populated or empty: 'first' means the beginning of the stream,
+%% and where the stream begins is unknown until the manifest resolves.
+routing_pending_spec_first_fails_closed(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+        fun() -> prop_pending_spec_first_fails_closed() end, [], 1000
+    ).
+
+prop_pending_spec_first_fails_closed() ->
+    ?FORALL(
+        Floor,
+        oneof([-1, range(0, 1_000_000)]),
+        begin
+            StreamId = <<"routing-pending-spec-first">>,
+            ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
+            Shared = osiris_log_shared:new(),
+            ok = osiris_log_shared:set_first_chunk_id(Shared, Floor),
+            Config = #{name => StreamId, shared => Shared},
+            ?LR:resolve_remote_location(first, Config) =:=
+                {error, {manifest_not_resolved, StreamId}}
         end
     ).
 


### PR DESCRIPTION
*Issue #, if available:* fixes https://github.com/amazon-mq/rabbitmq-stream-s3/issues/333

*Description of changes:* I was surprised to find https://github.com/amazon-mq/rabbitmq-stream-s3/issues/333 manually. That the bug survived is a failure of the documentation and P models, and there's room for improvement in the manifest cache API to make decisions around cache state explicit. There are a lot of changes in this branch around that theme, but the actual changes to the manifest cache and log reader are fairly straightforward.

When starting, we mark the manifest for a stream as pending if it hasn't been downloaded yet. This allows us to defer operations that need the manifest (e.g. reading from `first`) until it has been downloaded - they fail closed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
