### PR TITLE
log reader: Use 'unavailable' error when manifest is not yet resolved

### DIFF
--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -89,7 +89,7 @@ Discarding remote manifest and restarting from the local log.
 
 **Trigger.** A node restarts, emptying its in-memory manifest cache, and no publish follows. This is the most ordinary event in the catalog: an upgrade, a reboot, a crash-and-recover, followed by consumers reconnecting before producers do.
 
-**Impact assessment.** None. The member-init hooks mark the stream's cache row `pending` before the member finishes starting, and the replica reader's manifest resolution (writer node) or the writer's sync (replica nodes) replaces the marker moments later. A consumer that attaches inside that window has its subscription fail closed with `{error, {manifest_not_resolved, _}}` and retries; it cannot be silently attached at the local floor.
+**Impact assessment.** None. The member-init hooks mark the stream's cache row `pending` before the member finishes starting, and the replica reader's manifest resolution (writer node) or the writer's sync (replica nodes) replaces the marker moments later. A consumer that attaches inside that window has its subscription fail closed with `osiris_log_reader`'s `{error, unavailable}` and retries; it cannot be silently attached at the local floor.
 
 **Detection.**
 

--- a/docs/read-path.md
+++ b/docs/read-path.md
@@ -33,7 +33,7 @@ Decision logic with a resolved manifest:
 
 Decision logic without one:
 
-- If the row is `pending` (the plugin is attached on this node but the manifest has not been resolved or synced yet, for example in the first moments after a member starts): fail closed with `{error, {manifest_not_resolved, StreamId}}` for any spec the remote tier may hold (`first`, a below-floor offset, a timestamp, `{abs, _}`). The subscription fails and the client retries; falling back to the local tier here would silently skip the remote range below the local floor. The `resolve_failed_closed` counter records these.
+- If the row is `pending` (the plugin is attached on this node but the manifest has not been resolved or synced yet, for example in the first moments after a member starts): fail closed with `osiris_log_reader`'s `{error, unavailable}` for any spec the remote tier may hold (`first`, a below-floor offset, a timestamp, `{abs, _}`). The subscription fails and the client retries; falling back to the local tier here would silently skip the remote range below the local floor. The `resolve_failed_closed` counter records these.
 - If there is no row at all: the plugin never attached to this stream on this node (an un-tiered stream), so the local log is the whole stream and local resolution is exact.
 
 For timestamp-based specs, the log reader binary-searches the manifest's entries (each entry has `first_timestamp` and `last_timestamp`) to find the fragment containing the target timestamp.

--- a/src/rabbitmq_stream_s3_log_reader.erl
+++ b/src/rabbitmq_stream_s3_log_reader.erl
@@ -182,13 +182,15 @@ resolve_offset_spec(OffsetSpec, Config) ->
             {ok, ChunkId};
         {local, LocalSpec} ->
             osiris_log:resolve_offset_spec(LocalSpec, Config);
-        {error, {manifest_not_resolved, _}} = Err ->
+        {error, {manifest_not_resolved, _}} ->
             %% Same fail-closed accounting as init_offset_reader/2: without
             %% this, a caller that resolves through this callback instead of
             %% init_offset_reader/2 has its fail-closed attaches invisible to
-            %% the alertable counter.
+            %% the alertable counter. osiris_log_reader's transient_error/0
+            %% contract is the external shape; the specific reason stays
+            %% internal to this module.
             record_resolve_failed_closed(T0),
-            Err;
+            {error, unavailable};
         {error, _} = Err ->
             Err
     end.
@@ -202,7 +204,7 @@ init_offset_reader(OffsetSpec, Config) ->
         {local, LocalSpec} ->
             record_resolve(T0, local, OffsetSpec),
             init_local_reader(LocalSpec, Config);
-        {error, {manifest_not_resolved, StreamId}} = Err ->
+        {error, {manifest_not_resolved, StreamId}} ->
             %% Fail closed: the manifest cache row is still pending, so the
             %% remote tier's extent is unknown for a spec that may live in it.
             %% The consumer's retry lands after resolution (normally
@@ -210,7 +212,9 @@ init_offset_reader(OffsetSpec, Config) ->
             %% during the attach window; sustained repeats mean manifest
             %% resolution is stuck and the resolve_failed_closed counter (and
             %% the replica reader's manifest_resolution_failures) is the
-            %% alertable signal.
+            %% alertable signal. osiris_log_reader's transient_error/0 contract
+            %% ({error, unavailable}) is the external shape a caller sees; the
+            %% specific reason logged here stays internal to this module.
             ?LOG_INFO(
                 "Failing reader setup closed for stream '~ts': offset spec ~w "
                 "may be in the remote tier but the manifest is not yet "
@@ -219,7 +223,7 @@ init_offset_reader(OffsetSpec, Config) ->
                 ?DOMAIN
             ),
             record_resolve_failed_closed(T0),
-            Err;
+            {error, unavailable};
         {error, _} = Err ->
             Err
     end.

--- a/test/read_resolution_SUITE.erl
+++ b/test/read_resolution_SUITE.erl
@@ -45,15 +45,19 @@ all() ->
         routing_unattached_below_floor_resolves_first,
         routing_pending_below_floor_fails_closed,
         routing_pending_spec_first_fails_closed,
-        routing_empty_local_log_routes_remote
+        routing_empty_local_log_routes_remote,
+        pending_row_reports_unavailable_at_callback_boundary
     ].
 
 %% The routing properties drive the real `log_reader:resolve_remote_location/2`,
 %% which reads the cached manifest through `manifest_replica`. The pure-core cases
 %% above do not need it, but a singleton is cheap to keep for the whole suite.
 init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(osiris),
+    _ = seshat:new_group(rabbitmq_stream_s3),
     {ok, Pid} = rabbitmq_stream_s3_manifest_replica:start_link(),
     unlink(Pid),
+    ok = rabbitmq_stream_s3_log_reader:init_counters(),
     [{manifest_replica, Pid} | Config].
 
 end_per_suite(Config) ->
@@ -212,6 +216,21 @@ prop_pending_spec_first_fails_closed() ->
                 {error, {manifest_not_resolved, StreamId}}
         end
     ).
+
+%% resolve_remote_location/2 (exercised above) reports a pending row with the
+%% plugin's own internal reason, but init_offset_reader/2 and
+%% resolve_offset_spec/2 are the two functions that actually implement the
+%% osiris_log_reader callback contract: at that boundary the internal reason
+%% must be translated to osiris_log_reader's transient_error/0 contract
+%% ({error, unavailable}), not leaked out as a plugin-specific term.
+pending_row_reports_unavailable_at_callback_boundary(_Config) ->
+    StreamId = <<"pending-callback-boundary">>,
+    ok = rabbitmq_stream_s3_manifest_replica:mark_pending(StreamId),
+    Shared = osiris_log_shared:new(),
+    ok = osiris_log_shared:set_first_chunk_id(Shared, 100),
+    Cfg = #{name => StreamId, shared => Shared},
+    ?assertEqual({error, unavailable}, ?LR:init_offset_reader(first, Cfg)),
+    ?assertEqual({error, unavailable}, ?LR:resolve_offset_spec(first, Cfg)).
 
 %% With the local log empty (first_chunk_id = -1) and a populated remote tier,
 %% the beginning and any offset below the remote first resolve to the remote


### PR DESCRIPTION
This 'unavailable' state is newly added to osiris_log_reader (in the most recent force-push). It is handled by stream consumers in the server and translates to whatever protocol-specific code is suitable for a transient error.

This is a follow-up to #339

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
