### PR TITLE
Re-sync a replica whose manifest row is wedged in `pending`

### DIFF
--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -249,7 +249,15 @@ reconcile_child({_Id, Pid, worker, [osiris_replica]}) when is_pid(Pid) ->
         StreamId = stream_id_of(Pid),
         case rabbitmq_stream_s3_manifest_replica:is_context_registered(StreamId) of
             true ->
-                ok;
+                %% Context is registered, but the row may still be wedged in
+                %% pending with no applied sync (rabbitmq_stream_s3#362): a
+                %% member-restart burst can leave the final re-registration
+                %% unable to request a sync, and once publishing stops no edits
+                %% arrive to gap-detect and re-request one. Re-request a sync
+                %% from the writer when the row is unresolved. The writer's
+                %% register_acceptor handler re-syncs idempotently, so this is a
+                %% no-op once the row resolves.
+                maybe_resync_pending_replica(Pid, StreamId);
             false ->
                 ?LOG_INFO(
                     "Reconciliation: replica ~p for stream ~ts has no manifest "
@@ -286,6 +294,37 @@ register_replica_context(Pid, StreamId) ->
     rabbitmq_stream_s3_manifest_replica:register_replica_context(
         StreamId, Pid, Dir, Shared, Counter
     ).
+
+%% Re-request a manifest sync for a replica whose context is registered but
+%% whose cache row is still pending with no applied sync (rabbitmq_stream_s3#362).
+%% Sends {register_acceptor, node()} to the writer, whose handler re-syncs the
+%% persisted manifest idempotently. A resolved row reports not-awaiting, so this
+%% is a no-op on the steady-state ticks. The writer node comes from the queue
+%% record, the same source discover-time re-registration uses.
+maybe_resync_pending_replica(Pid, StreamId) ->
+    case rabbitmq_stream_s3_manifest_replica:is_awaiting_sync(StreamId) of
+        false ->
+            ok;
+        true ->
+            #{reference := Reference} = osiris_util:get_reader_context(Pid),
+            case rabbit_amqqueue:lookup(Reference) of
+                {ok, Q} ->
+                    WriterNode = maps:get(leader_node, amqqueue:get_type_state(Q)),
+                    ?LOG_INFO(
+                        "Reconciliation: replica for stream ~ts is registered but "
+                        "still awaiting its first sync; re-requesting from writer "
+                        "node ~p",
+                        [StreamId, WriterNode],
+                        #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
+                    ),
+                    gen_server:cast(
+                        {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
+                        {register_acceptor, node()}
+                    );
+                _ ->
+                    ok
+            end
+    end.
 
 append_retention(StreamId, Config) ->
     Fun = {'fun', local_retention_fun(StreamId)},

--- a/src/rabbitmq_stream_s3_hooks.erl
+++ b/src/rabbitmq_stream_s3_hooks.erl
@@ -270,7 +270,7 @@ reconcile_child({_Id, Pid, worker, [osiris_replica]}) when is_pid(Pid) ->
     catch
         Class:Reason ->
             ?LOG_WARNING(
-                "Reconciliation could not re-register replica ~p: ~ts:~p",
+                "Reconciliation could not reconcile replica ~p: ~ts:~p",
                 [Pid, Class, Reason],
                 #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
             )
@@ -307,23 +307,37 @@ maybe_resync_pending_replica(Pid, StreamId) ->
             ok;
         true ->
             #{reference := Reference} = osiris_util:get_reader_context(Pid),
-            case rabbit_amqqueue:lookup(Reference) of
-                {ok, Q} ->
-                    WriterNode = maps:get(leader_node, amqqueue:get_type_state(Q)),
+            case register_with_writer(StreamId, Reference) of
+                {ok, WriterNode} ->
                     ?LOG_INFO(
                         "Reconciliation: replica for stream ~ts is registered but "
-                        "still awaiting its first sync; re-requesting from writer "
-                        "node ~p",
+                        "still awaiting its first sync; re-requested a sync from "
+                        "writer node ~p",
                         [StreamId, WriterNode],
                         #{domain => ?RMQLOG_DOMAIN_STREAM_S3}
-                    ),
-                    gen_server:cast(
-                        {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
-                        {register_acceptor, node()}
                     );
-                _ ->
+                error ->
                     ok
             end
+    end.
+
+%% Look up the stream's writer node from the queue record and register this
+%% node as an acceptor with the writer's replica reader for manifest broadcast.
+%% The writer's register_acceptor handler re-syncs the persisted manifest
+%% idempotently. Returns {ok, WriterNode} so callers can log, or error when the
+%% queue record is unavailable (the writer's replica reader isn't up yet; the
+%% cast is skipped and the replica reader will proactively sync us on startup).
+register_with_writer(StreamId, Reference) ->
+    case rabbit_amqqueue:lookup(Reference) of
+        {ok, Q} ->
+            WriterNode = maps:get(leader_node, amqqueue:get_type_state(Q)),
+            gen_server:cast(
+                {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
+                {register_acceptor, node()}
+            ),
+            {ok, WriterNode};
+        _ ->
+            error
     end.
 
 append_retention(StreamId, Config) ->
@@ -412,18 +426,9 @@ attach_replica(Pid) ->
         StreamId, Pid, Dir, Shared, Counter
     ),
     %% Register with the writer's replica reader for manifest broadcast.
-    %% If the writer's replica reader isn't up yet, the cast is dropped;
+    %% If the writer's replica reader isn't up yet, the cast is skipped;
     %% the replica reader will proactively sync us on its startup.
-    case rabbit_amqqueue:lookup(Reference) of
-        {ok, Q} ->
-            WriterNode = maps:get(leader_node, amqqueue:get_type_state(Q)),
-            gen_server:cast(
-                {via, rabbitmq_stream_s3_registry, {StreamId, WriterNode}},
-                {register_acceptor, node()}
-            );
-        _ ->
-            ok
-    end,
+    _ = register_with_writer(StreamId, Reference),
     %% Inject the local-tier retention fun into the running replica while
     %% preserving its configured policy, via the same current-spec transform
     %% as attach_writer/1.

--- a/src/rabbitmq_stream_s3_manifest_replica.erl
+++ b/src/rabbitmq_stream_s3_manifest_replica.erl
@@ -86,6 +86,7 @@ manifest row.
     sync/5,
     register_replica_context/5,
     is_context_registered/1,
+    is_awaiting_sync/1,
     evaluate_local_retention/1,
     forget/1
 ]).
@@ -323,6 +324,18 @@ register_replica_context(StreamId, MemberPid, Dir, Shared, Counter) ->
 is_context_registered(StreamId) ->
     gen_server:call(?MODULE, {is_context_registered, StreamId}).
 
+-doc """
+Whether a stream on this node has a registered context whose cache row is still
+`pending`. This is the wedged shape from rabbitmq_stream_s3#362 -- a context
+exists (so readers fail closed on the pending row) but no manifest ever arrived
+to resolve it. The reconciler uses this to re-request a sync, since a
+registered-but-pending row is otherwise never healed once gap-detection goes
+quiet.
+""".
+-spec is_awaiting_sync(stream_id()) -> boolean().
+is_awaiting_sync(StreamId) ->
+    gen_server:call(?MODULE, {is_awaiting_sync, StreamId}).
+
 -doc "Evaluate local-tier retention for a stream on this node.".
 -spec evaluate_local_retention(stream_id()) -> ok | {error, term()}.
 evaluate_local_retention(StreamId) ->
@@ -472,6 +485,18 @@ handle_call(
     }};
 handle_call({is_context_registered, StreamId}, _From, #state{contexts = Ctxs} = State) ->
     {reply, maps:is_key(StreamId, Ctxs), State};
+handle_call(
+    {is_awaiting_sync, StreamId}, _From, #state{contexts = Ctxs} = State
+) ->
+    %% Wedged shape: a context is registered but the cache row is still pending,
+    %% so a reader on this node fails closed. The row state, not the seqs map, is
+    %% the authoritative check: put_manifest/2,3 (GC, the read path, writer
+    %% reseed) resolves the row without recording a sequence, so an absent seqs
+    %% entry does not imply pending. get_manifest/1 reads the ETS row directly.
+    Awaiting =
+        maps:is_key(StreamId, Ctxs) andalso
+            get_manifest(StreamId) =:= pending,
+    {reply, Awaiting, State};
 handle_call({evaluate_local_retention, StreamId}, _From, #state{contexts = Ctxs} = State) ->
     Reply =
         case maps:get(StreamId, Ctxs, undefined) of
@@ -911,6 +936,63 @@ is_stale_sync_test() ->
     %% A delayed sync from a deposed lower-epoch writer is stale, even with a
     %% higher sequence than the new writer has reached.
     ?assert(is_stale_sync(5, 10, {1, 6, Node})),
+    ok.
+
+%% is_awaiting_sync/1 must report the wedged shape (a registered context whose
+%% cache row is still pending) and must NOT false-positive on a row resolved via
+%% put_manifest, which writes the row without recording a sequence. Regression
+%% test for rabbitmq_stream_s3#362. Runs against a live singleton because the
+%% predicate reads the ETS row (get_manifest/1), not just gen_server state.
+is_awaiting_sync_test_() ->
+    {setup,
+        fun() ->
+            {ok, Pid} = start_link(),
+            Pid
+        end,
+        fun(Pid) ->
+            gen_server:stop(Pid)
+        end,
+        fun(_Pid) ->
+            S = <<"awaiting_sync_stream">>,
+            Shared = osiris_log_shared:new(),
+            Counter = counters:new(1, []),
+            [
+                %% No context at all: not awaiting.
+                ?_assertNot(is_awaiting_sync(S)),
+                %% Register a context. mark_pending is applied by register, so the
+                %% row is pending with a context: this is the wedged shape.
+                ?_test(begin
+                    ok = register_replica_context(S, self(), "/tmp/nx", Shared, Counter),
+                    ?assert(is_awaiting_sync(S))
+                end),
+                %% A sync resolves the row and records a sequence: no longer awaiting.
+                ?_test(begin
+                    M = #manifest{first_offset = 0, next_offset = 10, revision = 1},
+                    ok = sync(S, 1, 1, M),
+                    ?assertNot(is_awaiting_sync(S))
+                end),
+                %% Re-mark pending (as a member restart's re-register does) and confirm
+                %% it reports awaiting again even though a sequence was once recorded:
+                %% the row state, not the seqs map, is authoritative.
+                ?_test(begin
+                    ok = mark_pending_for_test(S),
+                    ?assert(is_awaiting_sync(S))
+                end),
+                %% put_manifest resolves the row WITHOUT recording a sequence (the GC
+                %% and read-path resolve). This must NOT read as awaiting: the earlier
+                %% seqs-based predicate false-positived here.
+                ?_test(begin
+                    M2 = #manifest{first_offset = 0, next_offset = 20, revision = 2},
+                    ok = put_manifest(S, M2, 1),
+                    ?assertNot(is_awaiting_sync(S))
+                end)
+            ]
+        end}.
+
+%% mark_pending inserts only if absent (insert_new), so a test that needs to
+%% force an already-resolved row back to pending overwrites it directly.
+mark_pending_for_test(StreamId) ->
+    true = ets:insert(?TABLE, {StreamId, pending, undefined}),
     ok.
 
 -endif.

--- a/src/rabbitmq_stream_s3_replica_reader.erl
+++ b/src/rabbitmq_stream_s3_replica_reader.erl
@@ -471,23 +471,36 @@ handle_cast(
         cfg = #cfg{stream = StreamId, epoch = Epoch}
     } = State
 ) ->
-    case maps:is_key(Node, Replicas) of
-        true ->
-            {noreply, State};
-        false ->
-            MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
-            %% Sync the *persisted* manifest, not the live one: sync_manifest/4
-            %% tags the sync with the manifest's revision as the sequence number
-            %% (see the {broadcast, _} effect), and that revision only advances
-            %% when a persist commits. Pairing the live manifest with the
-            %% persisted revision would cache an edit the replica was never told
-            %% about, which the next broadcast then re-delivers in-sequence so
-            %% the replica double-applies it (silent, unhealable divergence: no
-            %% gap is ever observed). Do not change this back to manifest/1.
-            Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
-            sync_manifest(StreamId, Epoch, Manifest, Node),
-            {noreply, State#state{replicas = Replicas#{Node => MonRef}}}
-    end;
+    %% Sync the *persisted* manifest, not the live one: sync_manifest/4
+    %% tags the sync with the manifest's revision as the sequence number
+    %% (see the {broadcast, _} effect), and that revision only advances
+    %% when a persist commits. Pairing the live manifest with the
+    %% persisted revision would cache an edit the replica was never told
+    %% about, which the next broadcast then re-delivers in-sequence so
+    %% the replica double-applies it (silent, unhealable divergence: no
+    %% gap is ever observed). Do not change this back to manifest/1.
+    Manifest = rabbitmq_stream_s3_replica_reader_core:persisted_manifest(Core),
+    %% Always re-sync, even when the node is already in the replicas map. A
+    %% replica's osiris member restarts on every "fell behind retention"
+    %% resync, and each restart's on_init(acceptor) hook re-sends
+    %% register_acceptor and re-marks the node's cache row pending, while this
+    %% writer's monitor is on the replica's manifest_replica process (which does
+    %% not restart), so the node never leaves the replicas map. Early-returning
+    %% here on the already-registered path left the row wedged in pending with
+    %% no sync to resolve it once publishing stopped and gap-detection went
+    %% quiet. The re-sync is idempotent: the replica's is_stale_sync/3 drops it
+    %% if the replica is already current, and applies it (resolving a pending
+    %% row with no recorded sequence) otherwise. See rabbitmq_stream_s3#362.
+    Replicas1 =
+        case maps:is_key(Node, Replicas) of
+            true ->
+                Replicas;
+            false ->
+                MonRef = monitor(process, {rabbitmq_stream_s3_manifest_replica, Node}),
+                Replicas#{Node => MonRef}
+        end,
+    sync_manifest(StreamId, Epoch, Manifest, Node),
+    {noreply, State#state{replicas = Replicas1}};
 handle_cast(
     {retention_updated, Retention}, #state{core = Core, cfg = #cfg{stream = StreamId}} = State
 ) ->


### PR DESCRIPTION
> [!NOTE]
> This PR description was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who directed the work and approved each commit but did not author this prose. The bug was found by Claude building a lagging-consumer fan-out test; the mechanism was traced against the deployed checkout and verified live on a 3-node cluster, both by direct manipulation and under real load. The analysis and the test are Claude's, so treat them as reviewable rather than settled.

*Issue #, if available:* fixes #362

*Description of changes:* a replica's manifest cache row can wedge in `pending` indefinitely on one node, so every offset-`first` subscribe to that stream on that node fails closed with `STREAM_NOT_AVAILABLE` while the stream is otherwise healthy. Nothing recovers it without a member restart or a manual re-sync; one stream stayed wedged for over an hour.

The row is resolved only by a sync from the writer landing in `maybe_apply_sync/8`. The writer sends one from `register_acceptor`, from an explicit `resync` request, and from `reconcile_replicas`. A member-restart burst (the "fell behind retention" resync churn) defeats all three: each restart's `release_stream` clears the row, `seqs` and `pending_resync`, and the final re-registration cannot request a sync (`pending_resync` was just cleared) while `register_acceptor` is a no-op at the writer because the node never left the writer's `replicas` map. The writer monitors the node's `manifest_replica` process, which does not restart, not the osiris member, which does. Once publishing stops, no edits arrive to gap-detect and request a sync, so the row stays `pending`.

**The cause fix (`rabbitmq_stream_s3_replica_reader`).** The writer's `register_acceptor` handler now re-syncs the persisted manifest even when the node is already registered, instead of early-returning. Every member restart re-fires `on_init(acceptor)`, which re-sends `register_acceptor`, so the writer heals the row on the next restart. The re-sync is idempotent: the replica's `is_stale_sync/3` drops it if the replica is already current. Both `sync` and `apply_edits` are cast from the same single writer-side reader process and read the same monotonic persisted manifest, so the extra sync cannot race or invert a broadcast into divergence.

**The backstop (`rabbitmq_stream_s3_hooks` + `rabbitmq_stream_s3_manifest_replica`).** The periodic reconciler previously did nothing for a context-registered replica. It now re-requests a sync when the row is still `pending`, via a new `is_awaiting_sync/1` that reads the ETS row state rather than the `seqs` map: `put_manifest/2,3` (GC, the read path, writer reseed) resolves a row without recording a sequence, so a `seqs`-absence check would false-positive on healthy rows.

*Testing:* added `is_awaiting_sync_test_`, covering the wedged shape, resolution by sync, and the `put_manifest` resolve that must not read as awaiting. It has teeth: with the earlier `seqs`-based predicate the `put_manifest` case fails; with the row-state predicate all cases pass. Full module eunit: 8 cases, 0 failures.

Verified live on a 3-node cluster. Forced the wedged shape on a replica and confirmed both recovery paths resolve it: the reconciler tick (`reconcile/0` -> `is_awaiting_sync` -> re-request) and a bare `register_acceptor` to the writer (what a member restart sends), which on unpatched code early-returned and left the row wedged. Then ran the lagging-consumer fan-out test for 30 minutes: roughly 490 "fell behind retention" resync-truncations per node (the wedge trigger, at far higher volume than the run that first wedged a stream) produced zero pending rows on all three nodes and zero broker errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
