### PR TITLE
Cancel unnecssary governor submissions

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -32,6 +32,14 @@ For the manifest cache this is enforced structurally, not by convention: branchi
 
 The direction of each explicit miss clause matters: consumers must fail in the direction that cannot lose data. Readers fail closed (error, the consumer retries), retention deletes nothing, GC skips, resolution goes to the authoritative store. A fallback that degrades silently reads as robustness in review and is exactly where correctness leaks out.
 
+## Derived gauges
+
+A gauge whose value is a pure function of process state should be published from that state on every handler return, not incremented and decremented at the edges. Counters live in `persistent_term` and outlive the process that maintains them; the state they describe does not. An inc/dec gauge therefore ratchets permanently on the one path that deliberately runs no cleanup - a crash, where the pending decrements are lost with the old incarnation's mailbox and the fresh one starts from empty state. A derived gauge self-heals, because `init/1` publishes from the empty state and each later mutation republishes the truth. It also cannot drift from the state it reports, since there is no second place to forget an edge.
+
+`rabbitmq_stream_s3_governor:derive_gauges/1` is the reference shape: one function, called on every callback return that can change what it reports. See the Derived gauges section of that module's moduledoc.
+
+Where a gauge spans several processes it cannot be derived from any one of them, and inc/dec is the only option. Then weld both edges to the single state mutation they mirror, so an edge cannot be added without the counter following: api_aws's `active_requests` counts one in-flight request per pool checkout across every pool, and its two edges live in `rabbitmq_stream_s3_api_aws_pool:add_checkout/3` and `del_checkout/3`, the only two places the `checkouts` maps change. Keep the counter's key, size, and indices private to the module that defines `?COUNTERS`, and reach it from elsewhere (including tests in other modules) through an exported accessor keyed by metric name rather than a restated index.
+
 ## Cold-state test dimension
 
 Every stateful fixture a test warms up implicitly is a state the suite must also construct cold. An end-to-end test that publishes and then reads has, as a side effect, seeded the manifest cache, attached the hooks, and resolved the manifest: the act of arranging the fixture destroys the cold-start state, so the warm path is the only path such suites can ever exercise.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -304,8 +304,13 @@ Owned by `rabbitmq_stream_s3_governor`. Single counter set per node, no per-stre
 |-------------------------------------|---------|-------------------------------------------------------------------|
 | `rabbitmq_stream_s3_governor_submissions_received`     | counter | Total transfer submissions received                               |
 | `rabbitmq_stream_s3_governor_oversized_admissions`     | counter | Transfers admitted on credit because they exceed the burst allowance; a persistently climbing value means the configured rate is low relative to fragment sizes |
+| `rabbitmq_stream_s3_governor_dropped_dead_replyto`     | counter | Submissions dropped because the requester was already dead, either at intake or while queued behind the token bucket; expected to climb during stream deletion or replica-reader restarts, and not an error |
 | `rabbitmq_stream_s3_governor_tasks_in_flight`          | gauge   | Transfer tasks currently executing                                |
 | `rabbitmq_stream_s3_governor_pending_submissions`      | gauge   | Submissions queued waiting for token-bucket capacity              |
+
+Both governor gauges are derived from the state they describe rather than incremented and decremented, so they self-heal after a governor crash instead of ratcheting. See the Derived gauges section of the `rabbitmq_stream_s3_governor` moduledoc, and [conventions.md](./conventions.md#derived-gauges).
+
+A transfer is cancelled when its requester dies (any death: crash, restart, or stream deletion) or when the replica reader explicitly cancels it. Cancellation reaches both queued and running work: queued submissions are dropped without spending tokens, and running tasks are killed. Queued drops for a dead requester are counted in `governor_dropped_dead_replyto`; an explicit cancel is not counted, since nothing went wrong.
 
 ### Reaper (per-node)
 

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -38,6 +38,12 @@ A wrapper around the AWS S3 HTTP API.
 %% For the pool. Not to be called by anyone else.
 -export([hostname/0, note_request_started/0, note_request_finished/0]).
 
+-ifdef(TEST).
+%% For tests that need to observe the counters this module owns, including the
+%% pool's, since the pool moves active_requests but does not own the counter.
+-export([with_counter/1]).
+-endif.
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, format_status/1]).
 
@@ -396,7 +402,7 @@ stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) 
                     %% caller killed mid-request is still balanced by the pool.
                     case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000) of
                         {ok, Conn} ->
-                            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+                            inc(?C_TOTAL_REQUESTS, 1),
                             StreamRef = gun:headers(Conn, Method, Path, Headers),
                             State = #{
                                 pool => Pool,
@@ -928,7 +934,7 @@ handle_async(
     ?LOG_WARNING(
         "S3 request timed out on ~tw/~tw: ~ts", [Conn, StreamRef, describe_stall(State)]
     ),
-    counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
+    inc(?C_REQUEST_TIMEOUTS, 1),
     %% gun cannot cancel an HTTP/1.1 stream on the wire - it only stops
     %% forwarding events to the owner. The cancelled stream continues to
     %% occupy the connection, blocking subsequent requests until its full
@@ -1076,7 +1082,7 @@ request(Method, Path, Headers0, Body, Opts) when
                     %% active_requests is owned by the pool, tied to the
                     %% checkout that request1/5 does below (see
                     %% note_request_started/0).
-                    counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+                    inc(?C_TOTAL_REQUESTS, 1),
                     request0(Method, Path, Headers, Body, Opts);
                 {error, _} = Err ->
                     Err
@@ -1130,24 +1136,24 @@ await_response(Conn, StreamRef, Timeout) ->
                     postprocess_response(Response),
                     {ok, Response};
                 {error, timeout} = Err ->
-                    counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
+                    inc(?C_REQUEST_TIMEOUTS, 1),
                     Err;
                 {error, _} = Err ->
                     Err
             end;
         {error, timeout} = Err ->
-            counters:add(counter(), ?C_REQUEST_TIMEOUTS, 1),
+            inc(?C_REQUEST_TIMEOUTS, 1),
             Err;
         {error, _} = Err ->
             Err
     end.
 
 postprocess_response(#{status := 403}) ->
-    counters:add(counter(), ?C_RESPONSE_403, 1);
+    inc(?C_RESPONSE_403, 1);
 postprocess_response(#{status := 503}) ->
-    counters:add(counter(), ?C_RESPONSE_503, 1);
+    inc(?C_RESPONSE_503, 1);
 postprocess_response(#{status := 500}) ->
-    counters:add(counter(), ?C_RESPONSE_500, 1);
+    inc(?C_RESPONSE_500, 1);
 postprocess_response(_) ->
     ok.
 
@@ -1180,7 +1186,7 @@ start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
     case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, ?READ_CHECKOUT_TIMEOUT_MS) of
         {ok, Conn} ->
             %% active_requests is owned by the pool, tied to this checkout.
-            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+            inc(?C_TOTAL_REQUESTS, 1),
             %% NOTE: no need to wrap this in try/catch and checkin the conn
             %% since gun:request/5 cannot exit/error/throw.
             StreamRef = gun:request(Conn, Method, Path, Headers, Body),
@@ -1865,8 +1871,16 @@ aws_chunked_encoded_length(ContentLength) ->
         end +
         TrailerLength.
 
-counter() ->
-    persistent_term:get(?COUNTER_KEY).
+%% All counter mutations go through inc/2 so a missing counter is a no-op rather
+%% than a badarg. `init/1` only installs the counter when this module is the
+%% configured backend, so every call site would otherwise need to know whether
+%% it can be reached with the counter absent.
+inc(Idx, N) ->
+    case persistent_term:get(?COUNTER_KEY, undefined) of
+        undefined -> ok;
+        Cnt -> counters:add(Cnt, Idx, N)
+    end,
+    ok.
 
 -doc """
 `active_requests` counts connections currently checked out of a pool: one
@@ -1888,43 +1902,84 @@ and there is no gauge to move in that case.
 """.
 -spec note_request_started() -> ok.
 note_request_started() ->
-    case persistent_term:get(?COUNTER_KEY, undefined) of
-        undefined -> ok;
-        Cnt -> counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1)
-    end,
-    ok.
+    inc(?C_ACTIVE_REQUESTS, 1).
 
 -doc #{equiv => note_request_started / 0}.
 -spec note_request_finished() -> ok.
 note_request_finished() ->
-    case persistent_term:get(?COUNTER_KEY, undefined) of
-        undefined -> ok;
-        Cnt -> counters:sub(Cnt, ?C_ACTIVE_REQUESTS, 1)
-    end,
-    ok.
+    inc(?C_ACTIVE_REQUESTS, -1).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
 note_request_started_and_finished_balance_test() ->
-    Cnt = counters:new(6, []),
-    persistent_term:put(?COUNTER_KEY, Cnt),
-    try
+    with_counter(fun(Read) ->
         ?assertEqual(ok, note_request_started()),
-        ?assertEqual(1, counters:get(Cnt, ?C_ACTIVE_REQUESTS)),
+        ?assertEqual(1, Read(active_requests)),
         ?assertEqual(ok, note_request_finished()),
-        ?assertEqual(0, counters:get(Cnt, ?C_ACTIVE_REQUESTS))
+        ?assertEqual(0, Read(active_requests))
+    end).
+
+%% Both edges must tolerate a missing counter: init/1 installs it only when this
+%% module is the configured backend, and the pool can be driven standalone.
+note_request_edges_are_noop_without_counters_test() ->
+    without_counter(fun() ->
+        ?assertEqual(ok, note_request_started()),
+        ?assertEqual(ok, note_request_finished())
+    end).
+
+%% Every counter mutation goes through inc/2, so one no-counter check covers all
+%% of them rather than each call site needing its own.
+inc_is_noop_without_counters_test() ->
+    without_counter(fun() ->
+        ?assertEqual(ok, inc(?C_TOTAL_REQUESTS, 1)),
+        ?assertEqual(ok, inc(?C_REQUEST_TIMEOUTS, 1))
+    end).
+
+-doc """
+Install a private counter at this module's `persistent_term` key, call
+`Fun(Read)`, then restore whatever was there before.
+
+`Read` takes a metric name from `?COUNTERS` (e.g. `active_requests`) and returns
+its current value. Callers get the counter's size and indices from the real
+`?COUNTERS` list rather than restating them, so adding a metric cannot leave a
+test asserting on the wrong slot.
+
+Exported because the pool moves `active_requests` while this module owns the
+counter, so the pool's own tests need it too.
+""".
+-spec with_counter(fun((fun((atom()) -> integer())) -> Ret)) -> Ret.
+with_counter(Fun) ->
+    Previous = persistent_term:get(?COUNTER_KEY, undefined),
+    Cnt = counters:new(length(?COUNTERS), []),
+    persistent_term:put(?COUNTER_KEY, Cnt),
+    Read = fun(Name) ->
+        {Name, Idx, _Type, _Help} = lists:keyfind(Name, 1, ?COUNTERS),
+        counters:get(Cnt, Idx)
+    end,
+    try
+        Fun(Read)
     after
-        persistent_term:erase(?COUNTER_KEY)
+        case Previous of
+            undefined -> persistent_term:erase(?COUNTER_KEY);
+            _ -> persistent_term:put(?COUNTER_KEY, Previous)
+        end
     end.
 
-note_request_edges_are_noop_without_counters_test() ->
-    case persistent_term:get(?COUNTER_KEY, undefined) of
-        undefined -> ok;
-        _ -> persistent_term:erase(?COUNTER_KEY)
-    end,
-    ?assertEqual(ok, note_request_started()),
-    ?assertEqual(ok, note_request_finished()).
+%% Run Fun with ?COUNTER_KEY absent, restoring whatever was there. Erasing
+%% without restoring would leave the module's real counter missing for whatever
+%% runs next in the same VM.
+without_counter(Fun) ->
+    Previous = persistent_term:get(?COUNTER_KEY, undefined),
+    _ = persistent_term:erase(?COUNTER_KEY),
+    try
+        Fun()
+    after
+        case Previous of
+            undefined -> ok;
+            _ -> persistent_term:put(?COUNTER_KEY, Previous)
+        end
+    end.
 
 transient_status_test() ->
     %% Retryable: server-side 5xx (except 501) and throttling.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -36,7 +36,7 @@ A wrapper around the AWS S3 HTTP API.
 -export([get_credentials/0]).
 
 %% For the pool. Not to be called by anyone else.
--export([hostname/0]).
+-export([hostname/0, note_request_abandoned/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, format_status/1]).
@@ -1877,8 +1877,47 @@ aws_chunked_encoded_length(ContentLength) ->
 counter() ->
     persistent_term:get(?COUNTER_KEY).
 
+-doc """
+Called by the pool when it reclaims a connection whose checking-out process
+died without checking it back in. `?C_ACTIVE_REQUESTS` is otherwise only
+decremented by `finish_async`/`finish_async_close`, which run in the
+checking-out process itself; a process killed mid-request (e.g. by
+`rabbitmq_stream_s3_governor:cancel/1`) never reaches either, so the pool -
+the only place that reliably learns of such an abandoned request - reports
+it here instead.
+
+A no-op if this module's counters aren't initialized: the pool can be driven
+in isolation (e.g. api_aws_pool_statem_SUITE) without this gen_server, and
+its own request-tracking gauge has nothing to correct in that case.
+""".
+-spec note_request_abandoned() -> ok.
+note_request_abandoned() ->
+    case persistent_term:get(?COUNTER_KEY, undefined) of
+        undefined -> ok;
+        Cnt -> counters:sub(Cnt, ?C_ACTIVE_REQUESTS, 1)
+    end,
+    ok.
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+note_request_abandoned_decrements_active_requests_test() ->
+    Cnt = counters:new(6, []),
+    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
+    persistent_term:put(?COUNTER_KEY, Cnt),
+    try
+        ?assertEqual(ok, note_request_abandoned()),
+        ?assertEqual(0, counters:get(Cnt, ?C_ACTIVE_REQUESTS))
+    after
+        persistent_term:erase(?COUNTER_KEY)
+    end.
+
+note_request_abandoned_is_noop_without_counters_test() ->
+    case persistent_term:get(?COUNTER_KEY, undefined) of
+        undefined -> ok;
+        _ -> persistent_term:erase(?COUNTER_KEY)
+    end,
+    ?assertEqual(ok, note_request_abandoned()).
 
 transient_status_test() ->
     %% Retryable: server-side 5xx (except 501) and throttling.

--- a/src/rabbitmq_stream_s3_api_aws.erl
+++ b/src/rabbitmq_stream_s3_api_aws.erl
@@ -36,7 +36,7 @@ A wrapper around the AWS S3 HTTP API.
 -export([get_credentials/0]).
 
 %% For the pool. Not to be called by anyone else.
--export([hostname/0, note_request_abandoned/0]).
+-export([hostname/0, note_request_started/0, note_request_finished/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, format_status/1]).
@@ -391,19 +391,12 @@ stream_put(Key, ContentLength, Opts0) when is_binary(Key) andalso is_map(Opts0) 
             of
                 {ok, Headers} ->
                     Pool = ?UPLOAD_POOL,
-                    %% Acquire the connection before touching the request
-                    %% gauges. checkout/2 returns {error, pool_busy} on a
-                    %% saturated pool, and C_ACTIVE_REQUESTS is only decremented
-                    %% by finish_async, which runs once we hold a connection and
-                    %% have built State. Incrementing before the checkout leaked
-                    %% the gauge on every failed checkout (a sustained partial
-                    %% outage that drains the pool drove active_requests up with
-                    %% no way back down).
+                    %% active_requests is owned by the pool and moved on the
+                    %% checkout itself, so a failed checkout cannot leak it and a
+                    %% caller killed mid-request is still balanced by the pool.
                     case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, 10_000) of
                         {ok, Conn} ->
-                            Cnt = counter(),
-                            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-                            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+                            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
                             StreamRef = gun:headers(Conn, Method, Path, Headers),
                             State = #{
                                 pool => Pool,
@@ -489,11 +482,11 @@ send_chunk(Conn, StreamRef, Chunk) when is_binary(Chunk) ->
 -spec stream_abort(async_state()) -> ok.
 stream_abort(#{conn := Conn} = State) ->
     %% The streaming PUT body was only partially sent, so this HTTP/1.1
-    %% connection is mid-request and cannot be reused. Close it (the pool's
-    %% 'DOWN' handler removes it and opens a replacement) and release the
-    %% active-request gauge without checking the connection back in. Mirrors
-    %% the timeout/cancel path; the half-sent PUT never reaches S3 as an
-    %% object, so nothing is left behind except an orphan at most.
+    %% connection is mid-request and cannot be reused. Close it without checking
+    %% it back in; the pool's 'DOWN' handler removes it, accounts the checkout
+    %% end (active_requests), and opens a replacement. Mirrors the timeout/cancel
+    %% path; the half-sent PUT never reaches S3 as an object, so nothing is left
+    %% behind except an orphan at most.
     gun:close(Conn),
     finish_async_close(State).
 
@@ -1029,12 +1022,15 @@ finish_async(#{conn := Conn, pool := Pool} = State) ->
         _ ->
             ok
     end,
-    counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
+    %% The pool decrements active_requests on the checkin below (see
+    %% note_request_finished/0).
     ok = rabbitmq_stream_s3_api_aws_pool:checkin(Pool, Conn).
 
 %% Finish an async request when the connection is being closed (e.g. on
 %% timeout). Same bookkeeping as `finish_async` but omits the pool checkin -
-%% the pool's 'DOWN' handler removes the conn and grows a replacement.
+%% the caller has already closed the connection, so the pool's 'DOWN' handler
+%% removes the conn, accounts the checkout end (active_requests), and grows a
+%% replacement.
 finish_async_close(State) ->
     case State of
         #{timer_ref := TimerRef, stream_ref := StreamRef} ->
@@ -1050,7 +1046,6 @@ finish_async_close(State) ->
         _ ->
             ok
     end,
-    counters:sub(counter(), ?C_ACTIVE_REQUESTS, 1),
     ok.
 
 -spec request(http_method(), key(), req_headers(), iodata(), request_opts()) ->
@@ -1078,14 +1073,11 @@ request(Method, Path, Headers0, Body, Opts) when
                 )
             of
                 {ok, Headers} ->
-                    Cnt = counter(),
-                    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-                    counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
-                    try
-                        request0(Method, Path, Headers, Body, Opts)
-                    after
-                        counters:sub(Cnt, ?C_ACTIVE_REQUESTS, 1)
-                    end;
+                    %% active_requests is owned by the pool, tied to the
+                    %% checkout that request1/5 does below (see
+                    %% note_request_started/0).
+                    counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
+                    request0(Method, Path, Headers, Body, Opts);
                 {error, _} = Err ->
                     Err
             end;
@@ -1187,9 +1179,8 @@ request_async(Method, Path, Headers0, Body, Opts) ->
 start_async_request(Pool, Method, Path, Headers, Body, Opts) ->
     case rabbitmq_stream_s3_api_aws_pool:checkout(Pool, ?READ_CHECKOUT_TIMEOUT_MS) of
         {ok, Conn} ->
-            Cnt = counter(),
-            counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
-            counters:add(Cnt, ?C_TOTAL_REQUESTS, 1),
+            %% active_requests is owned by the pool, tied to this checkout.
+            counters:add(counter(), ?C_TOTAL_REQUESTS, 1),
             %% NOTE: no need to wrap this in try/catch and checkin the conn
             %% since gun:request/5 cannot exit/error/throw.
             StreamRef = gun:request(Conn, Method, Path, Headers, Body),
@@ -1878,20 +1869,34 @@ counter() ->
     persistent_term:get(?COUNTER_KEY).
 
 -doc """
-Called by the pool when it reclaims a connection whose checking-out process
-died without checking it back in. `?C_ACTIVE_REQUESTS` is otherwise only
-decremented by `finish_async`/`finish_async_close`, which run in the
-checking-out process itself; a process killed mid-request (e.g. by
-`rabbitmq_stream_s3_governor:cancel/1`) never reaches either, so the pool -
-the only place that reliably learns of such an abandoned request - reports
-it here instead.
+`active_requests` counts connections currently checked out of a pool: one
+in-flight S3 request per checkout. The pool owns both edges, calling
+`note_request_started/0` when it hands a connection to a caller and
+`note_request_finished/0` when that checkout ends, whether by check-in, by the
+caller dying while holding it, or by the connection dying under it.
 
-A no-op if this module's counters aren't initialized: the pool can be driven
-in isolation (e.g. api_aws_pool_statem_SUITE) without this gen_server, and
-its own request-tracking gauge has nothing to correct in that case.
+Keeping both edges in the pool, at the checkout lifecycle points, is what makes
+the gauge balanced by construction. The alternative - incrementing in the
+requesting process and decrementing on each of its completion paths - left the
+gauge to drift: a caller killed mid-request (e.g. by
+`rabbitmq_stream_s3_governor:cancel/1`) or killed while still queued for a
+connection ran none of those paths, so an increment had no matching decrement.
+
+Both are a no-op if this module's counters aren't initialized: the pool can be
+driven in isolation (e.g. api_aws_pool_statem_SUITE) without this gen_server,
+and there is no gauge to move in that case.
 """.
--spec note_request_abandoned() -> ok.
-note_request_abandoned() ->
+-spec note_request_started() -> ok.
+note_request_started() ->
+    case persistent_term:get(?COUNTER_KEY, undefined) of
+        undefined -> ok;
+        Cnt -> counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1)
+    end,
+    ok.
+
+-doc #{equiv => note_request_started / 0}.
+-spec note_request_finished() -> ok.
+note_request_finished() ->
     case persistent_term:get(?COUNTER_KEY, undefined) of
         undefined -> ok;
         Cnt -> counters:sub(Cnt, ?C_ACTIVE_REQUESTS, 1)
@@ -1901,23 +1906,25 @@ note_request_abandoned() ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-note_request_abandoned_decrements_active_requests_test() ->
+note_request_started_and_finished_balance_test() ->
     Cnt = counters:new(6, []),
-    counters:add(Cnt, ?C_ACTIVE_REQUESTS, 1),
     persistent_term:put(?COUNTER_KEY, Cnt),
     try
-        ?assertEqual(ok, note_request_abandoned()),
+        ?assertEqual(ok, note_request_started()),
+        ?assertEqual(1, counters:get(Cnt, ?C_ACTIVE_REQUESTS)),
+        ?assertEqual(ok, note_request_finished()),
         ?assertEqual(0, counters:get(Cnt, ?C_ACTIVE_REQUESTS))
     after
         persistent_term:erase(?COUNTER_KEY)
     end.
 
-note_request_abandoned_is_noop_without_counters_test() ->
+note_request_edges_are_noop_without_counters_test() ->
     case persistent_term:get(?COUNTER_KEY, undefined) of
         undefined -> ok;
         _ -> persistent_term:erase(?COUNTER_KEY)
     end,
-    ?assertEqual(ok, note_request_abandoned()).
+    ?assertEqual(ok, note_request_started()),
+    ?assertEqual(ok, note_request_finished()).
 
 transient_status_test() ->
     %% Retryable: server-side 5xx (except 501) and throttling.

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -763,25 +763,13 @@ active_requests_balanced_across_checkout_ends_test() ->
         end
     end).
 
-%% Install a private counter at api_aws's persistent_term key so the pool's
-%% note_request_started/finished edges land somewhere readable, restoring
-%% whatever was there before. Returns a fun that reads the active_requests
-%% gauge. The key and index mirror rabbitmq_stream_s3_api_aws's own defines.
+%% Give Fun a reader for api_aws's active_requests gauge, which this module
+%% moves but api_aws owns. Delegating keeps the counter's key, size and indices
+%% in the one module that defines them.
 with_active_requests_counter(Fun) ->
-    Key = {rabbitmq_stream_s3_api_aws, counter},
-    ActiveRequestsIdx = 1,
-    Previous = persistent_term:get(Key, undefined),
-    Cnt = counters:new(6, []),
-    persistent_term:put(Key, Cnt),
-    ReadGauge = fun() -> counters:get(Cnt, ActiveRequestsIdx) end,
-    try
-        Fun(ReadGauge)
-    after
-        case Previous of
-            undefined -> persistent_term:erase(Key);
-            _ -> persistent_term:put(Key, Previous)
-        end
-    end.
+    rabbitmq_stream_s3_api_aws:with_counter(fun(Read) ->
+        Fun(fun() -> Read(active_requests) end)
+    end).
 
 await(Fun) ->
     await(Fun, 2000).

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -335,6 +335,12 @@ handle_down(MRef, Pid, #?MODULE{monitors = Monitors} = State0) when
 %% is not `head`, crashing gun's gen_statem with `function_clause`. Drop the
 %% connection and grow a replacement.
 %% See: https://github.com/amazon-mq/rabbitmq-stream-s3/issues/177
+%%
+%% This is also the only place that reliably learns a request was abandoned
+%% (e.g. the caller was killed by rabbitmq_stream_s3_governor:cancel/1) rather
+%% than finishing normally, so it reports that to the api module too - it
+%% would otherwise never decrement api_aws's active-requests gauge, since
+%% that only happens in the checking-out process itself.
 handle_down(
     MRef,
     _Pid,
@@ -345,6 +351,7 @@ handle_down(
         checkouts = maps:remove(Conn, Checkouts),
         checkouts_rev = maps:remove(MRef, CheckoutsRev)
     },
+    ok = rabbitmq_stream_s3_api_aws:note_request_abandoned(),
     {noreply, grow(close_connection(Conn, State1))};
 %% A pending caller process is down. Remove it from the pending queue.
 handle_down(_MRef, Pid, #?MODULE{pending = Pending0} = State0) ->

--- a/src/rabbitmq_stream_s3_api_aws_pool.erl
+++ b/src/rabbitmq_stream_s3_api_aws_pool.erl
@@ -215,6 +215,25 @@ handle_call(Request, From, State) ->
     ?LOG_INFO(?MODULE_STRING " received unexpected call from ~p: ~W", [From, Request, 10]),
     {noreply, State}.
 
+%% Record a connection as checked out and account the request. `add_checkout`
+%% and `del_checkout` are the only two places `checkouts`/`checkouts_rev` change,
+%% so api_aws's `active_requests` gauge - one in-flight request per checkout,
+%% shared across every pool and therefore incremented rather than derived - is
+%% welded to the map and cannot drift from it, whichever way the checkout ends.
+add_checkout(Conn, MRef, #?MODULE{checkouts = Checkouts, checkouts_rev = CheckoutsRev} = State) ->
+    ok = rabbitmq_stream_s3_api_aws:note_request_started(),
+    State#?MODULE{
+        checkouts = Checkouts#{Conn => MRef},
+        checkouts_rev = CheckoutsRev#{MRef => Conn}
+    }.
+
+del_checkout(Conn, MRef, #?MODULE{checkouts = Checkouts, checkouts_rev = CheckoutsRev} = State) ->
+    ok = rabbitmq_stream_s3_api_aws:note_request_finished(),
+    State#?MODULE{
+        checkouts = maps:remove(Conn, Checkouts),
+        checkouts_rev = maps:remove(MRef, CheckoutsRev)
+    }.
+
 %% Return a checked-in connection to `available` if it is still monitored
 %% (alive as far as we know). Otherwise drop it; the `DOWN` handler owns the
 %% cleanup of a connection that died while checked out.
@@ -227,15 +246,12 @@ maybe_make_available(_Conn, State) ->
 
 handle_checkin(
     Conn,
-    #?MODULE{checkouts = Checkouts0, checkouts_rev = CheckoutsRev0, counter = Cnt} = State0
+    #?MODULE{checkouts = Checkouts0, counter = Cnt} = State0
 ) when is_map_key(Conn, Checkouts0) ->
     MRef = maps:get(Conn, Checkouts0),
     counters:add(Cnt, ?C_CHECKINS, 1),
     erlang:demonitor(MRef, [flush]),
-    State1 = State0#?MODULE{
-        checkouts = maps:remove(Conn, Checkouts0),
-        checkouts_rev = maps:remove(MRef, CheckoutsRev0)
-    },
+    State1 = del_checkout(Conn, MRef, State0),
     {noreply, maybe_make_available(Conn, State1)};
 handle_checkin(_Conn, State) ->
     {noreply, State}.
@@ -338,20 +354,15 @@ handle_down(MRef, Pid, #?MODULE{monitors = Monitors} = State0) when
 %%
 %% This is also the only place that reliably learns a request was abandoned
 %% (e.g. the caller was killed by rabbitmq_stream_s3_governor:cancel/1) rather
-%% than finishing normally, so it reports that to the api module too - it
-%% would otherwise never decrement api_aws's active-requests gauge, since
-%% that only happens in the checking-out process itself.
+%% than finishing normally. `del_checkout` accounts it like any other checkout
+%% end: the caller never ran a completion path, so nothing else would.
 handle_down(
     MRef,
     _Pid,
-    #?MODULE{checkouts = Checkouts, checkouts_rev = CheckoutsRev} = State0
+    #?MODULE{checkouts_rev = CheckoutsRev} = State0
 ) when is_map_key(MRef, CheckoutsRev) ->
     Conn = maps:get(MRef, CheckoutsRev),
-    State1 = State0#?MODULE{
-        checkouts = maps:remove(Conn, Checkouts),
-        checkouts_rev = maps:remove(MRef, CheckoutsRev)
-    },
-    ok = rabbitmq_stream_s3_api_aws:note_request_abandoned(),
+    State1 = del_checkout(Conn, MRef, State0),
     {noreply, grow(close_connection(Conn, State1))};
 %% A pending caller process is down. Remove it from the pending queue.
 handle_down(_MRef, Pid, #?MODULE{pending = Pending0} = State0) ->
@@ -501,8 +512,6 @@ take_available(
     Pid,
     #?MODULE{
         available = Available0,
-        checkouts = Checkouts0,
-        checkouts_rev = CheckoutsRev0,
         usable_fun = UsableFun
     } = State0
 ) ->
@@ -511,11 +520,7 @@ take_available(
             case UsableFun(Conn) of
                 true ->
                     MRef = erlang:monitor(process, Pid),
-                    State = State0#?MODULE{
-                        available = Available,
-                        checkouts = Checkouts0#{Conn => MRef},
-                        checkouts_rev = CheckoutsRev0#{MRef => Conn}
-                    },
+                    State = add_checkout(Conn, MRef, State0#?MODULE{available = Available}),
                     {ok, Conn, cancel_idle_timer(Conn, State)};
                 false ->
                     %% Connection is down or disconnected; drop it and try the
@@ -532,8 +537,6 @@ checkout(
     #?MODULE{
         pending = Pending0,
         available = Available0,
-        checkouts = Checkouts0,
-        checkouts_rev = CheckoutsRev0,
         counter = Cnt,
         usable_fun = UsableFun
     } = State0
@@ -544,12 +547,13 @@ checkout(
                 true ->
                     counters:add(Cnt, ?C_CHECKOUTS, 1),
                     gen_server:reply(From, Conn),
-                    State1 = cancel_idle_timer(Conn, State0#?MODULE{
-                        pending = Pending,
-                        available = Available,
-                        checkouts = Checkouts0#{Conn => MRef},
-                        checkouts_rev = CheckoutsRev0#{MRef => Conn}
-                    }),
+                    State1 = cancel_idle_timer(
+                        Conn,
+                        add_checkout(Conn, MRef, State0#?MODULE{
+                            pending = Pending,
+                            available = Available
+                        })
+                    ),
                     checkout(State1);
                 false ->
                     %% Down connection at the head; drop it (leaving `monitors`
@@ -562,15 +566,12 @@ checkout(
             State0
     end.
 
-cancel(Conn, #?MODULE{checkouts = Checkouts0, checkouts_rev = CheckoutsRev0} = State0) when
+cancel(Conn, #?MODULE{checkouts = Checkouts0} = State0) when
     is_map_key(Conn, Checkouts0)
 ->
     CallerMRef = maps:get(Conn, Checkouts0),
     erlang:demonitor(CallerMRef, [flush]),
-    State0#?MODULE{
-        checkouts = maps:remove(Conn, Checkouts0),
-        checkouts_rev = maps:remove(CallerMRef, CheckoutsRev0)
-    };
+    del_checkout(Conn, CallerMRef, State0);
 cancel(Conn, State) ->
     %% Not checked out; if it is available, removing it from `available` (and
     %% cancelling its idle timer) is exactly `remove_available/2`.
@@ -706,6 +707,94 @@ checkout_timeout_returns_pool_busy_test() ->
         ok = checkin(busy_pool, Conn)
     after
         gen_server:stop(Pid)
+    end.
+
+%% api_aws's active_requests gauge is owned here. Prove it is balanced across
+%% every way a checkout ends: a clean check-in, the caller dying while holding
+%% the connection (the abandon path a governor-cancel kill takes), and the
+%% connection itself dying under a live caller.
+active_requests_balanced_across_checkout_ends_test() ->
+    with_active_requests_counter(fun(ActiveRequests) ->
+        Config = #{
+            name => balance_pool,
+            min_size => 2,
+            max_size => 2,
+            open_fun => fun test_open/0,
+            usable_fun => fun erlang:is_process_alive/1,
+            close_fun => fun test_close/1
+        },
+        {ok, Pid} = start_link(balance_pool, Config),
+        try
+            ?assertEqual(0, ActiveRequests()),
+
+            %% Clean check-in.
+            {ok, Conn1} = checkout(balance_pool, 1000),
+            ?assertEqual(1, ActiveRequests()),
+            ok = checkin(balance_pool, Conn1),
+            await(fun() -> ActiveRequests() =:= 0 end),
+
+            %% Caller dies while holding the connection: the pool's caller-DOWN
+            %% handler must account the end, since the caller ran no completion
+            %% path. This is the leak the old inc-in-caller design had.
+            Parent = self(),
+            Holder = spawn(fun() ->
+                {ok, _} = checkout(balance_pool, 1000),
+                Parent ! checked_out,
+                receive
+                    die -> ok
+                end
+            end),
+            receive
+                checked_out -> ok
+            after 1000 -> error(holder_setup_failed)
+            end,
+            ?assertEqual(1, ActiveRequests()),
+            Holder ! die,
+            await(fun() -> ActiveRequests() =:= 0 end),
+
+            %% Connection dies under a live caller: the connection-DOWN handler
+            %% must account the end too.
+            {ok, Conn3} = checkout(balance_pool, 1000),
+            ?assertEqual(1, ActiveRequests()),
+            exit(Conn3, kill),
+            await(fun() -> ActiveRequests() =:= 0 end)
+        after
+            gen_server:stop(Pid)
+        end
+    end).
+
+%% Install a private counter at api_aws's persistent_term key so the pool's
+%% note_request_started/finished edges land somewhere readable, restoring
+%% whatever was there before. Returns a fun that reads the active_requests
+%% gauge. The key and index mirror rabbitmq_stream_s3_api_aws's own defines.
+with_active_requests_counter(Fun) ->
+    Key = {rabbitmq_stream_s3_api_aws, counter},
+    ActiveRequestsIdx = 1,
+    Previous = persistent_term:get(Key, undefined),
+    Cnt = counters:new(6, []),
+    persistent_term:put(Key, Cnt),
+    ReadGauge = fun() -> counters:get(Cnt, ActiveRequestsIdx) end,
+    try
+        Fun(ReadGauge)
+    after
+        case Previous of
+            undefined -> persistent_term:erase(Key);
+            _ -> persistent_term:put(Key, Previous)
+        end
+    end.
+
+await(Fun) ->
+    await(Fun, 2000).
+
+await(_Fun, Remaining) when Remaining =< 0 ->
+    error(timeout_awaiting_condition);
+await(Fun, Remaining) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(5),
+            await(Fun, Remaining - 5)
     end.
 
 %% A fake connection is a plain process that only understands `stop`; the pool

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -11,11 +11,18 @@ The transfer function is opaque to the governor.
 
 When the configured rate is `unlimited`, submissions execute immediately
 with no pacing.
+
+A caller can cancel a batch of submissions by their `Ref`s via `cancel/1`: an
+admitted task is killed, a still-queued item is dropped before ever being
+spawned, and the pending queue is scanned once for the whole batch.
+Spawned tasks are monitored, not linked, so a governor restart does not
+kill tasks already running - they keep delivering their results directly to
+`ReplyTo` regardless of the governor's own lifecycle.
 """.
 
 -behaviour(gen_server).
 
--export([start_link/1, submit/4]).
+-export([start_link/1, submit/4, cancel/1]).
 -export([
     init/1,
     handle_call/3,
@@ -35,6 +42,7 @@ with no pacing.
 -define(C_TASKS_IN_FLIGHT, 2).
 -define(C_PENDING_SUBMISSIONS, 3).
 -define(C_OVERSIZED_ADMISSIONS, 4).
+-define(C_DROPPED_DEAD_REPLYTO, 5).
 -define(COUNTERS, [
     {governor_submissions_received, ?C_SUBMISSIONS_RECEIVED, counter,
         "Total transfer submissions received by the governor"},
@@ -45,7 +53,11 @@ with no pacing.
     {governor_oversized_admissions, ?C_OVERSIZED_ADMISSIONS, counter,
         "Transfers admitted whose size exceeded the token-bucket burst (admitted "
         "on credit, driving the bucket into debt). A persistently climbing value "
-        "means the configured burst is smaller than typical fragments"}
+        "means the configured burst is smaller than typical fragments"},
+    {governor_dropped_dead_replyto, ?C_DROPPED_DEAD_REPLYTO, counter,
+        "Submissions dropped because their requester was already dead: either "
+        "at intake, or while queued behind the token bucket. Protects against "
+        "any requester death (crash, restart), not just graceful deletion"}
 ]).
 -define(COUNTER_KEY, {?MODULE, counter}).
 
@@ -53,7 +65,13 @@ with no pacing.
     bucket :: rabbitmq_stream_s3_token_bucket:t() | unlimited,
     %% Pending submissions waiting for tokens.
     pending :: queue:queue(pending_item()),
-    timer_ref :: reference() | undefined
+    timer_ref :: reference() | undefined,
+    %% Ref => {Pid, MonRef} for every task currently executing, so cancel/1
+    %% can reach an admitted task by its caller-minted Ref.
+    tasks = #{} :: #{reference() => {pid(), reference()}},
+    %% MonRef => Ref, the reverse index the 'DOWN' handler uses to find which
+    %% submission a completed, crashed or killed monitor belonged to.
+    tasks_rev = #{} :: #{reference() => reference()}
 }).
 
 -type pending_item() :: {
@@ -83,6 +101,15 @@ where Result is the return value of `Fun`.
 submit(Fun, Size, ReplyTo, Ref) ->
     gen_server:cast(?MODULE, {submit, Fun, Size, ReplyTo, Ref}).
 
+-doc """
+Cancel a batch of previously submitted transfers.
+""".
+-spec cancel([reference()]) -> ok.
+cancel([]) ->
+    ok;
+cancel(Refs) ->
+    gen_server:cast(?MODULE, {cancel, Refs}).
+
 %% ------------------------------------------------------------------
 %% gen_server callbacks
 %% ------------------------------------------------------------------
@@ -109,7 +136,34 @@ handle_call(_Request, _From, State) ->
 
 handle_cast({submit, Fun, Size, ReplyTo, Ref}, State) ->
     inc(?C_SUBMISSIONS_RECEIVED, 1),
-    {noreply, dispatch({Fun, Size, ReplyTo, Ref}, State)};
+    case is_process_alive(ReplyTo) of
+        true ->
+            {noreply, dispatch({Fun, Size, ReplyTo, Ref}, State)};
+        false ->
+            %% The requester died between calling submit/4 and this cast
+            %% landing (e.g. a stream deletion or a crash). Drop it now
+            %% rather than pacing, spawning, and uploading for nobody: its
+            %% result would just be dropped into a dead mailbox anyway.
+            inc(?C_DROPPED_DEAD_REPLYTO, 1),
+            {noreply, State}
+    end;
+handle_cast({cancel, Refs0}, #state{tasks = Tasks} = State) ->
+    %% tasks/tasks_rev removal and the TASKS_IN_FLIGHT decrement happen in
+    %% the 'DOWN' handler below, the single cleanup path shared by normal
+    %% completion, a crash and a kill alike.
+    Refs = lists:filter(
+        fun(Ref) ->
+            case Tasks of
+                #{Ref := {Pid, _MonRef}} ->
+                    exit(Pid, kill),
+                    false;
+                #{} ->
+                    true
+            end
+        end,
+        Refs0
+    ),
+    {noreply, cancel_pending(Refs, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -123,6 +177,27 @@ handle_info(refill, #state{bucket = Bucket0} = State0) ->
             false -> schedule_refill()
         end,
     {noreply, State2#state{timer_ref = TimerRef}};
+handle_info(
+    {'DOWN', MonRef, process, _Pid, _Reason},
+    #state{tasks = Tasks, tasks_rev = TasksRev} = State
+) ->
+    case maps:take(MonRef, TasksRev) of
+        {Ref, TasksRev1} ->
+            dec(?C_TASKS_IN_FLIGHT, 1),
+            %% A resubmit (same-Ref retry) may have already overwritten this
+            %% Ref's entry with a newer, still-running task by the time this
+            %% DOWN (from the earlier attempt) is processed. Only remove the
+            %% entry if it still belongs to this MonRef, so a stale DOWN can't
+            %% erase a live task and leave it unreachable by cancel/1.
+            Tasks1 =
+                case Tasks of
+                    #{Ref := {_, MonRef}} -> maps:remove(Ref, Tasks);
+                    #{} -> Tasks
+                end,
+            {noreply, State#state{tasks = Tasks1, tasks_rev = TasksRev1}};
+        error ->
+            {noreply, State}
+    end;
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -144,8 +219,7 @@ format_state(#state{bucket = Bucket, pending = Pending}) ->
 %% ------------------------------------------------------------------
 
 dispatch(Item, #state{bucket = unlimited} = State) ->
-    spawn_task(Item),
-    State;
+    spawn_task(Item, State);
 dispatch(Item, #state{pending = Pending} = State) ->
     case queue:is_empty(Pending) of
         false ->
@@ -163,10 +237,30 @@ try_admit({_Fun, Size, _ReplyTo, _Ref} = Item, #state{bucket = Bucket0} = State)
     case rabbitmq_stream_s3_token_bucket:request(Size, Bucket0) of
         {ok, Bucket} ->
             count_oversized(Size, Bucket0),
-            spawn_task(Item),
-            State#state{bucket = Bucket};
+            spawn_task(Item, State#state{bucket = Bucket});
         {insufficient, _, _} ->
             enqueue(Item, State)
+    end.
+
+%% Remove every Ref in `Refs` from `pending` in a single pass; a no-op for
+%% any Ref whose task was already admitted and cleaned up, or that never had
+%% a live submission.
+cancel_pending([], State) ->
+    State;
+cancel_pending(Refs, #state{pending = Pending0} = State) ->
+    RefSet = sets:from_list(Refs, [{version, 2}]),
+    Pending = queue:filter(
+        fun({_Fun, _Size, _ReplyTo, ItemRef}) -> not sets:is_element(ItemRef, RefSet) end,
+        Pending0
+    ),
+    Len0 = queue:len(Pending0),
+    Len = queue:len(Pending),
+    case Len of
+        Len0 ->
+            State;
+        _ ->
+            set(?C_PENDING_SUBMISSIONS, Len),
+            State#state{pending = Pending}
     end.
 
 %% Append a submission to the pending queue and ensure the refill timer is
@@ -184,25 +278,42 @@ drain_pending(#state{pending = Pending0, bucket = Bucket0} = State) ->
     case queue:peek(Pending0) of
         empty ->
             State;
-        {value, {_Fun, Size, _ReplyTo, _Ref} = Item} ->
-            case rabbitmq_stream_s3_token_bucket:request(Size, Bucket0) of
-                {ok, Bucket} ->
-                    count_oversized(Size, Bucket0),
-                    spawn_task(Item),
+        {value, {_Fun, _Size, ReplyTo, _Ref} = Item} ->
+            case is_process_alive(ReplyTo) of
+                false ->
+                    %% The requester died while this item waited behind the
+                    %% token bucket. Drop it for free (no tokens spent) and
+                    %% keep draining: the head is being discarded outright,
+                    %% not skipped-and-retried, so this doesn't let a later
+                    %% item unfairly jump the FIFO order (see enqueue/2).
+                    inc(?C_DROPPED_DEAD_REPLYTO, 1),
                     Pending = queue:drop(Pending0),
                     set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
-                    drain_pending(State#state{
-                        pending = Pending,
-                        bucket = Bucket
-                    });
-                {insufficient, _, _} ->
-                    State
+                    drain_pending(State#state{pending = Pending});
+                true ->
+                    drain_pending_admit(Item, Pending0, Bucket0, State)
             end
     end.
 
-spawn_task({Fun, _Size, ReplyTo, Ref}) ->
+drain_pending_admit({_Fun, Size, _ReplyTo, _Ref} = Item, Pending0, Bucket0, State) ->
+    case rabbitmq_stream_s3_token_bucket:request(Size, Bucket0) of
+        {ok, Bucket} ->
+            count_oversized(Size, Bucket0),
+            Pending = queue:drop(Pending0),
+            set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
+            drain_pending(
+                spawn_task(Item, State#state{
+                    pending = Pending,
+                    bucket = Bucket
+                })
+            );
+        {insufficient, _, _} ->
+            State
+    end.
+
+spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_rev = TasksRev} = State) ->
     inc(?C_TASKS_IN_FLIGHT, 1),
-    spawn(fun() ->
+    {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result =
             try
@@ -210,9 +321,12 @@ spawn_task({Fun, _Size, ReplyTo, Ref}) ->
             catch
                 Class:Reason -> {error, {Class, Reason}}
             end,
-        dec(?C_TASKS_IN_FLIGHT, 1),
         ReplyTo ! {transfer_result, Ref, Result}
-    end).
+    end),
+    State#state{
+        tasks = Tasks#{Ref => {Pid, MonRef}},
+        tasks_rev = TasksRev#{MonRef => Ref}
+    }.
 
 schedule_refill() ->
     erlang:send_after(?REFILL_INTERVAL_MS, self(), refill).
@@ -284,6 +398,189 @@ completion_routes_back_test() ->
     Results = collect_results([Ref1, Ref2], 1000),
     ?assertEqual({ok, first}, maps:get(Ref1, Results)),
     ?assertEqual({error, boom}, maps:get(Ref2, Results)),
+    gen_server:stop(Pid).
+
+%% cancel/1 on an admitted, running task kills it: no result is ever
+%% delivered, and the task is dropped from the governor's bookkeeping.
+cancel_kills_running_task_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Self = self(),
+    Ref = make_ref(),
+    submit(
+        fun() ->
+            receive
+                never -> ok
+            end
+        end,
+        100,
+        Self,
+        Ref
+    ),
+    %% submit/1 and cancel/1 are both casts from this process to the same
+    %% registered name, so send order is preserved: by the time cancel is
+    %% handled, the task is already admitted and in `tasks`.
+    cancel([Ref]),
+    receive
+        {transfer_result, Ref, _} -> error(unexpected_result)
+    after 300 ->
+        %% Also gives the kill and the resulting 'DOWN' time to land.
+        ok
+    end,
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    gen_server:stop(Pid).
+
+%% cancel/1 on a still-queued item removes it before it is ever admitted.
+cancel_removes_pending_item_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    RefA = make_ref(),
+    RefQueued = make_ref(),
+    submit(fun() -> {ok, a} end, 1000, Self, RefA),
+    receive
+        {transfer_result, RefA, _} -> ok
+    after 1000 -> error(a_timeout)
+    end,
+    %% Bucket is now exhausted; this one queues (see try_admit/enqueue).
+    submit(fun() -> error(should_not_run) end, 500, Self, RefQueued),
+    cancel([RefQueued]),
+    receive
+        {transfer_result, RefQueued, _} -> error(unexpected_result)
+    after 500 -> ok
+    end,
+    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
+    gen_server:stop(Pid).
+
+%% cancel/1 accepts a batch: a single call can kill an admitted, running task
+%% and remove a still-queued item together, in one pass over the pending
+%% queue.
+cancel_batch_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    RefRunning = make_ref(),
+    RefQueued = make_ref(),
+    %% Bucket starts full: admitted immediately, then blocks forever,
+    %% leaving the bucket exhausted.
+    submit(
+        fun() ->
+            receive
+                never -> ok
+            end
+        end,
+        1000,
+        Self,
+        RefRunning
+    ),
+    %% Bucket is now exhausted; this one queues (see try_admit/enqueue).
+    submit(fun() -> error(should_not_run) end, 500, Self, RefQueued),
+    cancel([RefRunning, RefQueued]),
+    receive
+        {transfer_result, RefRunning, _} -> error(unexpected_result)
+    after 300 ->
+        %% Also gives the kill and the resulting 'DOWN' time to land.
+        ok
+    end,
+    receive
+        {transfer_result, RefQueued, _} -> error(unexpected_result)
+    after 0 -> ok
+    end,
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
+    gen_server:stop(Pid).
+
+%% Regression test for a Ref-reuse race: a resubmit (a transient-retry
+%% resubmission reuses the same Ref) can install a new, live task under a Ref
+%% before the earlier attempt's own 'DOWN' (sent by the runtime when that
+%% attempt's process exits) is processed by the governor. Before the identity
+%% check in the 'DOWN' handler, that stale DOWN would erase the live task's
+%% entry, leaving it unreachable - and therefore unkillable - by cancel/1.
+resubmit_survives_stale_down_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Self = self(),
+    Ref = make_ref(),
+    Fun = fun() ->
+        receive
+            never -> ok
+        end
+    end,
+    submit(Fun, 100, Self, Ref),
+    #state{tasks = Tasks0} = sys:get_state(Pid),
+    {OldTaskPid, OldMonRef} = maps:get(Ref, Tasks0),
+    %% Resubmit with the same Ref, as a transient-retry resubmission does:
+    %% installs a new, still-running task under the same key.
+    submit(Fun, 100, Self, Ref),
+    #state{tasks = Tasks1} = sys:get_state(Pid),
+    {NewTaskPid, NewMonRef} = maps:get(Ref, Tasks1),
+    ?assertNotEqual({OldTaskPid, OldMonRef}, {NewTaskPid, NewMonRef}),
+    %% Simulate the earlier attempt's own 'DOWN' arriving late, after the
+    %% resubmit already overwrote the entry.
+    Pid ! {'DOWN', OldMonRef, process, OldTaskPid, normal},
+    %% Sync: sys:get_status round-trips through the gen_server, guaranteeing
+    %% the DOWN above has already been processed.
+    _ = sys:get_status(Pid),
+    ?assertEqual({NewTaskPid, NewMonRef}, maps:get(Ref, (sys:get_state(Pid))#state.tasks)),
+    %% cancel/1 must still be able to reach (and kill) the live task.
+    cancel([Ref]),
+    receive
+        {transfer_result, Ref, _} -> error(unexpected_result)
+    after 300 -> ok
+    end,
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    gen_server:stop(Pid).
+
+%% A submission whose ReplyTo is already dead is dropped at intake, before
+%% ever touching the bucket or spawning anything.
+dispatch_drops_dead_replyto_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    DeadPid = spawn(fun() -> ok end),
+    Mon = monitor(process, DeadPid),
+    receive
+        {'DOWN', Mon, process, DeadPid, _} -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    submit(fun() -> error(should_not_run) end, 100, DeadPid, make_ref()),
+    %% Sync: a second, live submission proves the first cast was processed.
+    Self = self(),
+    SyncRef = make_ref(),
+    submit(fun() -> {ok, sync} end, 1, Self, SyncRef),
+    receive
+        {transfer_result, SyncRef, _} -> ok
+    after 1000 -> error(sync_timeout)
+    end,
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    gen_server:stop(Pid).
+
+%% A queued item whose ReplyTo dies before its turn to drain is dropped for
+%% free, without ever being admitted.
+drain_drops_dead_replyto_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    DeadPid = spawn(fun() -> ok end),
+    Mon = monitor(process, DeadPid),
+    receive
+        {'DOWN', Mon, process, DeadPid, _} -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    RefA = make_ref(),
+    submit(fun() -> {ok, a} end, 1000, Self, RefA),
+    receive
+        {transfer_result, RefA, _} -> ok
+    after 1000 -> error(a_timeout)
+    end,
+    %% Bucket is now exhausted; this queues behind it with a dead ReplyTo.
+    %% The periodic refill timer (armed by enqueue/2) may drop it on its own
+    %% before the explicit refill below, so this doesn't assert on the
+    %% queue's length in between - only that the item never runs and the
+    %% queue eventually settles at 0.
+    submit(fun() -> error(should_not_run) end, 500, DeadPid, make_ref()),
+    %% Force a drain synchronously rather than relying solely on the timer.
+    Pid ! refill,
+    RefSync = make_ref(),
+    submit(fun() -> {ok, sync} end, 1, Self, RefSync),
+    receive
+        {transfer_result, RefSync, _} -> ok
+    after 1000 -> error(sync_timeout)
+    end,
+    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
     gen_server:stop(Pid).
 
 pacing_delays_when_exhausted_test() ->

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -18,6 +18,14 @@ spawned, and the pending queue is scanned once for the whole batch.
 Spawned tasks are monitored, not linked, so a governor restart does not
 kill tasks already running - they keep delivering their results directly to
 `ReplyTo` regardless of the governor's own lifecycle.
+
+A planned shutdown (the application or node stopping, or an explicit
+`gen_server:stop/1`) is different from a restart: `terminate/2` kills every
+still-running task, since nothing will be left running to service them.
+A crash takes neither path - it is not a planned shutdown, and it is not a
+restart either (the governor itself, not its tasks, is what's restarting) -
+so tasks are deliberately left alone, consistent with the monitor-not-link
+choice above.
 """.
 
 -behaviour(gen_server).
@@ -28,7 +36,8 @@ kill tasks already running - they keep delivering their results directly to
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    format_status/1
+    format_status/1,
+    terminate/2
 ]).
 
 -export([init_counters/0]).
@@ -115,6 +124,10 @@ cancel(Refs) ->
 %% ------------------------------------------------------------------
 
 init(Opts) ->
+    %% Without this, a supervisor-issued shutdown signal (application/node
+    %% stop) would just kill this process outright, and terminate/2 below -
+    %% which cancels running tasks on that specific path - would never run.
+    process_flag(trap_exit, true),
     Bucket =
         case maps:get(rate, Opts, unlimited) of
             unlimited ->
@@ -203,6 +216,25 @@ handle_info(_Info, State) ->
 
 format_status(#{state := State} = Status) ->
     Status#{state := format_state(State)}.
+
+%% Cancel every running task on a planned shutdown (application/node stop, or
+%% an explicit gen_server:stop/1) so nothing keeps running once nothing is
+%% left to service it. A crash takes a different path here - Reason is none
+%% of normal/shutdown/{shutdown, _} - and deliberately leaves tasks alone:
+%% they are spawn_monitor'd, not linked, precisely so a governor restart
+%% does not kill uploads already in flight (see moduledoc).
+terminate(Reason, #state{tasks = Tasks}) when
+    Reason =:= normal; Reason =:= shutdown
+->
+    kill_tasks(Tasks);
+terminate({shutdown, _}, #state{tasks = Tasks}) ->
+    kill_tasks(Tasks);
+terminate(_Reason, _State) ->
+    ok.
+
+kill_tasks(Tasks) ->
+    maps:foreach(fun(_Ref, {Pid, _MonRef}) -> exit(Pid, kill) end, Tasks),
+    ok.
 
 format_state(#state{bucket = Bucket, pending = Pending}) ->
     #{
@@ -526,6 +558,53 @@ resubmit_survives_stale_down_test() ->
     end,
     ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
     gen_server:stop(Pid).
+
+%% A planned stop (gen_server:stop/1, reason `normal`) kills every
+%% still-running task rather than leaving it to finish on its own.
+terminate_kills_tasks_on_normal_stop_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Self = self(),
+    Ref = make_ref(),
+    submit(
+        fun() ->
+            receive
+                never -> ok
+            end
+        end,
+        100,
+        Self,
+        Ref
+    ),
+    #state{tasks = Tasks} = sys:get_state(Pid),
+    {TaskPid, _MonRef} = maps:get(Ref, Tasks),
+    Mon = monitor(process, TaskPid),
+    gen_server:stop(Pid),
+    receive
+        {'DOWN', Mon, process, TaskPid, killed} -> ok
+    after 1000 -> error(task_not_killed)
+    end.
+
+%% terminate/2 leaves tasks alone for any reason other than a planned
+%% shutdown - specifically so a governor crash-restart does not kill uploads
+%% already in flight (see moduledoc).
+terminate_leaves_tasks_on_crash_reason_test() ->
+    TaskPid = spawn(fun() ->
+        receive
+            never -> ok
+        end
+    end),
+    MonRef = monitor(process, TaskPid),
+    Ref = make_ref(),
+    State = #state{
+        bucket = unlimited,
+        pending = queue:new(),
+        tasks = #{Ref => {TaskPid, MonRef}},
+        tasks_rev = #{MonRef => Ref}
+    },
+    ok = terminate({error, some_crash}, State),
+    timer:sleep(50),
+    ?assert(is_process_alive(TaskPid)),
+    exit(TaskPid, kill).
 
 %% A submission whose ReplyTo is already dead is dropped at intake, before
 %% ever touching the bucket or spawning anything.

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -1371,6 +1371,65 @@ pending_gauge_is_derived_from_state_test() ->
         gen_server:stop(Pid)
     end).
 
+%% submissions_received counts intake, so it must count a submission whose
+%% requester is already dead too - that one never reaches a task, and the gap
+%% between it and dropped_dead_replyto is what makes the drop visible.
+submissions_received_counts_every_intake_test() ->
+    with_counter(fun(Cnt) ->
+        {ok, Pid} = start_link(#{rate => unlimited}),
+        Self = self(),
+        Ref = make_ref(),
+        submit(fun() -> {ok, live} end, 100, Self, Ref),
+        receive
+            {transfer_result, Ref, _} -> ok
+        after 1000 -> error(live_timeout)
+        end,
+        ?assertEqual(1, counters:get(Cnt, ?C_SUBMISSIONS_RECEIVED)),
+        Dead = spawn(fun() -> ok end),
+        await_dead(Dead),
+        submit(fun() -> error(should_not_run) end, 100, Dead, make_ref()),
+        await_state(Pid, fun(_) ->
+            counters:get(Cnt, ?C_SUBMISSIONS_RECEIVED) =:= 2
+        end),
+        ?assertEqual(1, counters:get(Cnt, ?C_DROPPED_DEAD_REPLYTO)),
+        gen_server:stop(Pid)
+    end).
+
+%% A transfer larger than the burst is admitted on credit rather than
+%% deadlocking, and is counted so a burst configured below typical fragment
+%% sizes is visible. Only the oversized admission counts, not the normal one.
+oversized_admissions_counts_credit_admissions_test() ->
+    with_counter(fun(Cnt) ->
+        {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+        Self = self(),
+        RefNormal = make_ref(),
+        submit(fun() -> {ok, normal} end, 500, Self, RefNormal),
+        receive
+            {transfer_result, RefNormal, _} -> ok
+        after 1000 -> error(normal_timeout)
+        end,
+        ?assertEqual(0, counters:get(Cnt, ?C_OVERSIZED_ADMISSIONS)),
+        %% 1500 > burst 1000: admitted once the bucket is fully saved up, then
+        %% driven into debt. It has to wait for the refill, hence the budget.
+        RefBig = make_ref(),
+        submit(fun() -> {ok, big} end, 1500, Self, RefBig),
+        receive
+            {transfer_result, RefBig, _} -> ok
+        after 5000 -> error(big_timeout)
+        end,
+        ?assertEqual(1, counters:get(Cnt, ?C_OVERSIZED_ADMISSIONS)),
+        gen_server:stop(Pid)
+    end).
+
+%% Wait until Pid is really gone, so is_process_alive/1 in the governor's intake
+%% is guaranteed to see it dead rather than racing the spawn.
+await_dead(Pid) ->
+    Mon = monitor(process, Pid),
+    receive
+        {'DOWN', Mon, process, Pid, _} -> ok
+    after 1000 -> error({still_alive, Pid})
+    end.
+
 %% Run Fun with a private counter installed, restoring whatever was there
 %% before. The key is global to the node, so a test must not leave the module's
 %% real counter erased or replaced for whatever runs next.

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -38,6 +38,22 @@ A crash takes neither path - it is not a planned shutdown, and it is not a
 restart either (the governor itself, not its tasks, is what's restarting) -
 so tasks are deliberately left alone, consistent with the monitor-not-link
 choice above.
+
+## Derived gauges
+
+Both gauges are pure functions of the state they describe, published by
+`derive_gauges/1` on every handler return, not independently mutated counters:
+
+- `governor_tasks_in_flight`     = `map_size(tasks)`
+- `governor_pending_submissions` = `queue:len(pending)`
+
+The counters live in `persistent_term` and so outlive the process, while `tasks`
+and `pending` do not. An inc/dec gauge therefore ratchets permanently on the one
+path that deliberately runs no cleanup: a crash leaves every running task's
+`'DOWN'` in a dead mailbox, and the fresh incarnation starts from `tasks = #{}`
+with no decrement left to issue. A derived gauge self-heals instead, because
+`init/1` publishes from the empty state and each later mutation republishes the
+truth.
 """.
 
 -behaviour(gen_server).
@@ -160,8 +176,11 @@ init(Opts) ->
             unlimited -> undefined;
             _ -> schedule_refill()
         end,
-    %% Counter is created by init_counters/0 from the API init step.
-    {ok, #state{bucket = Bucket, pending = queue:new(), timer_ref = TimerRef}}.
+    %% Counter is created by init_counters/0 from the API init step. It lives in
+    %% persistent_term, so it outlives this process: publish the gauges from the
+    %% empty state so a restart does not inherit the previous incarnation's
+    %% values (whose tasks and queue are gone along with its state).
+    {ok, derive_gauges(#state{bucket = Bucket, pending = queue:new(), timer_ref = TimerRef})}.
 
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown}, State}.
@@ -170,7 +189,7 @@ handle_cast({submit, Fun, Size, ReplyTo, Ref}, State) ->
     inc(?C_SUBMISSIONS_RECEIVED, 1),
     case is_process_alive(ReplyTo) of
         true ->
-            {noreply, dispatch({Fun, Size, ReplyTo, Ref}, State)};
+            {noreply, derive_gauges(dispatch({Fun, Size, ReplyTo, Ref}, State))};
         false ->
             %% The requester died between calling submit/4 and this cast
             %% landing (e.g. a stream deletion or a crash). Drop it now
@@ -181,10 +200,10 @@ handle_cast({submit, Fun, Size, ReplyTo, Ref}, State) ->
     end;
 handle_cast({cancel, Refs}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State) ->
     %% Kill every admitted attempt for these Refs; tasks/tasks_by_ref removal
-    %% and the TASKS_IN_FLIGHT decrement happen in the 'DOWN' handler below,
-    %% the single cleanup path shared by normal completion, a crash and a kill
-    %% alike. A Ref can have more than one live attempt (a same-Ref resubmit
-    %% while the earlier one is still running), so all of them are killed.
+    %% happens in the 'DOWN' handler below, the single cleanup path shared by
+    %% normal completion, a crash and a kill alike. A Ref can have more than one
+    %% live attempt (a same-Ref resubmit while the earlier one is still
+    %% running), so all of them are killed.
     %% A Ref can also be admitted and still queued at the same time, so every
     %% Ref is passed to cancel_pending/2 as well: a still-queued copy must not
     %% be left behind just because an admitted attempt for the same Ref existed.
@@ -200,7 +219,7 @@ handle_cast({cancel, Refs}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State)
         end,
         Refs
     ),
-    {noreply, cancel_pending(Refs, State)};
+    {noreply, derive_gauges(cancel_pending(Refs, State))};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -213,14 +232,13 @@ handle_info(refill, #state{bucket = Bucket0} = State0) ->
             true -> undefined;
             false -> schedule_refill()
         end,
-    {noreply, State2#state{timer_ref = TimerRef}};
+    {noreply, derive_gauges(State2#state{timer_ref = TimerRef})};
 handle_info(
     {'DOWN', MonRef, process, Pid, _Reason},
     #state{tasks = Tasks, tasks_by_ref = ByRef} = State
 ) ->
     case maps:take(MonRef, Tasks) of
         {{_, Ref, ReplyTo}, Tasks1} ->
-            dec(?C_TASKS_IN_FLIGHT, 1),
             %% Drop only this attempt's monitor from the Ref's list; a same-Ref
             %% resubmit may still have another attempt running under it. Remove
             %% the Ref key entirely once its last attempt is gone, so the index
@@ -231,13 +249,13 @@ handle_info(
                     Rest -> ByRef#{Ref => Rest}
                 end,
             State1 = State#state{tasks = Tasks1, tasks_by_ref = ByRef1},
-            {noreply, unwatch_requester(ReplyTo, State1)};
+            {noreply, derive_gauges(unwatch_requester(ReplyTo, State1))};
         error ->
             %% Not a task: a requester died. Kill everything it submitted -
             %% running or still queued - since its results now have nowhere to
             %% go. This is the only cancellation path a brutal kill, a crash,
             %% or a supervisor shutdown of the requester can reach.
-            {noreply, requester_down(MonRef, Pid, State)}
+            {noreply, derive_gauges(requester_down(MonRef, Pid, State))}
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -353,21 +371,12 @@ cancel_pending(Refs, #state{pending = Pending0} = State) ->
         fun({_Fun, _Size, _ReplyTo, ItemRef}) -> not sets:is_element(ItemRef, RefSet) end,
         Pending0
     ),
-    Len0 = queue:len(Pending0),
-    Len = queue:len(Pending),
-    case Len of
-        Len0 ->
-            State;
-        _ ->
-            set(?C_PENDING_SUBMISSIONS, Len),
-            State#state{pending = Pending}
-    end.
+    State#state{pending = Pending}.
 
 %% Append a submission to the pending queue and ensure the refill timer is
 %% running so it will eventually drain.
 enqueue(Item, State) ->
     Pending = queue:in(Item, State#state.pending),
-    set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
     State1 = State#state{pending = Pending},
     case State1#state.timer_ref of
         undefined -> State1#state{timer_ref = schedule_refill()};
@@ -388,7 +397,6 @@ drain_pending(#state{pending = Pending0, bucket = Bucket0} = State) ->
                     %% item unfairly jump the FIFO order (see enqueue/2).
                     inc(?C_DROPPED_DEAD_REPLYTO, 1),
                     Pending = queue:drop(Pending0),
-                    set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
                     drain_pending(State#state{pending = Pending});
                 true ->
                     drain_pending_admit(Item, Pending0, Bucket0, State)
@@ -400,7 +408,6 @@ drain_pending_admit({_Fun, Size, _ReplyTo, _Ref} = Item, Pending0, Bucket0, Stat
         {ok, Bucket} ->
             count_oversized(Size, Bucket0),
             Pending = queue:drop(Pending0),
-            set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
             drain_pending(
                 spawn_task(Item, State#state{
                     pending = Pending,
@@ -412,7 +419,6 @@ drain_pending_admit({_Fun, Size, _ReplyTo, _Ref} = Item, Pending0, Bucket0, Stat
     end.
 
 spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State) ->
-    inc(?C_TASKS_IN_FLIGHT, 1),
     {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
         Result =
@@ -491,17 +497,20 @@ inc(Idx, N) ->
         Cnt -> counters:add(Cnt, Idx, N)
     end.
 
-dec(Idx, N) ->
-    case counter() of
-        undefined -> ok;
-        Cnt -> counters:sub(Cnt, Idx, N)
-    end.
-
 set(Idx, V) ->
     case counter() of
         undefined -> ok;
         Cnt -> counters:put(Cnt, Idx, V)
     end.
+
+%% Publish both gauges from the state they describe, rather than incrementing
+%% and decrementing them independently. Called on every callback return that can
+%% change `tasks` or `pending`, and from `init/1`, so a gauge is never more than
+%% one in-progress callback away from the truth. See the moduledoc.
+derive_gauges(#state{tasks = Tasks, pending = Pending} = State) ->
+    set(?C_TASKS_IN_FLIGHT, map_size(Tasks)),
+    set(?C_PENDING_SUBMISSIONS, queue:len(Pending)),
+    State.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -1087,6 +1096,85 @@ queued_item_is_not_starved_by_later_submissions_test() ->
     %% The head (submitted first) must complete before the later small item.
     ?assertEqual([RefHead, RefSmall], collect_order([RefHead, RefSmall], 5000)),
     gen_server:stop(Pid).
+
+%% The tasks gauge must equal `map_size(tasks)` at all times, including after a
+%% crash and restart. The counters live in persistent_term and outlive the
+%% process; `tasks` does not. An inc/dec gauge ratcheted permanently here: a
+%% crash leaves each running task's 'DOWN' in a dead mailbox, so the decrement
+%% is never issued, and the new incarnation starts from `tasks = #{}` with
+%% nothing left to decrement.
+tasks_gauge_is_derived_from_state_test() ->
+    with_counter(fun(Cnt) ->
+        ?assertEqual(0, counters:get(Cnt, ?C_TASKS_IN_FLIGHT)),
+        {ok, Pid} = start_link(#{rate => unlimited}),
+        Self = self(),
+        Block = fun() ->
+            receive
+                never -> ok
+            end
+        end,
+        submit(Block, 100, Self, make_ref()),
+        submit(Block, 100, Self, make_ref()),
+        await_state(Pid, fun(#state{tasks = T}) -> map_size(T) =:= 2 end),
+        ?assertEqual(2, counters:get(Cnt, ?C_TASKS_IN_FLIGHT)),
+        #state{tasks = Tasks} = sys:get_state(Pid),
+        TaskPids = [P || {P, _Ref, _Owner} <- maps:values(Tasks)],
+        %% Kill the governor outright, as a supervisor shutdown timeout does.
+        %% No terminate/2 runs, and the tasks outlive it (they are monitored,
+        %% not linked), so both 'DOWN's are lost with the mailbox.
+        unlink(Pid),
+        Mon = monitor(process, Pid),
+        exit(Pid, kill),
+        receive
+            {'DOWN', Mon, process, Pid, _} -> ok
+        after 1000 -> error(governor_survived_kill)
+        end,
+        %% The restart the supervisor would do. init/1 publishes from the empty
+        %% state, so the stale 2 is corrected rather than inherited forever.
+        {ok, Pid2} = start_link(#{rate => unlimited}),
+        ?assertEqual(0, counters:get(Cnt, ?C_TASKS_IN_FLIGHT)),
+        lists:foreach(fun(P) -> exit(P, kill) end, TaskPids),
+        gen_server:stop(Pid2)
+    end).
+
+%% The pending gauge must equal `queue:len(pending)`, including on the paths
+%% that shrink the queue without admitting anything.
+pending_gauge_is_derived_from_state_test() ->
+    with_counter(fun(Cnt) ->
+        {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+        Self = self(),
+        RefA = make_ref(),
+        RefQueued = make_ref(),
+        %% Drain the bucket so the next submission has to queue.
+        submit(fun() -> {ok, a} end, 1000, Self, RefA),
+        receive
+            {transfer_result, RefA, _} -> ok
+        after 1000 -> error(a_timeout)
+        end,
+        submit(fun() -> {ok, queued} end, 900, Self, RefQueued),
+        await_state(Pid, fun(#state{pending = P}) -> queue:len(P) =:= 1 end),
+        ?assertEqual(1, counters:get(Cnt, ?C_PENDING_SUBMISSIONS)),
+        cancel([RefQueued]),
+        await_state(Pid, fun(#state{pending = P}) -> queue:is_empty(P) end),
+        ?assertEqual(0, counters:get(Cnt, ?C_PENDING_SUBMISSIONS)),
+        gen_server:stop(Pid)
+    end).
+
+%% Run Fun with a private counter installed, restoring whatever was there
+%% before. The key is global to the node, so a test must not leave the module's
+%% real counter erased or replaced for whatever runs next.
+with_counter(Fun) ->
+    Previous = persistent_term:get(?COUNTER_KEY, undefined),
+    Cnt = counters:new(length(?COUNTERS), []),
+    persistent_term:put(?COUNTER_KEY, Cnt),
+    try
+        Fun(Cnt)
+    after
+        case Previous of
+            undefined -> persistent_term:erase(?COUNTER_KEY);
+            _ -> persistent_term:put(?COUNTER_KEY, Previous)
+        end
+    end.
 
 %% Block until the governor's own state satisfies Fun, or fail the test.
 %% A killed task's 'DOWN' is delivered to the governor asynchronously, so the

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -12,9 +12,12 @@ The transfer function is opaque to the governor.
 When the configured rate is `unlimited`, submissions execute immediately
 with no pacing.
 
-A caller can cancel a batch of submissions by their `Ref`s via `cancel/1`: an
-admitted task is killed, a still-queued item is dropped before ever being
-spawned, and the pending queue is scanned once for the whole batch.
+A caller can cancel a batch of submissions by their `Ref`s via `cancel/1`:
+every admitted task for a `Ref` is killed, a still-queued item is dropped
+before ever being spawned, and the pending queue is scanned once for the whole
+batch. A single `Ref` can have both more than one running task and a queued
+item at the same time, because a resubmit reuses its `Ref`; `cancel/1` reaches
+all of them.
 Spawned tasks are monitored, not linked, so a governor restart does not
 kill tasks already running - they keep delivering their results directly to
 `ReplyTo` regardless of the governor's own lifecycle.
@@ -75,12 +78,15 @@ choice above.
     %% Pending submissions waiting for tokens.
     pending :: queue:queue(pending_item()),
     timer_ref :: reference() | undefined,
-    %% Ref => {Pid, MonRef} for every task currently executing, so cancel/1
-    %% can reach an admitted task by its caller-minted Ref.
+    %% MonRef => {Pid, Ref} for every task currently executing, one entry per
+    %% live attempt. Keyed by the monitor reference rather than the
+    %% caller-minted Ref because a resubmit reuses the same Ref: keying by Ref
+    %% let a second live attempt overwrite the first, orphaning a running task
+    %% that neither cancel/1 nor kill_tasks/1 could then reach.
     tasks = #{} :: #{reference() => {pid(), reference()}},
-    %% MonRef => Ref, the reverse index the 'DOWN' handler uses to find which
-    %% submission a completed, crashed or killed monitor belonged to.
-    tasks_rev = #{} :: #{reference() => reference()}
+    %% Ref => [MonRef], the secondary index cancel/1 uses to reach every live
+    %% attempt belonging to a caller-minted Ref.
+    tasks_by_ref = #{} :: #{reference() => [reference()]}
 }).
 
 -type pending_item() :: {
@@ -160,20 +166,24 @@ handle_cast({submit, Fun, Size, ReplyTo, Ref}, State) ->
             inc(?C_DROPPED_DEAD_REPLYTO, 1),
             {noreply, State}
     end;
-handle_cast({cancel, Refs}, #state{tasks = Tasks} = State) ->
-    %% Kill any admitted task for these Refs; tasks/tasks_rev removal and the
-    %% TASKS_IN_FLIGHT decrement happen in the 'DOWN' handler below, the single
-    %% cleanup path shared by normal completion, a crash and a kill alike.
-    %% A Ref can be admitted and still queued at the same time (a same-Ref
-    %% resubmit while the earlier attempt is still running), so every Ref is
-    %% also passed to cancel_pending/2: a still-queued copy must not be left
-    %% behind just because an admitted task for the same Ref existed.
+handle_cast({cancel, Refs}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State) ->
+    %% Kill every admitted attempt for these Refs; tasks/tasks_by_ref removal
+    %% and the TASKS_IN_FLIGHT decrement happen in the 'DOWN' handler below,
+    %% the single cleanup path shared by normal completion, a crash and a kill
+    %% alike. A Ref can have more than one live attempt (a same-Ref resubmit
+    %% while the earlier one is still running), so all of them are killed.
+    %% A Ref can also be admitted and still queued at the same time, so every
+    %% Ref is passed to cancel_pending/2 as well: a still-queued copy must not
+    %% be left behind just because an admitted attempt for the same Ref existed.
     lists:foreach(
         fun(Ref) ->
-            case Tasks of
-                #{Ref := {Pid, _MonRef}} -> exit(Pid, kill);
-                #{} -> ok
-            end
+            lists:foreach(
+                fun(MonRef) ->
+                    {Pid, _Ref} = maps:get(MonRef, Tasks),
+                    exit(Pid, kill)
+                end,
+                maps:get(Ref, ByRef, [])
+            )
         end,
         Refs
     ),
@@ -193,22 +203,21 @@ handle_info(refill, #state{bucket = Bucket0} = State0) ->
     {noreply, State2#state{timer_ref = TimerRef}};
 handle_info(
     {'DOWN', MonRef, process, _Pid, _Reason},
-    #state{tasks = Tasks, tasks_rev = TasksRev} = State
+    #state{tasks = Tasks, tasks_by_ref = ByRef} = State
 ) ->
-    case maps:take(MonRef, TasksRev) of
-        {Ref, TasksRev1} ->
+    case maps:take(MonRef, Tasks) of
+        {{_, Ref}, Tasks1} ->
             dec(?C_TASKS_IN_FLIGHT, 1),
-            %% A resubmit (same-Ref retry) may have already overwritten this
-            %% Ref's entry with a newer, still-running task by the time this
-            %% DOWN (from the earlier attempt) is processed. Only remove the
-            %% entry if it still belongs to this MonRef, so a stale DOWN can't
-            %% erase a live task and leave it unreachable by cancel/1.
-            Tasks1 =
-                case Tasks of
-                    #{Ref := {_, MonRef}} -> maps:remove(Ref, Tasks);
-                    #{} -> Tasks
+            %% Drop only this attempt's monitor from the Ref's list; a same-Ref
+            %% resubmit may still have another attempt running under it. Remove
+            %% the Ref key entirely once its last attempt is gone, so the index
+            %% does not accumulate empty lists.
+            ByRef1 =
+                case maps:get(Ref, ByRef, []) -- [MonRef] of
+                    [] -> maps:remove(Ref, ByRef);
+                    Rest -> ByRef#{Ref => Rest}
                 end,
-            {noreply, State#state{tasks = Tasks1, tasks_rev = TasksRev1}};
+            {noreply, State#state{tasks = Tasks1, tasks_by_ref = ByRef1}};
         error ->
             {noreply, State}
     end;
@@ -234,7 +243,7 @@ terminate(_Reason, _State) ->
     ok.
 
 kill_tasks(Tasks) ->
-    maps:foreach(fun(_Ref, {Pid, _MonRef}) -> exit(Pid, kill) end, Tasks),
+    maps:foreach(fun(_MonRef, {Pid, _Ref}) -> exit(Pid, kill) end, Tasks),
     ok.
 
 format_state(#state{bucket = Bucket, pending = Pending}) ->
@@ -344,7 +353,7 @@ drain_pending_admit({_Fun, Size, _ReplyTo, _Ref} = Item, Pending0, Bucket0, Stat
             State
     end.
 
-spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_rev = TasksRev} = State) ->
+spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State) ->
     inc(?C_TASKS_IN_FLIGHT, 1),
     {Pid, MonRef} = spawn_monitor(fun() ->
         logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_STREAM_S3}),
@@ -356,9 +365,12 @@ spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_rev = TasksRe
             end,
         ReplyTo ! {transfer_result, Ref, Result}
     end),
+    %% A resubmit reuses the same Ref while the earlier attempt may still be
+    %% running, so append to this Ref's monitor list rather than replacing it.
+    MonRefs = maps:get(Ref, ByRef, []),
     State#state{
-        tasks = Tasks#{Ref => {Pid, MonRef}},
-        tasks_rev = TasksRev#{MonRef => Ref}
+        tasks = Tasks#{MonRef => {Pid, Ref}},
+        tasks_by_ref = ByRef#{Ref => [MonRef | MonRefs]}
     }.
 
 schedule_refill() ->
@@ -520,13 +532,11 @@ cancel_batch_test() ->
     ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
     gen_server:stop(Pid).
 
-%% Regression test for a Ref-reuse race: a resubmit (a transient-retry
-%% resubmission reuses the same Ref) can install a new, live task under a Ref
-%% before the earlier attempt's own 'DOWN' (sent by the runtime when that
-%% attempt's process exits) is processed by the governor. Before the identity
-%% check in the 'DOWN' handler, that stale DOWN would erase the live task's
-%% entry, leaving it unreachable - and therefore unkillable - by cancel/1.
-resubmit_survives_stale_down_test() ->
+%% A resubmit (a transient-retry resubmission reuses the same Ref) can install
+%% a second, still-running task under a Ref while the earlier attempt is also
+%% still running. Both attempts must be tracked independently, and a late
+%% 'DOWN' from the earlier one must not disturb the live sibling.
+resubmit_tracks_both_attempts_test() ->
     {ok, Pid} = start_link(#{rate => unlimited}),
     Self = self(),
     Ref = make_ref(),
@@ -536,21 +546,26 @@ resubmit_survives_stale_down_test() ->
         end
     end,
     submit(Fun, 100, Self, Ref),
-    #state{tasks = Tasks0} = sys:get_state(Pid),
-    {OldTaskPid, OldMonRef} = maps:get(Ref, Tasks0),
-    %% Resubmit with the same Ref, as a transient-retry resubmission does:
-    %% installs a new, still-running task under the same key.
+    #state{tasks = Tasks0, tasks_by_ref = ByRef0} = sys:get_state(Pid),
+    [OldMonRef] = maps:get(Ref, ByRef0),
+    {OldTaskPid, Ref} = maps:get(OldMonRef, Tasks0),
+    %% Resubmit with the same Ref, as a transient-retry resubmission does. The
+    %% earlier attempt is still running, so both are now tracked.
     submit(Fun, 100, Self, Ref),
-    #state{tasks = Tasks1} = sys:get_state(Pid),
-    {NewTaskPid, NewMonRef} = maps:get(Ref, Tasks1),
-    ?assertNotEqual({OldTaskPid, OldMonRef}, {NewTaskPid, NewMonRef}),
-    %% Simulate the earlier attempt's own 'DOWN' arriving late, after the
-    %% resubmit already overwrote the entry.
+    #state{tasks = Tasks1, tasks_by_ref = ByRef1} = sys:get_state(Pid),
+    ?assertEqual(2, map_size(Tasks1)),
+    [NewMonRef] = maps:get(Ref, ByRef1) -- [OldMonRef],
+    {NewTaskPid, Ref} = maps:get(NewMonRef, Tasks1),
+    ?assertNotEqual(OldTaskPid, NewTaskPid),
+    %% The earlier attempt's own 'DOWN' must drop only its entry, leaving the
+    %% live sibling reachable.
     Pid ! {'DOWN', OldMonRef, process, OldTaskPid, normal},
     %% Sync: sys:get_status round-trips through the gen_server, guaranteeing
     %% the DOWN above has already been processed.
     _ = sys:get_status(Pid),
-    ?assertEqual({NewTaskPid, NewMonRef}, maps:get(Ref, (sys:get_state(Pid))#state.tasks)),
+    #state{tasks = Tasks2, tasks_by_ref = ByRef2} = sys:get_state(Pid),
+    ?assertEqual([NewMonRef], maps:get(Ref, ByRef2)),
+    ?assertEqual({NewTaskPid, Ref}, maps:get(NewMonRef, Tasks2)),
     %% cancel/1 must still be able to reach (and kill) the live task.
     cancel([Ref]),
     receive
@@ -558,6 +573,44 @@ resubmit_survives_stale_down_test() ->
     after 300 -> ok
     end,
     ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks_by_ref),
+    gen_server:stop(Pid).
+
+%% cancel/1 must kill EVERY live attempt under a Ref, not just the most recent
+%% one. Before keying `tasks` by monitor reference, a same-Ref resubmit
+%% overwrote the earlier attempt's entry, so cancel/1 killed only the newer
+%% task and the earlier one kept streaming its fragment to S3 for a deleted
+%% stream, holding an upload-pool connection and writing an orphan object.
+cancel_kills_every_attempt_under_a_ref_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Self = self(),
+    Ref = make_ref(),
+    Fun = fun() ->
+        receive
+            never -> ok
+        end
+    end,
+    submit(Fun, 100, Self, Ref),
+    submit(Fun, 100, Self, Ref),
+    #state{tasks = Tasks, tasks_by_ref = ByRef} = sys:get_state(Pid),
+    ?assertEqual(2, map_size(Tasks)),
+    MonRefs = maps:get(Ref, ByRef),
+    ?assertEqual(2, length(MonRefs)),
+    Pids = [P || MonRef <- MonRefs, {P, _} <- [maps:get(MonRef, Tasks)]],
+    Mons = [monitor(process, P) || P <- Pids],
+    cancel([Ref]),
+    %% Both attempts must die, not just the most recently installed one.
+    lists:foreach(
+        fun(Mon) ->
+            receive
+                {'DOWN', Mon, process, _, killed} -> ok
+            after 1000 -> error(attempt_not_killed)
+            end
+        end,
+        Mons
+    ),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks_by_ref),
     gen_server:stop(Pid).
 
 %% cancel/1 on a Ref that is both admitted (a running task) and still queued
@@ -585,8 +638,8 @@ cancel_reaches_admitted_and_queued_same_ref_test() ->
     %% Attempt 2 under the SAME Ref: bucket is exhausted, so it queues. The Ref
     %% is now both in `tasks` (attempt 1) and in `pending` (attempt 2).
     submit(fun() -> error(should_not_run) end, 500, Self, Ref),
-    #state{tasks = Tasks, pending = Pending} = sys:get_state(Pid),
-    ?assert(is_map_key(Ref, Tasks)),
+    #state{tasks_by_ref = ByRef, pending = Pending} = sys:get_state(Pid),
+    ?assert(is_map_key(Ref, ByRef)),
     ?assertEqual(1, queue:len(Pending)),
     cancel([Ref]),
     receive
@@ -615,8 +668,9 @@ terminate_kills_tasks_on_normal_stop_test() ->
         Self,
         Ref
     ),
-    #state{tasks = Tasks} = sys:get_state(Pid),
-    {TaskPid, _MonRef} = maps:get(Ref, Tasks),
+    #state{tasks = Tasks, tasks_by_ref = ByRef} = sys:get_state(Pid),
+    [MonRef] = maps:get(Ref, ByRef),
+    {TaskPid, Ref} = maps:get(MonRef, Tasks),
     Mon = monitor(process, TaskPid),
     gen_server:stop(Pid),
     receive
@@ -638,8 +692,8 @@ terminate_leaves_tasks_on_crash_reason_test() ->
     State = #state{
         bucket = unlimited,
         pending = queue:new(),
-        tasks = #{Ref => {TaskPid, MonRef}},
-        tasks_rev = #{MonRef => Ref}
+        tasks = #{MonRef => {TaskPid, Ref}},
+        tasks_by_ref = #{Ref => [MonRef]}
     },
     ok = terminate({error, some_crash}, State),
     timer:sleep(50),

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -160,21 +160,22 @@ handle_cast({submit, Fun, Size, ReplyTo, Ref}, State) ->
             inc(?C_DROPPED_DEAD_REPLYTO, 1),
             {noreply, State}
     end;
-handle_cast({cancel, Refs0}, #state{tasks = Tasks} = State) ->
-    %% tasks/tasks_rev removal and the TASKS_IN_FLIGHT decrement happen in
-    %% the 'DOWN' handler below, the single cleanup path shared by normal
-    %% completion, a crash and a kill alike.
-    Refs = lists:filter(
+handle_cast({cancel, Refs}, #state{tasks = Tasks} = State) ->
+    %% Kill any admitted task for these Refs; tasks/tasks_rev removal and the
+    %% TASKS_IN_FLIGHT decrement happen in the 'DOWN' handler below, the single
+    %% cleanup path shared by normal completion, a crash and a kill alike.
+    %% A Ref can be admitted and still queued at the same time (a same-Ref
+    %% resubmit while the earlier attempt is still running), so every Ref is
+    %% also passed to cancel_pending/2: a still-queued copy must not be left
+    %% behind just because an admitted task for the same Ref existed.
+    lists:foreach(
         fun(Ref) ->
             case Tasks of
-                #{Ref := {Pid, _MonRef}} ->
-                    exit(Pid, kill),
-                    false;
-                #{} ->
-                    true
+                #{Ref := {Pid, _MonRef}} -> exit(Pid, kill);
+                #{} -> ok
             end
         end,
-        Refs0
+        Refs
     ),
     {noreply, cancel_pending(Refs, State)};
 handle_cast(_Msg, State) ->
@@ -557,6 +558,45 @@ resubmit_survives_stale_down_test() ->
     after 300 -> ok
     end,
     ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    gen_server:stop(Pid).
+
+%% cancel/1 on a Ref that is both admitted (a running task) and still queued
+%% (a same-Ref resubmit while the earlier attempt is still running) must reach
+%% both: the running task is killed and the queued copy is dropped. Before the
+%% fix, finding a running task for the Ref filtered it out of the batch handed
+%% to cancel_pending/2, so the queued copy survived and would later be admitted
+%% and uploaded for an already-deleted stream.
+cancel_reaches_admitted_and_queued_same_ref_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    Ref = make_ref(),
+    %% Attempt 1: admitted immediately (bucket full), then blocks forever,
+    %% leaving the bucket exhausted.
+    submit(
+        fun() ->
+            receive
+                never -> ok
+            end
+        end,
+        1000,
+        Self,
+        Ref
+    ),
+    %% Attempt 2 under the SAME Ref: bucket is exhausted, so it queues. The Ref
+    %% is now both in `tasks` (attempt 1) and in `pending` (attempt 2).
+    submit(fun() -> error(should_not_run) end, 500, Self, Ref),
+    #state{tasks = Tasks, pending = Pending} = sys:get_state(Pid),
+    ?assert(is_map_key(Ref, Tasks)),
+    ?assertEqual(1, queue:len(Pending)),
+    cancel([Ref]),
+    receive
+        {transfer_result, Ref, _} -> error(unexpected_result)
+    after 300 ->
+        %% Also gives the kill and the resulting 'DOWN' time to land.
+        ok
+    end,
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
     gen_server:stop(Pid).
 
 %% A planned stop (gen_server:stop/1, reason `normal`) kills every

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -506,6 +506,11 @@ set(Idx, V) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% Barrier budget for await_state/2, generous because it is only ever paid in
+%% full when a test is about to fail anyway.
+-define(AWAIT_MS, 2000).
+-define(AWAIT_INTERVAL_MS, 5).
+
 unlimited_passes_through_test() ->
     {ok, Pid} = start_link(#{rate => unlimited}),
     Ref = make_ref(),
@@ -822,15 +827,17 @@ requester_death_kills_running_task_test() ->
     ?assert(is_map_key(Requester, Requesters)),
     TaskMon = monitor(process, TaskPid),
     Requester ! die,
+    %% The task is killed as a direct consequence of the requester's death.
     receive
         {'DOWN', TaskMon, process, TaskPid, killed} -> ok
     after 1000 -> error(task_not_killed)
     end,
-    %% The task's own 'DOWN' clears the bookkeeping, including the monitor.
-    _ = sys:get_status(Pid),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks_by_ref),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    %% This 'DOWN' is delivered to the test; the governor's own copy is a
+    %% separate signal with no ordering relation to it, so await the governor's
+    %% state rather than assuming its 'DOWN' has already been processed.
+    await_state(Pid, fun(#state{tasks = T, tasks_by_ref = B, requesters = R}) ->
+        T =:= #{} andalso B =:= #{} andalso R =:= #{}
+    end),
     gen_server:stop(Pid).
 
 %% A dying requester's still-queued submissions are dropped as well as its
@@ -866,13 +873,12 @@ requester_death_drops_queued_submissions_test() ->
     ?assertEqual(1, map_size((sys:get_state(Pid))#state.tasks)),
     ?assertEqual(1, queue:len((sys:get_state(Pid))#state.pending)),
     Requester ! die,
-    %% Sync twice: the requester 'DOWN' lands first, then the killed task's own.
-    _ = sys:get_status(Pid),
-    timer:sleep(100),
-    _ = sys:get_status(Pid),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
-    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    %% Two 'DOWN's have to land: the requester's, which kills the task and
+    %% drops the queued item, then the killed task's own, which clears the
+    %% bookkeeping. Await the end state rather than guessing how long that takes.
+    await_state(Pid, fun(#state{tasks = T, pending = P, requesters = R}) ->
+        T =:= #{} andalso queue:is_empty(P) andalso R =:= #{}
+    end),
     gen_server:stop(Pid).
 
 %% One requester's death must not disturb another's tasks. The requester
@@ -912,12 +918,16 @@ requester_death_spares_other_requesters_test() ->
     ?assertEqual(2, map_size(Tasks)),
     [SurvivorTask] = [P || {P, _R, Owner} <- maps:values(Tasks), Owner =:= Survivor],
     Doomed ! die,
-    timer:sleep(200),
-    _ = sys:get_status(Pid),
+    %% Await the doomed requester being fully reaped, then assert the survivor
+    %% was left untouched. Awaiting the reap first is what makes the survivor
+    %% assertions meaningful: they run after the governor has finished acting
+    %% on a death, not before it has started.
+    await_state(Pid, fun(#state{tasks = T, requesters = R}) ->
+        map_size(T) =:= 1 andalso maps:keys(R) =:= [Survivor]
+    end),
     ?assert(is_process_alive(SurvivorTask)),
-    #state{tasks = Tasks1, requesters = Requesters1} = sys:get_state(Pid),
-    ?assertEqual(1, map_size(Tasks1)),
-    ?assertEqual([Survivor], maps:keys(Requesters1)),
+    #state{tasks = Tasks1} = sys:get_state(Pid),
+    ?assertEqual([Survivor], [Owner || {_P, _R, Owner} <- maps:values(Tasks1)]),
     Survivor ! die,
     gen_server:stop(Pid).
 
@@ -941,14 +951,15 @@ requester_monitor_is_refcounted_test() ->
     ?assertMatch(#{Self := {_Mon, 2}}, Requesters),
     %% One task ends: the requester is still watched, with one task left.
     cancel([Ref1]),
-    timer:sleep(200),
-    _ = sys:get_status(Pid),
-    ?assertMatch(#{Self := {_Mon, 1}}, (sys:get_state(Pid))#state.requesters),
+    await_state(Pid, fun(#state{requesters = R}) ->
+        case R of
+            #{Self := {_Mon, Count}} -> Count =:= 1;
+            _ -> false
+        end
+    end),
     %% The last one ends: the monitor is released.
     cancel([Ref2]),
-    timer:sleep(200),
-    _ = sys:get_status(Pid),
-    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    await_state(Pid, fun(#state{requesters = R}) -> R =:= #{} end),
     gen_server:stop(Pid).
 
 %% A submission whose ReplyTo is already dead is dropped at intake, before
@@ -1076,6 +1087,27 @@ queued_item_is_not_starved_by_later_submissions_test() ->
     %% The head (submitted first) must complete before the later small item.
     ?assertEqual([RefHead, RefSmall], collect_order([RefHead, RefSmall], 5000)),
     gen_server:stop(Pid).
+
+%% Block until the governor's own state satisfies Fun, or fail the test.
+%% A killed task's 'DOWN' is delivered to the governor asynchronously, so the
+%% bookkeeping it drives (tasks, tasks_by_ref, requesters, pending) settles
+%% some time after the kill. Poll the state rather than sleeping a guessed
+%% duration: a sleep is either flaky under load or slower than it needs to be.
+%% sys:get_state is a sound barrier here because the governor is a plain
+%% gen_server (see docs/conventions.md on gen_batch_server, where it is not).
+await_state(Pid, Fun) ->
+    await_state(Pid, Fun, ?AWAIT_MS).
+
+await_state(Pid, _Fun, Remaining) when Remaining =< 0 ->
+    error({timeout_awaiting_state, sys:get_state(Pid)});
+await_state(Pid, Fun, Remaining) ->
+    case Fun(sys:get_state(Pid)) of
+        true ->
+            ok;
+        false ->
+            timer:sleep(?AWAIT_INTERVAL_MS),
+            await_state(Pid, Fun, Remaining - ?AWAIT_INTERVAL_MS)
+    end.
 
 collect_results(Refs, Timeout) ->
     collect_results(Refs, Timeout, #{}).

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -18,6 +18,15 @@ before ever being spawned, and the pending queue is scanned once for the whole
 batch. A single `Ref` can have both more than one running task and a queued
 item at the same time, because a resubmit reuses its `Ref`; `cancel/1` reaches
 all of them.
+
+Cancellation does not depend on the requester asking for it. The requester is
+monitored for as long as its task runs, and the task is killed when the
+requester dies, whatever killed it. A requester has many ways to die and only
+one of them can call `cancel/1` on the way out (a brutal kill can call
+nothing), so relying on an explicit cancel per teardown path leaves uploads
+running for a stream nobody is reading. This is the same policy already applied
+at intake and while queued: never transfer for a requester that is gone.
+
 Spawned tasks are monitored, not linked, so a governor restart does not
 kill tasks already running - they keep delivering their results directly to
 `ReplyTo` regardless of the governor's own lifecycle.
@@ -78,15 +87,19 @@ choice above.
     %% Pending submissions waiting for tokens.
     pending :: queue:queue(pending_item()),
     timer_ref :: reference() | undefined,
-    %% MonRef => {Pid, Ref} for every task currently executing, one entry per
-    %% live attempt. Keyed by the monitor reference rather than the
+    %% MonRef => {Pid, Ref, ReplyTo} for every task currently executing, one
+    %% entry per live attempt. Keyed by the monitor reference rather than the
     %% caller-minted Ref because a resubmit reuses the same Ref: keying by Ref
     %% let a second live attempt overwrite the first, orphaning a running task
     %% that neither cancel/1 nor kill_tasks/1 could then reach.
-    tasks = #{} :: #{reference() => {pid(), reference()}},
+    tasks = #{} :: #{reference() => {pid(), reference(), pid()}},
     %% Ref => [MonRef], the secondary index cancel/1 uses to reach every live
     %% attempt belonging to a caller-minted Ref.
-    tasks_by_ref = #{} :: #{reference() => [reference()]}
+    tasks_by_ref = #{} :: #{reference() => [reference()]},
+    %% ReplyTo => {MonRef, TaskCount} for every requester with at least one
+    %% task running. One monitor per requester however many tasks it has, so
+    %% the count is what decides when to demonitor.
+    requesters = #{} :: #{pid() => {reference(), pos_integer()}}
 }).
 
 -type pending_item() :: {
@@ -179,7 +192,7 @@ handle_cast({cancel, Refs}, #state{tasks = Tasks, tasks_by_ref = ByRef} = State)
         fun(Ref) ->
             lists:foreach(
                 fun(MonRef) ->
-                    {Pid, _Ref} = maps:get(MonRef, Tasks),
+                    {Pid, _Ref, _ReplyTo} = maps:get(MonRef, Tasks),
                     exit(Pid, kill)
                 end,
                 maps:get(Ref, ByRef, [])
@@ -202,11 +215,11 @@ handle_info(refill, #state{bucket = Bucket0} = State0) ->
         end,
     {noreply, State2#state{timer_ref = TimerRef}};
 handle_info(
-    {'DOWN', MonRef, process, _Pid, _Reason},
+    {'DOWN', MonRef, process, Pid, _Reason},
     #state{tasks = Tasks, tasks_by_ref = ByRef} = State
 ) ->
     case maps:take(MonRef, Tasks) of
-        {{_, Ref}, Tasks1} ->
+        {{_, Ref, ReplyTo}, Tasks1} ->
             dec(?C_TASKS_IN_FLIGHT, 1),
             %% Drop only this attempt's monitor from the Ref's list; a same-Ref
             %% resubmit may still have another attempt running under it. Remove
@@ -217,12 +230,57 @@ handle_info(
                     [] -> maps:remove(Ref, ByRef);
                     Rest -> ByRef#{Ref => Rest}
                 end,
-            {noreply, State#state{tasks = Tasks1, tasks_by_ref = ByRef1}};
+            State1 = State#state{tasks = Tasks1, tasks_by_ref = ByRef1},
+            {noreply, unwatch_requester(ReplyTo, State1)};
         error ->
-            {noreply, State}
+            %% Not a task: a requester died. Kill everything it submitted -
+            %% running or still queued - since its results now have nowhere to
+            %% go. This is the only cancellation path a brutal kill, a crash,
+            %% or a supervisor shutdown of the requester can reach.
+            {noreply, requester_down(MonRef, Pid, State)}
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
+
+%% Handle the death of a requester with tasks running. The monitor ref is
+%% matched against the recorded one so a stale 'DOWN' (a demonitor/flush that
+%% raced) cannot kill a fresh incarnation's tasks: a restarted reader is a new
+%% pid, but the pid alone is not proof of which monitor the 'DOWN' belongs to.
+requester_down(MonRef, ReplyTo, #state{requesters = Requesters} = State) ->
+    case Requesters of
+        #{ReplyTo := {MonRef, _Count}} ->
+            Refs = refs_for_requester(ReplyTo, State),
+            State1 = State#state{requesters = maps:remove(ReplyTo, Requesters)},
+            %% Reuse the cancel path so a queued copy of the same Ref is
+            %% dropped too, not just the running attempts.
+            kill_requester_tasks(ReplyTo, cancel_pending(Refs, State1));
+        _ ->
+            State
+    end.
+
+%% Every Ref this requester currently has admitted, for cancel_pending/2.
+refs_for_requester(ReplyTo, #state{tasks = Tasks}) ->
+    maps:fold(
+        fun
+            (_MonRef, {_Pid, Ref, Owner}, Acc) when Owner =:= ReplyTo -> [Ref | Acc];
+            (_MonRef, _Task, Acc) -> Acc
+        end,
+        [],
+        Tasks
+    ).
+
+%% Kill this requester's running tasks. The entries themselves are removed by
+%% each task's own 'DOWN', the single cleanup path shared with completion,
+%% a crash and cancel/1.
+kill_requester_tasks(ReplyTo, #state{tasks = Tasks} = State) ->
+    maps:foreach(
+        fun
+            (_MonRef, {Pid, _Ref, Owner}) when Owner =:= ReplyTo -> exit(Pid, kill);
+            (_MonRef, _Task) -> ok
+        end,
+        Tasks
+    ),
+    State.
 
 format_status(#{state := State} = Status) ->
     Status#{state := format_state(State)}.
@@ -243,7 +301,7 @@ terminate(_Reason, _State) ->
     ok.
 
 kill_tasks(Tasks) ->
-    maps:foreach(fun(_MonRef, {Pid, _Ref}) -> exit(Pid, kill) end, Tasks),
+    maps:foreach(fun(_MonRef, {Pid, _Ref, _ReplyTo}) -> exit(Pid, kill) end, Tasks),
     ok.
 
 format_state(#state{bucket = Bucket, pending = Pending}) ->
@@ -368,10 +426,37 @@ spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_by_ref = ByRe
     %% A resubmit reuses the same Ref while the earlier attempt may still be
     %% running, so append to this Ref's monitor list rather than replacing it.
     MonRefs = maps:get(Ref, ByRef, []),
-    State#state{
-        tasks = Tasks#{MonRef => {Pid, Ref}},
+    State1 = watch_requester(ReplyTo, State),
+    State1#state{
+        tasks = Tasks#{MonRef => {Pid, Ref, ReplyTo}},
         tasks_by_ref = ByRef#{Ref => [MonRef | MonRefs]}
     }.
+
+%% Start (or refcount) a monitor on a requester that now has a task running.
+%% One monitor covers all of a requester's tasks: a reader submits a fragment
+%% at a time and each extra monitor would mean an extra 'DOWN' to correlate.
+watch_requester(ReplyTo, #state{requesters = Requesters} = State) ->
+    case Requesters of
+        #{ReplyTo := {ReqMon, Count}} ->
+            State#state{requesters = Requesters#{ReplyTo => {ReqMon, Count + 1}}};
+        _ ->
+            ReqMon = monitor(process, ReplyTo),
+            State#state{requesters = Requesters#{ReplyTo => {ReqMon, 1}}}
+    end.
+
+%% Release one task's share of a requester's monitor, demonitoring once its
+%% last task is gone. The requester's own 'DOWN' does not come through here:
+%% requester_down/3 drops the whole entry in one step.
+unwatch_requester(ReplyTo, #state{requesters = Requesters} = State) ->
+    case Requesters of
+        #{ReplyTo := {ReqMon, 1}} ->
+            demonitor(ReqMon, [flush]),
+            State#state{requesters = maps:remove(ReplyTo, Requesters)};
+        #{ReplyTo := {ReqMon, Count}} ->
+            State#state{requesters = Requesters#{ReplyTo => {ReqMon, Count - 1}}};
+        _ ->
+            State
+    end.
 
 schedule_refill() ->
     erlang:send_after(?REFILL_INTERVAL_MS, self(), refill).
@@ -548,14 +633,14 @@ resubmit_tracks_both_attempts_test() ->
     submit(Fun, 100, Self, Ref),
     #state{tasks = Tasks0, tasks_by_ref = ByRef0} = sys:get_state(Pid),
     [OldMonRef] = maps:get(Ref, ByRef0),
-    {OldTaskPid, Ref} = maps:get(OldMonRef, Tasks0),
+    {OldTaskPid, Ref, Self} = maps:get(OldMonRef, Tasks0),
     %% Resubmit with the same Ref, as a transient-retry resubmission does. The
     %% earlier attempt is still running, so both are now tracked.
     submit(Fun, 100, Self, Ref),
     #state{tasks = Tasks1, tasks_by_ref = ByRef1} = sys:get_state(Pid),
     ?assertEqual(2, map_size(Tasks1)),
     [NewMonRef] = maps:get(Ref, ByRef1) -- [OldMonRef],
-    {NewTaskPid, Ref} = maps:get(NewMonRef, Tasks1),
+    {NewTaskPid, Ref, Self} = maps:get(NewMonRef, Tasks1),
     ?assertNotEqual(OldTaskPid, NewTaskPid),
     %% The earlier attempt's own 'DOWN' must drop only its entry, leaving the
     %% live sibling reachable.
@@ -565,7 +650,7 @@ resubmit_tracks_both_attempts_test() ->
     _ = sys:get_status(Pid),
     #state{tasks = Tasks2, tasks_by_ref = ByRef2} = sys:get_state(Pid),
     ?assertEqual([NewMonRef], maps:get(Ref, ByRef2)),
-    ?assertEqual({NewTaskPid, Ref}, maps:get(NewMonRef, Tasks2)),
+    ?assertEqual({NewTaskPid, Ref, Self}, maps:get(NewMonRef, Tasks2)),
     %% cancel/1 must still be able to reach (and kill) the live task.
     cancel([Ref]),
     receive
@@ -596,7 +681,7 @@ cancel_kills_every_attempt_under_a_ref_test() ->
     ?assertEqual(2, map_size(Tasks)),
     MonRefs = maps:get(Ref, ByRef),
     ?assertEqual(2, length(MonRefs)),
-    Pids = [P || MonRef <- MonRefs, {P, _} <- [maps:get(MonRef, Tasks)]],
+    Pids = [P || MonRef <- MonRefs, {P, _, _} <- [maps:get(MonRef, Tasks)]],
     Mons = [monitor(process, P) || P <- Pids],
     cancel([Ref]),
     %% Both attempts must die, not just the most recently installed one.
@@ -670,7 +755,7 @@ terminate_kills_tasks_on_normal_stop_test() ->
     ),
     #state{tasks = Tasks, tasks_by_ref = ByRef} = sys:get_state(Pid),
     [MonRef] = maps:get(Ref, ByRef),
-    {TaskPid, Ref} = maps:get(MonRef, Tasks),
+    {TaskPid, Ref, Self} = maps:get(MonRef, Tasks),
     Mon = monitor(process, TaskPid),
     gen_server:stop(Pid),
     receive
@@ -692,13 +777,179 @@ terminate_leaves_tasks_on_crash_reason_test() ->
     State = #state{
         bucket = unlimited,
         pending = queue:new(),
-        tasks = #{MonRef => {TaskPid, Ref}},
+        tasks = #{MonRef => {TaskPid, Ref, self()}},
         tasks_by_ref = #{Ref => [MonRef]}
     },
     ok = terminate({error, some_crash}, State),
     timer:sleep(50),
     ?assert(is_process_alive(TaskPid)),
     exit(TaskPid, kill).
+
+%% A requester that dies after its task was admitted must have that task
+%% killed. Only one reader teardown path calls cancel/1, so without the
+%% requester monitor a writer-DOWN stop, a crash, a supervisor shutdown or a
+%% brutal kill all left the upload streaming a fragment to S3 for a stream
+%% nobody is reading, holding an upload-pool connection.
+requester_death_kills_running_task_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Parent = self(),
+    %% Stands in for a replica reader: submits, then dies without cancelling.
+    Requester = spawn(fun() ->
+        Ref = make_ref(),
+        submit(
+            fun() ->
+                receive
+                    never -> ok
+                end
+            end,
+            100,
+            self(),
+            Ref
+        ),
+        %% Sync inside the requester: the state read below must see the task.
+        _ = sys:get_status(?MODULE),
+        Parent ! submitted,
+        receive
+            die -> ok
+        end
+    end),
+    receive
+        submitted -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    #state{tasks = Tasks, requesters = Requesters} = sys:get_state(Pid),
+    [{_MonRef, {TaskPid, _Ref, Requester}}] = maps:to_list(Tasks),
+    ?assert(is_map_key(Requester, Requesters)),
+    TaskMon = monitor(process, TaskPid),
+    Requester ! die,
+    receive
+        {'DOWN', TaskMon, process, TaskPid, killed} -> ok
+    after 1000 -> error(task_not_killed)
+    end,
+    %% The task's own 'DOWN' clears the bookkeeping, including the monitor.
+    _ = sys:get_status(Pid),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks_by_ref),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    gen_server:stop(Pid).
+
+%% A dying requester's still-queued submissions are dropped as well as its
+%% running ones: admitting a queued item after its requester is gone would
+%% spend tokens uploading a fragment whose result has nowhere to go.
+requester_death_drops_queued_submissions_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Parent = self(),
+    Requester = spawn(fun() ->
+        %% Attempt 1 is admitted immediately and blocks, exhausting the bucket.
+        submit(
+            fun() ->
+                receive
+                    never -> ok
+                end
+            end,
+            1000,
+            self(),
+            make_ref()
+        ),
+        %% A second Ref queues behind the exhausted bucket.
+        submit(fun() -> error(should_not_run) end, 500, self(), make_ref()),
+        _ = sys:get_status(?MODULE),
+        Parent ! submitted,
+        receive
+            die -> ok
+        end
+    end),
+    receive
+        submitted -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    ?assertEqual(1, map_size((sys:get_state(Pid))#state.tasks)),
+    ?assertEqual(1, queue:len((sys:get_state(Pid))#state.pending)),
+    Requester ! die,
+    %% Sync twice: the requester 'DOWN' lands first, then the killed task's own.
+    _ = sys:get_status(Pid),
+    timer:sleep(100),
+    _ = sys:get_status(Pid),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.tasks),
+    ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    gen_server:stop(Pid).
+
+%% One requester's death must not disturb another's tasks. The requester
+%% monitor is refcounted per requester, so the surviving reader keeps both its
+%% task and its monitor.
+requester_death_spares_other_requesters_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Parent = self(),
+    Blocker = fun() ->
+        submit(
+            fun() ->
+                receive
+                    never -> ok
+                end
+            end,
+            100,
+            self(),
+            make_ref()
+        ),
+        _ = sys:get_status(?MODULE),
+        Parent ! submitted,
+        receive
+            die -> ok
+        end
+    end,
+    Doomed = spawn(Blocker),
+    receive
+        submitted -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    Survivor = spawn(Blocker),
+    receive
+        submitted -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    #state{tasks = Tasks} = sys:get_state(Pid),
+    ?assertEqual(2, map_size(Tasks)),
+    [SurvivorTask] = [P || {P, _R, Owner} <- maps:values(Tasks), Owner =:= Survivor],
+    Doomed ! die,
+    timer:sleep(200),
+    _ = sys:get_status(Pid),
+    ?assert(is_process_alive(SurvivorTask)),
+    #state{tasks = Tasks1, requesters = Requesters1} = sys:get_state(Pid),
+    ?assertEqual(1, map_size(Tasks1)),
+    ?assertEqual([Survivor], maps:keys(Requesters1)),
+    Survivor ! die,
+    gen_server:stop(Pid).
+
+%% A requester submitting several transfers is monitored once, and the monitor
+%% is released only when its last task is gone: an unbalanced refcount would
+%% either leak monitors or stop watching a requester that still has uploads
+%% running.
+requester_monitor_is_refcounted_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Self = self(),
+    Ref1 = make_ref(),
+    Ref2 = make_ref(),
+    Fun = fun() ->
+        receive
+            never -> ok
+        end
+    end,
+    submit(Fun, 100, Self, Ref1),
+    submit(Fun, 100, Self, Ref2),
+    #state{requesters = Requesters} = sys:get_state(Pid),
+    ?assertMatch(#{Self := {_Mon, 2}}, Requesters),
+    %% One task ends: the requester is still watched, with one task left.
+    cancel([Ref1]),
+    timer:sleep(200),
+    _ = sys:get_status(Pid),
+    ?assertMatch(#{Self := {_Mon, 1}}, (sys:get_state(Pid))#state.requesters),
+    %% The last one ends: the monitor is released.
+    cancel([Ref2]),
+    timer:sleep(200),
+    _ = sys:get_status(Pid),
+    ?assertEqual(#{}, (sys:get_state(Pid))#state.requesters),
+    gen_server:stop(Pid).
 
 %% A submission whose ReplyTo is already dead is dropped at intake, before
 %% ever touching the bucket or spawning anything.

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -71,6 +71,7 @@ truth.
 -export([init_counters/0]).
 
 -include("include/logging.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -define(REFILL_INTERVAL_MS, 100).
 
@@ -162,6 +163,9 @@ init(Opts) ->
     %% Without this, a supervisor-issued shutdown signal (application/node
     %% stop) would just kill this process outright, and terminate/2 below -
     %% which cancels running tasks on that specific path - would never run.
+    %% This is the flag's only purpose here. It also makes exit signals from
+    %% any other link land in handle_info/2, which has an explicit clause to
+    %% keep them from being silently discarded.
     process_flag(trap_exit, true),
     Bucket =
         case maps:get(rate, Opts, unlimited) of
@@ -257,7 +261,26 @@ handle_info(
             %% or a supervisor shutdown of the requester can reach.
             {noreply, derive_gauges(requester_down(MonRef, Pid, State))}
     end;
+handle_info({'EXIT', Pid, Reason}, State) when Reason =/= normal ->
+    %% `gen_server` turns only the *parent's* exit signal into a `terminate/2`
+    %% call; a signal from any other link is delivered here instead. `trap_exit`
+    %% is set for the parent-shutdown path alone (see `init/1`), so its effect on
+    %% these other signals is incidental, and letting them fall through to the
+    %% catchall below is strictly weaker than the untrapped default, where an
+    %% abnormal signal from a link takes the process down. Restore that default
+    %% rather than discard the signal: nothing links to the governor today, so
+    %% arriving here means an unexpected link exists, and dying loudly surfaces
+    %% it. `terminate/2` leaves running tasks alone on this reason, which is the
+    %% correct choice for a crash-like exit (see the moduledoc).
+    ?LOG_WARNING(
+        "Governor received an exit signal from linked process ~p: ~p. Stopping, "
+        "since only the supervisor is expected to be linked",
+        [Pid, Reason],
+        #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+    ),
+    {stop, Reason, State};
 handle_info(_Info, State) ->
+    %% Includes `{'EXIT', _, normal}`, which an untrapped process ignores too.
     {noreply, State}.
 
 %% Handle the death of a requester with tasks running. The monitor ref is
@@ -798,6 +821,55 @@ terminate_leaves_tasks_on_crash_reason_test() ->
     timer:sleep(50),
     ?assert(is_process_alive(TaskPid)),
     exit(TaskPid, kill).
+
+%% `trap_exit` is set for the parent-shutdown path, but `gen_server` routes
+%% only the parent's signal to `terminate/2`: every other link's signal is
+%% delivered to `handle_info/2`. Without an explicit clause the catchall
+%% swallowed those, leaving the governor running where an untrapped process
+%% would have died - a link's crash became invisible.
+abnormal_exit_from_non_parent_link_stops_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    %% start_link/1 links the governor to this test process, which is therefore
+    %% its parent. Drop that link before provoking the stop, or the governor's
+    %% exit reason propagates here and fails the test from the outside.
+    unlink(Pid),
+    Mon = monitor(process, Pid),
+    %% A process other than the parent links itself and then crashes. `link/1`
+    %% runs before the receive, so the link is established once `go` arrives.
+    Linker = spawn(fun() ->
+        link(Pid),
+        receive
+            go -> exit(boom)
+        end
+    end),
+    Linker ! go,
+    receive
+        {'DOWN', Mon, process, Pid, boom} -> ok
+    after ?AWAIT_MS -> error(governor_survived_linked_crash)
+    end.
+
+%% A `normal` exit from a link is ignored, matching the untrapped default. The
+%% governor must not stop because some linked helper finished cleanly.
+normal_exit_from_non_parent_link_is_ignored_test() ->
+    {ok, Pid} = start_link(#{rate => unlimited}),
+    Linker = spawn(fun() ->
+        link(Pid),
+        receive
+            go -> ok
+        end
+    end),
+    LinkerMon = monitor(process, Linker),
+    Linker ! go,
+    %% Wait for the linker to actually exit: only then is its signal guaranteed
+    %% to be in the governor's queue, so the round-trip below is ordered after
+    %% it. Asserting liveness without this barrier would pass either way.
+    receive
+        {'DOWN', LinkerMon, process, Linker, normal} -> ok
+    after ?AWAIT_MS -> error(linker_did_not_exit)
+    end,
+    _ = sys:get_state(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
 
 %% A requester that dies after its task was admitted must have that task
 %% killed. Only one reader teardown path calls cancel/1, so without the

--- a/src/rabbitmq_stream_s3_governor.erl
+++ b/src/rabbitmq_stream_s3_governor.erl
@@ -20,12 +20,23 @@ item at the same time, because a resubmit reuses its `Ref`; `cancel/1` reaches
 all of them.
 
 Cancellation does not depend on the requester asking for it. The requester is
-monitored for as long as its task runs, and the task is killed when the
-requester dies, whatever killed it. A requester has many ways to die and only
-one of them can call `cancel/1` on the way out (a brutal kill can call
-nothing), so relying on an explicit cancel per teardown path leaves uploads
-running for a stream nobody is reading. This is the same policy already applied
-at intake and while queued: never transfer for a requester that is gone.
+monitored for as long as the governor holds any of its work, queued or running,
+and that work is discarded when the requester dies, whatever killed it. A
+requester has many ways to die and only one of them can call `cancel/1` on the
+way out (a brutal kill can call nothing), so relying on an explicit cancel per
+teardown path leaves uploads running for a stream nobody is reading. This is the
+same policy already applied at intake: never transfer for a requester that is
+gone.
+
+The monitor is taken at intake rather than when a task is spawned. A queued item
+can wait a long time behind the token bucket, and monitoring only running tasks
+left a requester whose items were all still queued unmonitored: its death was
+noticed only if one of its items happened to reach the head of the queue on a
+refill tick, since `drain_pending/1` inspects the head alone and stops at the
+first item it cannot admit. Behind a live head that is short of tokens, an
+arbitrary number of dead requesters' items could sit in the queue indefinitely,
+counted in `governor_pending_submissions` and invisible to
+`governor_dropped_dead_replyto`.
 
 Spawned tasks are monitored, not linked, so a governor restart does not
 kill tasks already running - they keep delivering their results directly to
@@ -113,9 +124,12 @@ truth.
     %% Ref => [MonRef], the secondary index cancel/1 uses to reach every live
     %% attempt belonging to a caller-minted Ref.
     tasks_by_ref = #{} :: #{reference() => [reference()]},
-    %% ReplyTo => {MonRef, TaskCount} for every requester with at least one
-    %% task running. One monitor per requester however many tasks it has, so
-    %% the count is what decides when to demonitor.
+    %% ReplyTo => {MonRef, ItemCount} for every requester with at least one
+    %% outstanding item, queued or running. One monitor per requester however
+    %% many items it has, so the count is what decides when to demonitor.
+    %% Counting queued items and not just running tasks is what lets a
+    %% requester's death be noticed while its work is still behind the token
+    %% bucket; see requester_down/3.
     requesters = #{} :: #{pid() => {reference(), pos_integer()}}
 }).
 
@@ -283,32 +297,27 @@ handle_info(_Info, State) ->
     %% Includes `{'EXIT', _, normal}`, which an untrapped process ignores too.
     {noreply, State}.
 
-%% Handle the death of a requester with tasks running. The monitor ref is
-%% matched against the recorded one so a stale 'DOWN' (a demonitor/flush that
-%% raced) cannot kill a fresh incarnation's tasks: a restarted reader is a new
-%% pid, but the pid alone is not proof of which monitor the 'DOWN' belongs to.
+%% Handle the death of a requester with outstanding items, queued or running.
+%% The monitor ref is matched against the recorded one so a stale 'DOWN' (a
+%% demonitor/flush that raced) cannot kill a fresh incarnation's tasks: a
+%% restarted reader is a new pid, but the pid alone is not proof of which
+%% monitor the 'DOWN' belongs to.
 requester_down(MonRef, ReplyTo, #state{requesters = Requesters} = State) ->
     case Requesters of
         #{ReplyTo := {MonRef, _Count}} ->
-            Refs = refs_for_requester(ReplyTo, State),
-            State1 = State#state{requesters = maps:remove(ReplyTo, Requesters)},
-            %% Reuse the cancel path so a queued copy of the same Ref is
-            %% dropped too, not just the running attempts.
-            kill_requester_tasks(ReplyTo, cancel_pending(Refs, State1));
+            %% Drop the queued items by requester, not via the Refs its running
+            %% tasks carry: a requester can have queued items and no admitted
+            %% task at all, and those must go too. Then drop the whole
+            %% `requesters` entry - the monitor is already gone, and the running
+            %% tasks being killed below clean up through their own 'DOWN'.
+            State1 = drop_pending_for_requester(ReplyTo, State),
+            State2 = State1#state{
+                requesters = maps:remove(ReplyTo, State1#state.requesters)
+            },
+            kill_requester_tasks(ReplyTo, State2);
         _ ->
             State
     end.
-
-%% Every Ref this requester currently has admitted, for cancel_pending/2.
-refs_for_requester(ReplyTo, #state{tasks = Tasks}) ->
-    maps:fold(
-        fun
-            (_MonRef, {_Pid, Ref, Owner}, Acc) when Owner =:= ReplyTo -> [Ref | Acc];
-            (_MonRef, _Task, Acc) -> Acc
-        end,
-        [],
-        Tasks
-    ).
 
 %% Kill this requester's running tasks. The entries themselves are removed by
 %% each task's own 'DOWN', the single cleanup path shared with completion,
@@ -359,9 +368,18 @@ format_state(#state{bucket = Bucket, pending = Pending}) ->
 %% Internal
 %% ------------------------------------------------------------------
 
-dispatch(Item, #state{bucket = unlimited} = State) ->
+%% Take the requester's watch here, once, covering the item for as long as the
+%% governor holds it - queued, running, or moving between the two. Watching only
+%% from spawn_task/2 left a requester whose items were all still queued
+%% unmonitored, so its death went unnoticed until one of its items reached the
+%% head of the queue on a refill tick (see drain_pending/1).
+dispatch({_Fun, _Size, ReplyTo, _Ref} = Item, State0) ->
+    State = watch_requester(ReplyTo, State0),
+    dispatch1(Item, State).
+
+dispatch1(Item, #state{bucket = unlimited} = State) ->
     spawn_task(Item, State);
-dispatch(Item, #state{pending = Pending} = State) ->
+dispatch1(Item, #state{pending = Pending} = State) ->
     case queue:is_empty(Pending) of
         false ->
             %% Items are already waiting for tokens. Queue behind them rather
@@ -388,16 +406,42 @@ try_admit({_Fun, Size, _ReplyTo, _Ref} = Item, #state{bucket = Bucket0} = State)
 %% a live submission.
 cancel_pending([], State) ->
     State;
-cancel_pending(Refs, #state{pending = Pending0} = State) ->
+cancel_pending(Refs, State) ->
     RefSet = sets:from_list(Refs, [{version, 2}]),
-    Pending = queue:filter(
-        fun({_Fun, _Size, _ReplyTo, ItemRef}) -> not sets:is_element(ItemRef, RefSet) end,
-        Pending0
+    {_Dropped, State1} = drop_pending(
+        fun({_Fun, _Size, _ReplyTo, ItemRef}) -> sets:is_element(ItemRef, RefSet) end,
+        State
     ),
-    State#state{pending = Pending}.
+    State1.
+
+%% Remove every queued item belonging to `ReplyTo`. Used when a requester dies:
+%% its items must go whether or not it also had a task admitted, so they are
+%% matched by requester rather than by the Refs its running tasks happen to
+%% carry. Each one counts as dropped-for-a-dead-requester, the same as if
+%% drain_pending/1 had found it at the head.
+drop_pending_for_requester(ReplyTo, State) ->
+    {Dropped, State1} = drop_pending(
+        fun({_Fun, _Size, ItemReplyTo, _Ref}) -> ItemReplyTo =:= ReplyTo end,
+        State
+    ),
+    inc(?C_DROPPED_DEAD_REPLYTO, Dropped),
+    State1.
+
+%% Drop every queued item `Drop` selects, releasing each one's requester watch.
+%% One pass over the queue however many items match. Returns how many were
+%% dropped, so callers can account for them.
+drop_pending(Drop, #state{pending = Pending0} = State) ->
+    {Dropped, Kept} = lists:partition(Drop, queue:to_list(Pending0)),
+    State1 = lists:foldl(
+        fun({_Fun, _Size, ReplyTo, _Ref}, Acc) -> unwatch_requester(ReplyTo, Acc) end,
+        State#state{pending = queue:from_list(Kept)},
+        Dropped
+    ),
+    {length(Dropped), State1}.
 
 %% Append a submission to the pending queue and ensure the refill timer is
-%% running so it will eventually drain.
+%% running so it will eventually drain. The requester's watch is already held by
+%% dispatch/2 and spans the item's whole life, so there is nothing to take here.
 enqueue(Item, State) ->
     Pending = queue:in(Item, State#state.pending),
     State1 = State#state{pending = Pending},
@@ -414,13 +458,16 @@ drain_pending(#state{pending = Pending0, bucket = Bucket0} = State) ->
             case is_process_alive(ReplyTo) of
                 false ->
                     %% The requester died while this item waited behind the
-                    %% token bucket. Drop it for free (no tokens spent) and
+                    %% token bucket, and its 'DOWN' has not been processed yet
+                    %% (once it is, requester_down/3 drops every one of its
+                    %% items at once). Drop it for free (no tokens spent) and
                     %% keep draining: the head is being discarded outright,
                     %% not skipped-and-retried, so this doesn't let a later
                     %% item unfairly jump the FIFO order (see enqueue/2).
                     inc(?C_DROPPED_DEAD_REPLYTO, 1),
                     Pending = queue:drop(Pending0),
-                    drain_pending(State#state{pending = Pending});
+                    State1 = unwatch_requester(ReplyTo, State#state{pending = Pending}),
+                    drain_pending(State1);
                 true ->
                     drain_pending_admit(Item, Pending0, Bucket0, State)
             end
@@ -431,6 +478,8 @@ drain_pending_admit({_Fun, Size, _ReplyTo, _Ref} = Item, Pending0, Bucket0, Stat
         {ok, Bucket} ->
             count_oversized(Size, Bucket0),
             Pending = queue:drop(Pending0),
+            %% The item moves from `pending` to `tasks` and keeps the single
+            %% watch it took at dispatch; nothing to adjust here.
             drain_pending(
                 spawn_task(Item, State#state{
                     pending = Pending,
@@ -455,15 +504,17 @@ spawn_task({Fun, _Size, ReplyTo, Ref}, #state{tasks = Tasks, tasks_by_ref = ByRe
     %% A resubmit reuses the same Ref while the earlier attempt may still be
     %% running, so append to this Ref's monitor list rather than replacing it.
     MonRefs = maps:get(Ref, ByRef, []),
-    State1 = watch_requester(ReplyTo, State),
-    State1#state{
+    %% The requester's watch was taken by dispatch/2 and is released by this
+    %% task's own 'DOWN', so it is not touched here.
+    State#state{
         tasks = Tasks#{MonRef => {Pid, Ref, ReplyTo}},
         tasks_by_ref = ByRef#{Ref => [MonRef | MonRefs]}
     }.
 
-%% Start (or refcount) a monitor on a requester that now has a task running.
-%% One monitor covers all of a requester's tasks: a reader submits a fragment
-%% at a time and each extra monitor would mean an extra 'DOWN' to correlate.
+%% Start (or refcount) a monitor on a requester that now has one more
+%% outstanding item, queued or running. One monitor covers all of a requester's
+%% items: a reader submits a fragment at a time and each extra monitor would
+%% mean an extra 'DOWN' to correlate.
 watch_requester(ReplyTo, #state{requesters = Requesters} = State) ->
     case Requesters of
         #{ReplyTo := {ReqMon, Count}} ->
@@ -473,9 +524,10 @@ watch_requester(ReplyTo, #state{requesters = Requesters} = State) ->
             State#state{requesters = Requesters#{ReplyTo => {ReqMon, 1}}}
     end.
 
-%% Release one task's share of a requester's monitor, demonitoring once its
-%% last task is gone. The requester's own 'DOWN' does not come through here:
-%% requester_down/3 drops the whole entry in one step.
+%% Release one item's share of a requester's monitor, demonitoring once its last
+%% outstanding item is gone - whether that item completed, was cancelled while
+%% queued, or was dropped as dead. The requester's own 'DOWN' does not come
+%% through here: requester_down/3 drops the whole entry in one step.
 unwatch_requester(ReplyTo, #state{requesters = Requesters} = State) ->
     case Requesters of
         #{ReplyTo := {ReqMon, 1}} ->
@@ -1097,6 +1149,93 @@ drain_drops_dead_replyto_test() ->
     after 1000 -> error(sync_timeout)
     end,
     ?assertEqual(0, queue:len((sys:get_state(Pid))#state.pending)),
+    gen_server:stop(Pid).
+
+%% A dead requester's queued items must be reclaimed even when they are buried
+%% behind a live item that cannot be admitted. drain_pending/1 only ever looks at
+%% the head and stops at the first item short of tokens, so before the requester
+%% was monitored from intake these items sat in `pending` for as long as the head
+%% was stuck: counted in the gauge, uncounted in dropped_dead_replyto, and
+%% holding their funs (and whatever those close over) live.
+requester_death_drops_items_buried_behind_a_live_head_test() ->
+    with_counter(fun(Cnt) ->
+        %% Rate 1000 B/s, burst 1000. The first item exhausts the bucket.
+        {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+        Self = self(),
+        RefDrain = make_ref(),
+        submit(fun() -> {ok, drained} end, 1000, Self, RefDrain),
+        receive
+            {transfer_result, RefDrain, _} -> ok
+        after 1000 -> error(drain_timeout)
+        end,
+        %% A live requester's item at the head: exactly burst, so it is not
+        %% "oversized" (which would be admitted on credit) but there are no
+        %% tokens, so it stays queued and blocks the drain.
+        submit(fun() -> {ok, head} end, 1000, Self, make_ref()),
+        %% Three items from a requester that dies, buried behind that head.
+        Parent = self(),
+        Requester = spawn(fun() ->
+            [submit(fun() -> error(should_not_run) end, 1, self(), make_ref()) || _ <- [1, 2, 3]],
+            _ = sys:get_status(?MODULE),
+            Parent ! submitted,
+            receive
+                die -> ok
+            end
+        end),
+        receive
+            submitted -> ok
+        after 1000 -> error(setup_failed)
+        end,
+        ?assertEqual(4, queue:len((sys:get_state(Pid))#state.pending)),
+        Before = counters:get(Cnt, ?C_DROPPED_DEAD_REPLYTO),
+        Requester ! die,
+        %% All three go on the requester's 'DOWN', without waiting for the head
+        %% to be admitted. Only the live head is left.
+        await_state(Pid, fun(#state{pending = P, requesters = R}) ->
+            queue:len(P) =:= 1 andalso not maps:is_key(Requester, R)
+        end),
+        ?assertEqual(Before + 3, counters:get(Cnt, ?C_DROPPED_DEAD_REPLYTO)),
+        %% The gauge follows the queue, and the surviving head is the live one.
+        ?assertEqual(1, counters:get(Cnt, ?C_PENDING_SUBMISSIONS)),
+        [{_Fun, _Size, HeadReplyTo, _Ref}] = queue:to_list((sys:get_state(Pid))#state.pending),
+        ?assertEqual(Self, HeadReplyTo),
+        gen_server:stop(Pid)
+    end).
+
+%% A requester with only queued work - nothing admitted - must still be
+%% monitored. Watching from spawn_task/2 alone left this requester invisible.
+queued_only_requester_is_monitored_test() ->
+    {ok, Pid} = start_link(#{rate => 1000, burst => 1000}),
+    Self = self(),
+    RefDrain = make_ref(),
+    submit(fun() -> {ok, drained} end, 1000, Self, RefDrain),
+    receive
+        {transfer_result, RefDrain, _} -> ok
+    after 1000 -> error(drain_timeout)
+    end,
+    Parent = self(),
+    Requester = spawn(fun() ->
+        submit(fun() -> error(should_not_run) end, 500, self(), make_ref()),
+        _ = sys:get_status(?MODULE),
+        Parent ! submitted,
+        receive
+            die -> ok
+        end
+    end),
+    receive
+        submitted -> ok
+    after 1000 -> error(setup_failed)
+    end,
+    %% The drain task's result arrives before its 'DOWN' is processed, so wait
+    %% for `tasks` to settle empty rather than asserting it outright. The
+    %% requester holds only a queued item, no admitted task, yet must be watched.
+    await_state(Pid, fun(#state{tasks = T, requesters = R}) ->
+        map_size(T) =:= 0 andalso maps:is_key(Requester, R)
+    end),
+    Requester ! die,
+    await_state(Pid, fun(#state{pending = P, requesters = R}) ->
+        queue:is_empty(P) andalso R =:= #{}
+    end),
     gen_server:stop(Pid).
 
 pacing_delays_when_exhausted_test() ->

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -2230,6 +2230,14 @@ reset_for_recovery(
     %% persist tick (the core is about to be replaced).
     maps:foreach(fun(_Ref, TimerRef) -> erlang:cancel_timer(TimerRef) end, Timers0),
     _ = cancel_timer(PersistTimer),
+    %% Recovery abandons these transfers: `recover` below clears the transfer
+    %% map, so their results are dropped as stale. This reader stays alive, so
+    %% the governor's requester monitor will not reap them either. Cancel them
+    %% here, while their Refs are still known, rather than leaving uploads
+    %% running whose results nothing will accept.
+    rabbitmq_stream_s3_governor:cancel(
+        maps:keys(rabbitmq_stream_s3_replica_reader_tasks:transfers(Tasks0))
+    ),
     State1 = close_log(State0),
     %% Tear down every in-flight async task before recovery replaces the core: a
     %% task's result is an ordinary message that demonitor's flush does not

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1150,10 +1150,14 @@ execute_effect(cancel_persist_timer, #state{persist_timer = Ref} = State) ->
 execute_effect(reinitialize, #state{cfg = #cfg{stream = StreamId}} = State0) ->
     ?LOG_INFO("~ts reinitializing after commit conflict", [StreamId]),
     resolve_and_start(reset_for_recovery(State0));
-execute_effect(stop, State) ->
-    %% The stream's metadata node was deleted (the queue was removed). Mark the
+execute_effect(stop, #state{tasks = Tasks} = State) ->
+    %% The stream's metadata node was deleted (the queue was removed). Cancel
+    %% every outstanding fragment upload in one batch so it stops occupying
+    %% upload-pool capacity for a stream that no longer exists, then mark the
     %% reader for shutdown; the handler that ran this effect returns
     %% {stop, normal} via maybe_stop/1.
+    Refs = maps:keys(rabbitmq_stream_s3_replica_reader_tasks:transfers(Tasks)),
+    rabbitmq_stream_s3_governor:cancel(Refs),
     State#state{stopping = true}.
 
 cancel_timer(undefined) -> ok;

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -84,6 +84,7 @@ groups() ->
             stream_deletion_cleans_remote_tier,
             stream_deletion_during_active_upload,
             persist_not_found_stops_reader,
+            in_flight_uploads_cancelled_on_stream_deletion,
             discover_attaches_to_existing_writer,
             on_init_writer_tolerates_already_started,
             two_layer_supervision_structure,
@@ -1004,6 +1005,99 @@ persist_not_found_stops_reader(Config) ->
         ct:fail("reader did not stop after a not_found persist")
     end,
     ?assertEqual(undefined, rabbitmq_stream_s3_registry:whereis_name({StreamId, node()})).
+
+in_flight_uploads_cancelled_on_stream_deletion(Config) ->
+    %% Issue #342: fragment uploads already submitted to the governor when a
+    %% stream is deleted must be cancelled immediately, not left running to
+    %% completion and wasting upload-pool capacity for a stream that no
+    %% longer exists.
+    StreamId = ?config(stream_id, Config),
+    ok = application:set_env(
+        rabbitmq_stream_s3, rabbitmq_stream_s3_api, rabbitmq_stream_s3_api_fault
+    ),
+    ok = rabbitmq_stream_s3_api_fault:setup(),
+
+    Writer = start_writer(Config, #{}, #{fragment_target_size => 500}),
+    Record = binary:copy(<<"D">>, 600),
+    Write = fun() ->
+        osiris_writer:write(Writer, Record),
+        flush_writer(Writer)
+    end,
+
+    %% First write: establishes the metadata node at a revision > 0, same as
+    %% persist_not_found_stops_reader. Its upload is not blocked.
+    Write(),
+    await_offset(Config, 1),
+    ?assertMatch({ok, #{revision := R}} when R > 0, rabbitmq_stream_s3_db:get(StreamId)),
+
+    ReaderPid = rabbitmq_stream_s3_registry:whereis_name({StreamId, node()}),
+
+    %% Delete the metadata node out from under the reader.
+    ok = khepri:delete(
+        rabbitmq_metadata, ?RABBITMQ_KHEPRI_ROOT_PATH([rabbitmq_stream_s3, StreamId])
+    ),
+    ?awaitMatch({error, not_found}, rabbitmq_stream_s3_db:get(StreamId), 1000),
+
+    %% Park a "trigger" fragment upload, held at stream_put like the two
+    %% below, but not released yet. Draining is strictly FIFO (a later
+    %% fragment can never apply to the manifest ahead of an earlier one still
+    %% in flight - see transfer_failed/3's issue #206 invariant), so this
+    %% must be the *first* of the three parked uploads: once released it
+    %% drains ahead of the other two, which is what triggers the persist that
+    %% fails with not_found and cancels them. Holding it (instead of letting
+    %% it complete immediately) avoids racing its completion against arming
+    %% the blocks for the writes below.
+    RefTrigger = rabbitmq_stream_s3_api_fault:block_once(stream_put, StreamId),
+    Write(),
+    TaskPidTrigger = rabbitmq_stream_s3_api_fault:await_blocked(RefTrigger, 10_000),
+
+    %% Now park two more fragment uploads in flight, one at a time
+    %% (block_once is one-shot; awaiting each before arming the next keeps
+    %% this deterministic, as in upload_path_recovers_from_trimmed_segment).
+    %% Nothing else is running at this point (the trigger is parked), so
+    %% there is no task left to race for these blocks.
+    Ref1 = rabbitmq_stream_s3_api_fault:block_once(stream_put, StreamId),
+    Write(),
+    TaskPid1 = rabbitmq_stream_s3_api_fault:await_blocked(Ref1, 10_000),
+
+    Ref2 = rabbitmq_stream_s3_api_fault:block_once(stream_put, StreamId),
+    Write(),
+    TaskPid2 = rabbitmq_stream_s3_api_fault:await_blocked(Ref2, 10_000),
+
+    Mon1 = monitor(process, TaskPid1),
+    Mon2 = monitor(process, TaskPid2),
+    ReaderMon = monitor(process, ReaderPid),
+
+    %% Release the trigger: it completes, drains first (it's ahead of the
+    %% other two in submission order), and its persist fails with not_found,
+    %% cancelling the two uploads still parked above.
+    ok = rabbitmq_stream_s3_api_fault:release(TaskPidTrigger, RefTrigger),
+
+    %% Both blocked uploads must be killed promptly: nothing would otherwise
+    %% ever release them, since they're parked in the fault backend forever.
+    %% The not_found persist triggered by releasing the trigger above fires
+    %% the core's stop effect asynchronously, so this may take a moment.
+    receive
+        {'DOWN', Mon1, process, TaskPid1, Reason1} -> ?assertEqual(killed, Reason1)
+    after 5000 -> ct:fail("upload task 1 was not cancelled")
+    end,
+    receive
+        {'DOWN', Mon2, process, TaskPid2, Reason2} -> ?assertEqual(killed, Reason2)
+    after 5000 -> ct:fail("upload task 2 was not cancelled")
+    end,
+    receive
+        {'DOWN', ReaderMon, process, ReaderPid, Reason} -> ?assertEqual(normal, Reason)
+    after 5000 -> ct:fail("reader did not stop")
+    end,
+
+    ?awaitMatch(
+        0,
+        maps:get(
+            governor_tasks_in_flight,
+            seshat:counters(rabbitmq_stream_s3, rabbitmq_stream_s3_governor)
+        ),
+        2000
+    ).
 
 discover_attaches_to_existing_writer(Config) ->
     StreamId = ?config(stream_id, Config),


### PR DESCRIPTION
*Issue #, if available:* closes #342

*Description of changes:* Upload submissions are casts to the governor. We can cancel some of these submissions if they are no longer necessary. Two examples: 1/ stream has been deleted, 2/ uploading replica reader process crashed. The two commits here cover these cases both for the regular path (stream deletion) and for degenerate cases like a large governor message backlog. We also introduce a new metric to capture this.

I expect that this change will be noticeable in my Jepsen tests which induce a very large governor backlog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
