### PR TITLE
Count the local-log-ahead recovery once and publish the reset range

### DIFF
--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1647,10 +1647,13 @@ handle_local_log_ahead(
         "remote tier.",
         [StreamId, NextOffset, Reason, LocalFirst, NextOffset]
     ),
-    %% Count the mid-stream (upload-path) recovery too, not just the reader-init
-    %% path (start_reading0/1), so the #225 trimmed-segment recovery is visible
-    %% in the local_log_ahead_recoveries metric and not only in the logs.
-    inc(State0, ?C_LOCAL_LOG_AHEAD_RECOVERIES, 1),
+    %% Do NOT count the recovery here. This path restarts through
+    %% resolve_and_start/1 -> start_reading/1 -> start_reading0/1, whose
+    %% local-ahead clause opens the data reader at the same stale next_offset,
+    %% takes the same {offset_out_of_range, {LocalFirst, _}} error and counts it.
+    %% Incrementing here as well reported one event as two, inflating every
+    %% measurement taken from the counter (the documented signal for telling a
+    %% benign recovery from the sustained #356 loop) by 2x on the upload path.
     resolve_and_start(reset_for_recovery(State0)).
 
 -spec drain(#state{}) -> #state{}.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -1593,6 +1593,13 @@ restart_at_local_floor(
         State#state.core, Core0
     ),
     ok = rabbitmq_stream_s3_manifest_replica:put_manifest(StreamId, FreshManifest, Epoch),
+    %% Publish the reset range. Without this the manifest_first_offset and
+    %% manifest_next_offset gauges keep reporting the range of the manifest that
+    %% was just discarded, so Prometheus and Grafana advertise a remote tier that
+    %% no longer exists and contradict both the cache row written above and
+    %% get_range/1. Observed after a leader restart: the gauges read
+    %% [129554, 194331) while every node's cache row read [257045, 257045).
+    update_manifest_gauges(FreshManifest, State),
     %% Propagate the reset to replicas. The fresh manifest carries the discarded
     %% manifest's revision (the broadcast sequence number), so the sync is not
     %% rejected as stale and subsequent broadcasts continue in sequence. Replicas

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -805,7 +805,7 @@ upload_path_recovers_from_trimmed_segment(Config) ->
     %% a second recovery, so the total is not deterministic. The first nonzero
     %% reading is: a double increment happens entirely within one reader callback,
     %% so no external observer can ever see 1 when both fire.
-    ?assertEqual(1, await_first_nonzero(Config, local_log_ahead_recoveries, 30_000)),
+    ?assertEqual(1, await_first_nonzero(Config, local_log_ahead_recoveries, 5_000)),
 
     %% Keep writing so the reset reader is driven by osiris offset notifications
     %% to drain and re-upload (in #225 writes are continuous). No permanent
@@ -816,7 +816,7 @@ upload_path_recovers_from_trimmed_segment(Config) ->
             Write(5),
             get_range(Config)
         end,
-        30_000
+        5_000
     ).
 
 remote_tier_ahead_discards_manifest(Config) ->

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -1626,7 +1626,8 @@ await_first_nonzero(Config, Name, Timeout, Start) ->
         _ ->
             Elapsed = erlang:monotonic_time(millisecond) - Start,
             case Elapsed > Timeout of
-                true -> ct:fail({counter_stayed_zero, Name, Timeout});
+                true ->
+                    ct:fail({counter_stayed_zero, Name, Timeout});
                 false ->
                     timer:sleep(5),
                     await_first_nonzero(Config, Name, Timeout, Start)

--- a/test/replica_reader_SUITE.erl
+++ b/test/replica_reader_SUITE.erl
@@ -792,6 +792,21 @@ upload_path_recovers_from_trimmed_segment(Config) ->
     %% stalling the manifest at NextA forever.
     ok = rabbitmq_stream_s3_api_fault:release(TaskPid, Ref),
 
+    %% This recovery counts exactly once. The upload path recovers by restarting
+    %% through resolve_and_start/1 -> start_reading0/1, whose local-ahead clause
+    %% re-opens at the same stale next_offset and does the counting; incrementing
+    %% on the upload path as well would report this single event as two. The count
+    %% is the documented signal for telling a benign one-shot recovery from a
+    %% sustained retention-outruns-upload loop (#356), so inflating it is not
+    %% cosmetic.
+    %%
+    %% Assert on the first nonzero reading rather than a final total: continued
+    %% writing under this test's tight max_bytes retention can legitimately drive
+    %% a second recovery, so the total is not deterministic. The first nonzero
+    %% reading is: a double increment happens entirely within one reader callback,
+    %% so no external observer can ever see 1 when both fire.
+    ?assertEqual(1, await_first_nonzero(Config, local_log_ahead_recoveries, 30_000)),
+
     %% Keep writing so the reset reader is driven by osiris offset notifications
     %% to drain and re-upload (in #225 writes are continuous). No permanent
     %% stall: the manifest leaves NextA and advances past it.
@@ -1586,3 +1601,34 @@ reconcile_recovers_replica_after_cache_restart(Config) ->
         end,
         5000
     ).
+
+%% Read one per-stream replica reader counter by name. This suite starts writers
+%% with `reference => StreamId` rather than a queue resource, so the reader
+%% registers under init_metrics/2's labelless fallback id.
+stream_counter(Config, Name) ->
+    StreamId = ?config(stream_id, Config),
+    Id = {rabbitmq_stream_s3_replica_reader, StreamId},
+    case seshat:counters(rabbitmq_stream_s3, Id, [Name]) of
+        #{Name := Value} -> Value;
+        undefined -> undefined
+    end.
+
+%% Poll a per-stream counter and return the first nonzero value observed. Used to
+%% assert the increment size of a single event, which a final total cannot pin
+%% down when the event can legitimately recur.
+await_first_nonzero(Config, Name, Timeout) ->
+    await_first_nonzero(Config, Name, Timeout, erlang:monotonic_time(millisecond)).
+
+await_first_nonzero(Config, Name, Timeout, Start) ->
+    case stream_counter(Config, Name) of
+        V when is_integer(V) andalso V > 0 ->
+            V;
+        _ ->
+            Elapsed = erlang:monotonic_time(millisecond) - Start,
+            case Elapsed > Timeout of
+                true -> ct:fail({counter_stayed_zero, Name, Timeout});
+                false ->
+                    timer:sleep(5),
+                    await_first_nonzero(Config, Name, Timeout, Start)
+            end
+    end.


### PR DESCRIPTION
> [!NOTE]
> This PR description was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who directed the work and approved each commit but did not author this prose. Both defects were found by Claude while investigating #356; the gauge divergence was observed on a live 3-node cluster. The analysis and the test design are Claude's, so treat them as reviewable rather than settled.

*Issue #, if available:* fixes #358

*Description of changes:* two independent metric defects in the local-log-ahead recovery path, one commit each. Neither affects data movement; both corrupt the observability the plugin's own alerting and runbooks depend on.

**1afa13f counts the local-log-ahead recovery once instead of twice.** `handle_local_log_ahead/4` incremented `local_log_ahead_recoveries` and then called `resolve_and_start/1`. That restart runs through `start_reading0/1`, which re-opens the data reader at the same stale `next_offset`, takes the same `offset_out_of_range` error, and increments the counter again. One logged recovery and one manifest discard therefore read as 2. f536999 added this second increment for an event `start_reading0/1` already counted, so the fix drops it and leaves `start_reading0/1` as the single counting point, matching how `remote_tier_ahead_recoveries` already works.

This matters because the counter is the documented signal for telling a benign one-shot recovery from the sustained loop in #356. `docs/operations.md:482` alerts on its rate, and #356's proposed refinement is a threshold separating "a few cycles, recovered" from "sustained, tier is gone"; any threshold tuned against the current counter is tuned against inflated numbers.

**36aacc7 publishes the reset range from `restart_at_local_floor/3`.** That function installed the fresh manifest, wrote it to the local cache and broadcast it to replicas, but never called `update_manifest_gauges/2`, so `manifest_first_offset` and `manifest_next_offset` kept reporting the range of the manifest just discarded. Observed on a 3-node `m7g.8xlarge` cluster after a leader restart: the gauges read `[129554, 194331)` while every node's cache row read `[257045, 257045)`, so Prometheus advertised 64777 offsets of remote tier that no longer existed. Both recovery directions reach this function, so both left the gauges stale, and `docs/failure-modes.md:80` tells operators to read `manifest_next_offset` to confirm a recovery happened.

**Testing.** No test anywhere in `test/` referenced `local_log_ahead_recoveries`, which is why the double-count went unnoticed. `upload_path_recovers_from_trimmed_segment` already drives exactly that path, so the assertion goes there.

Asserting a final total does not work: under that test's tight `max_bytes` retention, continued writing can legitimately drive a second genuine recovery, and the total was observed varying between 1 and 2 across runs with the fix in place. The assertion is on the first nonzero reading instead, which is deterministic because a double increment happens entirely within one reader callback and so can never be observed as 1. With it, the case fails 3/3 runs with the increment restored and passes 5/5 with it removed.

Full `replica_reader_SUITE`: 39 cases, 0 failures. The first commit was verified in isolation so it stands on its own.

The gauge fix has no test. Reproducing it needs a leader restart against a live cluster, which this suite has no harness for; it was found by observation rather than by a failing case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
